### PR TITLE
Update LLVM build configuration to include clang-tools-extra project

### DIFF
--- a/scripts/build-llvm-libs.py
+++ b/scripts/build-llvm-libs.py
@@ -59,7 +59,7 @@ def build_llvm(config):
         "-DCMAKE_BUILD_TYPE=" + config["build_type"],
         # Only build native to speed up building llvm.
         "-DLLVM_TARGETS_TO_BUILD=Native",
-        "-DLLVM_ENABLE_PROJECTS=clang",
+        "-DLLVM_ENABLE_PROJECTS=clang;clang-tools-extra",
         "-DCMAKE_INSTALL_PREFIX=" + config["install_dir"],
     ]
 


### PR DESCRIPTION
When compiling the project from scratch with LLVM, I discovered that `Tidy.cpp` requires a clang-tidy dependency. This dependency necessitates including clang-tools-extra when compiling LLVM.