### PR TITLE
chore: upgrade LLVM to 22.1.4

### DIFF
--- a/cmake/llvm.cmake
+++ b/cmake/llvm.cmake
@@ -92,13 +92,13 @@ function(setup_llvm LLVM_VERSION)
     add_library(llvm-libs INTERFACE IMPORTED)
     target_link_libraries(llvm-libs INTERFACE
         ${LLVM_RESOLVED}
-        clangAST clangASTMatchers clangBasic clangDriver
+        clangAST clangASTMatchers clangBasic clangDriver clangOptions
         clangFormat clangFrontend clangLex clangSema clangSerialization
         clangTidy clangTidyUtils
         clangTidyAbseilModule clangTidyAlteraModule clangTidyAndroidModule
         clangTidyBoostModule clangTidyBugproneModule clangTidyCERTModule
         clangTidyConcurrencyModule clangTidyCppCoreGuidelinesModule
-        clangTidyDarwinModule clangTidyFuchsiaModule
+        clangTidyCustomModule clangTidyDarwinModule clangTidyFuchsiaModule
         clangTidyGoogleModule clangTidyHICPPModule clangTidyLinuxKernelModule
         clangTidyLLVMModule clangTidyLLVMLibcModule clangTidyMiscModule
         clangTidyModernizeModule clangTidyMPIModule clangTidyObjCModule

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -1,7 +1,7 @@
 include_guard()
 
 include(${CMAKE_CURRENT_LIST_DIR}/llvm.cmake)
-setup_llvm("21.1.8+r1")
+setup_llvm("22.1.4")
 
 # install dependencies
 include(FetchContent)

--- a/docs/en/changelog/llvm-changelog.md
+++ b/docs/en/changelog/llvm-changelog.md
@@ -1,3 +1,44 @@
 # LLVM Changelog
 
 Breaking changes encountered during each LLVM upgrade, with upstream commit references.
+
+# LLVM 21 → 22
+
+Upgrade version: LLVM 22.1.4 (`llvmorg-22.1.4`)
+
+The single largest source of breaking changes is `91cdd35008e9` ([#147835](https://github.com/llvm/llvm-project/pull/147835)), which simultaneously restructured the type system and NNS representation.
+
+## Type System
+
+| Change                                                                                  | Commit         | PR                                                          | Impact                                                                                                                                            |
+| --------------------------------------------------------------------------------------- | -------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ElaboratedType` removed; keyword/qualifier merged into `TagType`, `TypedefType`, etc.  | `91cdd35008e9` | [#147835](https://github.com/llvm/llvm-project/pull/147835) | All `getAs<ElaboratedType>()` must be removed. TypePrinter behavior changed: non-canonical TagType keyword printing ignores `SuppressTagKeyword`. |
+| `InjectedClassNameType` now inherits `TagType`                                          | `91cdd35008e9` | [#147835](https://github.com/llvm/llvm-project/pull/147835) | `getAs<TagType>()` now matches InjectedClassNameType. `getInjectedSpecializationType()` removed.                                                  |
+| `DependentTemplateSpecializationType` removed, merged into `TemplateSpecializationType` | `ba9d1c41c41d` | [#158109](https://github.com/llvm/llvm-project/pull/158109) | All DTST visitors/handlers must migrate to TST.                                                                                                   |
+| `TagDecl::getTypeForDecl()` marked `= delete`                                           | `91cdd35008e9` | [#147835](https://github.com/llvm/llvm-project/pull/147835) | Use `ASTContext::getCanonicalTagType()` instead.                                                                                                  |
+| `UsingType::getFoundDecl()` renamed to `getDecl()`                                      | `91cdd35008e9` | [#147835](https://github.com/llvm/llvm-project/pull/147835) | Mechanical rename.                                                                                                                                |
+| `PredefinedSugarType` introduced (`__size_t`, `__ptrdiff_t`)                            | `7c402b8b81d2` | [#149613](https://github.com/llvm/llvm-project/pull/149613) | `sizeof` return type changed from `unsigned long` to `__size_t` sugar. Hover needs to desugar to avoid exposing internal type names.              |
+| Implicit var template specializations no longer retain written template args            | `1cb47c19f8ec` | [#156329](https://github.com/llvm/llvm-project/pull/156329) | `VarTemplateSpecializationDecl::getTemplateArgsAsWritten()` returns null for implicit specializations.                                            |
+
+## NestedNameSpecifier
+
+| Change                                 | Commit         | PR                                                          | Impact                                                                                                                      |
+| -------------------------------------- | -------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| NNS changed from pointer to value type | `91cdd35008e9` | [#147835](https://github.com/llvm/llvm-project/pull/147835) | `const NestedNameSpecifier*` → `NestedNameSpecifier`; `->` → `.`; `Kind::Identifier` and `Kind::NamespaceAlias` removed.    |
+| `NamespaceBaseDecl` introduced         | `4a9eaad9e128` | [#149123](https://github.com/llvm/llvm-project/pull/149123) | `getAsNamespace()` → `getAsNamespaceAndPrefix().Namespace` (returns `NamespaceBaseDecl*`, covers both namespace and alias). |
+
+## Driver / Frontend
+
+| Change                                                          | Commit         | PR                                                          | Impact                                                           |
+| --------------------------------------------------------------- | -------------- | ----------------------------------------------------------- | ---------------------------------------------------------------- |
+| `Options.td/inc` moved from `clang/Driver/` to `clang/Options/` | `f63d33da0a51` | [#167374](https://github.com/llvm/llvm-project/pull/167374) | Include path replacement.                                        |
+| `OPTION` macro gained 15th parameter (SubCommandIDsOffset)      | `fdbd17d1fb0d` | [#155026](https://github.com/llvm/llvm-project/pull/155026) | Custom `OPTION` macro definitions need `...` variadic parameter. |
+| `Driver::GetResourcesPath` moved to `clang::GetResourcesPath`   | `d090311aa7df` | [#169599](https://github.com/llvm/llvm-project/pull/169599) | Requires `#include "clang/Options/OptionUtils.h"`.               |
+| `CompilerInstance::createDiagnostics` VFS parameter removed     | `30633f308941` | [#158381](https://github.com/llvm/llvm-project/pull/158381) | Use `setVirtualFileSystem()` + `createFileManager()` instead.    |
+
+## Other
+
+| Change                                                                  | Commit         | PR                                                          | Impact                 |
+| ----------------------------------------------------------------------- | -------------- | ----------------------------------------------------------- | ---------------------- |
+| `llvm::sys::fs::make_absolute` → `llvm::sys::path::make_absolute`       | `f122484b998d` | [#161459](https://github.com/llvm/llvm-project/pull/161459) | Namespace replacement. |
+| `ClangTidyModuleRegistry.h` deprecated, merged into `ClangTidyModule.h` | `1bcf74006bcf` | [#173231](https://github.com/llvm/llvm-project/pull/173231) | Include replacement.   |

--- a/src/command/argument_parser.cpp
+++ b/src/command/argument_parser.cpp
@@ -12,6 +12,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "clang/Driver/Driver.h"
 #include "clang/Driver/Types.h"
+#include "clang/Options/OptionUtils.h"
 
 namespace clice {
 
@@ -22,11 +23,11 @@ namespace eo = kota::option;
 namespace detail {
 
 #define OPTTABLE_STR_TABLE_CODE
-#include "clang/Driver/Options.inc"
+#include "clang/Options/Options.inc"
 #undef OPTTABLE_STR_TABLE_CODE
 
 #define OPTTABLE_PREFIXES_TABLE_CODE
-#include "clang/Driver/Options.inc"
+#include "clang/Options/Options.inc"
 #undef OPTTABLE_PREFIXES_TABLE_CODE
 
 static_assert(OptionPrefixesTable[0].value() == 0, "pfx_none: 0 prefixes");
@@ -87,7 +88,8 @@ const eo::OptTable& table() {
                HELP,                                                                               \
                HELP_TEXTS,                                                                         \
                META_VAR,                                                                           \
-               VALUES)                                                                             \
+               VALUES,                                                                             \
+               ...)                                                                                \
     eo::Option{                                                                                    \
         .prefixes = prefixes(PREFIXES_OFFSET),                                                     \
         .prefixed_name = str_at(NAME_OFFSET),                                                      \
@@ -102,7 +104,7 @@ const eo::OptTable& table() {
         .help_text = HELP,                                                                         \
         .meta_var = META_VAR,                                                                      \
     },
-#include "clang/Driver/Options.inc"
+#include "clang/Options/Options.inc"
 #undef OPTION
     };
 
@@ -202,7 +204,7 @@ llvm::StringRef resource_dir() {
         if(exe.empty()) {
             return std::string{};
         }
-        return clang::driver::Driver::GetResourcesPath(exe);
+        return clang::GetResourcesPath(exe);
     }();
     return dir;
 }

--- a/src/command/argument_parser.h
+++ b/src/command/argument_parser.h
@@ -28,9 +28,10 @@ enum ID : unsigned {
                HELP,                                                                               \
                HELP_TEXTS,                                                                         \
                META_VAR,                                                                           \
-               VALUES)                                                                             \
+               VALUES,                                                                             \
+               ...)                                                                                \
     OPT_##ID,
-#include "clang/Driver/Options.inc"
+#include "clang/Options/Options.inc"
 #undef OPTION
 };
 

--- a/src/command/search_config.cpp
+++ b/src/command/search_config.cpp
@@ -25,7 +25,7 @@ SearchConfig extract_search_config(llvm::ArrayRef<const char*> arguments,
     auto make_absolute = [&](std::string_view path) -> std::string {
         llvm::SmallString<256> abs_path(path);
         if(!llvm::sys::path::is_absolute(abs_path)) {
-            llvm::sys::fs::make_absolute(directory, abs_path);
+            llvm::sys::path::make_absolute(directory, abs_path);
         }
         llvm::sys::path::remove_dots(abs_path, true);
         return abs_path.str().str();

--- a/src/compile/compilation.cpp
+++ b/src/compile/compilation.cpp
@@ -7,6 +7,7 @@
 #include "support/logging.h"
 
 #include "llvm/Support/Error.h"
+#include "clang/Driver/CreateInvocationFromArgs.h"
 #include "clang/Frontend/MultiplexConsumer.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/Lex/PreprocessorOptions.h"
@@ -247,13 +248,16 @@ CompilationStatus CompilationUnitRef::Self::run_clang(
 
     self.instance = std::make_unique<clang::CompilerInstance>(std::move(invocation));
     auto& instance = *self.instance;
-    instance.createDiagnostics(*params.vfs, diagnostic_consumer.release(), true);
+    instance.createDiagnostics(diagnostic_consumer.release(), true);
 
     if(auto remapping = clang::createVFSFromCompilerInvocation(instance.getInvocation(),
                                                                instance.getDiagnostics(),
                                                                params.vfs)) {
-        instance.createFileManager(std::move(remapping));
+        instance.setVirtualFileSystem(std::move(remapping));
+    } else {
+        instance.setVirtualFileSystem(params.vfs);
     }
+    instance.createFileManager();
 
     if(!instance.createTarget()) {
         return CompilationStatus::SetupFail;

--- a/src/compile/implement.h
+++ b/src/compile/implement.h
@@ -6,7 +6,7 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendActions.h"
 #include "clang-tidy/ClangTidyCheck.h"
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#include "clang-tidy/ClangTidyModule.h"
 #include "clang-tidy/ClangTidyOptions.h"
 
 namespace clice::tidy {

--- a/src/compile/tidy.cpp
+++ b/src/compile/tidy.cpp
@@ -10,7 +10,7 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang-tidy/ClangTidyCheck.h"
 #include "clang-tidy/ClangTidyDiagnosticConsumer.h"
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#include "clang-tidy/ClangTidyModule.h"
 #include "clang-tidy/ClangTidyOptions.h"
 
 namespace clice::tidy {

--- a/src/feature/hover.cpp
+++ b/src/feature/hover.cpp
@@ -148,18 +148,17 @@ auto print_type(clang::QualType type,
         type = type->castAs<clang::DecltypeType>()->getUnderlyingType();
     }
 
+    // Skip PredefinedSugarType (__size_t, __ptrdiff_t, etc.) — these are
+    // internal Clang sugar not meaningful to users.
+    if(!type.isNull()) {
+        if(auto* PST = type->getAs<clang::PredefinedSugarType>()) {
+            type = PST->desugar();
+        }
+    }
+
     PrintedType result;
     llvm::raw_string_ostream os(result.type);
 
-    /// Special case: if the outer type is a tag type without qualifiers, then
-    /// include the tag for extra clarity. This isn't very idiomatic, so don't
-    /// attempt it for complex cases, including pointers/references, template
-    /// specializations, etc.
-    if(!type.isNull() && !type.hasQualifiers() && policy.SuppressTagKeyword) {
-        if(auto* tag = llvm::dyn_cast<clang::TagType>(type.getTypePtr())) {
-            os << tag->getDecl()->getKindName() << " ";
-        }
-    }
     type.print(os, policy);
 
     if(!type.isNull() && options.show_aka) {
@@ -1051,11 +1050,11 @@ void add_layout_info(const clang::NamedDecl& decl, HoverInfo& info) {
 
     const auto& context = decl.getASTContext();
     if(auto* record = llvm::dyn_cast<clang::RecordDecl>(&decl)) {
-        if(auto size = context.getTypeSizeInCharsIfKnown(record->getTypeForDecl())) {
+        if(auto size = context.getTypeSizeInCharsIfKnown(context.getCanonicalTagType(record))) {
             info.size = size->getQuantity() * 8;
         }
         if(!record->isDependentType() && record->isCompleteDefinition()) {
-            info.align = context.getTypeAlign(record->getTypeForDecl());
+            info.align = context.getTypeAlign(context.getCanonicalTagType(record));
         }
         return;
     }

--- a/src/index/usr_generation.cpp
+++ b/src/index/usr_generation.cpp
@@ -504,14 +504,14 @@ bool USRGenerator::GenLoc(const Decl* D, bool IncludeOffset) {
 
 static void printQualifier(llvm::raw_ostream& Out,
                            const LangOptions& LangOpts,
-                           NestedNameSpecifier* NNS) {
+                           NestedNameSpecifier NNS) {
     // FIXME: Encode the qualifier, don't just print it.
     PrintingPolicy PO(LangOpts);
     PO.SuppressTagKeyword = true;
     PO.SuppressUnwrittenScope = true;
     PO.ConstantArraySizeAsWritten = false;
     PO.AnonymousTagLocations = false;
-    NNS->print(Out, PO);
+    NNS.print(Out, PO);
 }
 
 void USRGenerator::VisitType(QualType T) {
@@ -739,10 +739,8 @@ void USRGenerator::VisitType(QualType T) {
             Out << ':' << DNT->getIdentifier()->getName();
             return;
         }
-        if(const InjectedClassNameType* InjT = T->getAs<InjectedClassNameType>()) {
-            T = InjT->getInjectedSpecializationType();
-            continue;
-        }
+        // InjectedClassNameType inherits from TagType in LLVM 22,
+        // so it is already handled by the TagType branch above.
         if(const auto* VT = T->getAs<VectorType>()) {
             Out << (T->isExtVectorType() ? ']' : '[');
             Out << VT->getNumElements();

--- a/src/semantic/ast_utility.cpp
+++ b/src/semantic/ast_utility.cpp
@@ -209,10 +209,6 @@ llvm::StringRef identifier_of(const clang::NamedDecl& D) {
 }
 
 llvm::StringRef identifier_of(clang::QualType type) {
-    if(const auto* ET = llvm::dyn_cast<clang::ElaboratedType>(type)) {
-        return identifier_of(ET->getNamedType());
-    }
-
     if(const auto* BT = llvm::dyn_cast<clang::BuiltinType>(type)) {
         clang::PrintingPolicy PP(clang::LangOptions{});
         PP.adjustForCPlusPlus();
@@ -321,12 +317,6 @@ auto decl_of(clang::QualType type) -> const clang::NamedDecl* {
         return nullptr;
     }
 
-    // Strip type-sugar that wraps the underlying type without adding a decl
-    // (e.g. ElaboratedType for "struct Foo" vs plain "Foo").
-    if(auto ET = type->getAs<clang::ElaboratedType>()) {
-        type = ET->getNamedType();
-    }
-
     if(auto TST = type->getAs<clang::TemplateSpecializationType>()) {
         auto decl = TST->getTemplateName().getAsTemplateDecl();
         if(type->isDependentType()) {
@@ -418,8 +408,8 @@ std::string display_name_of(const clang::NamedDecl* decl) {
     // Handle 'using namespace'. They all have the same name - <using-directive>.
     if(auto* UD = llvm::dyn_cast<clang::UsingDirectiveDecl>(decl)) {
         out << "using namespace ";
-        if(auto* Qual = UD->getQualifier())
-            Qual->print(out, policy);
+        if(auto Qual = UD->getQualifier())
+            Qual.print(out, policy);
         UD->getNominatedNamespaceAsWritten()->printName(out);
         return out.str();
     }
@@ -446,8 +436,8 @@ std::string display_name_of(const clang::NamedDecl* decl) {
     }
 
     // Print nested name qualifier if it was written in the source code.
-    if(auto* qualifier = get_qualifier_loc(decl).getNestedNameSpecifier()) {
-        qualifier->print(out, policy);
+    if(auto qualifier = get_qualifier_loc(decl).getNestedNameSpecifier()) {
+        qualifier.print(out, policy);
     }
 
     // Print the name itself.
@@ -1208,8 +1198,8 @@ std::string print_name(const clang::NamedDecl& decl) {
     /// Handle 'using namespace'. They all have the same name - <using-directive>.
     if(auto* directive = llvm::dyn_cast<clang::UsingDirectiveDecl>(&decl)) {
         os << "using namespace ";
-        if(auto* qualifier = directive->getQualifier()) {
-            qualifier->print(os, policy);
+        if(auto qualifier = directive->getQualifier()) {
+            qualifier.print(os, policy);
         }
         directive->getNominatedNamespaceAsWritten()->printName(os);
         return name;
@@ -1236,8 +1226,8 @@ std::string print_name(const clang::NamedDecl& decl) {
     }
 
     /// Print nested name qualifier if it was written in the source code.
-    if(auto* qualifier = qualifier_loc(decl).getNestedNameSpecifier()) {
-        qualifier->print(os, policy);
+    if(auto qualifier = qualifier_loc(decl).getNestedNameSpecifier()) {
+        qualifier.print(os, policy);
     }
 
     /// Print the name itself.
@@ -1254,6 +1244,7 @@ clang::QualType declared_type(const clang::TypeDecl* decl) {
     if(const auto* spec = llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(decl)) {
         if(const auto* args = spec->getTemplateArgsAsWritten()) {
             return context.getTemplateSpecializationType(
+                clang::ElaboratedTypeKeyword::None,
                 clang::TemplateName(spec->getSpecializedTemplate()),
                 args->arguments(),
                 /*CanonicalArgs=*/{});

--- a/src/semantic/filtered_ast_visitor.h
+++ b/src/semantic/filtered_ast_visitor.h
@@ -107,7 +107,7 @@ public:
         return true;
     }
 
-    bool TraverseTypeLoc(clang::TypeLoc loc) {
+    bool TraverseTypeLoc(clang::TypeLoc loc, bool traverse_qualifier = true) {
         CHECK_DERIVED_IMPL(TraverseTypeLoc);
 
         if(!loc) {
@@ -116,10 +116,10 @@ public:
 
         /// FIXME: Workaround for `QualifiedTypeLoc`.
         if(auto QL = loc.getAs<clang::QualifiedTypeLoc>()) {
-            return Base::TraverseTypeLoc(QL.getUnqualifiedLoc());
+            return Base::TraverseTypeLoc(QL.getUnqualifiedLoc(), traverse_qualifier);
         }
 
-        return Base::TraverseTypeLoc(loc);
+        return Base::TraverseTypeLoc(loc, traverse_qualifier);
     }
 
     bool TraverseAttr(clang::Attr* attr) {
@@ -132,9 +132,8 @@ public:
         return Base::TraverseAttr(attr);
     }
 
-    /// We don't want to node withou location information.
-    constexpr bool TraverseNestedNameSpecifier
-        [[gnu::always_inline]] (clang::NestedNameSpecifier*) {
+    /// We don't want to node without location information.
+    constexpr bool TraverseNestedNameSpecifier [[gnu::always_inline]] (clang::NestedNameSpecifier) {
         CHECK_DERIVED_IMPL(TraverseNestedNameSpecifier);
         return true;
     }

--- a/src/semantic/find_target.cpp
+++ b/src/semantic/find_target.cpp
@@ -397,12 +397,8 @@ public:
                 outer.add(type->getAsTagDecl(), flags);
             }
 
-            void VisitElaboratedType(const clang::ElaboratedType* type) {
-                outer.add(type->desugar(), flags);
-            }
-
             void VisitUsingType(const clang::UsingType* type) {
-                outer.add(type->getFoundDecl(), flags);
+                outer.add(type->getDecl(), flags);
             }
 
             void VisitInjectedClassNameType(const clang::InjectedClassNameType* type) {
@@ -445,16 +441,6 @@ public:
                 if(outer.resolver) {
                     for(const clang::NamedDecl* decl:
                         outer.resolver->resolveDependentNameType(type)) {
-                        outer.add(decl, flags);
-                    }
-                }
-            }
-
-            void VisitDependentTemplateSpecializationType(
-                const clang::DependentTemplateSpecializationType* type) {
-                if(outer.resolver) {
-                    for(const clang::NamedDecl* decl:
-                        outer.resolver->resolveTemplateSpecializationType(type)) {
                         outer.add(decl, flags);
                     }
                 }
@@ -531,30 +517,20 @@ public:
         Visitor(*this, flags).Visit(type.getTypePtr());
     }
 
-    void add(const clang::NestedNameSpecifier* nns, RelSet flags) {
+    void add(clang::NestedNameSpecifier nns, RelSet flags) {
         if(!nns) {
             return;
         }
 
-        switch(nns->getKind()) {
-            case clang::NestedNameSpecifier::Namespace: add(nns->getAsNamespace(), flags); return;
-            case clang::NestedNameSpecifier::NamespaceAlias:
-                add(nns->getAsNamespaceAlias(), flags);
-                return;
-            case clang::NestedNameSpecifier::Identifier:
-                if(resolver) {
-                    add(resolver->resolveNestedNameSpecifierToType(nns), flags);
-                }
-                return;
-            case clang::NestedNameSpecifier::TypeSpec:
-                add(clang::QualType(nns->getAsType(), 0), flags);
-                return;
-            case clang::NestedNameSpecifier::Global:
-                /// This should be TUDecl, but we can't get a pointer to it!
-                return;
-            case clang::NestedNameSpecifier::Super: add(nns->getAsRecordDecl(), flags); return;
+        using Kind = clang::NestedNameSpecifier::Kind;
+        switch(nns.getKind()) {
+            case Kind::Namespace: add(nns.getAsNamespaceAndPrefix().Namespace, flags); return;
+            case Kind::Type: add(clang::QualType(nns.getAsType(), 0), flags); return;
+            case Kind::Global: return;
+            case Kind::MicrosoftSuper: add(nns.getAsRecordDecl(), flags); return;
+            case Kind::Null: return;
         }
-        llvm_unreachable("unhandled NestedNameSpecifier::SpecifierKind");
+        llvm_unreachable("unhandled NestedNameSpecifier::Kind");
     }
 
     void add(const clang::CXXCtorInitializer* init, RelSet flags) {
@@ -604,7 +580,7 @@ auto all_target_decls(const clang::DynTypedNode& node, const clang::HeuristicRes
     } else if(const auto* nns_loc = node.get<clang::NestedNameSpecifierLoc>()) {
         finder.add(nns_loc->getNestedNameSpecifier(), flags);
     } else if(const auto* nns = node.get<clang::NestedNameSpecifier>()) {
-        finder.add(nns, flags);
+        finder.add(*nns, flags);
     } else if(const auto* type_loc = node.get<clang::TypeLoc>()) {
         finder.add(type_loc->getType(), flags);
     } else if(const auto* type = node.get<clang::QualType>()) {

--- a/src/semantic/resolver.cpp
+++ b/src/semantic/resolver.cpp
@@ -14,7 +14,7 @@
 /// Architecture:
 ///   PseudoInstantiator (TreeTransform) — heuristic lookup in primary templates/partial specs
 ///     ├─ TransformDependentNameType       — lookup member in template, substitute, recurse
-///     ├─ TransformDependentTemplateSPTType — resolve DTST via hole()/lookup, CTD→TST
+///     ├─ TransformTemplateSpecializationType — resolve dep-TST via hole()/lookup, CTD→TST
 ///     ├─ TransformTemplateTypeParmType     — substitute from stack (+ default arg fallback)
 ///     ├─ TransformTypedefType              — delegate to SubstituteOnly (no lookup)
 ///     └─ TransformType                     — depth guard + null safety
@@ -179,7 +179,7 @@ static clang::QualType get_decl_type(clang::Decl* decl, clang::ASTContext& conte
 /// lookup. This breaks the typedef ↔ lookup cycle that would occur if typedef expansion
 /// triggered PseudoInstantiator's TransformDependentNameType.
 ///
-/// Handles: TypedefType, ElaboratedType, InjectedClassNameType, alias TST, TTPT.
+/// Handles: TypedefType, InjectedClassNameType, alias TST, TTPT.
 /// Does NOT handle: multi-element pack expansion, NTTP, template template params.
 class SubstituteOnly : public clang::TreeTransform<SubstituteOnly> {
     using Base = clang::TreeTransform<SubstituteOnly>;
@@ -531,15 +531,10 @@ public:
                 return lookup(clang::QualType(NNS.getAsType(), 0), name);
             }
 
-            case clang::NestedNameSpecifier::Kind::Null:
-            case clang::NestedNameSpecifier::Kind::Global:
-            case clang::NestedNameSpecifier::Kind::Namespace:
-            case clang::NestedNameSpecifier::Kind::MicrosoftSuper: {
+            default: {
                 return {};
             }
         }
-
-        return lookup_result();
     }
 
     /// Search for `name` in the dependent base classes of `CRD`. Each base type

--- a/src/semantic/resolver.cpp
+++ b/src/semantic/resolver.cpp
@@ -161,13 +161,13 @@ struct InstantiationStack {
 };
 
 /// Helper to extract underlying type from a Decl.
-static clang::QualType get_decl_type(clang::Decl* decl) {
+static clang::QualType get_decl_type(clang::Decl* decl, clang::ASTContext& context) {
     if(!decl)
         return clang::QualType();
     if(auto* TND = llvm::dyn_cast<clang::TypedefNameDecl>(decl))
         return TND->getUnderlyingType();
     if(auto* RD = llvm::dyn_cast<clang::RecordDecl>(decl))
-        return clang::QualType(RD->getTypeForDecl(), 0);
+        return context.getCanonicalTagType(RD);
     return clang::QualType();
 }
 
@@ -205,14 +205,11 @@ public:
 
     /// Desugar dependent typedefs to expose template parameters for substitution.
     clang::QualType TransformTypedefType(clang::TypeLocBuilder& TLB, clang::TypedefTypeLoc TL) {
-        if(auto* TND = TL.getTypedefNameDecl()) {
+        if(auto* TND = TL.getDecl()) {
             auto underlying = TND->getUnderlyingType();
             if(underlying->isDependentType()) {
                 auto type = TransformType(underlying);
                 if(!type.isNull()) {
-                    if(auto ET = llvm::dyn_cast<clang::ElaboratedType>(type)) {
-                        type = ET->getNamedType();
-                    }
                     TLB.pushTrivial(context, type, {});
                     return type;
                 }
@@ -221,25 +218,9 @@ public:
         return Base::TransformTypedefType(TLB, TL);
     }
 
-    clang::QualType TransformElaboratedType(clang::TypeLocBuilder& TLB,
-                                            clang::ElaboratedTypeLoc TL) {
-        clang::QualType type = TransformType(TL.getNamedTypeLoc().getType());
-        if(type.isNull()) {
-            return Base::TransformElaboratedType(TLB, TL);
-        }
-        TLB.pushTrivial(context, type, {});
-        return type;
-    }
-
     clang::QualType TransformInjectedClassNameType(clang::TypeLocBuilder& TLB,
                                                    clang::InjectedClassNameTypeLoc TL) {
-        auto ICT = TL.getTypePtr();
-        clang::QualType type = TransformType(ICT->getInjectedSpecializationType());
-        if(type.isNull()) {
-            return Base::TransformInjectedClassNameType(TLB, TL);
-        }
-        TLB.pushTrivial(context, type, {});
-        return type;
+        return Base::TransformInjectedClassNameType(TLB, TL);
     }
 
     using Base::TransformTemplateSpecializationType;
@@ -496,24 +477,25 @@ public:
         }
 
         if(auto TST = type->getAs<clang::TemplateSpecializationType>()) {
-            TD = TST->getTemplateName().getAsTemplateDecl();
-            args = TST->template_arguments();
-        } else if(auto DTST = type->getAs<clang::DependentTemplateSpecializationType>()) {
-            // If this DTST was already resolved (possibly to itself when unresolvable),
-            // skip the redundant lookup.
-            if(resolved.count(DTST)) {
-                return lookup_result();
-            }
+            auto TN = TST->getTemplateName();
+            if(auto* DTN = TN.getAsDependentTemplateName()) {
+                // This was formerly DependentTemplateSpecializationType.
+                if(resolved.count(TST)) {
+                    return lookup_result();
+                }
 
-            auto& template_name = DTST->getDependentTemplateName();
-            auto name = template_name.getName().getIdentifier();
-            if(!name) {
-                return {};
-            }
+                auto identifier = DTN->getName().getIdentifier();
+                if(!identifier) {
+                    return {};
+                }
 
-            if(auto decl = preferred(lookup(template_name.getQualifier(), name))) {
-                TD = decl;
-                args = DTST->template_arguments();
+                if(auto decl = preferred(lookup(DTN->getQualifier(), identifier))) {
+                    TD = decl;
+                    args = TST->template_arguments();
+                }
+            } else {
+                TD = TN.getAsTemplateDecl();
+                args = TST->template_arguments();
             }
         }
 
@@ -536,45 +518,23 @@ public:
         return lookup_result();
     }
 
-    lookup_result lookup(const clang::NestedNameSpecifier* NNS, clang::DeclarationName name) {
+    lookup_result lookup(clang::NestedNameSpecifier NNS, clang::DeclarationName name) {
         if(!NNS) {
             return lookup_result();
         }
 
-        if(auto iter = resolved.find(NNS); iter != resolved.end()) {
-            return lookup(iter->second, name);
-        }
-
         // Handle each NestedNameSpecifier kind:
-        // - Identifier: dependent name in NNS chain (e.g. `base::type::inner`), resolve recursively
-        // - TypeSpec: concrete or dependent type used as qualifier (e.g. `vector<T>::`)
-        // - Global/Namespace/NamespaceAlias/Super: not dependent, cannot resolve further
-        switch(NNS->getKind()) {
-            case clang::NestedNameSpecifier::Identifier: {
-                auto stack_size = stack.data.size();
-                auto* decl = preferred(lookup(NNS->getPrefix(), NNS->getAsIdentifier()));
-                auto type = get_decl_type(decl);
-                if(!type.isNull()) {
-                    type = substitute(type);
-                }
-                while(stack.data.size() > stack_size) {
-                    stack.pop();
-                }
-                if(!type.isNull()) {
-                    resolved.try_emplace(NNS, type);
-                    return lookup(type, name);
-                }
-                return {};
+        // - Type: concrete or dependent type used as qualifier (e.g. `vector<T>::`)
+        // - Global/Namespace/MicrosoftSuper/Null: not dependent, cannot resolve further
+        switch(NNS.getKind()) {
+            case clang::NestedNameSpecifier::Kind::Type: {
+                return lookup(clang::QualType(NNS.getAsType(), 0), name);
             }
 
-            case clang::NestedNameSpecifier::TypeSpec: {
-                return lookup(clang::QualType(NNS->getAsType(), 0), name);
-            }
-
-            case clang::NestedNameSpecifier::Global:
-            case clang::NestedNameSpecifier::Namespace:
-            case clang::NestedNameSpecifier::NamespaceAlias:
-            case clang::NestedNameSpecifier::Super: {
+            case clang::NestedNameSpecifier::Kind::Null:
+            case clang::NestedNameSpecifier::Kind::Global:
+            case clang::NestedNameSpecifier::Kind::Namespace:
+            case clang::NestedNameSpecifier::Kind::MicrosoftSuper: {
                 return {};
             }
         }
@@ -708,14 +668,14 @@ public:
     ///
     /// TODO: Replace with a general mechanism for resolving well-known standard
     /// library patterns, or improve the resolver to handle these chains naturally.
-    clang::QualType hole(clang::NestedNameSpecifier* NNS,
+    clang::QualType hole(clang::NestedNameSpecifier NNS,
                          const clang::IdentifierInfo* member,
                          TemplateArguments arguments) {
-        if(NNS->getKind() != clang::NestedNameSpecifier::TypeSpec) {
+        if(NNS.getKind() != clang::NestedNameSpecifier::Kind::Type) {
             return clang::QualType();
         }
 
-        auto TST = NNS->getAsType()->getAs<clang::TemplateSpecializationType>();
+        auto TST = NNS.getAsType()->getAs<clang::TemplateSpecializationType>();
         if(!TST) {
             return clang::QualType();
         }
@@ -738,17 +698,18 @@ public:
                     return clang::QualType();
                 auto T = arguments[0].getAsType();
 
-                auto prefix =
-                    clang::NestedNameSpecifier::Create(context, nullptr, Alloc.getTypePtr());
+                clang::NestedNameSpecifier prefix(Alloc.getTypePtr());
 
                 auto rebind = sema.getPreprocessor().getIdentifierInfo("rebind");
 
-                auto DTST = context.getDependentTemplateSpecializationType(
-                    clang::ElaboratedTypeKeyword::None,
-                    clang::DependentTemplateStorage(prefix, rebind, false),
-                    arguments);
+                clang::TemplateName DTN = context.getDependentTemplateName({prefix, rebind, false});
+                auto DTST =
+                    context.getTemplateSpecializationType(clang::ElaboratedTypeKeyword::None,
+                                                          DTN,
+                                                          arguments,
+                                                          {});
 
-                prefix = clang::NestedNameSpecifier::Create(context, prefix, DTST.getTypePtr());
+                prefix = clang::NestedNameSpecifier(DTST.getTypePtr());
 
                 auto other = sema.getPreprocessor().getIdentifierInfo("other");
                 auto DNT = context.getDependentNameType(clang::ElaboratedTypeKeyword::Typename,
@@ -770,9 +731,11 @@ public:
                     for(auto& arg: replaceArguments) {
                         canonicalArguments.emplace_back(context.getCanonicalTemplateArgument(arg));
                     }
-                    auto result = context.getTemplateSpecializationType(TST->getTemplateName(),
-                                                                        replaceArguments,
-                                                                        canonicalArguments);
+                    auto result =
+                        context.getTemplateSpecializationType(clang::ElaboratedTypeKeyword::None,
+                                                              TST->getTemplateName(),
+                                                              replaceArguments,
+                                                              canonicalArguments);
                     LOG_DEBUG(
                         "{}" "hole: 'allocator_traits::rebind_alloc' → '{}'",
                         pad(),
@@ -859,7 +822,9 @@ public:
 
     clang::QualType TransformDependentNameType(clang::TypeLocBuilder& TLB,
                                                clang::DependentNameTypeLoc TL,
-                                               bool DeducedTSTContext = false) {
+                                               bool DeducedTSTContext = false,
+                                               clang::QualType ObjectType = clang::QualType(),
+                                               clang::NamedDecl* UnqualLookup = nullptr) {
         auto* DNT = TL.getTypePtr();
         LOG_DEBUG("{}" "resolve '{}'", pad(), clang::QualType(DNT, 0).getAsString());
         ++indent;
@@ -897,10 +862,10 @@ public:
             return original;
         }
 
-        auto* NNS = NNSLoc.getNestedNameSpecifier();
+        auto NNS = NNSLoc.getNestedNameSpecifier();
         auto stack_size = stack.data.size();
         auto* decl = preferred(lookup(NNS, DNT->getIdentifier()));
-        auto type = get_decl_type(decl);
+        auto type = get_decl_type(decl, context);
 
         clang::QualType result;
         if(!type.isNull()) {
@@ -963,43 +928,50 @@ public:
         return original;
     }
 
-    using Base::TransformDependentTemplateSpecializationType;
+    using Base::TransformTemplateSpecializationType;
 
-    clang::QualType rebuild_dtst(clang::TypeLocBuilder& TLB,
-                                 clang::DependentTemplateSpecializationTypeLoc TL) {
-        auto* DTST = TL.getTypePtr();
-        return TLB.push<clang::DependentTemplateSpecializationTypeLoc>(clang::QualType(DTST, 0))
-            .getType();
-    }
+    clang::QualType TransformTemplateSpecializationType(clang::TypeLocBuilder& TLB,
+                                                        clang::TemplateSpecializationTypeLoc TL) {
+        auto* TST = TL.getTypePtr();
+        auto TN = TST->getTemplateName();
+        auto* DTN = TN.getAsDependentTemplateName();
 
-    clang::QualType TransformDependentTemplateSpecializationType(
-        clang::TypeLocBuilder& TLB,
-        clang::DependentTemplateSpecializationTypeLoc TL) {
-        auto* DTST = TL.getTypePtr();
-        LOG_DEBUG("{}" "resolve DTST '{}'", pad(), clang::QualType(DTST, 0).getAsString());
+        if(!DTN) {
+            // Non-dependent TST: handle alias templates.
+            if(TST->isTypeAlias()) {
+                clang::QualType type = substitute(TST->desugar());
+                if(!type.isNull()) {
+                    TLB.pushTrivial(context, type, {});
+                    return type;
+                }
+            }
+            return Base::TransformTemplateSpecializationType(TLB, TL);
+        }
+
+        // Dependent template specialization handling.
+        LOG_DEBUG("{}" "resolve dep-TST '{}'", pad(), clang::QualType(TST, 0).getAsString());
         ++indent;
 
-        if(auto iter = resolved.find(DTST); iter != resolved.end()) {
+        if(auto iter = resolved.find(TST); iter != resolved.end()) {
             --indent;
             TLB.pushTrivial(context, iter->second, {});
             return iter->second;
         }
 
         auto NNSLoc = TransformNestedNameSpecifierLoc(TL.getQualifierLoc());
-        if(!NNSLoc) {
-            LOG_DEBUG("{}→ <unresolved DTST>", pad());
-            --indent;
-            return rebuild_dtst(TLB, TL);
-        }
-        auto* NNS = NNSLoc.getNestedNameSpecifier();
+        clang::NestedNameSpecifier NNS =
+            NNSLoc ? NNSLoc.getNestedNameSpecifier() : DTN->getQualifier();
 
         clang::TemplateArgumentListInfo info;
-        using iterator = clang::TemplateArgumentLocContainerIterator<
-            clang::DependentTemplateSpecializationTypeLoc>;
-        if(TransformTemplateArguments(iterator(TL, 0), iterator(TL, TL.getNumArgs()), info)) {
-            LOG_DEBUG("{}→ <unresolved DTST>", pad());
+        using arg_iterator =
+            clang::TemplateArgumentLocContainerIterator<clang::TemplateSpecializationTypeLoc>;
+        if(TransformTemplateArguments(arg_iterator(TL, 0),
+                                      arg_iterator(TL, TL.getNumArgs()),
+                                      info)) {
+            auto original = clang::QualType(TST, 0);
+            TLB.pushTrivial(context, original, {});
             --indent;
-            return rebuild_dtst(TLB, TL);
+            return original;
         }
 
         llvm::SmallVector<clang::TemplateArgument, 4> arguments;
@@ -1007,17 +979,19 @@ public:
             arguments.push_back(arg.getArgument());
         }
 
-        auto* name = DTST->getDependentTemplateName().getName().getIdentifier();
+        auto* name = DTN->getName().getIdentifier();
         if(!name) {
-            LOG_DEBUG("{}→ <unresolved DTST>", pad());
+            LOG_DEBUG("{}→ <unresolved dep-TST>", pad());
             --indent;
-            return rebuild_dtst(TLB, TL);
+            auto original = clang::QualType(TST, 0);
+            TLB.pushTrivial(context, original, {});
+            return original;
         }
 
         if(auto result = hole(NNS, name, arguments); !result.isNull()) {
             LOG_DEBUG("{}" "hole: '{}' → '{}'", pad(), name->getName().str(), result.getAsString());
             --indent;
-            resolved.try_emplace(DTST, result);
+            resolved.try_emplace(TST, result);
             TLB.pushTrivial(context, result, {});
             return result;
         }
@@ -1027,7 +1001,6 @@ public:
             if(auto* TATD = llvm::dyn_cast<clang::TypeAliasTemplateDecl>(decl)) {
                 if(deduce_template_arguments(TATD, arguments)) {
                     auto type = substitute(TATD->getTemplatedDecl()->getUnderlyingType());
-                    // Pop lookup frames before further resolution.
                     while(stack.data.size() > stack_size) {
                         stack.pop();
                     }
@@ -1037,26 +1010,25 @@ public:
                     if(!type.isNull()) {
                         LOG_DEBUG("{}" "→ '{}' (alias)", pad(), type.getAsString());
                         --indent;
-                        resolved.try_emplace(DTST, type);
+                        resolved.try_emplace(TST, type);
                         TLB.pushTrivial(context, type, {});
                         return type;
                     }
                 }
             } else if(auto* CTD = llvm::dyn_cast<clang::ClassTemplateDecl>(decl)) {
-                // Resolve DTST to a concrete TemplateSpecializationType.
-                // e.g. __alloc_traits<allocator<T>>::rebind<T> → rebind<T> (a TST)
-                // This allows subsequent lookup of members (like "other") to work.
-                // Keep lookup frames on stack — the caller (e.g. TransformNestedNameSpecifierLoc
-                // processing A<X>::B<Y>::C<Z>) needs them for parameter substitution.
-                clang::TemplateName TN(CTD);
+                clang::TemplateName CTN(CTD);
                 llvm::SmallVector<clang::TemplateArgument> canonArgs;
                 for(auto& arg: arguments) {
                     canonArgs.push_back(context.getCanonicalTemplateArgument(arg));
                 }
-                auto result = context.getTemplateSpecializationType(TN, arguments, canonArgs);
+                auto result =
+                    context.getTemplateSpecializationType(clang::ElaboratedTypeKeyword::None,
+                                                          CTN,
+                                                          arguments,
+                                                          canonArgs);
                 LOG_DEBUG("{}" "→ TST '{}' (class)", pad(), result.getAsString());
                 --indent;
-                resolved.try_emplace(DTST, result);
+                resolved.try_emplace(TST, result);
                 TLB.pushTrivial(context, result, {});
                 return result;
             }
@@ -1065,11 +1037,12 @@ public:
             stack.pop();
         }
 
-        LOG_DEBUG("{}→ <unresolved DTST>", pad());
+        LOG_DEBUG("{}→ <unresolved dep-TST>", pad());
         --indent;
-        auto fallback = rebuild_dtst(TLB, TL);
-        resolved.try_emplace(DTST, fallback);
-        return fallback;
+        auto original = clang::QualType(TST, 0);
+        resolved.try_emplace(TST, original);
+        TLB.pushTrivial(context, original, {});
+        return original;
     }
 
     /// Desugar dependent typedefs by delegating to SubstituteOnly.
@@ -1077,14 +1050,11 @@ public:
     /// its own TransformTypedefType). Using substitute() here ensures that typedef
     /// expansion does NOT trigger heuristic lookup, preventing the typedef ↔ lookup cycle.
     clang::QualType TransformTypedefType(clang::TypeLocBuilder& TLB, clang::TypedefTypeLoc TL) {
-        if(auto* TND = TL.getTypedefNameDecl()) {
+        if(auto* TND = TL.getDecl()) {
             auto underlying = TND->getUnderlyingType();
             if(underlying->isDependentType()) {
                 auto type = substitute(underlying);
                 if(!type.isNull()) {
-                    if(auto ET = llvm::dyn_cast<clang::ElaboratedType>(type)) {
-                        type = ET->getNamedType();
-                    }
                     TLB.pushTrivial(context, type, {});
                     return type;
                 }
@@ -1138,7 +1108,7 @@ clang::QualType TemplateResolver::resugar(clang::QualType type, clang::Decl* dec
     return resugar.TransformType(type);
 }
 
-TemplateResolver::lookup_result TemplateResolver::lookup(const clang::NestedNameSpecifier* NNS,
+TemplateResolver::lookup_result TemplateResolver::lookup(clang::NestedNameSpecifier NNS,
                                                          clang::DeclarationName name) {
     PseudoInstantiator instantiator(sema, resolved);
     return instantiator.lookup(NNS, name);

--- a/src/semantic/resolver.h
+++ b/src/semantic/resolver.h
@@ -41,21 +41,10 @@ public:
     using lookup_result = clang::DeclContext::lookup_result;
 
     /// Look up the name in the given nested name specifier.
-    lookup_result lookup(const clang::NestedNameSpecifier* NNS, clang::DeclarationName name);
+    lookup_result lookup(clang::NestedNameSpecifier NNS, clang::DeclarationName name);
 
     lookup_result lookup(const clang::DependentNameType* type) {
         return lookup(type->getQualifier(), type->getIdentifier());
-    }
-
-    lookup_result lookup(const clang::DependentTemplateSpecializationType* type) {
-        auto& template_name = type->getDependentTemplateName();
-        auto identifier = template_name.getName().getIdentifier();
-        if(identifier) {
-            return lookup(template_name.getQualifier(), identifier);
-        } else {
-            /// TODO: Operators don't have an IdentifierInfo; need DeclarationName-based lookup.
-            return {};
-        }
     }
 
     lookup_result lookup(const clang::DependentScopeDeclRefExpr* expr) {

--- a/src/semantic/selection.cpp
+++ b/src/semantic/selection.cpp
@@ -756,8 +756,8 @@ public:
         return traverse_node(X, [&] { return Base::TraverseDecl(X); });
     }
 
-    bool TraverseTypeLoc(clang::TypeLoc X) {
-        return traverse_node(&X, [&] { return Base::TraverseTypeLoc(X); });
+    bool TraverseTypeLoc(clang::TypeLoc X, bool traverse_qualifier = true) {
+        return traverse_node(&X, [&] { return Base::TraverseTypeLoc(X, traverse_qualifier); });
     }
 
     bool TraverseTemplateArgumentLoc(const clang::TemplateArgumentLoc& X) {
@@ -814,7 +814,8 @@ public:
     // This means we'd never see 'int' in 'const int'! Work around that here.
     // (The reason for the behavior is to avoid traversing the nested Type twice,
     // but we ignore TraverseType anyway).
-    bool TraverseQualifiedTypeLoc(clang::QualifiedTypeLoc QX) {
+    bool TraverseQualifiedTypeLoc(clang::QualifiedTypeLoc QX,
+                                  [[maybe_unused]] bool traverse_qualifier = true) {
         return traverse_node<clang::TypeLoc>(&QX, [&] {
             return TraverseTypeLoc(QX.getUnqualifiedLoc());
         });
@@ -825,7 +826,7 @@ public:
     }
 
     // Uninteresting parts of the AST that don't have locations within them.
-    bool TraverseNestedNameSpecifier(clang::NestedNameSpecifier*) {
+    bool TraverseNestedNameSpecifier(clang::NestedNameSpecifier) {
         return true;
     }
 

--- a/src/semantic/semantic_visitor.h
+++ b/src/semantic/semantic_visitor.h
@@ -515,7 +515,7 @@ public:
     /// using Foo = int; Foo foo;
     ///                   ^~~~ reference
     VISIT_TYPELOC(TypedefTypeLoc) {
-        auto decl = loc.getTypedefNameDecl();
+        auto decl = loc.getDecl();
         auto location = loc.getNameLoc();
         handleDeclOccurrence(decl, RelationKind::Reference, location);
         handleRelation(decl, RelationKind::Reference, decl, location);
@@ -551,22 +551,6 @@ public:
     /// std::vector<T>::value_type
     ///                      ^~~~ reference
     VISIT_TYPELOC(DependentNameTypeLoc) {
-        auto location = loc.getNameLoc();
-        // for(auto decl: resolver.lookup(loc.getTypePtr())) {
-        //     handleDeclOccurrence(decl, RelationKind::WeakReference, location);
-        //     handleRelation(decl, RelationKind::WeakReference, decl, location);
-        // }
-        return true;
-    }
-
-    /// std::allocator<T>::rebind<U>
-    ///                       ^~~~ reference
-    VISIT_TYPELOC(DependentTemplateSpecializationTypeLoc) {
-        auto location = loc.getTemplateNameLoc();
-        // for(auto decl: resolver.lookup(loc.getTypePtr())) {
-        //     handleDeclOccurrence(decl, RelationKind::WeakReference, location);
-        //     handleRelation(decl, RelationKind::WeakReference, decl, location);
-        // }
         return true;
     }
 
@@ -575,33 +559,20 @@ public:
     /// ============================================================================
 
     bool VisitNestedNameSpecifierLoc(clang::NestedNameSpecifierLoc loc) {
-        auto NNS = loc.getNestedNameSpecifier();
-        switch(NNS->getKind()) {
-            case clang::NestedNameSpecifier::Namespace: {
-                auto decl = NNS->getAsNamespace();
+        auto nns = loc.getNestedNameSpecifier();
+        switch(nns.getKind()) {
+            case clang::NestedNameSpecifier::Kind::Namespace: {
+                auto [ns, prefix] = loc.castAsNamespaceAndPrefix();
                 auto location = loc.getLocalBeginLoc();
-                handleDeclOccurrence(decl, RelationKind::Reference, location);
-                handleRelation(decl, RelationKind::Reference, decl, location);
+                handleDeclOccurrence(ns, RelationKind::Reference, location);
+                handleRelation(ns, RelationKind::Reference, ns, location);
                 break;
             }
 
-            case clang::NestedNameSpecifier::NamespaceAlias: {
-                auto decl = NNS->getAsNamespaceAlias();
-                auto location = loc.getLocalBeginLoc();
-                handleDeclOccurrence(decl, RelationKind::Reference, location);
-                handleRelation(decl, RelationKind::Reference, decl, location);
-                break;
-            }
-
-            case clang::NestedNameSpecifier::Identifier: {
-                assert(NNS->isDependent() && "Identifier NNS should be dependent");
-                // FIXME: use TemplateResolver here.
-                break;
-            }
-
-            case clang::NestedNameSpecifier::TypeSpec:
-            case clang::NestedNameSpecifier::Global:
-            case clang::NestedNameSpecifier::Super: {
+            case clang::NestedNameSpecifier::Kind::Null:
+            case clang::NestedNameSpecifier::Kind::Type:
+            case clang::NestedNameSpecifier::Kind::Global:
+            case clang::NestedNameSpecifier::Kind::MicrosoftSuper: {
                 break;
             };
         }

--- a/src/semantic/semantic_visitor.h
+++ b/src/semantic/semantic_visitor.h
@@ -569,12 +569,9 @@ public:
                 break;
             }
 
-            case clang::NestedNameSpecifier::Kind::Null:
-            case clang::NestedNameSpecifier::Kind::Type:
-            case clang::NestedNameSpecifier::Kind::Global:
-            case clang::NestedNameSpecifier::Kind::MicrosoftSuper: {
+            default: {
                 break;
-            };
+            }
         }
 
         return true;

--- a/src/syntax/scan.cpp
+++ b/src/syntax/scan.cpp
@@ -10,6 +10,7 @@
 #include "clang/Basic/FileEntry.h"
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/SourceManager.h"
+#include "clang/Driver/CreateInvocationFromArgs.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendActions.h"
 #include "clang/Lex/PPCallbacks.h"
@@ -319,9 +320,10 @@ std::unique_ptr<clang::CompilerInstance>
     }
 
     auto instance = std::make_unique<clang::CompilerInstance>(std::move(invocation));
-    instance->createDiagnostics(*vfs, new clang::IgnoringDiagConsumer(), true);
+    instance->createDiagnostics(new clang::IgnoringDiagConsumer(), true);
     instance->getDiagnostics().setSuppressAllDiagnostics(true);
-    instance->createFileManager(vfs);
+    instance->setVirtualFileSystem(vfs);
+    instance->createFileManager();
 
     return instance;
 }

--- a/tests/snapshots/hover/snapshot/auto.cpp.snap.yml
+++ b/tests/snapshots/hover/snapshot/auto.cpp.snap.yml
@@ -45,14 +45,14 @@ input_file: auto.cpp
 04_auto_lambda:
   name: "auto"
   kind: Type
-  definition: "class(lambda)"
+  definition: "(lambda)"
   symbol_range: "[628, 632)"
   markdown: |
     ### type `auto`  
 
     ---
     ```cpp
-    class(lambda)
+    (lambda)
     ```
 
 05_auto_instantiation:
@@ -313,7 +313,7 @@ input_file: auto.cpp
   name: "auto"
   kind: Type
   documentation: "auto on alias"
-  definition: "cls_type // aka: alias_class::cls"
+  definition: "cls_type // aka: cls"
   symbol_range: "[2765, 2769)"
   markdown: |
     ### type `auto`  
@@ -323,7 +323,7 @@ input_file: auto.cpp
 
     ---
     ```cpp
-    cls_type // aka: alias_class::cls
+    cls_type // aka: cls
     ```
 
 24_auto_alias_template:

--- a/tests/snapshots/hover/snapshot/docs.cpp.snap.yml
+++ b/tests/snapshots/hover/snapshot/docs.cpp.snap.yml
@@ -80,7 +80,7 @@ input_file: docs.cpp
     ```
 
 05_var_tmpl_ref_doc:
-  name: "baz<X<int>>"
+  name: "baz"
   kind: Variable
   namespace_scope: "docs_ast::"
   documentation: "doc"
@@ -88,7 +88,7 @@ input_file: docs.cpp
   type: "docs_ast::X<int>"
   symbol_range: "[411, 414)"
   markdown: |
-    ### variable `baz<X<int>>`  
+    ### variable `baz`  
 
     ---
     Type: `docs_ast::X<int>`  
@@ -101,7 +101,7 @@ input_file: docs.cpp
     ```
 
 06_var_tmpl_assign_doc:
-  name: "baz<int>"
+  name: "baz"
   kind: Variable
   namespace_scope: "docs_ast::"
   documentation: "doc"
@@ -109,7 +109,7 @@ input_file: docs.cpp
   type: "int"
   symbol_range: "[426, 429)"
   markdown: |
-    ### variable `baz<int>`  
+    ### variable `baz`  
 
     ---
     Type: `int`  

--- a/tests/snapshots/hover/snapshot/lambdas.cpp.snap.yml
+++ b/tests/snapshots/hover/snapshot/lambdas.cpp.snap.yml
@@ -63,7 +63,7 @@ input_file: lambdas.cpp
   namespace_scope: "decltype_param::"
   local_scope: "foo::"
   definition: "decltype(lamb) bar"
-  type: "class decltype_param::(lambda)"
+  type: "decltype_param::(lambda)"
   return_type: "bool"
   parameters:
     - "int T"
@@ -93,7 +93,7 @@ input_file: lambdas.cpp
   namespace_scope: "lambda_variable::"
   local_scope: "foo::"
   definition: "auto lamb = [&bar](int T, bool B) -> bool {}"
-  type: "class (lambda)"
+  type: "(lambda)"
   return_type: "bool"
   parameters:
     - "int T"

--- a/tests/snapshots/hover/snapshot/tag_decls.cpp.snap.yml
+++ b/tests/snapshots/hover/snapshot/tag_decls.cpp.snap.yml
@@ -92,14 +92,14 @@ input_file: tag_decls.cpp
   namespace_scope: "enumerator::"
   local_scope: "Hello::"
   definition: "ONE"
-  type: "enum enumerator::Hello"
+  type: "enumerator::Hello"
   value: "0"
   symbol_range: "[873, 876)"
   markdown: |
     ### enumerator `ONE`  
 
     ---
-    Type: `enum enumerator::Hello`  
+    Type: `enumerator::Hello`  
     Value = `0`  
 
     ---
@@ -114,14 +114,14 @@ input_file: tag_decls.cpp
   namespace_scope: "using_enum::"
   local_scope: "Hello::"
   definition: "ONE"
-  type: "enum using_enum::Hello"
+  type: "using_enum::Hello"
   value: "0"
   symbol_range: "[1019, 1022)"
   markdown: |
     ### enumerator `ONE`  
 
     ---
-    Type: `enum using_enum::Hello`  
+    Type: `using_enum::Hello`  
     Value = `0`  
 
     ---
@@ -135,14 +135,14 @@ input_file: tag_decls.cpp
   kind: EnumMember
   namespace_scope: "anon_enum::"
   definition: "ONE"
-  type: "enum anon_enum::(unnamed)"
+  type: "anon_enum::(unnamed enum)"
   value: "0"
   symbol_range: "[1140, 1143)"
   markdown: |
     ### enumerator `ONE`  
 
     ---
-    Type: `enum anon_enum::(unnamed)`  
+    Type: `anon_enum::(unnamed enum)`  
     Value = `0`  
 
     ---
@@ -178,13 +178,13 @@ input_file: tag_decls.cpp
   namespace_scope: "typedef_embedded::"
   documentation: "Typedef with embedded definition"
   definition: "typedef struct Bar Foo"
-  type: "struct typedef_embedded::Bar"
+  type: "struct Bar"
   symbol_range: "[1339, 1342)"
   markdown: |
     ### type `Foo`  
 
     ---
-    Type: `struct typedef_embedded::Bar`  
+    Type: `struct Bar`  
     Typedef with embedded definition  
 
     ---

--- a/tests/snapshots/hover/snapshot/this_expr.cpp.snap.yml
+++ b/tests/snapshots/hover/snapshot/this_expr.cpp.snap.yml
@@ -19,40 +19,40 @@ input_file: this_expr.cpp
 02_this_template_class:
   name: "this"
   kind: Invalid
-  definition: "const Foo2<T> *"
+  definition: "const ns::Foo2<T> *"
   symbol_range: "[374, 378)"
   markdown: |
     ### `this`  
 
     ---
     ```cpp
-    const Foo2<T> *
+    const ns::Foo2<T> *
     ```
 
 03_this_specialization:
   name: "this"
   kind: Invalid
-  definition: "Foo3<int> *"
+  definition: "ns::Foo3<int> *"
   symbol_range: "[553, 557)"
   markdown: |
     ### `this`  
 
     ---
     ```cpp
-    Foo3<int> *
+    ns::Foo3<int> *
     ```
 
 04_this_partial_specialization:
   name: "this"
   kind: Invalid
-  definition: "const Foo4<int, F> *"
+  definition: "const ns::Foo4<int, F> *"
   symbol_range: "[773, 777)"
   markdown: |
     ### `this`  
 
     ---
     ```cpp
-    const Foo4<int, F> *
+    const ns::Foo4<int, F> *
     ```
 
 

--- a/tests/snapshots/hover/snapshot/values.cpp.snap.yml
+++ b/tests/snapshots/hover/snapshot/values.cpp.snap.yml
@@ -72,14 +72,14 @@ input_file: values.cpp
   namespace_scope: "enumerator_value::"
   local_scope: "Color::"
   definition: "GREEN = 5"
-  type: "enum enumerator_value::Color"
+  type: "enumerator_value::Color"
   value: "5"
   symbol_range: "[622, 627)"
   markdown: |
     ### enumerator `GREEN`  
 
     ---
-    Type: `enum enumerator_value::Color`  
+    Type: `enumerator_value::Color`  
     Value = `5`  
 
     ---

--- a/tests/unit/feature/inlay_hint_tests.cpp
+++ b/tests/unit/feature/inlay_hint_tests.cpp
@@ -627,7 +627,7 @@ TEST_CASE(Types) {
         )c");
     EXPECT_SIZE(2);
     EXPECT_HINT("0", ": S1");
-    EXPECT_HINT("1", ": S2::Inner<int>");
+    EXPECT_HINT("1", ": Inner<int>");
 
     // Lambda
     run(R"c(

--- a/tests/unit/index/usr_tests.cpp
+++ b/tests/unit/index/usr_tests.cpp
@@ -367,9 +367,6 @@ struct S {
 )cpp");
     t2.run();
 
-    llvm::errs() << "injected S:    " << t1.lookup("f") << "\n";
-    llvm::errs() << "explicit S<T>: " << t2.lookup("f") << "\n";
-
     ASSERT_EQ(t1.lookup("f"), t2.lookup("f"));
 }
 

--- a/tests/unit/index/usr_tests.cpp
+++ b/tests/unit/index/usr_tests.cpp
@@ -348,6 +348,31 @@ public:
     ASSERT_NE(usr1, usr2);
 }
 
+TEST_CASE(InjectedClassName) {
+    // S and S<T> inside a class template body should produce identical USRs
+    // for functions with the same signature (injected class name == S<T>).
+    USRTester t1("main.cpp", R"cpp(
+template<typename T>
+struct S {
+    void $(f)f(S other);
+};
+)cpp");
+    t1.run();
+
+    USRTester t2("main.cpp", R"cpp(
+template<typename T>
+struct S {
+    void $(f)f(S<T> other);
+};
+)cpp");
+    t2.run();
+
+    llvm::errs() << "injected S:    " << t1.lookup("f") << "\n";
+    llvm::errs() << "explicit S<T>: " << t2.lookup("f") << "\n";
+
+    ASSERT_EQ(t1.lookup("f"), t2.lookup("f"));
+}
+
 };  // TEST_SUITE(USR)
 
 }  // namespace

--- a/tests/unit/semantic/selection_tests.cpp
+++ b/tests/unit/semantic/selection_tests.cpp
@@ -442,9 +442,9 @@ TEST_CASE(Types) {
 TEST_CASE(CXXFeatures) {
     EXPECT_SELECT(R"(
           template <typename T>
-          int x = @[T::$U::]ccc();
+          int x = T::@[$U]::ccc();
           )",
-                  "NestedNameSpecifierLoc");
+                  "DependentNameTypeLoc");
     EXPECT_SELECT(R"(
           struct Foo {};
           struct Bar : @[v$ir$tual private Foo] {};
@@ -486,9 +486,9 @@ TEST_CASE(UsingEnum) {
                   "TypedefTypeLoc");
     EXPECT_SELECT(R"(
         namespace ns { enum class A {}; };
-        using enum @[$ns::]A;
+        @[using enum $ns::A];
         )",
-                  "NestedNameSpecifierLoc");
+                  "UsingEnumDecl");
     EXPECT_SELECT(R"(
         namespace ns { enum class A {}; };
         @[using $enum ns::A];


### PR DESCRIPTION
## Summary

Upgrade LLVM dependency from 21.1.8 to 22.1.4. Single commit, pure API adaptation — no infrastructure changes (those landed in #476).

## LLVM 22 Breaking Changes Adapted

All changes documented in `docs/en/changelog/llvm-changelog.md` with upstream commit references.

**Type system** (5 of 7 from the same mega-commit [#147835](https://github.com/llvm/llvm-project/pull/147835)):
- `ElaboratedType` removed — keyword/qualifier merged into `TagType`
- `InjectedClassNameType` now inherits `TagType`
- `DependentTemplateSpecializationType` merged into `TemplateSpecializationType`
- `TagDecl::getTypeForDecl()` deleted → `ASTContext::getCanonicalTagType()`
- `UsingType::getFoundDecl()` → `getDecl()`
- `PredefinedSugarType` (`__size_t`) — desugar in hover
- Implicit var template specs no longer retain written args

**NNS**: pointer → value type; `Kind::Identifier`/`NamespaceAlias` removed; `NamespaceBaseDecl` introduced

**Driver/Frontend**: `Options.inc` path changed; `OPTION` macro 15th param; `GetResourcesPath` moved; `createDiagnostics` VFS param removed

**Other**: `fs::make_absolute` → `path::make_absolute`; `ClangTidyModuleRegistry.h` deprecated

## Notable behavior changes
- Hover no longer adds `struct`/`class`/`enum` prefix (removed tag-keyword hack — LLVM 22 TypePrinter handles elaboration natively)
- `PredefinedSugarType` desugared in hover to avoid `__size_t` display

## Test plan
- [x] Unit tests: 716 passed locally
- [x] Integration tests: 177 passed locally
- [x] Smoke tests: 3/3 passed locally
- [ ] CI: all platforms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded to a newer LLVM/Clang release, bringing updated language and tooling support.

* **Bug Fixes**
  * Improved hover/type rendering with cleaner type names and more accurate record layout sizing.
  * Enhanced indexing/USR and semantic selection for injected class names and qualified/nested-name constructs.
  * Improved Clang resource path, option parsing, and VFS/diagnostics setup for more reliable analysis.

* **Documentation**
  * Added LLVM upgrade breaking-change notes (LLVM 21 → 22).

* **Tests**
  * Updated hover snapshots and unit expectations to match the new rendering/selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->