### PR TITLE
feat: implement dummy `workspace/executeCommand`

### DIFF
--- a/include/Protocol/Basic.h
+++ b/include/Protocol/Basic.h
@@ -17,6 +17,8 @@ using decimal = double;
 
 using string = std::string;
 
+using any = llvm::json::Value;
+
 template <typename T>
 using array = std::vector<T>;
 

--- a/include/Protocol/Basic.h
+++ b/include/Protocol/Basic.h
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include "llvm/Support/JSON.h"
+
 namespace clice::proto {
 
 using integer = std::int32_t;

--- a/include/Protocol/Feature/ExecuteCommand.h
+++ b/include/Protocol/Feature/ExecuteCommand.h
@@ -6,7 +6,7 @@ namespace clice::proto {
 
 struct ExecuteCommandParams {
     string command;
-    array<llvm::json::Value> arguments;
+    array<any> arguments;
 };
 
 struct TextDocumentParams {

--- a/include/Protocol/Feature/ExecuteCommand.h
+++ b/include/Protocol/Feature/ExecuteCommand.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "../Basic.h"
+
+namespace clice::proto {
+
+struct ExecuteCommandParams {
+    string command;
+    array<llvm::json::Value> arguments;
+};
+
+struct TextDocumentParams {
+    /// The text document.
+    TextDocumentIdentifier textDocument;
+};
+
+}  // namespace clice::proto

--- a/include/Protocol/TextDocument.h
+++ b/include/Protocol/TextDocument.h
@@ -11,6 +11,7 @@
 #include "Feature/DocumentHighlight.h"
 #include "Feature/DocumentLink.h"
 #include "Feature/DocumentSymbol.h"
+#include "Feature/ExecuteCommand.h"
 #include "Feature/FoldingRange.h"
 #include "Feature/Formatting.h"
 #include "Feature/Hover.h"

--- a/include/Server/Server.h
+++ b/include/Server/Server.h
@@ -192,6 +192,8 @@ private:
 private:
     using Result = async::Task<json::Value>;
 
+    auto on_execute_command(proto::ExecuteCommandParams params) -> Result;
+
     auto on_completion(proto::CompletionParams params) -> Result;
 
     auto on_hover(proto::HoverParams params) -> Result;

--- a/src/Server/Server.cpp
+++ b/src/Server/Server.cpp
@@ -102,6 +102,8 @@ Server::Server() : indexer(database, config, kind) {
     register_callback<&Server::on_shutdown>("shutdown");
     register_callback<&Server::on_exit>("exit");
 
+    register_callback<&Server::on_execute_command>("workspace/executeCommand");
+
     register_callback<&Server::on_did_open>("textDocument/didOpen");
     register_callback<&Server::on_did_change>("textDocument/didChange");
     register_callback<&Server::on_did_save>("textDocument/didSave");
@@ -182,6 +184,10 @@ async::Task<> Server::on_receive(json::Value value) {
     }
 
     co_return;
+}
+
+async::Task<json::Value> Server::on_execute_command(proto::ExecuteCommandParams params) {
+    co_return json::Value{};
 }
 
 }  // namespace clice


### PR DESCRIPTION
This PR focuses on adding protocol definitions about `workspace/executeCommand`. clice may add specific custom commands in future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace command execution support to the language server, enabling clients to invoke custom commands with flexible parameter handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->