### PR TITLE
fix(server): track open files on disk and honest tracker baselines

### DIFF
--- a/src/server/state/file_tracker.cpp
+++ b/src/server/state/file_tracker.cpp
@@ -55,7 +55,9 @@ bool FileTracker::reseed(std::uint32_t path_id) {
     auto path = workspace.path_pool.resolve(path_id);
     llvm::sys::fs::file_status status;
     if(llvm::sys::fs::status(path, status)) {
-        baseline.erase(path_id);
+        // Saved-then-vanished: keep the baseline so the next sweep can
+        // observe the removal and deliver DiskRemoved; the save itself
+        // still cascades conservatively.
         return true;
     }
     auto hash = hash_file(path);

--- a/src/server/state/file_tracker.cpp
+++ b/src/server/state/file_tracker.cpp
@@ -17,28 +17,58 @@ namespace clice {
 
 FileTracker::FileTracker(Workspace& workspace,
                          const SessionStore& store,
-                         std::string workspace_root) :
+                         std::string workspace_root,
+                         llvm::StringRef consumed_path,
+                         CDBStamp consumed) :
     workspace(workspace), store(store), workspace_root(std::move(workspace_root)) {
     cdb_path = discover_compile_commands(workspace.config, this->workspace_root);
-    // A change landing between the workspace load and this stat is caught
-    // anyway: the stamp only gates reloads, and the reload's diff is
-    // computed from content, so it never reports spurious changes.
-    applied = stat_cdb();
+    if(!consumed_path.empty() && cdb_path == consumed_path) {
+        // The stamp of the content the workspace load actually read (see
+        // stat_file): a rewrite that landed between that read and this
+        // constructor differs from it and reloads on the first tick.
+        applied = consumed;
+    } else {
+        applied = stat_cdb();
+    }
 }
 
-FileTracker::CDBStamp FileTracker::stat_cdb() const {
+FileTracker::CDBStamp FileTracker::stat_file(llvm::StringRef path) {
     CDBStamp stamp;
-    if(cdb_path.empty()) {
+    if(path.empty()) {
         return stamp;
     }
     llvm::sys::fs::file_status status;
-    if(llvm::sys::fs::status(cdb_path, status)) {
+    if(llvm::sys::fs::status(path, status)) {
         return stamp;
     }
     stamp.exists = true;
     stamp.size = status.getSize();
     stamp.mtime_ns = fs::mtime_ns(status);
     return stamp;
+}
+
+FileTracker::CDBStamp FileTracker::stat_cdb() const {
+    return stat_file(cdb_path);
+}
+
+bool FileTracker::reseed(std::uint32_t path_id) {
+    auto path = workspace.path_pool.resolve(path_id);
+    llvm::sys::fs::file_status status;
+    if(llvm::sys::fs::status(path, status)) {
+        baseline.erase(path_id);
+        return true;
+    }
+    auto hash = hash_file(path);
+    if(hash == 0) {
+        // Unreadable right now: leave the old baseline for the sweep's
+        // retry logic and let the caller cascade.
+        return true;
+    }
+    auto it = baseline.find(path_id);
+    bool changed = it == baseline.end() || it->second.missing || it->second.hash != hash;
+    baseline[path_id] =
+        FileState{.size = status.getSize(), .mtime_ns = fs::mtime_ns(status), .hash = hash};
+    return changed;
 }
 
 llvm::SmallVector<FileEvent> FileTracker::tick_cdb(bool force) {
@@ -159,18 +189,6 @@ kota::task<llvm::SmallVector<FileEvent>> FileTracker::tick_workspace() {
         auto batch_end = std::min(begin + batch_size, files.size());
         for(std::size_t i = begin; i < batch_end; ++i) {
             auto path_id = files[i];
-            if(store.find(path_id)) {
-                // Open buffers are the truth and didSave owns their disk
-                // sync; drop the baseline so the file re-seeds silently
-                // once it closes (BufferClosed already reindexes it).
-                // TODO: a disk change landing while the file is open (git
-                // checkout on an open header, closed without saving) is
-                // forgotten by this reset — dependents are not cascaded.
-                // Desync hardening owns that case.
-                baseline.erase(path_id);
-                continue;
-            }
-
             auto path = workspace.path_pool.resolve(path_id);
             llvm::sys::fs::file_status status;
             bool exists = !llvm::sys::fs::status(path, status);
@@ -192,6 +210,24 @@ kota::task<llvm::SmallVector<FileEvent>> FileTracker::tick_workspace() {
                     }
                 }
                 baseline.try_emplace(path_id, state);
+                // The seed must not absorb a change that landed before
+                // this first sweep could see the file: a TU shard records
+                // the content indexing consumed, and a mismatch means the
+                // change predates the seed — dispatch it like any other.
+                // Only CDB sources are checked: header shards carry no
+                // deps of their own (need_update is conservatively true
+                // for them), and a pre-seed header edit reaches its
+                // including TUs through their dep hashes anyway.
+                if(exists && workspace.cdb.has_entry(path)) {
+                    auto shard = workspace.merged_indices.find(path_id);
+                    if(shard != workspace.merged_indices.end() && shard->second.loaded() &&
+                       shard->second.need_update()) {
+                        LOG_INFO("Pre-seed change detected for {} (shard is stale), dispatching",
+                                 path);
+                        events.push_back(FileEvent::disk_changed(path_id));
+                        changed += 1;
+                    }
+                }
                 continue;
             }
 

--- a/src/server/state/file_tracker.h
+++ b/src/server/state/file_tracker.h
@@ -10,6 +10,7 @@
 #include "kota/async/async.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace clice {
 
@@ -31,10 +32,44 @@ namespace clice {
 /// unit-testable against plain data structures.
 class FileTracker {
 public:
-    /// Discovers the compile_commands.json itself (it may not exist yet)
-    /// and records the stamp the currently loaded CDB corresponds to.
-    /// Construct after the workspace is loaded.
-    FileTracker(Workspace& workspace, const SessionStore& store, std::string workspace_root);
+    /// (existence, size, mtime) identity of the CDB file.
+    struct CDBStamp {
+        bool exists = false;
+        std::uint64_t size = 0;
+        std::int64_t mtime_ns = 0;
+
+        friend bool operator==(const CDBStamp&, const CDBStamp&) = default;
+    };
+
+    /// Stat a CDB candidate. The workspace loader calls this BEFORE
+    /// reading the file and hands the stamp to the constructor: the
+    /// baseline must describe the content the load consumed. Statting
+    /// after the load leaves a window where a rewrite lands in between
+    /// and is never reloaded — the stamp then gates against the new file
+    /// while memory holds the old commands, permanently. The reversed
+    /// race (a rewrite between this stat and the read) only costs one
+    /// spurious reload with an empty diff.
+    static CDBStamp stat_file(llvm::StringRef path);
+
+    /// Discovers the compile_commands.json itself (it may not exist yet).
+    /// `consumed_path`/`consumed` describe the database the workspace
+    /// load actually read (see stat_file); when discovery lands on the
+    /// same path, that stamp seeds `applied`. Construct after the
+    /// workspace is loaded.
+    FileTracker(Workspace& workspace,
+                const SessionStore& store,
+                std::string workspace_root,
+                llvm::StringRef consumed_path,
+                CDBStamp consumed);
+
+    /// Refresh a file's baseline from the disk right now, silently, and
+    /// report whether its content differs from the recorded baseline.
+    /// Called on didSave: the save's cascade already handles the change,
+    /// so the next sweep must not re-report it — and a save that did not
+    /// change the bytes reports false, letting the dispatcher skip the
+    /// cascade entirely. Unknown or unreadable files report true (the
+    /// conservative direction: cascade rather than miss).
+    bool reseed(std::uint32_t path_id);
 
     /// One CDB poll tick. Stats the known compile_commands.json — or keeps
     /// discovering one when none was found yet, which is how a database
@@ -50,17 +85,21 @@ public:
     /// reload just yields an empty diff.
     llvm::SmallVector<FileEvent> tick_cdb(bool force = false);
 
-    /// One workspace sweep. Stats every file the dependency graph knows,
-    /// skipping open buffers; a (mtime, size) suspect is confirmed by
-    /// content hash before DiskChanged is emitted, so touch-only changes
-    /// (mtime bump, identical bytes) stay silent. A stat failure on a
-    /// known file emits DiskRemoved once; a transient content-read failure
-    /// emits nothing and is retried on the next tick.
+    /// One workspace sweep. Stats every file the dependency graph knows —
+    /// open buffers included: their disk state matters to dependents (who
+    /// always read the disk), so an external write to an open file emits
+    /// DiskChanged like any other. didSave keeps the baseline in step via
+    /// reseed(). A (mtime, size) suspect is confirmed by content hash
+    /// before DiskChanged is emitted, so touch-only changes (mtime bump,
+    /// identical bytes) stay silent. A stat failure on a known file emits
+    /// DiskRemoved once; a transient content-read failure emits nothing
+    /// and is retried on the next tick.
     ///
-    /// Files seen for the first time only seed the baseline and emit
+    /// Files seen for the first time seed the baseline and normally emit
     /// nothing — the first sweep after startup is silent by construction
-    /// (startup storm guard), and files entering the graph later start
-    /// tracking silently too.
+    /// (startup storm guard). One exception: a file whose index shard
+    /// exists but no longer matches the disk changed before the seed
+    /// could see it, and that change still needs dispatching.
     ///
     /// Stats run synchronously in batches, yielding to the event loop
     /// between batches; each round's duration is perf-logged.
@@ -70,15 +109,6 @@ public:
     kota::task<llvm::SmallVector<FileEvent>> tick_workspace();
 
 private:
-    /// (existence, size, mtime) identity of the CDB file.
-    struct CDBStamp {
-        bool exists = false;
-        std::uint64_t size = 0;
-        std::int64_t mtime_ns = 0;
-
-        friend bool operator==(const CDBStamp&, const CDBStamp&) = default;
-    };
-
     CDBStamp stat_cdb() const;
 
     /// Last-known on-disk state of a tracked file.

--- a/src/server/state/invalidator.cpp
+++ b/src/server/state/invalidator.cpp
@@ -182,13 +182,13 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                 // read settles it; an unreadable file counts as changed.
                 auto disk = read_file(workspace.path_pool.resolve(event.path_id));
                 if(!disk) {
-                    // Deleted while it was open: the tracker skips open
-                    // files, so this close is the first observation of the
-                    // missing file. Keep any shard serving (same deliberate
-                    // choice as DiskRemoved) instead of recording a
-                    // ContentChanged that would suppress it forever; the
-                    // tracker's next sweep observes the removal and delivers
-                    // the full DiskRemoved cascade.
+                    // Deleted while it was open: the sweep may already
+                    // have delivered DiskRemoved, but a close landing
+                    // before the next sweep is the first observation. Keep
+                    // any shard serving (same deliberate choice as
+                    // DiskRemoved) instead of recording a ContentChanged
+                    // that would suppress it forever; the sweep delivers
+                    // (or already delivered) the full removal cascade.
                     dirty.add_clear_reindex(event.path_id);
                     break;
                 }

--- a/src/server/state/invalidator.cpp
+++ b/src/server/state/invalidator.cpp
@@ -206,12 +206,15 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
             case FileEvent::Kind::DiskChanged: {
                 auto path_id = event.path_id;
                 if(store.find(path_id)) {
-                    // Open file: the buffer is the truth, so no disk rescan —
-                    // what the disk change means for this file is decided by
-                    // the next compile's deps validation. Recompile so that
-                    // validation actually runs. The shard describes the old
-                    // disk regardless of the buffer; queue its reindex like
-                    // a save (skipped-and-repaired-on-close without agents).
+                    // Open file: the buffer stays the truth for its own
+                    // compile — what the disk change means for it is
+                    // decided by the next compile's deps validation, so
+                    // recompile to make that validation run. Dependents
+                    // read the disk, never the buffer, so the change
+                    // cascades to them exactly like a save. The shard
+                    // describes the old disk regardless of the buffer;
+                    // queue its reindex.
+                    cascade_disk_content_change(path_id, dirty);
                     dirty.mark_ast_dirty.push_back(path_id);
                     dirty.add_reindex_content_changed(path_id);
                     break;

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -130,7 +130,11 @@ void MasterServer::initialize() {
     if(!workspace_root.empty()) {
         // Construct after the workspace load so the tracker's baseline CDB
         // stamp matches the database that was just loaded.
-        tracker = std::make_unique<FileTracker>(workspace, sessions, workspace_root);
+        tracker = std::make_unique<FileTracker>(workspace,
+                                                sessions,
+                                                workspace_root,
+                                                consumed_cdb_path,
+                                                consumed_cdb_stamp);
         auto& tracker_cfg = workspace.config.tracker;
         if(*tracker_cfg.cdb_poll_seconds > 0) {
             bg_tasks.spawn(cdb_poll_task());
@@ -283,6 +287,28 @@ void MasterServer::on_agentic_query() {
 }
 
 void MasterServer::dispatch(llvm::ArrayRef<FileEvent> events) {
+    // A save that did not change the file's bytes must not cascade: vim's
+    // bare :w would otherwise dirty every dependent for nothing. The
+    // tracker's baseline knows the consumed content; reseeding it here
+    // also keeps the next sweep from re-reporting a real save as an
+    // external change. Without a tracker (no workspace) every save is
+    // conservatively treated as a change.
+    llvm::SmallVector<FileEvent> filtered;
+    if(tracker) {
+        for(auto& event: events) {
+            if(event.kind == FileEvent::Kind::BufferSaved && !tracker->reseed(event.path_id)) {
+                LOG_DEBUG("didSave without a content change, skipping cascade: {}",
+                          workspace.path_pool.resolve(event.path_id));
+                continue;
+            }
+            filtered.push_back(event);
+        }
+        if(filtered.empty() && !events.empty()) {
+            return;
+        }
+        events = filtered;
+    }
+
     auto dirty = invalidator.apply(events);
 
     for(auto path_id: dirty.reset_trial) {
@@ -483,6 +509,10 @@ void MasterServer::load_workspace() {
     }
 
     ScopedTimer cdb_timer;
+    // Stat before the read: the tracker's baseline must describe the
+    // content this load consumes (see FileTracker::stat_file).
+    consumed_cdb_path = cdb_path;
+    consumed_cdb_stamp = FileTracker::stat_file(cdb_path);
     auto count = workspace.cdb.load(cdb_path).value_or(0);
     LOG_INFO("Loaded CDB from {} with {} entries", cdb_path, count);
     LOG_PERF("startup", "phase=cdb_load entries={} elapsed_ms={}", count, cdb_timer.ms());

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -293,8 +293,12 @@ void MasterServer::dispatch(llvm::ArrayRef<FileEvent> events) {
     // also keeps the next sweep from re-reporting a real save as an
     // external change. Without a tracker (no workspace) every save is
     // conservatively treated as a change.
+    // Single pass on purpose: reseed is a read-modify-write of the
+    // baseline, so it must run exactly once per save — a probing pre-pass
+    // would absorb a real change and then drop its event.
     llvm::SmallVector<FileEvent> filtered;
     if(tracker) {
+        filtered.reserve(events.size());
         for(auto& event: events) {
             if(event.kind == FileEvent::Kind::BufferSaved && !tracker->reseed(event.path_id)) {
                 LOG_DEBUG("didSave without a content change, skipping cascade: {}",

--- a/src/server/transport/master_server.h
+++ b/src/server/transport/master_server.h
@@ -12,6 +12,7 @@
 #include "server/service/feature_router.h"
 #include "server/service/query.h"
 #include "server/state/config.h"
+#include "server/state/file_tracker.h"
 #include "server/state/invalidator.h"
 #include "server/state/session.h"
 #include "server/state/session_store.h"
@@ -26,8 +27,6 @@
 #include "llvm/ADT/StringRef.h"
 
 namespace clice {
-
-class FileTracker;
 
 namespace deco = kota::deco;
 
@@ -157,6 +156,12 @@ public:
     /// workspace-less sessions); its polling loops run in bg_tasks, and the
     /// clice/internal/poll test hook drives ticks directly.
     std::unique_ptr<FileTracker> tracker;
+
+    /// The compile_commands.json path and pre-read stamp of the load the
+    /// current CDB entries came from; seeds the tracker's baseline (see
+    /// FileTracker::stat_file).
+    std::string consumed_cdb_path;
+    FileTracker::CDBStamp consumed_cdb_stamp;
 
     /// Wakes subscribers after a new message landed in notify_log. Pure
     /// wake-up per the Signal contract: subscribers keep a sequence cursor

--- a/tests/integration/features/test_file_tracker.py
+++ b/tests/integration/features/test_file_tracker.py
@@ -232,9 +232,6 @@ async def test_cdb_flag_change_reindexes_closed(client, tmp_path):
 
 
 async def test_open_file_disk_change_tracked(client, tmp_path):
-    """An external disk write to an OPEN file must emit an event: the open
-    buffer stays the truth for its own compile, but dependents read the
-    disk and their state must cascade (F47)."""
     (tmp_path / "header.h").write_text(HEADER_V1, newline="\n")
     (tmp_path / "main.cpp").write_text(
         '#include "header.h"\nint use() { return alpha(); }\n', newline="\n"
@@ -274,10 +271,6 @@ async def test_open_file_disk_change_tracked(client, tmp_path):
 
 
 async def test_pre_seed_edit_reindexed(client, tmp_path):
-    """A disk edit landing after startup indexing but before the first
-    workspace sweep must not be absorbed as the baseline (F53): the shard
-    records what indexing consumed, and a mismatch at seed time is a
-    change like any other."""
     (tmp_path / "lib.cpp").write_text(
         "int original_symbol() { return 1; }\n", newline="\n"
     )
@@ -301,9 +294,35 @@ async def test_pre_seed_edit_reindexed(client, tmp_path):
     )
 
 
+async def test_pre_seed_header_edit_cascades(client, tmp_path):
+    (tmp_path / "dep.h").write_text(
+        "inline int dep_original() { return 1; }\n", newline="\n"
+    )
+    (tmp_path / "user.cpp").write_text(
+        '#include "dep.h"\nint use() { return dep_original(); }\n', newline="\n"
+    )
+    (tmp_path / "probe.cpp").write_text("int probe() { return 0; }\n", newline="\n")
+    write_cdb(tmp_path, ["user.cpp", "probe.cpp"])
+    await client.initialize(tmp_path)
+
+    probe_uri, _ = await client.open_and_wait(tmp_path / "probe.cpp")
+    assert await wait_for_index(client, probe_uri, "dep_original"), "initial index"
+
+    # A pre-seed HEADER edit has no CDB entry of its own: it must reach
+    # the including TU through that TU's shard dep hashes.
+    await asyncio.sleep(MTIME_GRANULARITY)
+    (tmp_path / "dep.h").write_text(
+        "inline int dep_renamed() { return 1; }\n", newline="\n"
+    )
+    assert await events_of(client, "workspace") == 1, (
+        "the including TU must be dispatched for the pre-seed header edit"
+    )
+    assert await wait_for_index(client, probe_uri, "dep_renamed"), (
+        "the header edit must be reindexed through its including TU"
+    )
+
+
 async def test_noop_save_no_cascade(client, tmp_path):
-    """A save that does not change the header's bytes (vim :w) must not
-    dirty its dependents (F46): the tracker baseline knows the content."""
     (tmp_path / "header.h").write_text(HEADER_V1, newline="\n")
     (tmp_path / "dep.cpp").write_text(
         '#include "header.h"\nint dep_use() { return alpha(); }\n', newline="\n"

--- a/tests/integration/features/test_file_tracker.py
+++ b/tests/integration/features/test_file_tracker.py
@@ -4,6 +4,9 @@ seeds the stat baseline, so tests poll once before mutating the disk."""
 
 import asyncio
 
+import pytest
+from lsprotocol.types import DidSaveTextDocumentParams, TextDocumentIdentifier
+
 from tests.tools.compile_commands import write_cdb
 from tests.tools.checks import (
     assert_has_errors,
@@ -226,3 +229,95 @@ async def test_cdb_flag_change_reindexes_closed(client, tmp_path):
     assert await wait_for_index(client, main_uri, "feature_on"), (
         "closed file was not reindexed after its flags changed"
     )
+
+
+async def test_open_file_disk_change_tracked(client, tmp_path):
+    """An external disk write to an OPEN file must emit an event: the open
+    buffer stays the truth for its own compile, but dependents read the
+    disk and their state must cascade (F47)."""
+    (tmp_path / "header.h").write_text(HEADER_V1, newline="\n")
+    (tmp_path / "main.cpp").write_text(
+        '#include "header.h"\nint use() { return alpha(); }\n', newline="\n"
+    )
+    (tmp_path / "closed.cpp").write_text(
+        '#include "header.h"\nint closed_use() { return alpha(); }\n', newline="\n"
+    )
+    write_cdb(tmp_path, ["main.cpp", "closed.cpp"])
+    await client.initialize(tmp_path)
+
+    main_uri, _ = await client.open_and_wait(tmp_path / "main.cpp")
+    assert await wait_for_index(client, main_uri, "closed_use"), "initial index"
+    header_uri, _ = await client.open_and_wait(tmp_path / "header.h")
+
+    assert await events_of(client, "workspace") == 0  # seeding sweep
+
+    # git-checkout style: rewrite the OPEN header on disk, no didSave.
+    await asyncio.sleep(MTIME_GRANULARITY)
+    (tmp_path / "header.h").write_text(
+        "inline int renamed_alpha() { return 1; }\n", newline="\n"
+    )
+    assert await events_of(client, "workspace") == 1, (
+        "the open file's disk change must not be swallowed"
+    )
+
+    # Open dependent was cascaded: its next pull sees the missing symbol.
+    await wait_for_recompile(client, main_uri)
+    assert_has_errors(client, main_uri, "open dependent must see the disk rename")
+
+    # Closed dependent's shard was requeued: the new symbol lands. Close
+    # the header first — an open dirty file's own shard is skipped by the
+    # freshness contract, which would hide the definition it carries.
+    client.close(header_uri)
+    assert await wait_for_index(client, main_uri, "renamed_alpha"), (
+        "closed dependent's index must catch up with the disk"
+    )
+
+
+async def test_pre_seed_edit_reindexed(client, tmp_path):
+    """A disk edit landing after startup indexing but before the first
+    workspace sweep must not be absorbed as the baseline (F53): the shard
+    records what indexing consumed, and a mismatch at seed time is a
+    change like any other."""
+    (tmp_path / "lib.cpp").write_text(
+        "int original_symbol() { return 1; }\n", newline="\n"
+    )
+    (tmp_path / "probe.cpp").write_text("int probe() { return 0; }\n", newline="\n")
+    write_cdb(tmp_path, ["lib.cpp", "probe.cpp"])
+    await client.initialize(tmp_path)
+
+    probe_uri, _ = await client.open_and_wait(tmp_path / "probe.cpp")
+    assert await wait_for_index(client, probe_uri, "original_symbol"), "initial index"
+
+    # The edit lands before any tracker tick: the first sweep would seed it.
+    await asyncio.sleep(MTIME_GRANULARITY)
+    (tmp_path / "lib.cpp").write_text(
+        "int renamed_symbol() { return 1; }\n", newline="\n"
+    )
+    assert await events_of(client, "workspace") == 1, (
+        "the pre-seed edit must be dispatched, not seeded away"
+    )
+    assert await wait_for_index(client, probe_uri, "renamed_symbol"), (
+        "the pre-seed edit must be reindexed"
+    )
+
+
+async def test_noop_save_no_cascade(client, tmp_path):
+    """A save that does not change the header's bytes (vim :w) must not
+    dirty its dependents (F46): the tracker baseline knows the content."""
+    (tmp_path / "header.h").write_text(HEADER_V1, newline="\n")
+    (tmp_path / "dep.cpp").write_text(
+        '#include "header.h"\nint dep_use() { return alpha(); }\n', newline="\n"
+    )
+    write_cdb(tmp_path, ["dep.cpp"])
+    await client.initialize(tmp_path)
+
+    dep_uri, _ = await client.open_and_wait(tmp_path / "dep.cpp")
+    header_uri, _ = await client.open_and_wait(tmp_path / "header.h")
+    assert await events_of(client, "workspace") == 0  # seeding sweep
+
+    # Save without any change: nothing may recompile.
+    client.text_document_did_save(
+        DidSaveTextDocumentParams(text_document=TextDocumentIdentifier(uri=header_uri))
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await wait_for_recompile(client, dep_uri, timeout=3.0)

--- a/tests/integration/server/test_memory_ownership.py
+++ b/tests/integration/server/test_memory_ownership.py
@@ -113,8 +113,16 @@ async def test_save_writes_only_dirty_shards(client, tmp_path):
     )
 
     # A round with nothing to write commits zero shards: saving the open
-    # file schedules a round, but its shard is served by the session and
-    # background indexing skips open files.
+    # file (with a real change — an unchanged save is dropped outright)
+    # schedules a round, but background indexing skips open files.
+    changed = "int func_0_changed() { return 0; }\n"
+    (tmp_path / "file0.cpp").write_text(changed)
+    client.text_document_did_change(
+        DidChangeTextDocumentParams(
+            text_document=VersionedTextDocumentIdentifier(uri=uri, version=2),
+            content_changes=[TextDocumentContentChangeWholeDocument(text=changed)],
+        )
+    )
     client.text_document_did_save(
         DidSaveTextDocumentParams(text_document=TextDocumentIdentifier(uri=uri))
     )

--- a/tests/unit/server/file_tracker_tests.cpp
+++ b/tests/unit/server/file_tracker_tests.cpp
@@ -8,6 +8,48 @@ namespace {
 
 TEST_SUITE(FileTracker) {
 
+TEST_CASE(StaleConsumedStampReloads) {
+    TempDir tmp;
+    tmp.touch("main.cpp", R"(int main() {})");
+    tmp.touch("lib.cpp", R"(int lib() { return 1; })");
+
+    Workspace workspace;
+    SessionStore store;
+
+    // The loader's sequence: stat first, then read. A rewrite landing
+    // between the read and the tracker's construction must look like a
+    // change against the consumed stamp — statting at construction time
+    // instead would absorb it and never reload (F03).
+    write_cdb(tmp,
+              workspace.cdb,
+              build_cdb_json({
+                  {tmp.root, tmp.path("main.cpp"), {}}
+    }));
+    auto consumed = FileTracker::stat_file(tmp.path("compile_commands.json"));
+
+    // The rewrite: lands after the load, before the tracker exists. The
+    // extra entry changes the file size, so the stamp differs from the
+    // consumed one regardless of mtime granularity.
+    tmp.touch("compile_commands.json",
+              build_cdb_json({
+                  {tmp.root, tmp.path("main.cpp"), {}},
+                  {tmp.root, tmp.path("lib.cpp"),  {}}
+    }));
+
+    FileTracker tracker(workspace,
+                        store,
+                        tmp.root.str().str(),
+                        tmp.path("compile_commands.json"),
+                        consumed);
+
+    // Two natural (unforced) ticks: settle, then reload.
+    ASSERT_TRUE(tracker.tick_cdb().empty());
+    auto events = tracker.tick_cdb();
+    ASSERT_EQ(events.size(), 1u);
+    ASSERT_EQ(events[0].kind, FileEvent::Kind::CDBChanged);
+    ASSERT_EQ(events[0].cdb.added.size(), 1u);
+}
+
 TEST_CASE(CDBTickDebounces) {
     TempDir tmp;
     tmp.touch("main.cpp", R"(int main() {})");
@@ -20,7 +62,7 @@ TEST_CASE(CDBTickDebounces) {
               build_cdb_json({
                   {tmp.root, tmp.path("main.cpp"), {}}
     }));
-    FileTracker tracker(workspace, store, tmp.root.str().str());
+    FileTracker tracker(workspace, store, tmp.root.str().str(), "", {});
 
     // Rewrite with one more entry: the first tick only records the pending
     // stamp, the second sees it stable and reloads.
@@ -53,7 +95,7 @@ TEST_CASE(CDBTickForceImmediate) {
               build_cdb_json({
                   {tmp.root, tmp.path("main.cpp"), {}}
     }));
-    FileTracker tracker(workspace, store, tmp.root.str().str());
+    FileTracker tracker(workspace, store, tmp.root.str().str(), "", {});
 
     tmp.touch("compile_commands.json",
               build_cdb_json({
@@ -72,7 +114,7 @@ TEST_CASE(CDBTickDiscoversLate) {
     Workspace workspace;
     SessionStore store;
     // No compile_commands.json at construction time.
-    FileTracker tracker(workspace, store, tmp.root.str().str());
+    FileTracker tracker(workspace, store, tmp.root.str().str(), "", {});
     ASSERT_TRUE(tracker.tick_cdb(/*force=*/true).empty());
 
     tmp.touch("compile_commands.json",
@@ -96,7 +138,7 @@ TEST_CASE(CDBTickDeleteRecreate) {
               build_cdb_json({
                   {tmp.root, tmp.path("main.cpp"), {}}
     }));
-    FileTracker tracker(workspace, store, tmp.root.str().str());
+    FileTracker tracker(workspace, store, tmp.root.str().str(), "", {});
 
     // Deletion (mid-regeneration): keep serving the loaded entries.
     fs::remove_all(tmp.path("compile_commands.json"));
@@ -124,7 +166,7 @@ TEST_CASE(WorkspaceTickStateMachine) {
     auto header = workspace.path_pool.intern(tmp.path("header.h"));
     workspace.dep_graph.set_includes(tu, 0, {header});
     workspace.dep_graph.build_reverse_map();
-    FileTracker tracker(workspace, store, tmp.root.str().str());
+    FileTracker tracker(workspace, store, tmp.root.str().str(), "", {});
 
     auto body = [&]() -> kota::task<> {
         // First sweep seeds the baseline silently, even though main.cpp is
@@ -174,7 +216,7 @@ TEST_CASE(WorkspaceTickStateMachine) {
     loop.run();
 }
 
-TEST_CASE(WorkspaceTickSkipsOpen) {
+TEST_CASE(OpenFileChangeTracked) {
     TempDir tmp;
     tmp.touch("header.h", R"(int x = 1;)");
 
@@ -185,14 +227,29 @@ TEST_CASE(WorkspaceTickSkipsOpen) {
     workspace.dep_graph.set_includes(header, 0, {});
     workspace.dep_graph.build_reverse_map();
     store.open(header);
-    FileTracker tracker(workspace, store, tmp.root.str().str());
+    FileTracker tracker(workspace, store, tmp.root.str().str(), "", {});
 
     auto body = [&]() -> kota::task<> {
         EXPECT_TRUE((co_await tracker.tick_workspace()).empty());
 
-        // The open buffer is the truth: its disk changes are not tracked.
+        // The open buffer stays the truth for its own compile, but the
+        // disk change matters to dependents (they read the disk) — it
+        // must be tracked and dispatched, not swallowed.
         tmp.touch("header.h", R"(int x = 2;)");
+        auto events = co_await tracker.tick_workspace();
+        EXPECT_EQ(events.size(), 1u);
+        if(!events.empty()) {
+            EXPECT_EQ(events[0].kind, FileEvent::Kind::DiskChanged);
+            EXPECT_EQ(events[0].path_id, header);
+        }
+
+        // A didSave reseed absorbs the editor's own write silently.
+        tmp.touch("header.h", R"(int x = 3;)");
+        EXPECT_TRUE(tracker.reseed(header));
         EXPECT_TRUE((co_await tracker.tick_workspace()).empty());
+
+        // And a reseed over unchanged bytes reports no change.
+        EXPECT_FALSE(tracker.reseed(header));
     };
     auto task = body();
     loop.schedule(task);

--- a/tests/unit/server/invalidator_tests.cpp
+++ b/tests/unit/server/invalidator_tests.cpp
@@ -356,15 +356,16 @@ TEST_CASE(DiskChangeOpenMarksDirty) {
     Invalidator invalidator(workspace, store, resolver);
     auto dirty = invalidator.apply(FileEvent::disk_changed(open_file));
 
-    // The buffer is the truth for an open file: recompile so the next
-    // compile's deps validation judges the disk change, but no rescan and
-    // no cascade. The file's shard describes the old disk, so its reindex
-    // queues alongside (skipped while open-file indexing is off).
+    // The buffer stays the truth for the open file's own compile (its
+    // recompile lets deps validation judge the disk change), but the
+    // change cascades like a save: dependents read the disk, and the
+    // file's own trial state re-earns. The shard describes the old disk,
+    // so its reindex queues alongside.
     ASSERT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<std::uint32_t>{open_file});
     ASSERT_EQ(dirty.reindex_content_changed, llvm::SmallVector<std::uint32_t>{open_file});
     ASSERT_TRUE(dirty.reindex_deps_only.empty());
-    ASSERT_TRUE(dirty.reset_trial.empty());
-    ASSERT_FALSE(dirty.recheck_contexts);
+    ASSERT_EQ(dirty.reset_trial, llvm::SmallVector<std::uint32_t>{open_file});
+    ASSERT_EQ(dirty.reset_header_mode, llvm::SmallVector<std::uint32_t>{open_file});
 }
 
 TEST_CASE(DiskChangeClosedCascades) {

--- a/tests/unit/server/invalidator_tests.cpp
+++ b/tests/unit/server/invalidator_tests.cpp
@@ -366,6 +366,7 @@ TEST_CASE(DiskChangeOpenMarksDirty) {
     ASSERT_TRUE(dirty.reindex_deps_only.empty());
     ASSERT_EQ(dirty.reset_trial, llvm::SmallVector<std::uint32_t>{open_file});
     ASSERT_EQ(dirty.reset_header_mode, llvm::SmallVector<std::uint32_t>{open_file});
+    ASSERT_TRUE(dirty.recheck_contexts);
 }
 
 TEST_CASE(DiskChangeClosedCascades) {


### PR DESCRIPTION
## Background

The file tracker's baseline was a stamp gate seeded from whatever its first look at a file happened to see — never from the content the server actually consumed. Three lost-event holes shared that root cause:

- **Open files were unmonitored.** The workspace sweep skipped them and erased their baseline outright (an acknowledged TODO). A git checkout or code generator rewriting an open header emitted nothing: the open file itself never learned of the change, and closed dependents' index shards stayed stale for the rest of the session.
- **The first sweep absorbed earlier changes.** An edit landing between startup indexing and the first sweep became the baseline itself: the old symbols kept serving for the whole session.
- **A CDB rewrite in the startup window was lost permanently.** The tracker stat'd the database after the workspace load; a rewrite landing in between recorded the new stamp while memory held the old commands, so no later poll ever reloaded (reproduced deterministically at rewrite delays up to ~30ms).

A fourth, adjacent waste: a save that changed nothing (a bare `:w`) still ran the full invalidation cascade over every dependent.

## Changes

- The sweep now tracks open files like any other: an external write emits DiskChanged, and the invalidator cascades it to dependents exactly like a save — dependents read the disk, never the buffer, while the open file's own compile still lets its dependency validation judge the change. `didSave` keeps the baseline in step through the new `reseed()`, so the editor's own writes are absorbed silently.
- `reseed()` also reports whether the saved bytes actually differ, and the dispatcher drops unchanged saves outright — no more cascade for a no-op save. The filter is deliberately single-pass: reseeding is a read-modify-write, so it runs exactly once per save.
- First-sight seeding cross-checks CDB sources against their index shard (shards carry the consumed content hashes): a mismatch means the change predates the seed, and it is dispatched instead of becoming the baseline. Header edits in the same window reach their including TUs through those dep hashes.
- The CDB baseline stamp now describes the content the load consumed: the loader stats the file before reading it and hands the stamp to the tracker. The reversed race costs one spurious reload with an empty diff — the safe direction.

## Testing

All verified red before the fix (TDD): an external rewrite of an open header emits an event, cascades errors into an open dependent, and requeues the closed dependent's shard; a pre-seed rename is dispatched and reindexed (both directly for a source and transitively for a header via its including TU); an unchanged save recompiles nothing (bounded negative wait). Unit tests pin the consumed-stamp reload, the open-file tracking round-trip (including reseed's silent absorb and no-change report), and the cascade effects of the open-file disk change. Full suites green in RelWithDebInfo and Debug (1021 unit, 303 integration, 3/3 smoke).

## Notes

- The first sweep now runs the shard staleness check for CDB sources it sees for the first time — cold-start-only synchronous I/O, in line with the startup indexer's own checks; flagged for observation on very large projects.
- Query-side freshness semantics (an open dirty file's shard being skipped by the freshness contract) are untouched and tracked separately in the ledger.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * External changes to open files are now detected and propagated to dependent files.
  * Changes made before workspace tracking begins are no longer missed.
  * Saved files with unchanged content no longer trigger unnecessary recompilation or indexing.
  * Dependent files are refreshed when header changes affect their indexed results.

* **Improvements**
  * Compile database updates are detected more reliably, including changes during startup.
  * Open-file behavior now keeps editor content authoritative while still tracking relevant disk changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->