### PR TITLE
feat: add compression for PCH/PCM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,10 +45,22 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/libuv/libuv.git
     GIT_TAG v1.x
 )
-FetchContent_MakeAvailable(tomlplusplus libuv)
+
+message(STATUS "Fetching lz4...")
+# Disable building the lz4 command line executable
+set(LZ4_BUILD_CLI OFF)
+FetchContent_Declare(
+    lz4
+    GIT_REPOSITORY https://github.com/lz4/lz4.git
+    GIT_TAG v1.10.0
+    SOURCE_SUBDIR build/cmake
+)
+
+FetchContent_MakeAvailable(tomlplusplus libuv lz4)
 
 message(STATUS "Found tomlplusplus: ${tomlplusplus_SOURCE_DIR}")
 message(STATUS "Found libuv: ${libuv_SOURCE_DIR}")
+message(STATUS "Found lz4: ${lz4_SOURCE_DIR}")
 
 if(WIN32)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
@@ -147,7 +159,7 @@ target_compile_options(clice-core PUBLIC ${CLICE_CXX_FLAGS})
 target_link_options(clice-core PUBLIC ${CLICE_LINKER_FLAGS})
 
 target_include_directories(clice-core PUBLIC "${CMAKE_SOURCE_DIR}/include")
-target_link_libraries(clice-core PUBLIC uv_a tomlplusplus::tomlplusplus llvm-libs)
+target_link_libraries(clice-core PUBLIC uv_a tomlplusplus::tomlplusplus llvm-libs lz4_static)
 
 # clice executable
 add_executable(clice "${CMAKE_SOURCE_DIR}/src/Driver/clice.cc")

--- a/include/Support/Compression.h
+++ b/include/Support/Compression.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include <memory>
+
+namespace llvm {
+class MemoryBuffer;
+}
+
+namespace clice {
+
+/**
+ *  @brief Compresses a pre-compiled file (PCH/PCM) using LZ4 and removes the original file.
+ * 
+ * The compressed file has a custom format: an 8-byte header for the
+ * original size (uint64_t), followed by the LZ4 compressed data.
+ * 
+ * @param path The path to the pre-compiled file to compress.
+ */
+void compressPreCompiledFile(std::string path);
+/**
+ *  @brief Compresses a file using LZ4 and saves it to an output path.
+ * 
+ * The compressed file has a custom format: an 8-byte header for the
+ * original size (uint64_t), followed by the LZ4 compressed data.
+ * 
+ * @param inputPath The path to the file to compress.
+ * @param outputPath The path where the compressed file will be saved.
+ * @return true on success, false on failure (e.g., input file not found).
+ */
+bool compressToFile(std::string inputPath, std::string outputPath);
+/**
+ *  @brief Decompresses a file compressed with `compressToFile`.
+ * 
+ * The function reads the custom format: an 8-byte header for the
+ * original size (uint64_t), followed by the LZ4 compressed data.
+ * 
+ * @param path The path to the compressed file.
+ * @return A unique pointer to a MemoryBuffer containing the decompressed data,
+ *         or nullptr on failure (e.g., file not found or decompression error).
+ */
+std::unique_ptr<llvm::MemoryBuffer> decompressFile(std::string path);
+
+} // namespace clice

--- a/include/Support/Compression.h
+++ b/include/Support/Compression.h
@@ -13,19 +13,19 @@ namespace clice {
 
 /**
  *  @brief Compresses a pre-compiled file (PCH/PCM) using LZ4 and removes the original file.
- * 
+ *
  * The compressed file has a custom format: an 8-byte header for the
  * original size (uint64_t), followed by the LZ4 compressed data.
- * 
+ *
  * @param path The path to the pre-compiled file to compress.
  */
-void compressPreCompiledFile(std::string path);
+void compressPreCompiledFile(llvm::StringRef path);
 /**
  *  @brief Compresses a file using LZ4 and saves it to an output path.
- * 
+ *
  * The compressed file has a custom format: an 8-byte header for the
  * original size (uint64_t), followed by the LZ4 compressed data.
- * 
+ *
  * @param inputPath The path to the file to compress.
  * @param outputPath The path where the compressed file will be saved.
  * @return true on success, false on failure (e.g., input file not found).
@@ -33,14 +33,14 @@ void compressPreCompiledFile(std::string path);
 bool compressToFile(std::string inputPath, std::string outputPath);
 /**
  *  @brief Decompresses a file compressed with `compressToFile`.
- * 
+ *
  * The function reads the custom format: an 8-byte header for the
  * original size (uint64_t), followed by the LZ4 compressed data.
- * 
+ *
  * @param path The path to the compressed file.
  * @return A unique pointer to a MemoryBuffer containing the decompressed data,
  *         or nullptr on failure (e.g., file not found or decompression error).
  */
 std::unique_ptr<llvm::MemoryBuffer> decompressFile(std::string path);
 
-} // namespace clice
+}  // namespace clice

--- a/include/Support/Compression.h
+++ b/include/Support/Compression.h
@@ -19,7 +19,7 @@ namespace clice {
  *
  * @param path The path to the pre-compiled file to compress.
  */
-void compressPreCompiledFile(llvm::StringRef path);
+void compressPreCompiledFile(std::string path);
 /**
  *  @brief Compresses a file using LZ4 and saves it to an output path.
  *

--- a/src/Compiler/Compilation.cpp
+++ b/src/Compiler/Compilation.cpp
@@ -120,11 +120,11 @@ auto create_invocation(CompilationParams& params,
     params.buffers.clear();
 
     auto [pch, bound] = params.pch;
-    if (pch.ends_with(".lz4")) {
+    if(pch.ends_with(".lz4")) {
         // When a compressed PCH/PCM is found, we decompress it into a memory buffer.
         // To allow clang to read this in-memory PCH/PCM as if it were a file on disk,
         // we create a virtual file system (VFS). This VFS overlays the real file system.
-        if (auto buffer = decompressFile(pch)) {
+        if(auto buffer = decompressFile(pch)) {
             std::string pch_path = pch;
             pch_path.resize(pch_path.size() - 4);
 
@@ -138,7 +138,7 @@ auto create_invocation(CompilationParams& params,
 
             pp_opts.ImplicitPCHInclude = std::move(pch_path);
         } else {
-            pp_opts.ImplicitPCHInclude = std::move(pch);
+            log::warn("Failed to decompress PCH '{}', proceeding without it.", pch);
         }
     } else {
         pp_opts.ImplicitPCHInclude = std::move(pch);

--- a/src/Compiler/Compilation.cpp
+++ b/src/Compiler/Compilation.cpp
@@ -7,6 +7,7 @@
 #include "clang/Frontend/MultiplexConsumer.h"
 #include "Support/Compression.h"
 #include "Support/FileSystem.h"
+#include "Support/Logger.h"
 
 namespace clice {
 

--- a/src/Server/Document.cpp
+++ b/src/Server/Document.cpp
@@ -315,7 +315,7 @@ async::Task<> Server::build_ast(std::string path, std::string content) {
     params.add_remapped_file(path, content);
     params.pch = {pch->path, pch->preamble.size()};
     // if compressed PCH exists, use it
-    if (fs::exists(params.pch.first + ".lz4")) {
+    if(fs::exists(params.pch.first + ".lz4")) {
         params.pch.first = params.pch.first + ".lz4";
     }
     file->diagnostics->clear();

--- a/src/Support/Compression.cpp
+++ b/src/Support/Compression.cpp
@@ -7,36 +7,41 @@
 
 namespace clice {
 
-void compressPreCompiledFile(std::string path){
-    if (!fs::exists(path)) {
+void compressPreCompiledFile(llvm::StringRef path) {
+    if(!fs::exists(path)) {
         log::warn("PreCompiledFile does not exist: {}", path);
-    } else if (!compressToFile(path, path + ".lz4")) {
-        log::fatal("Fail to compress PreCompiledFile: {}", path);
+    } else if(!compressToFile(path, path + ".lz4")) {
+        log::warn("Fail to compress PreCompiledFile: {}", path);
     } else {
-        if (auto ec = fs::remove(path)) {
-            log::fatal("Fail to remove original PreCompiledFile: {}. Reason: {}", path, ec.message());
+        if(auto ec = fs::remove(path)) {
+            log::warn("Fail to remove original PreCompiledFile: {}. Reason: {}",
+                      path,
+                      ec.message());
         }
     }
 }
 
 bool compressToFile(std::string inputPath, std::string outputPath) {
     auto content = fs::read(inputPath);
-    if (!content) {
+    if(!content) {
         return false;
     }
     uint64_t originalSize = content->size();
     int maxCompressedSize = LZ4_compressBound(originalSize);
     std::vector<char> compressed(maxCompressedSize + sizeof(uint64_t));
-    
+
     // Our custom format: Prepend the 8-byte original size as a header
     // before the compressed data.
     memcpy(compressed.data(), &originalSize, sizeof(uint64_t));
 
-    int compressedDataSize = LZ4_compress_default(content->data(), compressed.data() + sizeof(uint64_t), originalSize, maxCompressedSize);
-    if (compressedDataSize <= 0) {
+    int compressedDataSize = LZ4_compress_default(content->data(),
+                                                  compressed.data() + sizeof(uint64_t),
+                                                  originalSize,
+                                                  maxCompressedSize);
+    if(compressedDataSize <= 0) {
         return false;
     }
-    
+
     size_t totalSize = compressedDataSize + sizeof(uint64_t);
 
     llvm::StringRef dataToWrite(compressed.data(), totalSize);
@@ -46,14 +51,14 @@ bool compressToFile(std::string inputPath, std::string outputPath) {
 
 std::unique_ptr<llvm::MemoryBuffer> decompressFile(std::string path) {
     auto content = fs::read(path);
-    if (!content) {
-        log::fatal("Fail to read compressed file: {}", path);
+    if(!content) {
+        log::warn("Fail to read compressed file: {}", path);
         return nullptr;
     }
 
-    if (content->size() < sizeof(uint64_t)) {
-        log::fatal("Fail to read compressed file: {}", path);
-        return nullptr; // Not enough data for size header
+    if(content->size() < sizeof(uint64_t)) {
+        log::warn("Fail to read compressed file: {}", path);
+        return nullptr;  // Not enough data for size header
     }
 
     // Our custom format: Prepend the 8-byte original size as a header
@@ -65,19 +70,22 @@ std::unique_ptr<llvm::MemoryBuffer> decompressFile(std::string path) {
     size_t compressedDataSize = content->size() - sizeof(uint64_t);
 
     auto buffer = llvm::WritableMemoryBuffer::getNewUninitMemBuffer(originalSize);
-    if (!buffer) {
-        log::fatal("Fail to allocate memory buffer for decompression: {}", path);
+    if(!buffer) {
+        log::warn("Fail to allocate memory buffer for decompression: {}", path);
         return nullptr;
     }
 
-    int decompressedSize = LZ4_decompress_safe(compressedData, buffer->getBufferStart(), compressedDataSize, originalSize);
+    int decompressedSize = LZ4_decompress_safe(compressedData,
+                                               buffer->getBufferStart(),
+                                               compressedDataSize,
+                                               originalSize);
 
-    if (decompressedSize < 0) { // LZ4 returns negative on error
-        log::fatal("Fail to decompress file: {}", path);
+    if(decompressedSize < 0) {  // LZ4 returns negative on error
+        log::warn("Fail to decompress file: {}", path);
         return nullptr;
     }
-    
-    if (static_cast<uint64_t>(decompressedSize) != originalSize) {
+
+    if(static_cast<uint64_t>(decompressedSize) != originalSize) {
         // This case should ideally not happen if the stored size is correct
         return nullptr;
     }
@@ -85,4 +93,4 @@ std::unique_ptr<llvm::MemoryBuffer> decompressFile(std::string path) {
     return buffer;
 }
 
-} // namespace clice
+}  // namespace clice

--- a/src/Support/Compression.cpp
+++ b/src/Support/Compression.cpp
@@ -1,0 +1,88 @@
+#include "Support/Compression.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "lz4.h"
+#include <string>
+#include "Support/FileSystem.h"
+#include "Support/Logger.h"
+
+namespace clice {
+
+void compressPreCompiledFile(std::string path){
+    if (!fs::exists(path)) {
+        log::warn("PreCompiledFile does not exist: {}", path);
+    } else if (!compressToFile(path, path + ".lz4")) {
+        log::fatal("Fail to compress PreCompiledFile: {}", path);
+    } else {
+        if (auto ec = fs::remove(path)) {
+            log::fatal("Fail to remove original PreCompiledFile: {}. Reason: {}", path, ec.message());
+        }
+    }
+}
+
+bool compressToFile(std::string inputPath, std::string outputPath) {
+    auto content = fs::read(inputPath);
+    if (!content) {
+        return false;
+    }
+    uint64_t originalSize = content->size();
+    int maxCompressedSize = LZ4_compressBound(originalSize);
+    std::vector<char> compressed(maxCompressedSize + sizeof(uint64_t));
+    
+    // Our custom format: Prepend the 8-byte original size as a header
+    // before the compressed data.
+    memcpy(compressed.data(), &originalSize, sizeof(uint64_t));
+
+    int compressedDataSize = LZ4_compress_default(content->data(), compressed.data() + sizeof(uint64_t), originalSize, maxCompressedSize);
+    if (compressedDataSize <= 0) {
+        return false;
+    }
+    
+    size_t totalSize = compressedDataSize + sizeof(uint64_t);
+
+    llvm::StringRef dataToWrite(compressed.data(), totalSize);
+    auto result = fs::write(outputPath, dataToWrite);
+    return result.has_value();
+}
+
+std::unique_ptr<llvm::MemoryBuffer> decompressFile(std::string path) {
+    auto content = fs::read(path);
+    if (!content) {
+        log::fatal("Fail to read compressed file: {}", path);
+        return nullptr;
+    }
+
+    if (content->size() < sizeof(uint64_t)) {
+        log::fatal("Fail to read compressed file: {}", path);
+        return nullptr; // Not enough data for size header
+    }
+
+    // Our custom format: Prepend the 8-byte original size as a header
+    // before the compressed data.
+    uint64_t originalSize;
+    memcpy(&originalSize, content->data(), sizeof(uint64_t));
+
+    const char* compressedData = content->data() + sizeof(uint64_t);
+    size_t compressedDataSize = content->size() - sizeof(uint64_t);
+
+    auto buffer = llvm::WritableMemoryBuffer::getNewUninitMemBuffer(originalSize);
+    if (!buffer) {
+        log::fatal("Fail to allocate memory buffer for decompression: {}", path);
+        return nullptr;
+    }
+
+    int decompressedSize = LZ4_decompress_safe(compressedData, buffer->getBufferStart(), compressedDataSize, originalSize);
+
+    if (decompressedSize < 0) { // LZ4 returns negative on error
+        log::fatal("Fail to decompress file: {}", path);
+        return nullptr;
+    }
+    
+    if (static_cast<uint64_t>(decompressedSize) != originalSize) {
+        // This case should ideally not happen if the stored size is correct
+        return nullptr;
+    }
+
+    return buffer;
+}
+
+} // namespace clice

--- a/src/Support/Compression.cpp
+++ b/src/Support/Compression.cpp
@@ -7,7 +7,7 @@
 
 namespace clice {
 
-void compressPreCompiledFile(llvm::StringRef path) {
+void compressPreCompiledFile(std::string path) {
     if(!fs::exists(path)) {
         log::warn("PreCompiledFile does not exist: {}", path);
     } else if(!compressToFile(path, path + ".lz4")) {

--- a/tests/unit/Compiler/Module.cpp
+++ b/tests/unit/Compiler/Module.cpp
@@ -1,5 +1,6 @@
 #include "Test/Test.h"
 #include "Compiler/Compilation.h"
+#include "Support/Compression.h"
 #include "llvm/Support/ToolOutputFile.h"
 
 namespace clice::testing {
@@ -29,6 +30,8 @@ auto buildPCM = [](llvm::StringRef file, llvm::StringRef code) {
     if(!compile(params, pcm)) {
         llvm::errs() << "Failed to build PCM\n";
         std::abort();
+    } else {
+        compressPreCompiledFile(pcm.path);
     }
 
     return pcm;

--- a/xmake.lua
+++ b/xmake.lua
@@ -41,6 +41,7 @@ end
 
 add_requires(libuv_require, "toml++")
 add_requires("llvm", {system = false})
+add_requires("lz4")
 
 add_rules("mode.release", "mode.debug", "mode.releasedbg")
 set_languages("c++23")
@@ -51,7 +52,7 @@ target("clice-core")
     add_files("src/**.cpp|Driver/*.cpp")
     add_includedirs("include", {public = true})
 
-    add_packages("libuv", "toml++", {public = true})
+    add_packages("libuv", "toml++", "lz4", {public = true})
 
     if is_mode("debug") then 
         add_packages("llvm", {


### PR DESCRIPTION
This PR implements default LZ4 compression for PCH/PCM.

There are a couple of points I'm not sure about
- whether or not to make compression optional in the config
- whether or not zstd would have a better compression ratio with similar overhead to lz4
- I'm not sure if clang can output PCH to memory instead of disk, if it can I'll improve the current implementation to compress files from memory

related to #209 