### PR TITLE
fix(release): upload vsix to release before marketplace publish

### DIFF
--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -146,15 +146,6 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Publish to Marketplace
-        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || inputs.release_tag != '' }}
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: |
-          FLAG="${{ (inputs.prerelease || contains(github.ref_name, '-')) && '--pre-release' || '' }}"
-          pixi run publish-vscode -p "$VSCE_PAT" $FLAG \
-            --packagePath "$GITHUB_WORKSPACE/$(ls editors/vscode/*.vsix)"
-
       - name: Upload .vsix to Release
         uses: softprops/action-gh-release@v3
         if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || inputs.release_tag != '' }}
@@ -163,3 +154,12 @@ jobs:
           tag_name: ${{ inputs.release_tag || github.ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to Marketplace
+        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || inputs.release_tag != '' }}
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          FLAG="${{ (inputs.prerelease || contains(github.ref_name, '-')) && '--pre-release' || '' }}"
+          pixi run publish-vscode -p "$VSCE_PAT" $FLAG \
+            --packagePath "$GITHUB_WORKSPACE/$(ls editors/vscode/*.vsix)"


### PR DESCRIPTION
The first nightly (v0.1.26071809) uploaded all 12 server assets but lost its 6 vsix release assets: the Marketplace publish step failed on a missing VSCE_PAT and blocked the subsequent release-asset upload. Reordering makes the GitHub release complete regardless of Marketplace credential state; the Marketplace step still fails visibly when the PAT is absent or invalid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow so the VS Code extension is uploaded to the release before being published to the marketplace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->