### PR TITLE
feat(server): discoverable log location and config dump

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -64,8 +64,10 @@ nightly orchestration) is release-time-only.
 
 ## Crash log support
 
-Ask the user for the log (worker `.log` from the workspace `.clice/logs/` or
-the cache dir). The crash section starts with `clice <version> <target>` —
+Ask the user for the log (worker `.log` from the session log directory —
+printed at startup in the editor's clice output panel, by default
+`~/.cache/clice/<workspace>-<hash>/logs/<session>/`, falling back to the
+workspace `.clice/logs/` when no home directory is available). The crash section starts with `clice <version> <target>` —
 download that release's `*.symbols.tar.xz` (GSYM) and run:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The versioning rule is the VS Code Marketplace convention: **even minor = stable
 
 For the freshest bits, every green [`main` CI run](https://github.com/clice-io/clice/actions/workflows/main.yml?query=branch%3Amain+is%3Asuccess) attaches installable artifacts (binaries and platform vsix) to its run page, so a fix can be tried the moment it merges (GitHub login required for artifact downloads).
 
-Each release also ships `*.symbols` packages: if clice crashes, attach the newest log from your workspace's `.clice/logs/` to an issue and the matching symbols let us reconstruct the exact stack.
+Each release also ships `*.symbols` packages: if clice crashes, attach the newest server log to an issue and the matching symbols let us reconstruct the exact stack. The log location is printed at startup in your editor's clice output panel (`Session log directory:` — by default under `~/.cache/clice/<workspace>-<hash>/logs/`).
 
 ### Editor Setup
 

--- a/docs/clice.toml
+++ b/docs/clice.toml
@@ -14,11 +14,12 @@ clang_tidy = false
 # exceeds this limit, the least recently used files will be removed.
 # The default value is 8.
 max_active_file = 8
-# Directory for storing on-disk caches (PCH, PCM and index files) and logs.
-# When unset, clice defaults to a per-workspace directory under the XDG
-# cache: ~/.cache/clice/<workspace>-<hash>, with logs in its logs/
-# subdirectory. The values below relocate both into the workspace instead.
-cache_dir = "${workspace}/.clice/cache"
+# clice's per-workspace data root: caches are stored in its cache/
+# subdirectory (PCH, PCM and index files) and logs in logs/ (unless
+# logging_dir overrides that). When unset, clice defaults to an XDG
+# directory: ~/.cache/clice/<workspace>-<hash>. The values below relocate
+# everything into the workspace instead.
+cache_dir = "${workspace}/.clice"
 logging_dir = "${workspace}/.clice/logs"
 # Compile commands files or directories to search for compile_commands.json files.
 compile_commands_paths = ["${workspace}/build"]

--- a/docs/clice.toml
+++ b/docs/clice.toml
@@ -16,7 +16,7 @@ clang_tidy = false
 max_active_file = 8
 # Directory for storing on-disk caches (PCH, PCM and index files) and logs.
 # When unset, clice defaults to a per-workspace directory under the XDG
-# cache: ~/.cache/clice/<workspace-name>-<hash>, with logs in its logs/
+# cache: ~/.cache/clice/<workspace>-<hash>, with logs in its logs/
 # subdirectory. The values below relocate both into the workspace instead.
 cache_dir = "${workspace}/.clice/cache"
 logging_dir = "${workspace}/.clice/logs"

--- a/docs/clice.toml
+++ b/docs/clice.toml
@@ -14,7 +14,10 @@ clang_tidy = false
 # exceeds this limit, the least recently used files will be removed.
 # The default value is 8.
 max_active_file = 8
-# Directory for storing on-disk caches (PCH, PCM and index files).
+# Directory for storing on-disk caches (PCH, PCM and index files) and logs.
+# When unset, clice defaults to a per-workspace directory under the XDG
+# cache: ~/.cache/clice/<workspace-name>-<hash>, with logs in its logs/
+# subdirectory. The values below relocate both into the workspace instead.
 cache_dir = "${workspace}/.clice/cache"
 logging_dir = "${workspace}/.clice/logs"
 # Compile commands files or directories to search for compile_commands.json files.

--- a/docs/clice.toml
+++ b/docs/clice.toml
@@ -14,12 +14,11 @@ clang_tidy = false
 # exceeds this limit, the least recently used files will be removed.
 # The default value is 8.
 max_active_file = 8
-# clice's per-workspace data root: caches are stored in its cache/
-# subdirectory (PCH, PCM and index files) and logs in logs/ (unless
-# logging_dir overrides that). When unset, clice defaults to an XDG
-# directory: ~/.cache/clice/<workspace>-<hash>. The values below relocate
-# everything into the workspace instead.
-cache_dir = "${workspace}/.clice"
+# Directory for storing on-disk caches (PCH, PCM and index files) and logs.
+# When unset, clice defaults to a per-workspace directory under the XDG
+# cache: ~/.cache/clice/<workspace>-<hash>, with logs in its logs/
+# subdirectory. The values below relocate both into the workspace instead.
+cache_dir = "${workspace}/.clice/cache"
 logging_dir = "${workspace}/.clice/logs"
 # Compile commands files or directories to search for compile_commands.json files.
 compile_commands_paths = ["${workspace}/build"]

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -32,11 +32,11 @@ Maximum number of active files to keep in memory. **Not yet wired** — the opti
 
 ### `project.cache_dir`
 
-| Type     | Default                                                 |
-| -------- | ------------------------------------------------------- |
-| `string` | `$XDG_CACHE_HOME/clice/<hash>` or `${workspace}/.clice` |
+| Type     | Default                                                        |
+| -------- | -------------------------------------------------------------- |
+| `string` | `$XDG_CACHE_HOME/clice/<name>-<hash>` or `${workspace}/.clice` |
 
-Directory for the unified on-disk cache (PCH, PCM, and index artifacts all live here). The default uses XDG_CACHE_HOME (or `~/.cache`) with a workspace-specific hash subdirectory. Falls back to `${workspace}/.clice` if the XDG directory cannot be created.
+Directory for the unified on-disk cache (PCH, PCM, and index artifacts all live here). The default uses XDG_CACHE_HOME (or `~/.cache`) with a per-workspace subdirectory named after the workspace directory plus a short hash, e.g. `~/.cache/clice/myproject-1a2b3c4d`. Falls back to `${workspace}/.clice` if the XDG directory cannot be created. The resolved paths are printed at startup in the effective configuration dump (visible in your editor's clice output panel).
 
 ### `project.logging_dir`
 
@@ -44,7 +44,7 @@ Directory for the unified on-disk cache (PCH, PCM, and index artifacts all live 
 | -------- | ------------------- |
 | `string` | `${cache_dir}/logs` |
 
-Directory for log files.
+Directory for log files. Each server session logs into its own timestamped subdirectory; the startup log line `Session log directory:` shows the exact path.
 
 ### `project.compile_commands_paths`
 

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -32,9 +32,9 @@ Maximum number of active files to keep in memory. **Not yet wired** — the opti
 
 ### `project.cache_dir`
 
-| Type     | Default                                                        |
-| -------- | -------------------------------------------------------------- |
-| `string` | `$XDG_CACHE_HOME/clice/<name>-<hash>` or `${workspace}/.clice` |
+| Type     | Default                                                             |
+| -------- | ------------------------------------------------------------------- |
+| `string` | `$XDG_CACHE_HOME/clice/<workspace>-<hash>` or `${workspace}/.clice` |
 
 Directory for the unified on-disk cache (PCH, PCM, and index artifacts all live here). The default uses XDG_CACHE_HOME (or `~/.cache`) with a per-workspace subdirectory named after the workspace directory plus a short hash, e.g. `~/.cache/clice/myproject-1a2b3c4d`. Falls back to `${workspace}/.clice` if the XDG directory cannot be created. The resolved paths are printed at startup in the effective configuration dump (visible in your editor's clice output panel).
 

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -36,7 +36,7 @@ Maximum number of active files to keep in memory. **Not yet wired** — the opti
 | -------- | ------------------------------------------------------------------- |
 | `string` | `$XDG_CACHE_HOME/clice/<workspace>-<hash>` or `${workspace}/.clice` |
 
-Directory for the unified on-disk cache (PCH, PCM, and index artifacts all live here). The default uses XDG_CACHE_HOME (or `~/.cache`) with a per-workspace subdirectory named after the workspace directory plus a short hash, e.g. `~/.cache/clice/myproject-1a2b3c4d`. Falls back to `${workspace}/.clice` if the XDG directory cannot be created. The resolved paths are printed at startup in the effective configuration dump (visible in your editor's clice output panel).
+clice's per-workspace data root: PCH, PCM, and index artifacts are stored in its `cache/` subdirectory, logs in `logs/` (unless `logging_dir` overrides that). The default uses XDG_CACHE_HOME (or `~/.cache`) with a per-workspace subdirectory named after the workspace directory plus a short hash, e.g. `~/.cache/clice/myproject-1a2b3c4d`. Falls back to `${workspace}/.clice` if the XDG directory cannot be created. The resolved paths are printed at startup in the effective configuration dump (visible in your editor's clice output panel).
 
 ### `project.logging_dir`
 

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -36,7 +36,7 @@ Maximum number of active files to keep in memory. **Not yet wired** — the opti
 | -------- | ------------------------------------------------------------------- |
 | `string` | `$XDG_CACHE_HOME/clice/<workspace>-<hash>` or `${workspace}/.clice` |
 
-clice's per-workspace data root: PCH, PCM, and index artifacts are stored in its `cache/` subdirectory, logs in `logs/` (unless `logging_dir` overrides that). The default uses XDG_CACHE_HOME (or `~/.cache`) with a per-workspace subdirectory named after the workspace directory plus a short hash, e.g. `~/.cache/clice/myproject-1a2b3c4d`. Falls back to `${workspace}/.clice` if the XDG directory cannot be created. The resolved paths are printed at startup in the effective configuration dump (visible in your editor's clice output panel).
+Directory for the unified on-disk cache (PCH, PCM, and index artifacts all live here). The default uses XDG_CACHE_HOME (or `~/.cache`) with a per-workspace subdirectory named after the workspace directory plus a short hash, e.g. `~/.cache/clice/myproject-1a2b3c4d`. Falls back to `${workspace}/.clice` if the XDG directory cannot be created. The resolved paths are printed at startup in the effective configuration dump (visible in your editor's clice output panel).
 
 ### `project.logging_dir`
 

--- a/docs/zh/guide/configuration.md
+++ b/docs/zh/guide/configuration.md
@@ -32,11 +32,11 @@ clice 从工作区根目录的 `clice.toml` 中读取配置；若该文件不存
 
 ### `project.cache_dir`
 
-| 类型     | 默认值                                                  |
-| -------- | ------------------------------------------------------- |
-| `string` | `$XDG_CACHE_HOME/clice/<hash>` 或 `${workspace}/.clice` |
+| 类型     | 默认值                                                         |
+| -------- | -------------------------------------------------------------- |
+| `string` | `$XDG_CACHE_HOME/clice/<name>-<hash>` 或 `${workspace}/.clice` |
 
-统一磁盘缓存的存储目录（PCH、PCM 与索引产物都在这里）。默认使用 XDG_CACHE_HOME（或 `~/.cache`）下的工作区专用哈希子目录。如果 XDG 目录无法创建，则回退到 `${workspace}/.clice`。
+统一磁盘缓存的存储目录（PCH、PCM 与索引产物都在这里）。默认使用 XDG_CACHE_HOME（或 `~/.cache`）下以工作区目录名加短哈希命名的子目录，例如 `~/.cache/clice/myproject-1a2b3c4d`。如果 XDG 目录无法创建，则回退到 `${workspace}/.clice`。实际解析出的路径会在启动时的有效配置日志中打印（可在编辑器的 clice 输出面板查看）。
 
 ### `project.logging_dir`
 
@@ -44,7 +44,7 @@ clice 从工作区根目录的 `clice.toml` 中读取配置；若该文件不存
 | -------- | ------------------- |
 | `string` | `${cache_dir}/logs` |
 
-日志文件目录。
+日志文件目录。每个服务器会话在其中创建独立的时间戳子目录；启动日志中的 `Session log directory:` 一行给出确切路径。
 
 ### `project.compile_commands_paths`
 

--- a/docs/zh/guide/configuration.md
+++ b/docs/zh/guide/configuration.md
@@ -36,7 +36,7 @@ clice 从工作区根目录的 `clice.toml` 中读取配置；若该文件不存
 | -------- | ------------------------------------------------------------------- |
 | `string` | `$XDG_CACHE_HOME/clice/<workspace>-<hash>` 或 `${workspace}/.clice` |
 
-clice 的每工作区数据根目录：PCH、PCM 与索引产物存放在其 `cache/` 子目录，日志在 `logs/`（除非 `logging_dir` 另行指定）。默认使用 XDG_CACHE_HOME（或 `~/.cache`）下以工作区目录名加短哈希命名的子目录，例如 `~/.cache/clice/myproject-1a2b3c4d`。如果 XDG 目录无法创建，则回退到 `${workspace}/.clice`。实际解析出的路径会在启动时的有效配置日志中打印（可在编辑器的 clice 输出面板查看）。
+统一磁盘缓存的存储目录（PCH、PCM 与索引产物都在这里）。默认使用 XDG_CACHE_HOME（或 `~/.cache`）下以工作区目录名加短哈希命名的子目录，例如 `~/.cache/clice/myproject-1a2b3c4d`。如果 XDG 目录无法创建，则回退到 `${workspace}/.clice`。实际解析出的路径会在启动时的有效配置日志中打印（可在编辑器的 clice 输出面板查看）。
 
 ### `project.logging_dir`
 

--- a/docs/zh/guide/configuration.md
+++ b/docs/zh/guide/configuration.md
@@ -36,7 +36,7 @@ clice 从工作区根目录的 `clice.toml` 中读取配置；若该文件不存
 | -------- | ------------------------------------------------------------------- |
 | `string` | `$XDG_CACHE_HOME/clice/<workspace>-<hash>` 或 `${workspace}/.clice` |
 
-统一磁盘缓存的存储目录（PCH、PCM 与索引产物都在这里）。默认使用 XDG_CACHE_HOME（或 `~/.cache`）下以工作区目录名加短哈希命名的子目录，例如 `~/.cache/clice/myproject-1a2b3c4d`。如果 XDG 目录无法创建，则回退到 `${workspace}/.clice`。实际解析出的路径会在启动时的有效配置日志中打印（可在编辑器的 clice 输出面板查看）。
+clice 的每工作区数据根目录：PCH、PCM 与索引产物存放在其 `cache/` 子目录，日志在 `logs/`（除非 `logging_dir` 另行指定）。默认使用 XDG_CACHE_HOME（或 `~/.cache`）下以工作区目录名加短哈希命名的子目录，例如 `~/.cache/clice/myproject-1a2b3c4d`。如果 XDG 目录无法创建，则回退到 `${workspace}/.clice`。实际解析出的路径会在启动时的有效配置日志中打印（可在编辑器的 clice 输出面板查看）。
 
 ### `project.logging_dir`
 

--- a/docs/zh/guide/configuration.md
+++ b/docs/zh/guide/configuration.md
@@ -32,9 +32,9 @@ clice 从工作区根目录的 `clice.toml` 中读取配置；若该文件不存
 
 ### `project.cache_dir`
 
-| 类型     | 默认值                                                         |
-| -------- | -------------------------------------------------------------- |
-| `string` | `$XDG_CACHE_HOME/clice/<name>-<hash>` 或 `${workspace}/.clice` |
+| 类型     | 默认值                                                              |
+| -------- | ------------------------------------------------------------------- |
+| `string` | `$XDG_CACHE_HOME/clice/<workspace>-<hash>` 或 `${workspace}/.clice` |
 
 统一磁盘缓存的存储目录（PCH、PCM 与索引产物都在这里）。默认使用 XDG_CACHE_HOME（或 `~/.cache`）下以工作区目录名加短哈希命名的子目录，例如 `~/.cache/clice/myproject-1a2b3c4d`。如果 XDG 目录无法创建，则回退到 `${workspace}/.clice`。实际解析出的路径会在启动时的有效配置日志中打印（可在编辑器的 clice 输出面板查看）。
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -36,8 +36,10 @@ downloads live on the [GitHub releases and CI pages](https://github.com/clice-io
 
 ## Troubleshooting
 
-Server logs live in the `clice` output channel and in your workspace's
-`.clice/logs/`. If the server crashes, please attach the newest log there to a
+Server logs live in the `clice` output channel, which also prints the
+on-disk log directory at startup (`Session log directory:` — by default
+under `~/.cache/clice/<workspace>-<hash>/logs/`). If the server crashes,
+please attach the newest log from there to a
 [GitHub issue](https://github.com/clice-io/clice/issues) — releases ship
 symbol packages that let us reconstruct the exact stack.
 

--- a/src/server/state/config.cpp
+++ b/src/server/state/config.cpp
@@ -43,9 +43,14 @@ static std::string resolve_xdg_cache_dir(llvm::StringRef workspace_root) {
         return {};
     }
 
-    // Use a hash of workspace_root to create a unique subdirectory.
+    // "<basename>-<hash>": the basename lets users map cache directories
+    // back to their workspaces, the hash keeps same-named workspaces apart.
     auto hash = llvm::xxh3_64bits(workspace_root);
-    auto dir = path::join(base, "clice", std::format("{:016x}", hash));
+    std::string_view name = path::filename(workspace_root.rtrim("/\\"));
+    if(name.empty() || name == "." || name == "..")
+        name = "workspace";
+    auto dir =
+        path::join(base, "clice", std::format("{}-{:08x}", name, static_cast<std::uint32_t>(hash)));
 
     if(auto ec = llvm::sys::fs::create_directories(dir)) {
         LOG_WARN("Failed to create XDG cache directory {}: {}", dir, ec.message());

--- a/src/server/state/config.cpp
+++ b/src/server/state/config.cpp
@@ -55,6 +55,10 @@ static std::string resolve_xdg_cache_dir(llvm::StringRef workspace_root) {
         name = name.take_front(64);
         while(!name.empty() && (static_cast<unsigned char>(name.back()) & 0xC0) == 0x80)
             name = name.drop_back();
+        // A complete trailing character loses its continuation bytes above;
+        // drop its lead byte too rather than keep invalid UTF-8.
+        if(!name.empty() && static_cast<unsigned char>(name.back()) >= 0xC0)
+            name = name.drop_back();
     }
     auto dir =
         path::join(base, "clice", std::format("{}-{:08x}", name, static_cast<std::uint32_t>(hash)));

--- a/src/server/state/config.cpp
+++ b/src/server/state/config.cpp
@@ -46,7 +46,7 @@ static std::string resolve_xdg_cache_dir(llvm::StringRef workspace_root) {
     // "<basename>-<hash>": the basename lets users map cache directories
     // back to their workspaces, the hash keeps same-named workspaces apart.
     auto hash = llvm::xxh3_64bits(workspace_root);
-    std::string_view name = path::filename(workspace_root.rtrim("/\\"));
+    llvm::StringRef name = path::filename(workspace_root.rtrim("/\\"));
     if(name.empty() || name == "." || name == "..")
         name = "workspace";
     auto dir =

--- a/src/server/state/config.cpp
+++ b/src/server/state/config.cpp
@@ -49,6 +49,13 @@ static std::string resolve_xdg_cache_dir(llvm::StringRef workspace_root) {
     llvm::StringRef name = path::filename(workspace_root.rtrim("/\\"));
     if(name.empty() || name == "." || name == "..")
         name = "workspace";
+    // Keep the leaf well under filesystem name limits (255 bytes on common
+    // filesystems) without splitting a UTF-8 sequence mid-codepoint.
+    if(name.size() > 64) {
+        name = name.take_front(64);
+        while(!name.empty() && (static_cast<unsigned char>(name.back()) & 0xC0) == 0x80)
+            name = name.drop_back();
+    }
     auto dir =
         path::join(base, "clice", std::format("{}-{:08x}", name, static_cast<std::uint32_t>(hash)));
 

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -101,8 +101,9 @@ void MasterServer::initialize() {
         auto pid = llvm::sys::Process::getProcessId();
         session_log_dir =
             path::join(cfg.logging_dir, std::format("{:%Y-%m-%d_%H-%M-%S}_{}", now, pid));
-        logging::file_logger("master", session_log_dir, logging::options);
-        LOG_INFO("Session log directory: {}", session_log_dir);
+        if(logging::file_logger("master", session_log_dir, logging::options)) {
+            LOG_INFO("Session log directory: {}", session_log_dir);
+        }
     }
 
     // Dump every configuration layer — the config file verbatim, the

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -74,6 +74,16 @@ void MasterServer::initialize() {
                                                    &config_issues,
                                                    &config_path,
                                                    /*with_defaults=*/false);
+    // Capture the raw sources now: the configuration dump below can only run
+    // once the merged config has named the log directory.
+    std::string raw_toml;
+    if(!config_path.empty()) {
+        if(auto content = fs::read(config_path)) {
+            raw_toml = std::move(*content);
+        }
+    }
+    std::string raw_init_options = init_options_json;
+
     if(!init_options_json.empty()) {
         if(auto ov = kota::codec::json::parse(init_options_json, workspace.config); !ov) {
             LOG_GUIDANCE("Failed to apply initializationOptions: {}", ov.error().to_string());
@@ -95,9 +105,22 @@ void MasterServer::initialize() {
         LOG_INFO("Session log directory: {}", session_log_dir);
     }
 
-    // Dump the effective post-default configuration. The stderr mirror puts
-    // it in the editor's output panel — the one place users can discover the
-    // hashed cache/log location, and the first thing to ask for in reports.
+    // Dump every configuration layer — the config file verbatim, the
+    // client's initializationOptions overlay, and the merged result after
+    // defaults. Absence is stated explicitly so "was my config even read?"
+    // never needs a support round-trip; the stderr mirror puts all of it in
+    // the editor's output panel.
+    if(config_path.empty()) {
+        LOG_INFO("Configuration file: Missing");
+    } else {
+        LOG_INFO("Configuration file {}:\n{}", config_path, raw_toml);
+    }
+    if(raw_init_options.empty()) {
+        LOG_INFO("initializationOptions: Missing");
+    } else {
+        auto pretty = kota::codec::json::prettify(raw_init_options);
+        LOG_INFO("initializationOptions:\n{}", pretty ? *pretty : raw_init_options);
+    }
     if(auto json = kota::codec::json::to_string(workspace.config)) {
         auto pretty = kota::codec::json::prettify(*json);
         LOG_INFO("Effective configuration:\n{}", pretty ? *pretty : *json);

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -95,6 +95,14 @@ void MasterServer::initialize() {
         LOG_INFO("Session log directory: {}", session_log_dir);
     }
 
+    // Dump the effective post-default configuration. The stderr mirror puts
+    // it in the editor's output panel — the one place users can discover the
+    // hashed cache/log location, and the first thing to ask for in reports.
+    if(auto json = kota::codec::json::to_string(workspace.config)) {
+        auto pretty = kota::codec::json::prettify(*json);
+        LOG_INFO("Effective configuration:\n{}", pretty ? *pretty : *json);
+    }
+
     LOG_INFO("Server ready (stateful={}, stateless={}, idle={}ms)",
              cfg.stateful_worker_count.value,
              cfg.stateless_worker_count.value,

--- a/src/support/logging.cpp
+++ b/src/support/logging.cpp
@@ -51,13 +51,13 @@ void stderr_logger(std::string_view name, const Options& options) {
     spdlog::set_default_logger(std::move(logger));
 }
 
-void file_logger(std::string_view name,
+bool file_logger(std::string_view name,
                  std::string_view dir,
                  const Options& options,
                  bool mirror_stderr) {
     if(auto ec = llvm::sys::fs::create_directories(dir)) {
         spdlog::error("Failed to create log directory {}: {}", std::string(dir), ec.message());
-        return;
+        return false;
     }
     auto filepath = path::join(dir, std::format("{}.log", name));
     // Verify we can write to the file before constructing the sink.
@@ -67,7 +67,7 @@ void file_logger(std::string_view name,
         llvm::raw_fd_ostream test(filepath, ec, llvm::sys::fs::OF_Append);
         if(ec) {
             spdlog::error("Failed to open log file {}: {}", filepath, ec.message());
-            return;
+            return false;
         }
     }
     auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(filepath);
@@ -107,6 +107,7 @@ void file_logger(std::string_view name,
     }
 
     install_crash_handler(filepath, /*stderr_trace=*/mirror_stderr);
+    return true;
 }
 
 static std::unique_ptr<llvm::raw_fd_ostream> crash_log_stream;

--- a/src/support/logging.h
+++ b/src/support/logging.h
@@ -102,7 +102,9 @@ void stderr_logger(std::string_view name, const Options& options);
 /// With mirror_stderr, every line is also written to stderr — the master
 /// uses this so editors can show its log; workers must pass false (their
 /// stderr is reserved for crash output, relayed by the pool).
-void file_logger(std::string_view name,
+/// Returns false when the log directory or file cannot be set up — logging
+/// then stays on the previously installed sinks.
+bool file_logger(std::string_view name,
                  std::string_view dir,
                  const Options& options,
                  bool mirror_stderr = true);

--- a/tests/integration/lifecycle/test_config.py
+++ b/tests/integration/lifecycle/test_config.py
@@ -147,5 +147,8 @@ async def test_config_dump_logged(executable, tmp_path):
     assert logs, "expected a master.log"
     text = "".join(logs)
     assert "Session log directory:" in text
+    # All three config layers are dumped: file, overlay, merged result.
+    assert "Configuration file" in text
+    assert "initializationOptions" in text
     assert "Effective configuration:" in text
     assert '"cache_dir"' in text

--- a/tests/integration/lifecycle/test_config.py
+++ b/tests/integration/lifecycle/test_config.py
@@ -130,3 +130,22 @@ async def test_config_diagnostic_clears_after_fix(executable, tmp_path):
         assert_no_anomaly(client, tmp_path)
     finally:
         await shutdown_client(client)
+
+
+async def test_config_dump_logged(executable, tmp_path):
+    # The startup log is the discoverable record of the resolved paths.
+    client = await make_client(executable, tmp_path)
+    try:
+        assert_no_anomaly(client, tmp_path)
+    finally:
+        await shutdown_client(client)
+
+    logs = [
+        p.read_text(errors="replace")
+        for p in (tmp_path / ".clice" / "logs").rglob("master.log")
+    ]
+    assert logs, "expected a master.log"
+    text = "".join(logs)
+    assert "Session log directory:" in text
+    assert "Effective configuration:" in text
+    assert '"cache_dir"' in text

--- a/tests/tools/prepare.py
+++ b/tests/tools/prepare.py
@@ -39,6 +39,8 @@ def xdg_cache_dir(workspace: Path) -> Path | None:
         raw = raw[:64]
         while raw and (raw[-1] & 0xC0) == 0x80:
             raw = raw[:-1]
+        if raw and raw[-1] >= 0xC0:
+            raw = raw[:-1]
         name = raw.decode()
     # xxh3_64bits is not available in stdlib; use xxhash if present,
     # otherwise fall back to a brute-force glob.

--- a/tests/tools/prepare.py
+++ b/tests/tools/prepare.py
@@ -34,6 +34,12 @@ def xdg_cache_dir(workspace: Path) -> Path | None:
             return None
         base = os.path.join(home, ".cache")
     name = workspace.name or "workspace"
+    raw = name.encode()
+    if len(raw) > 64:
+        raw = raw[:64]
+        while raw and (raw[-1] & 0xC0) == 0x80:
+            raw = raw[:-1]
+        name = raw.decode()
     # xxh3_64bits is not available in stdlib; use xxhash if present,
     # otherwise fall back to a brute-force glob.
     try:

--- a/tests/tools/prepare.py
+++ b/tests/tools/prepare.py
@@ -9,6 +9,7 @@ Stale .clice caches are removed so every run starts fresh.
 """
 
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -22,9 +23,9 @@ from tests.tools.compile_commands import generate_cdb, generate_test_data_cdbs  
 def xdg_cache_dir(workspace: Path) -> Path | None:
     """Return the XDG cache directory clice would use for *workspace*.
 
-    Mirrors resolvexdg_cache_dir() in src/server/state/config.cpp:
-    $XDG_CACHE_HOME/clice/<xxh3_64 hash>  or  ~/.cache/clice/<hash>.
-    We approximate xxh3_64 with the same 16-hex-digit format.
+    Mirrors resolve_xdg_cache_dir() in src/server/state/config.cpp:
+    $XDG_CACHE_HOME/clice/<basename>-<hash8>  or  ~/.cache/clice/<basename>-<hash8>,
+    where <hash8> is the low 32 bits of xxh3_64 of the workspace path.
     """
     base = os.environ.get("XDG_CACHE_HOME") or ""
     if not base:
@@ -32,13 +33,14 @@ def xdg_cache_dir(workspace: Path) -> Path | None:
         if not home:
             return None
         base = os.path.join(home, ".cache")
+    name = workspace.name or "workspace"
     # xxh3_64bits is not available in stdlib; use xxhash if present,
     # otherwise fall back to a brute-force glob.
     try:
         import xxhash
 
         h = xxhash.xxh3_64(str(workspace).encode()).intdigest()
-        return Path(base) / "clice" / f"{h:016x}"
+        return Path(base) / "clice" / f"{name}-{h & 0xFFFFFFFF:08x}"
     except ImportError:
         return Path(base) / "clice"
 
@@ -53,10 +55,10 @@ def clean_cache(workspace: Path) -> None:
     if xdg is None:
         return
     if xdg.name == "clice":
-        # No xxhash — glob all hash subdirectories.
+        # No xxhash — glob all <basename>-<hash8> subdirectories.
         if xdg.is_dir():
             for child in xdg.iterdir():
-                if child.is_dir() and len(child.name) == 16:
+                if child.is_dir() and re.fullmatch(r".+-[0-9a-f]{8}", child.name):
                     shutil.rmtree(child)
     elif xdg.is_dir():
         shutil.rmtree(xdg)

--- a/tests/unit/server/config_tests.cpp
+++ b/tests/unit/server/config_tests.cpp
@@ -341,6 +341,21 @@ TEST_CASE(XdgRootWorkspace) {
         path::filename(std::string_view(config.project.cache_dir)).starts_with("workspace-"));
 }
 
+TEST_CASE(XdgLongBasename) {
+    // A basename near the filesystem's 255-byte component limit must be
+    // truncated so the leaf (name + "-" + 8 hex) still fits.
+    TempDir tmp;
+    auto cache_base = tmp.path("xdg");
+    set_env("XDG_CACHE_HOME", cache_base.c_str());
+    Config config;
+    config.apply_defaults("/ws/" + std::string(200, 'x'));
+    unset_env("XDG_CACHE_HOME");
+
+    llvm::StringRef leaf = path::filename(std::string_view(config.project.cache_dir));
+    EXPECT_TRUE(leaf.starts_with(std::string(64, 'x')));
+    EXPECT_EQ(leaf.size(), 64u + 9u);
+}
+
 TEST_CASE(XdgTrailingSlash) {
     TempDir tmp;
     auto cache_base = tmp.path("xdg");

--- a/tests/unit/server/config_tests.cpp
+++ b/tests/unit/server/config_tests.cpp
@@ -296,6 +296,62 @@ TEST_CASE(XdgHashUnique) {
     EXPECT_EQ(std::string_view(a.project.cache_dir), std::string_view(c.project.cache_dir));
 }
 
+TEST_CASE(XdgNameHashFormat) {
+    // The cache leaf is "<basename>-<8 hex digits>" so users can map
+    // directories back to their workspaces.
+    TempDir tmp;
+    auto cache_base = tmp.path("xdg");
+    set_env("XDG_CACHE_HOME", cache_base.c_str());
+    Config config;
+    config.apply_defaults("/some/ws/myproject");
+    unset_env("XDG_CACHE_HOME");
+
+    llvm::StringRef leaf = path::filename(std::string_view(config.project.cache_dir));
+    EXPECT_TRUE(leaf.starts_with("myproject-"));
+    llvm::StringRef hex = leaf.drop_front(std::string_view("myproject-").size());
+    EXPECT_EQ(hex.size(), 8u);
+    EXPECT_EQ(hex.find_first_not_of("0123456789abcdef"), llvm::StringRef::npos);
+}
+
+TEST_CASE(XdgSameNameDiffer) {
+    // Same basename under different parents: the hash must keep them apart.
+    TempDir tmp;
+    auto cache_base = tmp.path("xdg");
+    set_env("XDG_CACHE_HOME", cache_base.c_str());
+    Config a, b;
+    a.apply_defaults("/first/proj");
+    b.apply_defaults("/second/proj");
+    unset_env("XDG_CACHE_HOME");
+
+    EXPECT_TRUE(path::filename(std::string_view(a.project.cache_dir)).starts_with("proj-"));
+    EXPECT_TRUE(path::filename(std::string_view(b.project.cache_dir)).starts_with("proj-"));
+    EXPECT_NE(std::string_view(a.project.cache_dir), std::string_view(b.project.cache_dir));
+}
+
+TEST_CASE(XdgRootWorkspace) {
+    // A root workspace has no basename; the leaf must not degenerate to "-<hash>".
+    TempDir tmp;
+    auto cache_base = tmp.path("xdg");
+    set_env("XDG_CACHE_HOME", cache_base.c_str());
+    Config config;
+    config.apply_defaults("/");
+    unset_env("XDG_CACHE_HOME");
+
+    EXPECT_TRUE(
+        path::filename(std::string_view(config.project.cache_dir)).starts_with("workspace-"));
+}
+
+TEST_CASE(XdgTrailingSlash) {
+    TempDir tmp;
+    auto cache_base = tmp.path("xdg");
+    set_env("XDG_CACHE_HOME", cache_base.c_str());
+    Config config;
+    config.apply_defaults("/some/ws/");
+    unset_env("XDG_CACHE_HOME");
+
+    EXPECT_TRUE(path::filename(std::string_view(config.project.cache_dir)).starts_with("ws-"));
+}
+
 TEST_CASE(HomeFallback) {
     // With XDG_CACHE_HOME unset but HOME set, cache dir should be under $HOME/.cache/clice.
     TempDir tmp;


### PR DESCRIPTION
Users could not find their server logs: the default cache directory is a bare 16-hex hash under the XDG cache, there was no way to map a workspace to its directory, and the docs wrongly claimed logs live in the workspace's `.clice/logs/` (that is only the no-home fallback). On top of that, the server never logged what configuration it was actually running with.

- **Readable cache directories**: the per-workspace XDG subdirectory is now `<workspace-basename>-<hash8>` (e.g. `~/.cache/clice/myproject-1a2b3c4d`) instead of a bare hash. Degenerate roots (`/`, trailing separators) fall back to `workspace-<hash8>`.
- **Full configuration dump at startup**: the master now logs every configuration layer — the `clice.toml` file verbatim (or `Missing`), the client's `initializationOptions` as pretty-printed JSON (or `Missing`), and the merged effective configuration after defaults. The stderr mirror puts all of it in the editor's output panel, so the resolved `cache_dir`/`logging_dir` and the answer to "was my config even read?" are one copy-paste away. The existing `Session log directory:` line remains.
- **Docs corrected**: README, extension README, and the en/zh configuration guides now describe the real default location and point users at the output panel.
- `tests/tools/prepare.py` mirrors the new directory format.

Tests: 4 new unit cases covering the naming format, same-basename disambiguation, root/trailing-slash edge cases; 1 new integration test asserting all three dump layers land in `master.log`. Full suites green locally (1032 unit / 300 integration / 3 smoke).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated crash-recovery guidance to use the newest server log from the editor’s output panel, with the default session path `~/.cache/clice/<workspace>-<hash>/logs/<session>/` and fallback to workspace `.clice/logs/`.
  * Expanded cache/log configuration docs (including per-workspace cache naming, per-session timestamped log folders, and resolved startup paths).
* **Improvements**
  * Refined the default XDG cache directory naming to `<workspace-basename>-<8-hex-hash>`.
  * Enhanced startup logs to clearly show config-layer inputs and only print session log directory when file logging is successfully set up.
* **Tests**
  * Added/updated integration and unit coverage for config dump logging and cache directory naming/normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->