### PR TITLE
test: add MSCV case of compiler toolchain test

### DIFF
--- a/.github/workflows/test-cmake.yml
+++ b/.github/workflows/test-cmake.yml
@@ -16,9 +16,16 @@ jobs:
           - os: macos-15
             build_type: Debug
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: pwsh
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup MSVC Developer Environment (Windows)
+        if: matrix.os == 'windows-2025'
+        uses: ilammy/msvc-dev-cmd@v1
 
       - uses: ./.github/actions/setup-pixi
 

--- a/tests/unit/Compiler/ToolchainTests.cpp
+++ b/tests/unit/Compiler/ToolchainTests.cpp
@@ -100,6 +100,11 @@ TEST_CASE(MSVC, {.skip = !CIEnvironment || !Windows}) {
     params.arguments = arguments;
     params.add_remapped_file(file->c_str(), R"(
             #include <iostream>
+
+            #if __cplusplus < 202302L
+            #error "C++23 required"
+            #endif
+
             int main() {
                 std::cout << "Hello world!" << std::endl;
                 return 0;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved MSVC toolchain test to run only in appropriate Windows CI environments and to more thoroughly validate compilation behavior.

* **Chores**
  * CI workflow updated to ensure MSVC developer tools are prepared on Windows runners before build and test steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->