### PR TITLE
Documenting GCC toolchain settings

### DIFF
--- a/docs/en/dev/build.md
+++ b/docs/en/dev/build.md
@@ -77,7 +77,7 @@ You can also refer to llvm's official build tutorial [Building LLVM with CMake](
 
 ### GCC Toolchain
 
-clice requires `GCC libstdc++ >= 14`. If you would like to use a different GCC toolchain and also link statically against its `libstdc++`, you should provide all flags in a single `cmake` command:
+clice requires `GCC libstdc++ >= 14`. You could use a different GCC toolchain and also link statically against its `libstdc++`:
 
 ```bash
 cmake .. -DCMAKE_C_FLAGS="--gcc-toolchain=/usr/local/gcc-14.3.0/" \

--- a/docs/en/dev/build.md
+++ b/docs/en/dev/build.md
@@ -75,6 +75,20 @@ $ python3 <clice>/scripts/build-llvm-libs.py debug
 
 You can also refer to llvm's official build tutorial [Building LLVM with CMake](https://llvm.org/docs/CMake.html).
 
+### GCC Toolchain
+
+clice requires `GCC libstdc++ >= 14`. If you would like to use a different GCC toolchain, you can separately specify the toolchain path for clice:
+
+```bash
+cmake .. -DCMAKE_C_FLAGS="--gcc-toolchain=/usr/local/gcc-14.3.0/" -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/local/gcc-14.3.0/"
+```
+
+To run clice using the libstdc++ with the toolchain instead of that from the system environment, you need to specify using the libstdc++ static library when building:
+
+```bash
+cmake .. -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++"
+```
+
 ## Building
 
 After handling the prerequisites, you can start building clice. We provide two build methods: cmake/xmake.

--- a/docs/en/dev/build.md
+++ b/docs/en/dev/build.md
@@ -77,17 +77,12 @@ You can also refer to llvm's official build tutorial [Building LLVM with CMake](
 
 ### GCC Toolchain
 
-clice requires `GCC libstdc++ >= 14`. If you would like to use a different GCC toolchain, you can separately specify the toolchain path for clice:
+clice requires `GCC libstdc++ >= 14`. If you would like to use a different GCC toolchain and also link statically against its `libstdc++`, you should provide all flags in a single `cmake` command:
 
 ```bash
-cmake .. -DCMAKE_C_FLAGS="--gcc-toolchain=/usr/local/gcc-14.3.0/" -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/local/gcc-14.3.0/"
-```
-
-To run clice using the libstdc++ with the toolchain instead of that from the system environment, you need to specify using the libstdc++ static library when building:
-
-```bash
-cmake .. -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++"
-```
+cmake .. -DCMAKE_C_FLAGS="--gcc-toolchain=/usr/local/gcc-14.3.0/" \
+         -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/local/gcc-14.3.0/" \
+         -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++"
 
 ## Building
 

--- a/docs/zh/dev/build.md
+++ b/docs/zh/dev/build.md
@@ -77,17 +77,12 @@ $ python3 <clice>/scripts/build-llvm-libs.py debug
 
 ### GCC Toolchain
 
-clice要求`GCC libstdc++ >= 14`。如果想要使用不同的 GCC 工具链，可以单独为 clice 指定工具链路径：
+clice要求`GCC libstdc++ >= 14`。如果想要使用不同的 GCC 工具链并静态链接其 `libstdc++`，可以在一条 `cmake` 命令中提供所有选项：
 
 ```bash
-cmake .. -DCMAKE_C_FLAGS="--gcc-toolchain=/usr/local/gcc-14.3.0/" -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/local/gcc-14.3.0/"
-```
-
-同时，若希望使用工具链下的 libstdc++ 运行 clice，需要在构建的时候指定使用 libstdc++ 静态库：
-
-```bash
-cmake .. -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++"
-```
+cmake .. -DCMAKE_C_FLAGS="--gcc-toolchain=/usr/local/gcc-14.3.0/" \
+         -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/local/gcc-14.3.0/" \
+         -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++"
 
 
 ## Building

--- a/docs/zh/dev/build.md
+++ b/docs/zh/dev/build.md
@@ -77,7 +77,7 @@ $ python3 <clice>/scripts/build-llvm-libs.py debug
 
 ### GCC Toolchain
 
-clice要求`GCC libstdc++ >= 14`。以下命令使用不同的 GCC 工具链并静态链接其 `libstdc++`：
+clice 要求 `GCC libstdc++ >= 14` 。以下命令使用不同的 GCC 工具链并静态链接其 `libstdc++`：
 
 ```bash
 cmake .. -DCMAKE_C_FLAGS="--gcc-toolchain=/usr/local/gcc-14.3.0/" \

--- a/docs/zh/dev/build.md
+++ b/docs/zh/dev/build.md
@@ -75,6 +75,21 @@ $ python3 <clice>/scripts/build-llvm-libs.py debug
 
 也可以参考 llvm 的官方构建教程 [Building LLVM with CMake](https://llvm.org/docs/CMake.html)。
 
+### GCC Toolchain
+
+clice要求`GCC libstdc++ >= 14`。如果想要使用不同的 GCC 工具链，可以单独为 clice 指定工具链路径：
+
+```bash
+cmake .. -DCMAKE_C_FLAGS="--gcc-toolchain=/usr/local/gcc-14.3.0/" -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/local/gcc-14.3.0/"
+```
+
+同时，若希望使用工具链下的 libstdc++ 运行 clice，需要在构建的时候指定使用 libstdc++ 静态库：
+
+```bash
+cmake .. -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++"
+```
+
+
 ## Building
 
 在处理好前置依赖之后，可以开始构建 clice 了，我们提供 cmake/xmake 两种构建方式。

--- a/docs/zh/dev/build.md
+++ b/docs/zh/dev/build.md
@@ -77,7 +77,7 @@ $ python3 <clice>/scripts/build-llvm-libs.py debug
 
 ### GCC Toolchain
 
-clice要求`GCC libstdc++ >= 14`。如果想要使用不同的 GCC 工具链并静态链接其 `libstdc++`，可以在一条 `cmake` 命令中提供所有选项：
+clice要求`GCC libstdc++ >= 14`。以下命令使用不同的 GCC 工具链并静态链接其 `libstdc++`：
 
 ```bash
 cmake .. -DCMAKE_C_FLAGS="--gcc-toolchain=/usr/local/gcc-14.3.0/" \


### PR DESCRIPTION
> The suggestion is not practicial for clice distributed binary (so we shouldn't change the CI), and the package bundlers must solve the library problem for us. I've changed the goal to suggest that in dev docs.

resolves #198 