### PR TITLE
feat: load clice server plugins

### DIFF
--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -66,16 +66,20 @@ set(FLATBUFFERS_BUILD_GRPC OFF CACHE BOOL "" FORCE)
 set(FLATBUFFERS_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(FLATBUFFERS_BUILD_FLATHASH OFF CACHE BOOL "" FORCE)
 
-# cpptrace
-FetchContent_Declare(
-    cpptrace
-    GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
-    GIT_TAG        v1.0.4
-    GIT_SHALLOW    TRUE
-)
-set(CPPTRACE_DISABLE_CXX_20_MODULES ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(libuv spdlog tomlplusplus croaring flatbuffers)
 
-FetchContent_MakeAvailable(libuv spdlog tomlplusplus croaring flatbuffers cpptrace)
+if(CLICE_ENABLE_TEST)
+    # cpptrace
+    FetchContent_Declare(
+        cpptrace
+        GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
+        GIT_TAG        v1.0.4
+        GIT_SHALLOW    TRUE
+    )
+    set(CPPTRACE_DISABLE_CXX_20_MODULES ON CACHE BOOL "" FORCE)
+
+    FetchContent_MakeAvailable(cpptrace)
+endif()
 
 if(WIN32)
     target_compile_definitions(uv_a PRIVATE _CRT_SECURE_NO_WARNINGS)

--- a/docs/en/dev/server-plugin.md
+++ b/docs/en/dev/server-plugin.md
@@ -22,6 +22,20 @@ clice_get_server_plugin_info() {
 
 See [PluginDef.h](/include/Server/PluginDef.h) for more details.
 
+## Compiling a plugin
+
+The plugin must be compiled with the same dependencies and compiler options as clice, otherwise it will cause undefined behavior. [config/llvm-manifest.json](config/llvm-manifest.json) defines the build information used by clice.
+
+## Loading plugins
+
+For security reasons, clice does not allow loading plugins through configuration files, but must specify the plugin path through command line options.
+
+When `clice` starts, it will load all plugins specified in the command line. You can specify the plugin path through the `--plugin-path` option.
+
+```shell
+$ clice --plugin-path /path/to/my-plugin.so
+```
+
 ## Getting content of `CLICE_PLUGIN_DEF_HASH`
 
 There are two values to return in the `clice_get_server_plugin_info` function.

--- a/docs/en/dev/server-plugin.md
+++ b/docs/en/dev/server-plugin.md
@@ -24,7 +24,7 @@ See [PluginDef.h](/include/Server/PluginDef.h) for more details.
 
 ## Compiling a plugin
 
-The plugin must be compiled with the same dependencies and compiler options as clice, otherwise it will cause undefined behavior. [config/llvm-manifest.json](config/llvm-manifest.json) defines the build information used by clice.
+The plugin must be compiled with the same dependencies and compiler options as clice, otherwise it will cause undefined behavior. [config/llvm-manifest.json](/config/llvm-manifest.json) defines the build information used by clice.
 
 ## Loading plugins
 

--- a/docs/en/dev/server-plugin.md
+++ b/docs/en/dev/server-plugin.md
@@ -1,0 +1,60 @@
+You can implement a clice server plugin to extend clice's functionality.
+
+## Use case
+
+When you use `clice` as lsp backend of LLM agents, e.g. claude code, you can add plugin to provide some extra features.
+
+## Writing a plugin
+
+When a plugin is loaded by the server, it will call `clice_get_server_plugin_info` to obtain information about this plugin and about how to register its customization points.
+
+This function needs to be implemented by the plugin, see the example below:
+
+```c++
+extern "C" ::clice::PluginInfo LLVM_ATTRIBUTE_WEAK
+clice_get_server_plugin_info() {
+  return {
+    CLICE_PLUGIN_API_VERSION, "MyPlugin", "v0.1", CLICE_PLUGIN_DEF_HASH,
+    [](ServerPluginBuilder builder) {  ... }
+  };
+}
+```
+
+See [PluginDef.h](/include/Server/PluginDef.h) for more details.
+
+## Getting content of `CLICE_PLUGIN_DEF_HASH`
+
+There are two values to return in the `clice_get_server_plugin_info` function.
+
+- `CLICE_PLUGIN_API_VERSION` is used to ensure compability of the `clice_get_server_plugin_info` function between the plugin and the server.
+- `CLICE_PLUGIN_DEF_HASH` is used to ensure the consistency of the C++ declarations between the plugin and the server.
+
+To debug the content of `CLICE_PLUGIN_DEF_HASH`, you can run following command:
+
+```shell
+$ git clone https://github.com/clice-io/clice.git
+$ cd clice
+$ git checkout `clice --version --git-describe`
+$ python scripts/plugin-def.py content
+```
+
+You will get a C source code file, content of which is like this:
+
+```cpp
+#if 0
+// begin of config/llvm-manifest.json
+[
+  {
+    "version": "21.1.4+r1",
+    "filename": "arm64-macos-clang-debug-asan.tar.xz",
+    "sha256": "7da4b7d63edefecaf11773e7e701c575140d1a07329bbbb038673b6ee4516ff5",
+    "lto": false,
+    "asan": true,
+    "platform": "macosx",
+    "build_type": "Debug"
+  },
+  ...
+]
+...
+#endif
+```

--- a/docs/en/dev/server-plugin.md
+++ b/docs/en/dev/server-plugin.md
@@ -2,7 +2,7 @@ You can implement a clice server plugin to extend clice's functionality.
 
 ## Use case
 
-When you use `clice` as lsp backend of LLM agents, e.g. claude code, you can add plugin to provide some extra features.
+When you use `clice` as LSP backend of LLM agents, e.g. claude code, you can add plugin to provide some extra features.
 
 ## Writing a plugin
 

--- a/docs/zh/dev/server-plugin.md
+++ b/docs/zh/dev/server-plugin.md
@@ -24,7 +24,7 @@ clice_get_server_plugin_info() {
 
 ## 编译插件
 
-插件必须使用与 clice 一致的依赖和编译器选项来编译，否则会导致 undefined behavior。[config/llvm-manifest.json](config/llvm-manifest.json) 中定义了 clice 使用的构建信息。
+插件必须使用与 clice 一致的依赖和编译器选项来编译，否则会导致 undefined behavior。[config/llvm-manifest.json](/config/llvm-manifest.json) 中定义了 clice 使用的构建信息。
 
 ## 加载插件
 

--- a/docs/zh/dev/server-plugin.md
+++ b/docs/zh/dev/server-plugin.md
@@ -4,7 +4,7 @@
 
 当你使用 `clice` 作为 LLM 代理的 LSP 后端时，比如 claude code，你可以添加插件来提供一些额外功能。
 
-## 编写一个插件
+## 编写插件
 
 当一个插件被服务器加载时，它会调用 `clice_get_server_plugin_info` 来获取关于这个插件的信息以及如何注册它的定制点。
 
@@ -21,6 +21,20 @@ clice_get_server_plugin_info() {
 ```
 
 请参考 [PluginDef.h](/include/Server/PluginDef.h) 了解更多细节。
+
+## 编译插件
+
+插件必须使用与 clice 一致的依赖和编译器选项来编译，否则会导致 undefined behavior。[config/llvm-manifest.json](config/llvm-manifest.json) 中定义了 clice 使用的构建信息。
+
+## 加载插件
+
+为了安全考虑，clice 不允许通过配置文件来加载插件，而必须通过命令行选项来指定插件的路径。
+
+在 `clice` 启动时，它会加载所有在命令行中指定的插件。你可以通过 `--plugin-path` 选项来指定插件的路径。
+
+```shell
+$ clice --plugin-path /path/to/my-plugin.so
+```
 
 ## 获取 `CLICE_PLUGIN_DEF_HASH` 的内容
 

--- a/docs/zh/dev/server-plugin.md
+++ b/docs/zh/dev/server-plugin.md
@@ -1,0 +1,60 @@
+你可以在 clice 中实现一个 server plugin 来扩展 clice 的功能。
+
+## 用例
+
+当你使用 `clice` 作为 LLM 代理的 LSP 后端时，比如 claude code，你可以添加插件来提供一些额外功能。
+
+## 编写一个插件
+
+当一个插件被服务器加载时，它会调用 `clice_get_server_plugin_info` 来获取关于这个插件的信息以及如何注册它的定制点。
+
+这个函数需要由插件实现，请参考下面的示例：
+
+```cpp
+extern "C" ::clice::PluginInfo LLVM_ATTRIBUTE_WEAK
+clice_get_server_plugin_info() {
+  return {
+    CLICE_PLUGIN_API_VERSION, "MyPlugin", "v0.1", CLICE_PLUGIN_DEF_HASH,
+    [](ServerPluginBuilder builder) {  ... }
+  };
+}
+```
+
+请参考 [PluginDef.h](/include/Server/PluginDef.h) 了解更多细节。
+
+## 获取 `CLICE_PLUGIN_DEF_HASH` 的内容
+
+在 `clice_get_server_plugin_info` 函数中需要返回两个值。
+
+- `CLICE_PLUGIN_API_VERSION` 用于确保插件和服务器之间的 `clice_get_server_plugin_info` 函数的一致性。
+- `CLICE_PLUGIN_DEF_HASH` 用于确保插件和服务器之间的 C++ 声明的一致性。
+
+要调试 `CLICE_PLUGIN_DEF_HASH` 的内容，你可以运行以下命令：
+
+```shell
+$ git clone https://github.com/clice-io/clice.git
+$ cd clice
+$ git checkout `clice --version --git-describe`
+$ python scripts/plugin-def.py content > /tmp/plugin-proto.h
+```
+
+你将会得到一个 C 源码格式的文件，内容大致如下：
+
+```cpp
+#if 0
+// begin of config/llvm-manifest.json
+[
+  {
+    "version": "21.1.4+r1",
+    "filename": "arm64-macos-clang-debug-asan.tar.xz",
+    "sha256": "7da4b7d63edefecaf11773e7e701c575140d1a07329bbbb038673b6ee4516ff5",
+    "lto": false,
+    "asan": true,
+    "platform": "macosx",
+    "build_type": "Debug"
+  },
+  ...
+]
+...
+#endif
+```

--- a/include/Protocol/Basic.h
+++ b/include/Protocol/Basic.h
@@ -17,6 +17,8 @@ using decimal = double;
 
 using string = std::string;
 
+using any = llvm::json::Value;
+
 template <typename T>
 using array = std::vector<T>;
 

--- a/include/Protocol/Basic.h
+++ b/include/Protocol/Basic.h
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include "llvm/Support/JSON.h"
+
 namespace clice::proto {
 
 using integer = std::int32_t;

--- a/include/Protocol/Feature/ExecuteCommand.h
+++ b/include/Protocol/Feature/ExecuteCommand.h
@@ -6,7 +6,7 @@ namespace clice::proto {
 
 struct ExecuteCommandParams {
     string command;
-    array<llvm::json::Value> arguments;
+    array<any> arguments;
 };
 
 struct TextDocumentParams {

--- a/include/Protocol/Feature/ExecuteCommand.h
+++ b/include/Protocol/Feature/ExecuteCommand.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "../Basic.h"
+
+namespace clice::proto {
+
+struct ExecuteCommandParams {
+    string command;
+    array<llvm::json::Value> arguments;
+};
+
+struct TextDocumentParams {
+    /// The text document.
+    TextDocumentIdentifier textDocument;
+};
+
+}  // namespace clice::proto

--- a/include/Protocol/TextDocument.h
+++ b/include/Protocol/TextDocument.h
@@ -11,6 +11,7 @@
 #include "Feature/DocumentHighlight.h"
 #include "Feature/DocumentLink.h"
 #include "Feature/DocumentSymbol.h"
+#include "Feature/ExecuteCommand.h"
 #include "Feature/FoldingRange.h"
 #include "Feature/Formatting.h"
 #include "Feature/Hover.h"

--- a/include/Server/Indexer.h
+++ b/include/Server/Indexer.h
@@ -44,6 +44,11 @@ public:
         if(it2 != project_index.indices.end()) {
             auto path = project_index.path_pool.path(it2->second);
             it->second = index::MergedIndex::load(path);
+        } else {
+            std::println(stderr,
+                         "failed to load project index for path_id: {} {}",
+                         path_id,
+                         project_index.indices.size());
         }
 
         return it->second;
@@ -66,6 +71,14 @@ public:
     /// TODO: Calls ...
 
     /// TODO: Types ...
+
+    bool empty() const {
+        return project_index.indices.empty();
+    }
+
+    size_t size() const {
+        return project_index.indices.size();
+    }
 
 private:
     CompilationDatabase& database;

--- a/include/Server/Plugin.h
+++ b/include/Server/Plugin.h
@@ -2,15 +2,12 @@
 #include <expected>
 
 #include "PluginProtocol.h"
-#include "Async/Async.h"
 
-#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/JSON.h"
 
 // clang-format off
 /// Run `python scripts/plugin-def.py update` to update the hash.
-#define CLICE_PLUGIN_DEF_HASH "sha256:c46f7edfda0455327c65d40b9315ad5dc39153326c8cc63f1d8de2e2d0e7735a"
+#define CLICE_PLUGIN_DEF_HASH "sha256:e7f911c923f9cdcec6c0edea328292bd48771f7139d4489ed694a72e9af33fc1"
 // clang-format on
 
 namespace clice {

--- a/include/Server/Plugin.h
+++ b/include/Server/Plugin.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <expected>
 
+#include "PluginProtocol.h"
 #include "Async/Async.h"
 
 #include "llvm/ADT/ArrayRef.h"
@@ -9,17 +10,15 @@
 
 // clang-format off
 /// Run `python scripts/plugin-def.py update` to update the hash.
-#define CLICE_PLUGIN_DEF_HASH "sha256:e35ff1adfbc385f7bae605e82ca4e7e70cfbf0f933bb8d57169d0d29abe5b6f7"
+#define CLICE_PLUGIN_DEF_HASH "sha256:c46f7edfda0455327c65d40b9315ad5dc39153326c8cc63f1d8de2e2d0e7735a"
 // clang-format on
 
 namespace clice {
 
+/// The hash of the definitions exposed to server plugins.
+constexpr std::string_view plugin_definition_hash = CLICE_PLUGIN_DEF_HASH;
+
 class Server;
-
-#define CLICE_PLUGIN_PROTOCOL
-
-#include "PluginDef.h"
-#undef CLICE_PLUGIN_PROTOCOL
 
 struct ServerPluginBuilder;
 
@@ -27,15 +26,6 @@ struct ServerPluginBuilder;
 ///
 /// An instance of this class wraps a loaded server plugin and gives access to its interface.
 class Plugin {
-public:
-    struct Self;
-
-    Plugin(Self* self) : self(self) {}
-
-    Self* operator->() {
-        return self;
-    }
-
 public:
     /// Attempts to load a server plugin from a given file.
     ///
@@ -56,21 +46,17 @@ public:
     /// Registers the server callbacks for the loaded plugin.
     void register_server_callbacks(ServerPluginBuilder& builder) const;
 
+public:
+    struct Self;
+
+    Plugin(Self* self) : self(self) {}
+
+    Self* operator->() {
+        return self;
+    }
+
 protected:
     Self* self;
-};
-
-struct ServerPluginBuilder {
-public:
-    ServerPluginBuilder(ServerRef server_ref) : server_ref(server_ref) {}
-
-#define CliceServerPluginAPI(METHOD, ...) void METHOD(void* plugin_data, __VA_ARGS__)
-
-#include "PluginDef.h"
-#undef CliceServerPluginAPI
-
-protected:
-    ServerRef server_ref;
 };
 
 }  // namespace clice

--- a/include/Server/Plugin.h
+++ b/include/Server/Plugin.h
@@ -61,7 +61,10 @@ protected:
 };
 
 struct ServerPluginBuilder {
-#define CliceServerPluginAPI(METHOD, ...) void METHOD(__VA_ARGS__)
+public:
+    ServerPluginBuilder(ServerRef server_ref) : server_ref(server_ref) {}
+
+#define CliceServerPluginAPI(METHOD, ...) void METHOD(void* plugin_data, __VA_ARGS__)
 
 #include "PluginDef.h"
 #undef CliceServerPluginAPI

--- a/include/Server/Plugin.h
+++ b/include/Server/Plugin.h
@@ -1,0 +1,73 @@
+#pragma once
+#include <expected>
+
+#include "Async/Async.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/JSON.h"
+
+// clang-format off
+/// Run `python scripts/plugin-def.py update` to update the hash.
+#define CLICE_PLUGIN_DEF_HASH "sha256:e35ff1adfbc385f7bae605e82ca4e7e70cfbf0f933bb8d57169d0d29abe5b6f7"
+// clang-format on
+
+namespace clice {
+
+class Server;
+
+#define CLICE_PLUGIN_PROTOCOL
+
+#include "PluginDef.h"
+#undef CLICE_PLUGIN_PROTOCOL
+
+struct ServerPluginBuilder;
+
+/// A loaded server plugin.
+///
+/// An instance of this class wraps a loaded server plugin and gives access to its interface.
+class Plugin {
+public:
+    struct Self;
+
+    Plugin(Self* self) : self(self) {}
+
+    Self* operator->() {
+        return self;
+    }
+
+public:
+    /// Attempts to load a server plugin from a given file.
+    ///
+    /// Returns an error if either the library cannot be found or loaded,
+    /// there is no public entry point, or the plugin implements the wrong API
+    /// version.
+    static std::expected<Plugin, std::string> load(const std::string& file_path);
+
+    /// Gets the file path of the loaded plugin.
+    llvm::StringRef file_path() const;
+
+    /// Gets the name of the loaded plugin.
+    llvm::StringRef name() const;
+
+    /// Gets the version of the loaded plugin.
+    llvm::StringRef version() const;
+
+    /// Registers the server callbacks for the loaded plugin.
+    void register_server_callbacks(ServerPluginBuilder& builder) const;
+
+protected:
+    Self* self;
+};
+
+struct ServerPluginBuilder {
+#define CliceServerPluginAPI(METHOD, ...) void METHOD(__VA_ARGS__)
+
+#include "PluginDef.h"
+#undef CliceServerPluginAPI
+
+protected:
+    ServerRef server_ref;
+};
+
+}  // namespace clice

--- a/include/Server/PluginDef.h
+++ b/include/Server/PluginDef.h
@@ -69,6 +69,9 @@ CliceServerPluginAPI(get_server_ref, ServerRef& server);
 using lifecycle_hook_t = async::Task<> (*)(ServerRef server, void* plugin_data);
 
 CliceServerPluginAPI(on_initialize, lifecycle_hook_t callback);
+CliceServerPluginAPI(on_initialized, lifecycle_hook_t callback);
+CliceServerPluginAPI(on_shutdown, lifecycle_hook_t callback);
+CliceServerPluginAPI(on_exit, lifecycle_hook_t callback);
 CliceServerPluginAPI(on_did_change_configuration, lifecycle_hook_t callback);
 using command_handler_t =
     async::Task<llvm::json::Value> (*)(ServerRef server,

--- a/include/Server/PluginDef.h
+++ b/include/Server/PluginDef.h
@@ -58,9 +58,6 @@ public:
 
     Server& server() const;
 
-    /// Gets the configuration for the given section.
-    std::expected<llvm::json::Value, std::string> get_configuration(llvm::StringRef section);
-
 protected:
     Self* self;
 };
@@ -69,12 +66,14 @@ protected:
 /// Defines the library APIs to register callbacks for a plugin.
 #ifdef CliceServerPluginAPI
 CliceServerPluginAPI(get_server_ref, ServerRef& server);
-using configuration_handler_t = async::Task<> (*)(ServerRef server, void* plugin_data);
-CliceServerPluginAPI(on_did_change_configuration, configuration_handler_t callback);
+using lifecycle_hook_t = async::Task<> (*)(ServerRef server, void* plugin_data);
+
+CliceServerPluginAPI(on_initialize, lifecycle_hook_t callback);
+CliceServerPluginAPI(on_did_change_configuration, lifecycle_hook_t callback);
 using command_handler_t =
     async::Task<llvm::json::Value> (*)(ServerRef server,
                                        void* plugin_data,
-                                       const llvm::ArrayRef<llvm::StringRef>& arguments);
+                                       llvm::ArrayRef<llvm::StringRef> arguments);
 CliceServerPluginAPI(register_commmand_handler,
                      llvm::StringRef command,
                      command_handler_t callback);

--- a/include/Server/PluginDef.h
+++ b/include/Server/PluginDef.h
@@ -28,7 +28,7 @@ extern "C" {
         void (*register_server_callbacks)(ServerPluginBuilder& builder);
     };
 
-    /// The public entry point for a pass plugin.
+    /// The public entry point for a server plugin.
     ///
     /// When a plugin is loaded by the server, it will call this entry point to
     /// obtain information about this plugin and about how to register its customization points.

--- a/include/Server/PluginDef.h
+++ b/include/Server/PluginDef.h
@@ -1,0 +1,81 @@
+/// The API version of the clice plugin.
+/// Update this version when you change:
+/// - The definition of struct `PluginInfo`.
+/// - The definition of function `clice_get_server_plugin_info`.
+/// Note: you don't have to update this version if you only change other APIs, which is guaranteed
+/// by the `PluginInfo::definition_hash`.
+#ifndef CLICE_PLUGIN_API_VERSION
+#define CLICE_PLUGIN_API_VERSION 1
+#elif CLICE_PLUGIN_API_VERSION != 1
+#error "CLICE_PLUGIN_API_VERSION must be 1, but got " CLICE_PLUGIN_API_VERSION
+#endif
+
+/// Defines the library APIs that loads a plugin.
+#ifdef CLICE_PLUGIN_PROTOCOL
+struct ServerPluginBuilder;
+extern "C" {
+    /// A C-compatible struct that contains information about the plugin.
+    struct PluginInfo {
+        /// The clice API version of the plugin.
+        std::uint32_t api_version;
+        /// The name of the plugin.
+        const char* name;
+        /// The version of the plugin.
+        const char* version;
+        /// The plugin definition hash.
+        const char* definition_hash;
+        /// Registers the server callbacks for the loaded plugin.
+        void (*register_server_callbacks)(ServerPluginBuilder& builder);
+    };
+
+    /// The public entry point for a pass plugin.
+    ///
+    /// When a plugin is loaded by the server, it will call this entry point to
+    /// obtain information about this plugin and about how to register its customization points.
+    /// This function needs to be implemented by the plugin, see the example below:
+    ///
+    /// ```
+    /// extern "C" ::clice::PluginInfo LLVM_ATTRIBUTE_WEAK
+    /// clice_get_server_plugin_info() {
+    ///   return {
+    ///     CLICE_PLUGIN_API_VERSION, "MyPlugin", "v0.1", CLICE_PLUGIN_DEF_HASH,
+    ///     [](ServerPluginBuilder builder) {  ... }
+    ///   };
+    /// }
+    /// ```
+    PluginInfo LLVM_ATTRIBUTE_WEAK clice_get_server_plugin_info();
+}
+
+struct ServerRef {
+public:
+    struct Self;
+
+    ServerRef(Self* self) : self(self) {}
+
+    Self* operator->() const {
+        return self;
+    }
+
+    Server& server() const;
+
+    /// Gets the configuration for the given section.
+    std::expected<llvm::json::Value, std::string> get_configuration(llvm::StringRef section);
+
+protected:
+    Self* self;
+};
+#endif
+
+/// Defines the library APIs to register callbacks for a plugin.
+#ifdef CliceServerPluginAPI
+CliceServerPluginAPI(get_server_ref, ServerRef& server);
+using configuration_handler_t = async::Task<> (*)(ServerRef server, void* plugin_data);
+CliceServerPluginAPI(on_did_change_configuration, configuration_handler_t callback);
+using command_handler_t =
+    async::Task<llvm::json::Value> (*)(ServerRef server,
+                                       void* plugin_data,
+                                       const llvm::ArrayRef<llvm::StringRef>& arguments);
+CliceServerPluginAPI(register_commmand_handler,
+                     llvm::StringRef command,
+                     command_handler_t callback);
+#endif

--- a/include/Server/PluginProtocol.h
+++ b/include/Server/PluginProtocol.h
@@ -14,7 +14,9 @@
 
 #include "Async/Async.h"
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/JSON.h"
 
 namespace clice {
 

--- a/include/Server/PluginProtocol.h
+++ b/include/Server/PluginProtocol.h
@@ -1,14 +1,12 @@
+#pragma once
+
 /// The API version of the clice plugin.
 /// Update this version when you change:
 /// - The definition of struct `PluginInfo`.
 /// - The definition of function `clice_get_server_plugin_info`.
 /// Note: you don't have to update this version if you only change other APIs, which is guaranteed
 /// by the `PluginInfo::definition_hash`.
-#ifndef CLICE_PLUGIN_API_VERSION
 #define CLICE_PLUGIN_API_VERSION 1
-#elif CLICE_PLUGIN_API_VERSION != 1
-#error "CLICE_PLUGIN_API_VERSION must be 1, but got " CLICE_PLUGIN_API_VERSION
-#endif
 
 #include <cstdint>
 

--- a/include/Server/Server.h
+++ b/include/Server/Server.h
@@ -11,6 +11,8 @@
 #include "Feature/DocumentLink.h"
 #include "Protocol/Protocol.h"
 
+#include <llvm/ADT/FunctionExtras.h>
+
 namespace clice {
 
 struct OpenFile {
@@ -114,7 +116,7 @@ private:
 
 class Server {
 public:
-    Server(std::vector<Plugin>&& plugins);
+    Server();
 
     using Self = Server;
 
@@ -243,7 +245,15 @@ private:
 
     Indexer indexer;
 
-    /// All loaded server plugins.
+private:
+    friend struct ServerPluginBuilder;
+    using lifecycle_hook_t = llvm::unique_function<async::Task<>()>;
+    using command_handler_t = llvm::unique_function<async::Task<llvm::json::Value>(
+        llvm::ArrayRef<llvm::StringRef> arguments)>;
+
+    std::vector<lifecycle_hook_t> initialize_hooks;
+    std::vector<lifecycle_hook_t> did_change_configuration_hooks;
+    llvm::StringMap<command_handler_t> command_handlers;
     std::vector<Plugin> plugins;
 };
 

--- a/include/Server/Server.h
+++ b/include/Server/Server.h
@@ -252,6 +252,9 @@ private:
         llvm::ArrayRef<llvm::StringRef> arguments)>;
 
     std::vector<lifecycle_hook_t> initialize_hooks;
+    std::vector<lifecycle_hook_t> initialized_hooks;
+    std::vector<lifecycle_hook_t> shutdown_hooks;
+    std::vector<lifecycle_hook_t> exit_hooks;
     std::vector<lifecycle_hook_t> did_change_configuration_hooks;
     llvm::StringMap<command_handler_t> command_handlers;
     std::vector<Plugin> plugins;

--- a/include/Server/Server.h
+++ b/include/Server/Server.h
@@ -195,6 +195,8 @@ private:
 private:
     using Result = async::Task<json::Value>;
 
+    auto on_execute_command(proto::ExecuteCommandParams params) -> Result;
+
     auto on_completion(proto::CompletionParams params) -> Result;
 
     auto on_hover(proto::HoverParams params) -> Result;

--- a/include/Server/Server.h
+++ b/include/Server/Server.h
@@ -3,6 +3,7 @@
 #include "Config.h"
 #include "Convert.h"
 #include "Indexer.h"
+#include "Plugin.h"
 #include "Async/Async.h"
 #include "Compiler/Command.h"
 #include "Compiler/Diagnostic.h"
@@ -113,7 +114,7 @@ private:
 
 class Server {
 public:
-    Server();
+    Server(std::vector<Plugin>&& plugins);
 
     using Self = Server;
 
@@ -241,6 +242,9 @@ private:
     config::Config config;
 
     Indexer indexer;
+
+    /// All loaded server plugins.
+    std::vector<Plugin> plugins;
 };
 
 }  // namespace clice

--- a/include/Server/Utility.h
+++ b/include/Server/Utility.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define bail(...) std::unexpected(std::format(__VA_ARGS__))

--- a/scripts/plugin-def.py
+++ b/scripts/plugin-def.py
@@ -1,12 +1,7 @@
-# read include/Server/PluginDef.h and substitute CLICE_PLUGIN_DEF_HASH in include/Server/Plugin.h
-# hash is in `sha256:<hash>` format.
-
 import hashlib
 import re
 from pathlib import Path
 import sys
-
-#
 
 clice_apis = []
 

--- a/scripts/plugin-def.py
+++ b/scripts/plugin-def.py
@@ -1,0 +1,103 @@
+# read include/Server/PluginDef.h and substitute CLICE_PLUGIN_DEF_HASH in include/Server/Plugin.h
+# hash is in `sha256:<hash>` format.
+
+import hashlib
+import re
+from pathlib import Path
+import sys
+
+#
+
+clice_apis = []
+
+# all of the files in `include/`, other than `include/Server/Plugin.h`
+for path in Path("include/").glob("**/*.h"):
+    if path.name == "Plugin.h":
+        continue
+    clice_apis.append(path)
+
+clice_apis = [
+    # the dependencies of the clice.
+    Path("config/llvm-manifest.json"),
+    # the clice C/C++ sources.
+    *sorted(clice_apis),
+]
+
+
+def fatal(message: str):
+    print(f"error: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def sha256sum(paths: list[Path]) -> str:
+    digest = hashlib.sha256()
+    for path in paths:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    return digest.hexdigest()
+
+
+def clice_api_content():
+    content = []
+    content.append("#if 0")
+    for path in clice_apis:
+        with path.open("r") as file:
+            content.append(f"// begin of {path}")
+            content.append(file.read())
+            content.append(f"// end of {path}")
+    content.append("#endif")
+    return "\n".join(content)
+
+
+def plugin_def_hash():
+    hash_val = sha256sum(clice_apis)
+    return f"sha256:{hash_val}"
+
+
+def update():
+    hash_val = plugin_def_hash()
+    with open("include/Server/Plugin.h", "r") as file:
+        content = file.read()
+    content = re.sub(
+        r"#define CLICE_PLUGIN_DEF_HASH .*",
+        f'#define CLICE_PLUGIN_DEF_HASH "{hash_val}"',
+        content,
+    )
+    with open("include/Server/Plugin.h", "w") as file:
+        file.write(content)
+
+
+def check():
+    hash_val = plugin_def_hash()
+    with open("include/Server/Plugin.h", "r") as file:
+        content = file.read()
+    match = re.search(r'#define CLICE_PLUGIN_DEF_HASH "(.*)"', content)
+    if match is None:
+        fatal("plugin def hash not found in include/Server/Plugin.h")
+    if match.group(1) != hash_val:
+        fatal(
+            f"plugin def hash mismatch in include/Server/Plugin.h, expected: {hash_val}, actual: {match.group(1)}"
+        )
+    print(f"plugin def hash is up to date: {hash_val}")
+
+
+def main():
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "update":
+            update()
+            check()
+        elif sys.argv[1] == "check":
+            check()
+        elif sys.argv[1] == "content":
+            print(clice_api_content())
+        else:
+            fatal(
+                f"invalid command: {sys.argv[1]}, expected: update, check",
+            )
+    else:
+        fatal("no command provided, expected: update, check")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/Compiler/Command.cpp
+++ b/src/Compiler/Command.cpp
@@ -643,10 +643,23 @@ std::vector<UpdateInfo> CompilationDatabase::load_compile_database(llvm::StringR
             llvm::BumpPtrAllocator local;
             llvm::StringSaver saver(local);
             llvm::SmallVector<const char*, 32> agrs;
+            auto hasCC1 = false;
             for(auto& argument: *arguments) {
                 if(argument.kind() == json::Value::String) {
                     agrs.emplace_back(saver.save(*argument.getAsString()).data());
+                    if(argument.getAsString() == "-cc1") {
+                        hasCC1 = true;
+                        break;
+                    }
                 }
+            }
+            if(hasCC1) {
+                std::println(stderr, "cannot handle arguments: {}", *file);
+                for(auto& arg: *arguments) {
+                    std::print(stderr, "{} ", arg);
+                }
+                std::println(stderr, "");
+                continue;
             }
             item.info = self->save_compilation_info(*file, *directory, agrs);
         } else if(command) {

--- a/src/Compiler/Compilation.cpp
+++ b/src/Compiler/Compilation.cpp
@@ -3,13 +3,13 @@
 #include "Implement.h"
 #include "AST/Utility.h"
 #include "Compiler/Command.h"
-#include "Compiler/Diagnostic.h"
 #include "Support/Logging.h"
 
-#include "llvm/Support/Error.h"
+#include "clang/Frontend/FrontendActions.h"
 #include "clang/Frontend/MultiplexConsumer.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/Lex/PreprocessorOptions.h"
+#include "clang-tidy/ClangTidyModuleRegistry.h"
 
 namespace clice {
 
@@ -114,7 +114,7 @@ auto create_invocation(CompilationUnitRef::Self& self,
                                                       *diagnostic_engine,
                                                       params.arguments[0])) {
             LOG_ERROR_RET(nullptr,
-                          " Fail to create invocation, arguments list is: {}",
+                          " Fail to create invocation from database, arguments list is: {}",
                           print_argv(params.arguments));
         }
     } else {

--- a/src/Compiler/Toolchain.cpp
+++ b/src/Compiler/Toolchain.cpp
@@ -287,7 +287,7 @@ CompilerFamily driver_family(llvm::StringRef driver) {
 
 std::vector<const char*> query_toolchain(const QueryParams& params) {
     auto arguments = params.arguments;
-    llvm::StringRef driver = arguments[0];
+    llvm::StringRef driver = "clang";  // arguments[0];
 
     /// Note: The name used to invoke the compiler driver affects its behavior.
     /// For example, `/usr/bin/clang++` is often a symbolic link to

--- a/src/Server/Config.cpp
+++ b/src/Server/Config.cpp
@@ -96,7 +96,8 @@ static void parse_toml(Object& object, auto&& value, Config& config) {
 auto Config::parse(llvm::StringRef workspace) -> std::expected<void, std::string> {
     this->workspace = workspace;
 
-    auto path = path::join(workspace, "clice.toml");
+    // auto path = path::join(workspace, "clice.toml");
+    auto path = "/mnt/sda2/tfuzz/packages/tfuzz/src/clice.toml";
 
     std::string error_message;
     if(fs::exists(path)) {

--- a/src/Server/Implement.h
+++ b/src/Server/Implement.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "Server/Plugin.h"
+#include "Server/Server.h"
+
+namespace clice {
+
+struct ServerRef::Self {
+public:
+    Self(Server* server_instance) : server_instance(server_instance) {}
+
+    Server& server() const {
+        return *server_instance;
+    }
+
+    Server* server_instance;
+};
+
+}  // namespace clice

--- a/src/Server/Lifecycle.cpp
+++ b/src/Server/Lifecycle.cpp
@@ -47,6 +47,11 @@ async::Task<json::Value> Server::on_initialize(proto::InitializeParams params) {
         }
     }
 
+    /// Run initialize hooks.
+    for(auto& hook: initialize_hooks) {
+        co_await hook();
+    }
+
     /// Load cache info.
     load_cache_info();
 

--- a/src/Server/Lifecycle.cpp
+++ b/src/Server/Lifecycle.cpp
@@ -114,18 +114,35 @@ async::Task<json::Value> Server::on_initialize(proto::InitializeParams params) {
 }
 
 async::Task<> Server::on_initialized(proto::InitializedParams) {
+    /// Run initialized hooks.
+    for(auto& hook: initialized_hooks) {
+        co_await hook();
+    }
+
     indexer.load_from_disk();
     co_await indexer.index_all();
+
     co_return;
 }
 
 async::Task<json::Value> Server::on_shutdown(proto::ShutdownParams params) {
+    /// Run shutdown hooks.
+    for(auto& hook: shutdown_hooks) {
+        co_await hook();
+    }
+
     co_return json::Value(nullptr);
 }
 
 async::Task<> Server::on_exit(proto::ExitParams params) {
+    /// Run exit hooks.
+    for(auto& hook: exit_hooks) {
+        co_await hook();
+    }
+
     save_cache_info();
     indexer.save_to_disk();
+
     async::stop();
     co_return;
 }

--- a/src/Server/Lifecycle.cpp
+++ b/src/Server/Lifecycle.cpp
@@ -120,8 +120,13 @@ async::Task<> Server::on_initialized(proto::InitializedParams) {
     }
 
     indexer.load_from_disk();
-    co_await indexer.index_all();
-
+    if(indexer.empty()) {
+        LOG_INFO("project_index is empty, index all");
+        co_await indexer.index_all();
+    } else {
+        LOG_INFO("project_index is not empty");
+    }
+    std::println(stderr, "project_index indexed");
     co_return;
 }
 

--- a/src/Server/Lifecycle.cpp
+++ b/src/Server/Lifecycle.cpp
@@ -1,3 +1,4 @@
+#include "Server/Plugin.h"
 #include "Server/Server.h"
 
 #include <llvm/Support/FileSystem.h>

--- a/src/Server/Plugin.cpp
+++ b/src/Server/Plugin.cpp
@@ -101,6 +101,24 @@ void ServerPluginBuilder::on_initialize(void* plugin_data, lifecycle_hook_t call
         [=]() -> async::Task<> { co_await callback(server, plugin_data); });
 }
 
+void ServerPluginBuilder::on_initialized(void* plugin_data, lifecycle_hook_t callback) {
+    auto server = server_ref;
+    server_ref.server().initialized_hooks.push_back(
+        [=]() -> async::Task<> { co_await callback(server, plugin_data); });
+}
+
+void ServerPluginBuilder::on_shutdown(void* plugin_data, lifecycle_hook_t callback) {
+    auto server = server_ref;
+    server_ref.server().shutdown_hooks.push_back(
+        [=]() -> async::Task<> { co_await callback(server, plugin_data); });
+}
+
+void ServerPluginBuilder::on_exit(void* plugin_data, lifecycle_hook_t callback) {
+    auto server = server_ref;
+    server_ref.server().exit_hooks.push_back(
+        [=]() -> async::Task<> { co_await callback(server, plugin_data); });
+}
+
 void ServerPluginBuilder::on_did_change_configuration(void* plugin_data,
                                                       lifecycle_hook_t callback) {
     auto server = server_ref;

--- a/src/Server/Plugin.cpp
+++ b/src/Server/Plugin.cpp
@@ -1,0 +1,111 @@
+#include "Server/Plugin.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/DynamicLibrary.h"
+
+namespace clice {
+
+struct ServerRef::Self {
+    Server* server;
+};
+
+Server& ServerRef::server() const {
+    return *self->server;
+}
+
+struct Plugin::Self {
+    /// The file path of the plugin.
+    std::string file_path;
+    /// The dynamic library data of the plugin.
+    llvm::sys::DynamicLibrary library;
+    /// The name of the plugin.
+    std::string name;
+    /// The version of the plugin.
+    std::string version;
+    /// Registers the server callbacks for the loaded plugin.
+    void (*register_server_callbacks)(ServerPluginBuilder& builder);
+};
+
+std::expected<Plugin, std::string> Plugin::load(const std::string& file_path) {
+    std::string err;
+    auto library = llvm::sys::DynamicLibrary::getPermanentLibrary(file_path.c_str(), &err);
+    if(!library.isValid()) {
+        return std::unexpected("Could not load library '" + file_path + "': " + err);
+    }
+
+    Plugin P{
+        new Self{file_path, library}
+    };
+
+    /// `clice_get_server_plugin_info` should be resolved to the definition from the plugin
+    /// we are currently loading.
+    intptr_t get_details_fn = (intptr_t)library.getAddressOfSymbol("clice_get_server_plugin_info");
+
+    if(!get_details_fn) {
+        /// If the symbol isn't found, this is probably a legacy plugin, which is an
+        /// error.
+        return std::unexpected("Plugin entry point not found in '" + file_path +
+                               "'. Is this a clice server plugin?");
+    }
+
+    auto info = reinterpret_cast<decltype(clice_get_server_plugin_info)*>(get_details_fn)();
+
+    /// First, we check whether the plugin is compatible with the clice plugin API.
+    if(info.api_version != CLICE_PLUGIN_API_VERSION) {
+        return std::unexpected("Wrong API version on plugin '" + file_path + "'. Got version " +
+                               std::to_string(info.api_version) + ", supported version is " +
+                               std::to_string(CLICE_PLUGIN_API_VERSION) + ".");
+    }
+
+    /// Then, we safely get definition hash from the plugin, and check if it is consistent with
+    /// the expected hash. This ensures that the plugin has consistent declarations with the server.
+    std::string definition_hash = info.definition_hash;
+    if(definition_hash != CLICE_PLUGIN_DEF_HASH) {
+        return std::unexpected("Wrong definition hash on plugin '" + file_path + "'. Got '" +
+                               definition_hash + "', expected '" + CLICE_PLUGIN_DEF_HASH + "'.");
+    }
+
+    if(!info.register_server_callbacks) {
+        return std::unexpected("Empty `register_server_callbacks` function in plugin '" +
+                               file_path + "'.");
+    }
+
+    P->name = info.name;
+    P->version = info.version;
+    P->register_server_callbacks = info.register_server_callbacks;
+
+    return P;
+}
+
+llvm::StringRef Plugin::file_path() const {
+    return self->file_path;
+}
+
+llvm::StringRef Plugin::name() const {
+    return self->name;
+}
+
+llvm::StringRef Plugin::version() const {
+    return self->version;
+}
+
+using command_handler_t =
+    async::Task<llvm::json::Value> (*)(ServerRef server,
+                                       const llvm::ArrayRef<llvm::StringRef>& arguments);
+
+void ServerPluginBuilder::get_server_ref(ServerRef& server) {
+    server = server_ref;
+}
+
+void ServerPluginBuilder::on_did_change_configuration(configuration_handler_t callback) {
+    std::println(stderr, "on_changed_configuration");
+    abort();
+}
+
+void ServerPluginBuilder::register_commmand_handler(llvm::StringRef command,
+                                                    command_handler_t callback) {
+    std::println(stderr, "register_commmand_handler: {}", command);
+    abort();
+}
+
+}  // namespace clice

--- a/src/Server/Server.cpp
+++ b/src/Server/Server.cpp
@@ -96,8 +96,7 @@ async::Task<> Server::registerCapacity(llvm::StringRef id,
     });
 }
 
-Server::Server(std::vector<Plugin>&& plugins) :
-    indexer(database, config, kind), plugins(std::move(plugins)) {
+Server::Server() : indexer(database, config, kind) {
     register_callback<&Server::on_initialize>("initialize");
     register_callback<&Server::on_initialized>("initialized");
     register_callback<&Server::on_shutdown>("shutdown");

--- a/src/Server/Server.cpp
+++ b/src/Server/Server.cpp
@@ -96,7 +96,8 @@ async::Task<> Server::registerCapacity(llvm::StringRef id,
     });
 }
 
-Server::Server() : indexer(database, config, kind) {
+Server::Server(std::vector<Plugin>&& plugins) :
+    indexer(database, config, kind), plugins(std::move(plugins)) {
     register_callback<&Server::on_initialize>("initialize");
     register_callback<&Server::on_initialized>("initialized");
     register_callback<&Server::on_shutdown>("shutdown");

--- a/src/Server/Server.cpp
+++ b/src/Server/Server.cpp
@@ -102,6 +102,8 @@ Server::Server() : indexer(database, config, kind) {
     register_callback<&Server::on_shutdown>("shutdown");
     register_callback<&Server::on_exit>("exit");
 
+    register_callback<&Server::on_execute_command>("workspace/executeCommand");
+
     register_callback<&Server::on_did_open>("textDocument/didOpen");
     register_callback<&Server::on_did_change>("textDocument/didChange");
     register_callback<&Server::on_did_save>("textDocument/didSave");
@@ -182,6 +184,10 @@ async::Task<> Server::on_receive(json::Value value) {
     }
 
     co_return;
+}
+
+async::Task<json::Value> Server::on_execute_command(proto::ExecuteCommandParams params) {
+    co_return json::Value{};
 }
 
 }  // namespace clice

--- a/src/Server/Server.cpp
+++ b/src/Server/Server.cpp
@@ -1,6 +1,15 @@
 #include "Server/Server.h"
 
+#include "Compiler/CompilationUnit.h"
+#include "Protocol/Basic.h"
+#include "Support/FileSystem.h"
 #include "Support/Logging.h"
+
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "clang/ASTMatchers/ASTMatchersInternal.h"
+#include "clang/ASTMatchers/ASTMatchersMacros.h"
+#include <clang/AST/Decl.h>
 
 namespace clice {
 
@@ -186,7 +195,288 @@ async::Task<> Server::on_receive(json::Value value) {
     co_return;
 }
 
+/// Matches named declarations with a specific name.
+///
+/// See \c hasName() and \c hasAnyName() in ASTMatchers.h for details.
+class ContainOffsetMatcher :
+    public clang::ast_matchers::internal::SingleNodeMatcherInterface<clang::FunctionDecl> {
+public:
+    explicit ContainOffsetMatcher(std::vector<std::pair<clang::FileID, size_t>> offsets) :
+        offsets(offsets) {}
+
+    bool matchesNode(const clang::FunctionDecl& Node) const override {
+        auto& ctx = Node.getASTContext();
+        auto& mgr = ctx.getSourceManager();
+        const auto* body = Node.getBody();
+        if(!body) {
+            return false;
+        }
+        auto location = body->getBeginLoc();
+        auto end_location = body->getEndLoc();
+        auto [begin_fid, begin_offset] = mgr.getDecomposedLoc(location);
+        auto [end_fid, end_offset] = mgr.getDecomposedLoc(end_location);
+        if(begin_fid.isInvalid() || end_fid.isInvalid() || begin_fid != end_fid) {
+            return false;
+        }
+
+        for(const auto& [expected_fid, expected_offset]: offsets) {
+            if(expected_fid != begin_fid) {
+                continue;
+            }
+            if(begin_offset <= expected_offset && expected_offset < end_offset) [[unlikely]] {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    clang::FileID fid;
+    std::vector<std::pair<clang::FileID, size_t>> offsets;
+};
+
+inline clang::ast_matchers::internal::Matcher<clang::FunctionDecl>
+    containOffset(std::vector<std::pair<clang::FileID, size_t>> offsets) {
+    return clang::ast_matchers::internal::Matcher<clang::FunctionDecl>(
+        new ContainOffsetMatcher(offsets));
+}
+
+/// A reference site is a function declaration and its content.
+struct CallSite {
+    /// The name of the caller function of the callee.
+    std::string name;
+    /// The location of the caller function of the callee.
+    proto::Location location;
+    /// The content of the caller function of the callee.
+    std::string content;
+};
+
+/// The result of the call graph command.
+struct CallGraphResult {
+    /// The signature of the symbol.
+    std::string signature;
+    /// The content of the symbol.
+    std::string content;
+    /// The locations of the symbol declarations.
+    std::vector<proto::Location> locations;
+    /// The call sites of the symbol.
+    std::vector<CallSite> callSites;
+};
+
 async::Task<json::Value> Server::on_execute_command(proto::ExecuteCommandParams params) {
+    auto& command = params.command;
+    auto& arguments = params.arguments;
+
+    if(command == "workspace/constructionInfo") {
+        proto::TextDocumentParams identifier =
+            json::deserialize<proto::TextDocumentParams>(arguments[0]);
+        // std::string symbol = json::deserialize<std::string>(arguments[1]);
+        auto symbol_name = *arguments[1].getAsString();
+        std::println(stderr,
+                     "constructionInfo: {} uri: {}",
+                     symbol_name.str(),
+                     identifier.textDocument.uri);
+
+        auto path = mapping.to_path(identifier.textDocument.uri);
+        auto file = opening_files.get_or_add(path);
+
+        {
+            bool hasAst = false;
+            {
+                auto guard = co_await file->ast_built_lock.try_lock();
+                hasAst = !!file->ast;
+            }
+
+            if(!hasAst) {
+                // Read the content of the file.
+                auto content = clice::fs::read(path);
+
+                if(!content) {
+                    LOG_ERROR("Failed to read the content of the file: {}", path);
+                    co_return json::Value{};
+                }
+
+                co_await build_ast(path, *content);
+            }
+        }
+
+        /// Try get the lock, the waiter on the lock will be resumed when
+        /// guard is destroyed.
+        auto guard = co_await file->ast_built_lock.try_lock();
+        auto& ast = file->ast;
+        if(!ast) {
+            LOG_ERROR("AST not built for file: {}", path);
+            co_return json::Value{};
+        }
+
+        auto& ast_context = ast->context();
+
+        class FindDeclASTConsumer : public clang::ast_matchers::MatchFinder::MatchCallback {
+        public:
+            llvm::SmallVector<const clang::FunctionDecl*, 1> matched_decls;
+            const clang::FunctionDecl* any_decl = nullptr;
+            const clang::FunctionDecl* matched_def = nullptr;
+
+            void run(const clang::ast_matchers::MatchFinder::MatchResult& result) override {
+                if(auto* decl = result.Nodes.getNodeAs<clang::FunctionDecl>("func")) {
+                    if(decl->getDefinition() == decl) {
+                        any_decl = matched_def = decl;
+                    } else {
+                        if(!any_decl) {
+                            any_decl = decl;
+                        }
+                        matched_decls.push_back(decl);
+                    }
+                }
+            }
+        };
+
+        FindDeclASTConsumer consumer;
+        {
+            // match the symbol
+            clang::ast_matchers::MatchFinder finder;
+            clang::ast_matchers::DeclarationMatcher matcher =
+                clang::ast_matchers::functionDecl(clang::ast_matchers::hasName(symbol_name))
+                    .bind("func");
+            finder.addMatcher(matcher, &consumer);
+            finder.matchAST(ast_context);
+        }
+
+        // print the matched symbols
+        std::println(stderr, "matched decls: {}", consumer.matched_decls.size());
+        std::println(stderr, "matched def: {}", !!consumer.matched_def);
+
+        if(auto* any_decl = consumer.any_decl) {
+            auto location = any_decl->getLocation();
+            auto [fid, offset] = ast_context.getSourceManager().getDecomposedLoc(location);
+            auto file_path =
+                ast_context.getSourceManager().getFileEntryForID(fid)->tryGetRealPathName();
+
+            if(file_path.empty()) {
+                LOG_ERROR("Failed to get the real path of the symbol in file: {} {}",
+                          symbol_name,
+                          path);
+                co_return json::Value{};
+            }
+
+            std::println(stderr, "location: {} {}", file_path, offset);
+
+            auto locations = co_await indexer.references(file_path, offset);
+
+            std::vector<std::pair<clang::FileID, size_t>> offsets;
+            llvm::StringRef content = ast->interested_content();
+            auto& mgr = ast_context.getSourceManager();
+            PositionConverter converter(content, kind);
+            for(auto& location: locations) {
+                auto path = mapping.to_path(location.uri);
+                auto file_ref = mgr.getFileManager().getFileRef(path);
+                if(!file_ref) {
+                    LOG_ERROR("Failed to get the file ref of the location: {} {}",
+                              location.uri,
+                              path);
+                    continue;
+                }
+                auto file_id = mgr.translateFile(*file_ref);
+                offsets.push_back({file_id, clice::to_offset(kind, content, location.range.start)});
+            }
+
+            std::ranges::sort(offsets);
+
+            class AllDeclASTConsumer : public clang::ast_matchers::MatchFinder::MatchCallback {
+            public:
+                llvm::SmallDenseSet<const clang::FunctionDecl*, 1> matched_decls;
+
+                void run(const clang::ast_matchers::MatchFinder::MatchResult& result) override {
+                    if(auto* decl = result.Nodes.getNodeAs<clang::FunctionDecl>("func")) {
+                        matched_decls.insert(decl);
+                    }
+                }
+            };
+
+            AllDeclASTConsumer consumer;
+            {
+                // match the symbol
+                clang::ast_matchers::MatchFinder finder;
+                clang::ast_matchers::DeclarationMatcher matcher =
+                    clang::ast_matchers::functionDecl(clang::ast_matchers::isDefinition(),
+                                                      containOffset(offsets))
+                        .bind("func");
+                finder.addMatcher(matcher, &consumer);
+                finder.matchAST(ast_context);
+            }
+
+            std::vector<CallSite> call_sites;
+            std::vector<const clang::FunctionDecl*> matched_decls(consumer.matched_decls.begin(),
+                                                                  consumer.matched_decls.end());
+            std::sort(matched_decls.begin(),
+                      matched_decls.end(),
+                      [](const clang::FunctionDecl* a, const clang::FunctionDecl* b) {
+                          return a->getLocation() < b->getLocation();
+                      });
+            for(auto& decl: matched_decls) {
+                auto location = decl->getLocation();
+                auto [fid, offset] = mgr.getDecomposedLoc(location);
+                auto file_path = mgr.getFileEntryForID(fid)->tryGetRealPathName();
+                auto content = mgr.getBufferOrNone(fid)->getBuffer();
+                PositionConverter converter(content, kind);
+                auto begin = converter.toPosition(offset);
+
+                // getSourceRange
+                auto source_range = decl->getSourceRange();
+                // auto source_text = content.substr(source_range.getBegin().getOffset(),
+                // source_range.getEnd().getOffset());
+                auto [begin_fid, begin_offset] = mgr.getDecomposedLoc(source_range.getBegin());
+                auto [end_fid, end_offset] = mgr.getDecomposedLoc(source_range.getEnd());
+                // todo: why +1?
+                auto func_content =
+                    end_offset > begin_offset
+                        ? content.substr(begin_offset, end_offset + 1 - begin_offset).str()
+                        : "";
+
+                call_sites.push_back(CallSite{
+                    decl->getNameAsString(),
+                    {mapping.to_uri(file_path), begin},
+                    func_content,
+                });
+            }
+            std::string signature;
+            {
+                // begin loc
+                auto begin_loc = any_decl->getBeginLoc();
+                auto [begin_fid, begin_offset] = mgr.getDecomposedLoc(begin_loc);
+                // body start or end loc
+                // auto body_start_loc = any_decl->getBody()->getBeginLoc();
+                auto body = any_decl->getBody();
+                auto end_loc = body ? body->getBeginLoc() : any_decl->getEndLoc();
+                auto [end_fid, end_offset] = mgr.getDecomposedLoc(end_loc);
+
+                if(begin_fid == end_fid && begin_offset <= end_offset) {
+                    auto content = mgr.getBufferOrNone(begin_fid)->getBuffer();
+                    signature =
+                        content.substr(begin_offset, end_offset + (body ? 0 : 1) - begin_offset)
+                            .str();
+                }
+            }
+            std::string func_content;
+            {
+                auto source_range = any_decl->getSourceRange();
+                auto [begin_fid, begin_offset] = mgr.getDecomposedLoc(source_range.getBegin());
+                auto [end_fid, end_offset] = mgr.getDecomposedLoc(source_range.getEnd());
+                func_content = content.substr(begin_offset, end_offset + 1 - begin_offset).str();
+            }
+
+            CallGraphResult result;
+
+            result.signature = std::move(signature);
+            result.content = std::move(func_content);
+            result.locations = std::move(locations);
+            result.callSites = std::move(call_sites);
+
+            spdlog::details::registry::instance().flush_all();
+
+            co_return json::serialize(result);
+        }
+    }
+
     co_return json::Value{};
 }
 


### PR DESCRIPTION
This PR adds support to customize clice through server plugins. You can implement a clice server plugin to extend clice's functionality.

## Use case

When you use `clice` as LSP backend of LLM agents, e.g. claude code, you can add plugin to provide some extra features.

## Writing a plugin

When a plugin is loaded by the server, it will call `clice_get_server_plugin_info` to obtain information about this plugin and about how to register its customization points.

This function needs to be implemented by the plugin, see the example below:

```c++
extern "C" ::clice::PluginInfo LLVM_ATTRIBUTE_WEAK
clice_get_server_plugin_info() {
  return {
    CLICE_PLUGIN_API_VERSION, "MyPlugin", "v0.1", CLICE_PLUGIN_DEF_HASH,
    [](ServerPluginBuilder builder) {  ... }
  };
}
```

## Compiling a plugin

The plugin must be compiled with the same dependencies and compiler options as clice, otherwise it will cause undefined behavior.

## Loading plugins

For security reasons, clice does not allow loading plugins through configuration files, but must specify the plugin path through command line options.

When `clice` starts, it will load all plugins specified in the command line. You can specify the plugin path through the `--plugin-path` option.

```shell
$ clice --plugin-path /path/to/my-plugin.so
```

## Getting content of `CLICE_PLUGIN_DEF_HASH`

There are two values to return in the `clice_get_server_plugin_info` function.

- `CLICE_PLUGIN_API_VERSION` is used to ensure compability of the `clice_get_server_plugin_info` function between the plugin and the server.
- `CLICE_PLUGIN_DEF_HASH` is used to ensure the consistency of the C++ declarations between the plugin and the server.

To debug the content of `CLICE_PLUGIN_DEF_HASH`, you can run following command:

```shell
$ git clone https://github.com/clice-io/clice.git
$ cd clice
$ git checkout `clice --version --git-describe`
$ python scripts/plugin-def.py content
```