### PR TITLE
Test-filter can add suite name, also fix incorrect behaviour when use GlobalPattern syntax in args.

### DIFF
--- a/include/Compiler/CompilationUnit.h
+++ b/include/Compiler/CompilationUnit.h
@@ -12,7 +12,7 @@ namespace clice {
 /// All AST related information needed for language server.
 class CompilationUnit {
 public:
-    /// The kind describes how we preprocess ths source file
+    /// The kind describes how we preprocess this source file
     /// to get this compilation unit.
     enum class Kind : std::uint8_t {
         /// From preprocessing the source file. Therefore directives

--- a/include/Compiler/CompilationUnit.h
+++ b/include/Compiler/CompilationUnit.h
@@ -15,7 +15,7 @@ public:
     /// The kind describes how we preprocess ths source file
     /// to get this compilation unit.
     enum class Kind : std::uint8_t {
-        /// From preprocessing the source file. Therefore diretives
+        /// From preprocessing the source file. Therefore directives
         /// are available but AST nodes are not.
         Preprocess,
 


### PR DESCRIPTION
Also, i suspect the behaviour within `GlobalPattern`, `{,}`  syntax  only works when passing an argument while it seems that there's
no connection between them.
A further fix may be done by @aurora0x27 .