### PR TITLE
feat: refine auto type inlay hints

### DIFF
--- a/docs/en/features/inlay-hints.md
+++ b/docs/en/features/inlay-hints.md
@@ -56,7 +56,7 @@
 - [x] Structured binding type hints
 - [x] Lambda return type hints
 - [x] Range-based for loop variable type hints
-- [ ] Lambda init-capture type hints ([clangd#1163](https://github.com/clangd/clangd/issues/1163))
+- [x] Lambda init-capture type hints ([clangd#1163](https://github.com/clangd/clangd/issues/1163))
 
   ```cpp
   auto f = [val = compute()] {};
@@ -67,7 +67,7 @@
 
 - [x] Don't show type hint when deduction fails ([clangd#1475](https://github.com/clangd/clangd/issues/1475))
 
-- [ ] Don't show type hint when the type is explicitly specified ([clangd#1749](https://github.com/clangd/clangd/issues/1749))
+- [x] Don't show type hint when the type is explicitly specified ([clangd#1749](https://github.com/clangd/clangd/issues/1749))
 
   ```cpp
   auto x = static_cast<int>(val);  // no type hint — already explicit

--- a/docs/zh/features/inlay-hints.md
+++ b/docs/zh/features/inlay-hints.md
@@ -56,7 +56,7 @@
 - [x] Structured binding 类型提示
 - [x] Lambda 返回类型提示
 - [x] Range-based for 循环变量类型提示
-- [ ] Lambda init-capture 类型提示（[clangd#1163](https://github.com/clangd/clangd/issues/1163)）
+- [x] Lambda init-capture 类型提示（[clangd#1163](https://github.com/clangd/clangd/issues/1163)）
 
   ```cpp
   auto f = [val = compute()] {};
@@ -67,7 +67,7 @@
 
 - [x] 推导失败时不显示类型提示（[clangd#1475](https://github.com/clangd/clangd/issues/1475)）
 
-- [ ] 类型已显式指定时不显示类型提示（[clangd#1749](https://github.com/clangd/clangd/issues/1749)）
+- [x] 类型已显式指定时不显示类型提示（[clangd#1749](https://github.com/clangd/clangd/issues/1749)）
 
   ```cpp
   auto x = static_cast<int>(val);  // 无需类型提示 — 已是显式的

--- a/src/feature/inlay_hints.cpp
+++ b/src/feature/inlay_hints.cpp
@@ -656,14 +656,27 @@ public:
         }
 
         auto type = var->getType();
-        if(auto* auto_type = type->getContainedAutoType()) {
-            if(auto_type->isDeduced() && !type->isDependentType()) {
+        if(!type.isNull() && !type->isDependentType()) {
+            auto* auto_type = type->getContainedAutoType();
+            if(var->isInitCapture() || (auto_type && auto_type->isDeduced())) {
+                auto* init = var->getInit();
+                if(init) {
+                    init = init->IgnoreUnlessSpelledInSource();
+                    // The initializer already spells the type, so the hint would duplicate it.
+                    if(llvm::isa<clang::ExplicitCastExpr>(init) ||
+                       llvm::isa<clang::CXXTemporaryObjectExpr>(init)) {
+                        return true;
+                    }
+                }
+
                 // Our current approach is to place the hint on the variable
                 // and accordingly print the full type
                 // (e.g. for `const auto& x = 42`, print `const int&`).
+                // Lambda init-captures behave the same way, but their `auto`
+                // is implicit.
                 // Alternatively, we could place the hint on the `auto`
                 // (and then just print the type deduced for the `auto`).
-                builder.add_type_hint(var->getLocation(), var->getType(), /*Prefix=*/": ");
+                builder.add_type_hint(var->getLocation(), type, /*Prefix=*/": ");
             }
         }
 

--- a/tests/corpus/expressions/auto/explicit_type.cpp
+++ b/tests/corpus/expressions/auto/explicit_type.cpp
@@ -1,0 +1,15 @@
+// auto initialized from explicitly spelled types
+namespace auto_explicit_type {
+
+struct Box {
+    explicit Box(int);
+};
+
+void test(int val) {
+    auto x = static_cast<int>(val);
+    auto y = int{42};
+    auto object = Box{42};
+    auto z = val + 1;
+}
+
+}  // namespace auto_explicit_type

--- a/tests/corpus/expressions/lambda/init_capture.cpp
+++ b/tests/corpus/expressions/lambda/init_capture.cpp
@@ -1,0 +1,21 @@
+// lambda init-captures
+namespace lambda_init_capture {
+
+struct InterestingType {};
+
+InterestingType foo(int);
+int compute();
+
+void issue_example() {
+    auto f = [val = compute()] {
+    };
+    (void)f;
+}
+
+void test(int x) {
+    auto lambda = [interesting = foo(x), braced{foo(x)}, &ref = x, pointer = &x]() {
+        return pointer + ref;
+    };
+}
+
+}  // namespace lambda_init_capture

--- a/tests/snapshots/document_symbol/snapshot/expressions/auto/explicit_type.cpp.snap.yml
+++ b/tests/snapshots/document_symbol/snapshot/expressions/auto/explicit_type.cpp.snap.yml
@@ -1,0 +1,14 @@
+---
+source: document_symbol_tests.cpp
+created_at: 2026-06-18
+input_file: expressions/auto/explicit_type.cpp
+---
+- { name: "auto_explicit_type", kind: Namespace, range: "1:0-14:1", selection_range: "1:10-1:28" }
+-   { name: "Box", kind: Struct, range: "3:0-5:1", selection_range: "3:7-3:10", detail: "struct" }
+-     { name: "Box", kind: Method, range: "4:4-4:21", selection_range: "4:13-4:16", detail: "(int)" }
+-   { name: "test", kind: Function, range: "7:0-12:1", selection_range: "7:5-7:9", detail: "void (int)" }
+-     { name: "x", kind: Variable, range: "8:4-8:34", selection_range: "8:9-8:10", detail: "int" }
+-     { name: "y", kind: Variable, range: "9:4-9:20", selection_range: "9:9-9:10", detail: "int" }
+-     { name: "object", kind: Variable, range: "10:4-10:25", selection_range: "10:9-10:15", detail: "Box" }
+-     { name: "z", kind: Variable, range: "11:4-11:20", selection_range: "11:9-11:10", detail: "int" }
+

--- a/tests/snapshots/document_symbol/snapshot/expressions/lambda/init_capture.cpp.snap.yml
+++ b/tests/snapshots/document_symbol/snapshot/expressions/lambda/init_capture.cpp.snap.yml
@@ -1,0 +1,19 @@
+---
+source: document_symbol_tests.cpp
+created_at: 2026-06-18
+input_file: expressions/lambda/init_capture.cpp
+---
+- { name: "lambda_init_capture", kind: Namespace, range: "1:0-20:1", selection_range: "1:10-1:29" }
+-   { name: "InterestingType", kind: Struct, range: "3:0-3:25", selection_range: "3:7-3:22", detail: "struct" }
+-   { name: "foo", kind: Function, range: "5:0-5:24", selection_range: "5:16-5:19", detail: "InterestingType (int)" }
+-   { name: "compute", kind: Function, range: "6:0-6:13", selection_range: "6:4-6:11", detail: "int ()" }
+-   { name: "issue_example", kind: Function, range: "8:0-12:1", selection_range: "8:5-8:18", detail: "void ()" }
+-     { name: "f", kind: Variable, range: "9:4-10:5", selection_range: "9:9-9:10", detail: "(lambda)" }
+-       { name: "val", kind: Variable, range: "9:14-9:29", selection_range: "9:14-9:17", detail: "int" }
+-   { name: "test", kind: Function, range: "14:0-18:1", selection_range: "14:5-14:9", detail: "void (int)" }
+-     { name: "lambda", kind: Variable, range: "15:4-17:5", selection_range: "15:9-15:15", detail: "(lambda)" }
+-       { name: "interesting", kind: Variable, range: "15:19-15:39", selection_range: "15:19-15:30", detail: "InterestingType" }
+-       { name: "braced", kind: Variable, range: "15:41-15:55", selection_range: "15:41-15:47", detail: "InterestingType" }
+-       { name: "ref", kind: Variable, range: "15:58-15:65", selection_range: "15:58-15:61", detail: "int &" }
+-       { name: "pointer", kind: Variable, range: "15:67-15:79", selection_range: "15:67-15:74", detail: "int *" }
+

--- a/tests/snapshots/folding_range/snapshot/expressions/auto/explicit_type.cpp.snap.yml
+++ b/tests/snapshots/folding_range/snapshot/expressions/auto/explicit_type.cpp.snap.yml
@@ -1,0 +1,9 @@
+---
+source: folding_range_tests.cpp
+created_at: 2026-06-18
+input_file: expressions/auto/explicit_type.cpp
+---
+- { range: "1:29-14:1", kind: namespace, collapsed_text: "{...}" }
+- { range: "3:11-5:1", kind: struct, collapsed_text: "{...}" }
+- { range: "7:19-12:1", kind: functionBody, collapsed_text: "{...}" }
+

--- a/tests/snapshots/folding_range/snapshot/expressions/lambda/init_capture.cpp.snap.yml
+++ b/tests/snapshots/folding_range/snapshot/expressions/lambda/init_capture.cpp.snap.yml
@@ -1,0 +1,11 @@
+---
+source: folding_range_tests.cpp
+created_at: 2026-06-18
+input_file: expressions/lambda/init_capture.cpp
+---
+- { range: "1:30-20:1", kind: namespace, collapsed_text: "{...}" }
+- { range: "8:21-12:1", kind: functionBody, collapsed_text: "{...}" }
+- { range: "9:31-10:5", kind: compoundStmt, collapsed_text: "{...}" }
+- { range: "14:17-18:1", kind: functionBody, collapsed_text: "{...}" }
+- { range: "15:83-17:5", kind: compoundStmt, collapsed_text: "{...}" }
+

--- a/tests/snapshots/inlay_hint/snapshot/expressions/auto/explicit_type.cpp.snap.yml
+++ b/tests/snapshots/inlay_hint/snapshot/expressions/auto/explicit_type.cpp.snap.yml
@@ -1,0 +1,10 @@
+---
+source: inlay_hint_tests.cpp
+created_at: 2026-06-18
+input_file: expressions/auto/explicit_type.cpp
+---
+- { pos: "8:10", kind: Type, label: ": int" }
+- { pos: "9:10", kind: Type, label: ": int" }
+- { pos: "10:15", kind: Type, label: ": Box" }
+- { pos: "11:10", kind: Type, label: ": int" }
+

--- a/tests/snapshots/inlay_hint/snapshot/expressions/auto/explicit_type.cpp.snap.yml
+++ b/tests/snapshots/inlay_hint/snapshot/expressions/auto/explicit_type.cpp.snap.yml
@@ -3,8 +3,5 @@ source: inlay_hint_tests.cpp
 created_at: 2026-06-18
 input_file: expressions/auto/explicit_type.cpp
 ---
-- { pos: "8:10", kind: Type, label: ": int" }
-- { pos: "9:10", kind: Type, label: ": int" }
-- { pos: "10:15", kind: Type, label: ": Box" }
 - { pos: "11:10", kind: Type, label: ": int" }
 

--- a/tests/snapshots/inlay_hint/snapshot/expressions/lambda/init_capture.cpp.snap.yml
+++ b/tests/snapshots/inlay_hint/snapshot/expressions/lambda/init_capture.cpp.snap.yml
@@ -1,0 +1,15 @@
+---
+source: inlay_hint_tests.cpp
+created_at: 2026-06-18
+input_file: expressions/lambda/init_capture.cpp
+---
+- { pos: "9:10", kind: Type, label: ": (lambda)" }
+- { pos: "9:17", kind: Type, label: ": int" }
+- { pos: "9:30", kind: Type, label: "-> void" }
+- { pos: "15:15", kind: Type, label: ": (lambda)" }
+- { pos: "15:30", kind: Type, label: ": InterestingType" }
+- { pos: "15:47", kind: Type, label: ": InterestingType" }
+- { pos: "15:61", kind: Type, label: ": int &" }
+- { pos: "15:74", kind: Type, label: ": int *" }
+- { pos: "15:82", kind: Type, label: "-> int *" }
+

--- a/tests/snapshots/semantic_tokens/snapshot/expressions/auto/explicit_type.cpp.snap.yml
+++ b/tests/snapshots/semantic_tokens/snapshot/expressions/auto/explicit_type.cpp.snap.yml
@@ -1,0 +1,37 @@
+---
+source: semantic_tokens_tests.cpp
+created_at: 2026-06-18
+input_file: expressions/auto/explicit_type.cpp
+---
+- { loc: "0:0", text: "// auto initialized from explicitly spelled types", kind: Comment }
+- { loc: "1:0", text: "namespace", kind: Keyword }
+- { loc: "1:10", text: "auto_explicit_type", kind: Namespace, modifiers: [Definition] }
+- { loc: "3:0", text: "struct", kind: Keyword }
+- { loc: "3:7", text: "Box", kind: Struct, modifiers: [Definition] }
+- { loc: "4:4", text: "explicit", kind: Keyword }
+- { loc: "4:13", text: "Box", kind: Method, modifiers: [Declaration, ConstructorOrDestructor] }
+- { loc: "4:17", text: "int", kind: Keyword }
+- { loc: "4:20", text: ")", kind: Parameter, modifiers: [Definition] }
+- { loc: "7:0", text: "void", kind: Keyword }
+- { loc: "7:5", text: "test", kind: Function, modifiers: [Definition] }
+- { loc: "7:10", text: "int", kind: Keyword }
+- { loc: "7:14", text: "val", kind: Parameter, modifiers: [Definition] }
+- { loc: "8:4", text: "auto", kind: Keyword }
+- { loc: "8:9", text: "x", kind: Variable, modifiers: [Definition] }
+- { loc: "8:13", text: "static_cast", kind: Keyword }
+- { loc: "8:25", text: "int", kind: Keyword }
+- { loc: "8:30", text: "val", kind: Parameter }
+- { loc: "9:4", text: "auto", kind: Keyword }
+- { loc: "9:9", text: "y", kind: Variable, modifiers: [Definition] }
+- { loc: "9:13", text: "int", kind: Keyword }
+- { loc: "9:17", text: "42", kind: Number }
+- { loc: "10:4", text: "auto", kind: Keyword }
+- { loc: "10:9", text: "object", kind: Variable, modifiers: [Definition] }
+- { loc: "10:18", text: "Box", kind: Struct }
+- { loc: "10:22", text: "42", kind: Number }
+- { loc: "11:4", text: "auto", kind: Keyword }
+- { loc: "11:9", text: "z", kind: Variable, modifiers: [Definition] }
+- { loc: "11:13", text: "val", kind: Parameter }
+- { loc: "11:19", text: "1", kind: Number }
+- { loc: "14:3", text: "// namespace auto_explicit_type", kind: Comment }
+

--- a/tests/snapshots/semantic_tokens/snapshot/expressions/lambda/init_capture.cpp.snap.yml
+++ b/tests/snapshots/semantic_tokens/snapshot/expressions/lambda/init_capture.cpp.snap.yml
@@ -1,0 +1,45 @@
+---
+source: semantic_tokens_tests.cpp
+created_at: 2026-06-18
+input_file: expressions/lambda/init_capture.cpp
+---
+- { loc: "0:0", text: "// lambda init-captures", kind: Comment }
+- { loc: "1:0", text: "namespace", kind: Keyword }
+- { loc: "1:10", text: "lambda_init_capture", kind: Namespace, modifiers: [Definition] }
+- { loc: "3:0", text: "struct", kind: Keyword }
+- { loc: "3:7", text: "InterestingType", kind: Struct, modifiers: [Definition] }
+- { loc: "5:0", text: "InterestingType", kind: Struct }
+- { loc: "5:16", text: "foo", kind: Function, modifiers: [Declaration] }
+- { loc: "5:20", text: "int", kind: Keyword }
+- { loc: "5:23", text: ")", kind: Parameter, modifiers: [Definition] }
+- { loc: "6:0", text: "int", kind: Keyword }
+- { loc: "6:4", text: "compute", kind: Function, modifiers: [Declaration] }
+- { loc: "8:0", text: "void", kind: Keyword }
+- { loc: "8:5", text: "issue_example", kind: Function, modifiers: [Definition] }
+- { loc: "9:4", text: "auto", kind: Keyword }
+- { loc: "9:9", text: "f", kind: Variable, modifiers: [Definition] }
+- { loc: "9:14", text: "val", kind: Variable, modifiers: [Definition] }
+- { loc: "9:20", text: "compute", kind: Function }
+- { loc: "11:5", text: "void", kind: Keyword }
+- { loc: "11:10", text: "f", kind: Variable }
+- { loc: "14:0", text: "void", kind: Keyword }
+- { loc: "14:5", text: "test", kind: Function, modifiers: [Definition] }
+- { loc: "14:10", text: "int", kind: Keyword }
+- { loc: "14:14", text: "x", kind: Parameter, modifiers: [Definition] }
+- { loc: "15:4", text: "auto", kind: Keyword }
+- { loc: "15:9", text: "lambda", kind: Variable, modifiers: [Definition] }
+- { loc: "15:19", text: "interesting", kind: Variable, modifiers: [Definition] }
+- { loc: "15:33", text: "foo", kind: Function }
+- { loc: "15:37", text: "x", kind: Parameter }
+- { loc: "15:41", text: "braced", kind: Variable, modifiers: [Definition] }
+- { loc: "15:48", text: "foo", kind: Function }
+- { loc: "15:52", text: "x", kind: Parameter }
+- { loc: "15:58", text: "ref", kind: Variable, modifiers: [Definition] }
+- { loc: "15:64", text: "x", kind: Parameter }
+- { loc: "15:67", text: "pointer", kind: Variable, modifiers: [Definition] }
+- { loc: "15:78", text: "x", kind: Parameter }
+- { loc: "16:8", text: "return", kind: Keyword }
+- { loc: "16:15", text: "pointer", kind: Variable }
+- { loc: "16:25", text: "ref", kind: Variable }
+- { loc: "20:3", text: "// namespace lambda_init_capture", kind: Comment }
+

--- a/tests/snapshots/tu_index/snapshot/expressions/auto/explicit_type.cpp.snap.yml
+++ b/tests/snapshots/tu_index/snapshot/expressions/auto/explicit_type.cpp.snap.yml
@@ -1,0 +1,19 @@
+---
+source: tu_index_tests.cpp
+created_at: 2026-06-18
+input_file: expressions/auto/explicit_type.cpp
+---
+- { loc: "1:10", kind: Namespace, text: "auto_explicit_type", relations: [Definition] }
+- { loc: "3:7", kind: Struct, text: "Box", relations: [Definition] }
+- { loc: "4:13", kind: Method, text: "Box", relations: [Declaration] }
+- { loc: "4:20", kind: Parameter, text: ")", relations: [Definition] }
+- { loc: "7:5", kind: Function, text: "test", relations: [Definition] }
+- { loc: "7:14", kind: Parameter, text: "val", relations: [Definition] }
+- { loc: "8:9", kind: Variable, text: "x", relations: [Definition] }
+- { loc: "8:30", kind: Parameter, text: "val", relations: [Reference] }
+- { loc: "9:9", kind: Variable, text: "y", relations: [Definition] }
+- { loc: "10:9", kind: Variable, text: "object", relations: [Definition] }
+- { loc: "10:18", kind: Struct, text: "Box", relations: [Reference] }
+- { loc: "11:9", kind: Variable, text: "z", relations: [Definition] }
+- { loc: "11:13", kind: Parameter, text: "val", relations: [Reference] }
+

--- a/tests/snapshots/tu_index/snapshot/expressions/lambda/init_capture.cpp.snap.yml
+++ b/tests/snapshots/tu_index/snapshot/expressions/lambda/init_capture.cpp.snap.yml
@@ -1,0 +1,32 @@
+---
+source: tu_index_tests.cpp
+created_at: 2026-06-18
+input_file: expressions/lambda/init_capture.cpp
+---
+- { loc: "1:10", kind: Namespace, text: "lambda_init_capture", relations: [Definition] }
+- { loc: "3:7", kind: Struct, text: "InterestingType", relations: [Definition] }
+- { loc: "5:0", kind: Struct, text: "InterestingType", relations: [Reference] }
+- { loc: "5:16", kind: Function, text: "foo", relations: [Declaration] }
+- { loc: "5:23", kind: Parameter, text: ")", relations: [Definition] }
+- { loc: "6:4", kind: Function, text: "compute", relations: [Declaration] }
+- { loc: "8:5", kind: Function, text: "issue_example", relations: [Definition] }
+- { loc: "9:9", kind: Variable, text: "f", relations: [Definition] }
+- { loc: "9:14", kind: Variable, text: "val", relations: [Definition] }
+- { loc: "9:20", kind: Function, text: "compute", relations: [Reference] }
+- { loc: "11:10", kind: Variable, text: "f", relations: [Reference] }
+- { loc: "14:5", kind: Function, text: "test", relations: [Definition] }
+- { loc: "14:14", kind: Parameter, text: "x", relations: [Definition] }
+- { loc: "15:9", kind: Variable, text: "lambda", relations: [Definition] }
+- { loc: "15:19", kind: Variable, text: "interesting", relations: [Definition] }
+- { loc: "15:33", kind: Function, text: "foo", relations: [Reference] }
+- { loc: "15:37", kind: Parameter, text: "x", relations: [Reference] }
+- { loc: "15:41", kind: Variable, text: "braced", relations: [Definition] }
+- { loc: "15:48", kind: Function, text: "foo", relations: [Reference] }
+- { loc: "15:52", kind: Parameter, text: "x", relations: [Reference] }
+- { loc: "15:58", kind: Variable, text: "ref", relations: [Definition] }
+- { loc: "15:64", kind: Parameter, text: "x", relations: [Reference] }
+- { loc: "15:67", kind: Variable, text: "pointer", relations: [Definition] }
+- { loc: "15:78", kind: Parameter, text: "x", relations: [Reference] }
+- { loc: "16:15", kind: Variable, text: "pointer", relations: [Reference] }
+- { loc: "16:25", kind: Variable, text: "ref", relations: [Reference] }
+

--- a/tests/unit/feature/inlay_hint_tests.cpp
+++ b/tests/unit/feature/inlay_hint_tests.cpp
@@ -754,14 +754,13 @@ TEST_CASE(Types) {
 
             auto h$(6) = decltype(0)$(7){};
         )c");
-    EXPECT_SIZE(8);
+    EXPECT_SIZE(7);
     EXPECT_HINT("0", ": int");
     EXPECT_HINT("1", ": int");
     EXPECT_HINT("2", ": int");
     EXPECT_HINT("3", ": int");
     EXPECT_HINT("4", ": int");
     EXPECT_HINT("5", ": int");
-    EXPECT_HINT("6", ": int");
     EXPECT_HINT("7", ": int");
 
     // Long type name


### PR DESCRIPTION
- add corpus snapshot coverage for lambda init-capture type hints and explicit-type auto initializers
- make lambda init-capture type hint handling explicit
- suppress redundant auto type hints when the initializer already spells the type, such as static_cast<int>(val), int{42}, and Box{42}
- mark clangd#1163 and clangd#1749 as completed in English and Chinese docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded inlay hint support for lambda init-captures and deduced-`auto` variables, showing inferred types in more scenarios.
* **Bug Fixes**
  * Reduced redundant type inlay hints when the initializer already expresses the effective type (such as explicit casts or temporary object forms).
* **Documentation**
  * Updated the inlay hints checklist (English and Chinese) to mark two “Type Hints” items as completed.
* **Tests**
  * Added new auto/lambda init-capture test corpus and updated related snapshot suites; adjusted a unit-test expectation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->