### PR TITLE
Init clang tidy

### DIFF
--- a/docs/clice.toml
+++ b/docs/clice.toml
@@ -13,6 +13,9 @@
     # Compile commands directories to search for compile_commands.json files.
     compile_commands_dirs = ["${workspace}/build"]
 
+    # Enable clang-tidy diagnostics.
+    clang_tidy = false
+
     # Maximum number of active files to keep in memory. If the number of active files
     # exceeds this limit, the least recently used files will be removed. 
     # The default value is 8. Whatever the number you set, the minimum is 1, the maximum is 512.

--- a/docs/clice.toml
+++ b/docs/clice.toml
@@ -13,7 +13,8 @@
     # Compile commands directories to search for compile_commands.json files.
     compile_commands_dirs = ["${workspace}/build"]
 
-    # Enable clang-tidy diagnostics.
+    # Enable experimental clang-tidy diagnostics. 
+    # This feature is tracked in https://github.com/clice-project/clice/issues/90.
     clang_tidy = false
 
     # Maximum number of active files to keep in memory. If the number of active files

--- a/include/Server/Config.h
+++ b/include/Server/Config.h
@@ -17,6 +17,7 @@ void init(std::string_view workplace);
 
 struct ServerOptions {
     std::vector<std::string> compile_commands_dirs = {"${workspace}/build"};
+    bool clang_tidy = false;
     size_t max_active_file = 8;
 };
 

--- a/src/Server/Document.cpp
+++ b/src/Server/Document.cpp
@@ -328,8 +328,8 @@ async::Task<> Server::build_ast(std::string path, std::string content) {
 
     /// Run Clang-Tidy
     if(config::server.clang_tidy) {
-        log::fatal(
-            "clang-tidy is not supported yet. Tracked in https://github.com/clice-project/clice/issues/90.");
+        log::warn(
+            "clang-tidy is not fully supported yet. Tracked in https://github.com/clice-project/clice/issues/90.");
     }
 
     /// Send diagnostics

--- a/src/Server/Document.cpp
+++ b/src/Server/Document.cpp
@@ -326,6 +326,12 @@ async::Task<> Server::build_ast(std::string path, std::string content) {
         co_return;
     }
 
+    /// Run Clang-Tidy
+    if(config::server.clang_tidy) {
+        log::fatal(
+            "clang-tidy is not supported yet. Tracked in https://github.com/clice-project/clice/issues/90.");
+    }
+
     /// Send diagnostics
     auto diagnostics = co_await async::submit(
         [&, kind = this->kind] { return feature::diagnostics(kind, mapping, *ast); });

--- a/tests/data/clang_tidy/clice.toml
+++ b/tests/data/clang_tidy/clice.toml
@@ -1,0 +1,6 @@
+### clice configuration
+
+[server]
+
+    # Enable clang-tidy diagnostics.
+    clang_tidy = true

--- a/tests/data/clang_tidy/main.cpp
+++ b/tests/data/clang_tidy/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello World!" << std::endl;
+    return 0;
+}

--- a/tests/integration/test_file_operation.py
+++ b/tests/integration/test_file_operation.py
@@ -7,9 +7,7 @@ from ..fixtures.client import LSPClient
 
 @pytest.mark.asyncio
 async def test_did_open(executable, test_data_dir, resource_dir):
-    client = LSPClient([
-        executable, "--mode=pipe", f"--resource-dir={resource_dir}"
-    ])
+    client = LSPClient([executable, "--mode=pipe", f"--resource-dir={resource_dir}"])
     await client.start()
 
     await client.initialize(test_data_dir / "hello_world")
@@ -21,9 +19,7 @@ async def test_did_open(executable, test_data_dir, resource_dir):
 
 @pytest.mark.asyncio
 async def test_did_change(executable, test_data_dir, resource_dir):
-    client = LSPClient([
-        executable, "--mode=pipe", f"--resource-dir={resource_dir}"
-    ])
+    client = LSPClient([executable, "--mode=pipe", f"--resource-dir={resource_dir}"])
     await client.start()
 
     await client.initialize(test_data_dir / "hello_world")
@@ -39,4 +35,24 @@ async def test_did_change(executable, test_data_dir, resource_dir):
 
     await asyncio.sleep(5)
     logging.info("Send exit")
+    await client.exit()
+
+
+@pytest.mark.asyncio
+async def test_clang_tidy(executable, test_data_dir, resource_dir):
+    config_path = test_data_dir / "clang_tidy" / "clice.toml"
+    client = LSPClient(
+        [
+            executable,
+            "--mode=pipe",
+            f"--resource-dir={resource_dir}",
+            f"--config={config_path}",
+        ]
+    )
+    await client.start()
+
+    await client.initialize(test_data_dir / "clang_tidy")
+    await client.did_open("main.cpp")
+
+    await asyncio.sleep(5)
     await client.exit()


### PR DESCRIPTION
The `clang_tidy` option matches the clangd CLI option: `--clang-tidy`. With this flag, we can develop the clang tidy feature and enable this by default when we feel confident.

Related issue: #90