### PR TITLE
fix(index): scale blob verifier table budget with blob size

### DIFF
--- a/src/index/merged_index.cpp
+++ b/src/index/merged_index.cpp
@@ -423,8 +423,7 @@ MergedIndex MergedIndex::load(llvm::StringRef path) {
     // discard any shard whose format version differs (including version-less
     // shards, which report 0). A discarded shard is treated as "not on disk"
     // and the background indexer rebuilds it.
-    auto data = reinterpret_cast<const std::uint8_t*>((*buffer)->getBufferStart());
-    fbs::Verifier verifier(data, (*buffer)->getBufferSize());
+    auto verifier = blob_verifier((*buffer)->getBufferStart(), (*buffer)->getBufferSize());
     if(!verifier.VerifyBuffer<binary::MergedIndex>(nullptr)) {
         return MergedIndex();
     }

--- a/src/index/preamble_state.cpp
+++ b/src/index/preamble_state.cpp
@@ -138,15 +138,8 @@ std::shared_ptr<PreambleState> PreambleState::load(llvm::StringRef path) {
 
     // A stale or truncated blob must never crash the server. Verify it is
     // a structurally valid flatbuffer, then discard any blob whose format
-    // version differs (version-less blobs read back 0). The table budget
-    // is far above the default: a large preamble's symbol table alone can
-    // exceed a million entries, and a verification failure here would
-    // otherwise send every compile into a rebuild loop.
-    auto data = reinterpret_cast<const std::uint8_t*>((*buffer)->getBufferStart());
-    fbs::Verifier verifier(data,
-                           (*buffer)->getBufferSize(),
-                           /*max_depth=*/64,
-                           /*max_tables=*/1u << 26);
+    // version differs (version-less blobs read back 0).
+    auto verifier = blob_verifier((*buffer)->getBufferStart(), (*buffer)->getBufferSize());
     if(!verifier.VerifyBuffer<binary::PreambleState>(nullptr)) {
         return nullptr;
     }

--- a/src/index/project_index.cpp
+++ b/src/index/project_index.cpp
@@ -101,7 +101,7 @@ std::optional<ProjectIndex> ProjectIndex::from(const void* data,
                                                std::size_t size,
                                                clice::PathPool& pool,
                                                llvm::SmallVectorImpl<std::uint32_t>& shards) {
-    fbs::Verifier verifier(static_cast<const std::uint8_t*>(data), size);
+    auto verifier = blob_verifier(data, size);
     if(!verifier.VerifyBuffer<binary::ProjectIndex>()) {
         return std::nullopt;
     }

--- a/src/index/serialization.h
+++ b/src/index/serialization.h
@@ -18,6 +18,18 @@ namespace fbs = flatbuffers;
 /// older builds, which read back the field's default of 0.
 constexpr inline std::uint32_t index_format_version = 1;
 
+/// Verifier for the self-written blobs in the cache store. The default
+/// table budget (one million) rejects large but perfectly valid blobs — a
+/// whole-project symbol table alone can carry millions of tables. Distinct
+/// tables occupy at least four bytes each, so a byte-proportional budget
+/// admits every blob a writer can produce while keeping verification work
+/// bounded by blob size.
+inline fbs::Verifier blob_verifier(const void* data, std::size_t size) {
+    return fbs::Verifier(static_cast<const std::uint8_t*>(data),
+                         size,
+                         {.max_tables = static_cast<fbs::uoffset_t>(size / 4 + 1)});
+}
+
 namespace {
 
 template <typename Range>

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -376,7 +376,7 @@ void Indexer::load() {
                 }
             }
         } else {
-            LOG_INFO("Discarding old-format ProjectIndex blob");
+            LOG_INFO("Discarding unreadable or old-format ProjectIndex blob");
         }
     }
 

--- a/tests/unit/index/project_index_tests.cpp
+++ b/tests/unit/index/project_index_tests.cpp
@@ -151,6 +151,28 @@ TEST_CASE(SerializationRoundTrip) {
     }
 }
 
+TEST_CASE(GiantIndexRoundTrip) {
+    // 600k symbols serialize to well over a million flatbuffer tables —
+    // the verifier's default budget — which real whole-project indices
+    // exceed; a rejected blob reads back as "no index on disk" and the
+    // startup sweep then deletes every shard.
+    index::ProjectIndex project;
+    for(std::uint64_t hash = 1; hash <= 600'000; ++hash) {
+        project.symbols[hash].name = std::to_string(hash);
+    }
+
+    clice::PathPool pool;
+    llvm::SmallString<4096> buf;
+    llvm::raw_svector_ostream os(buf);
+    project.serialize(os, pool, {});
+
+    clice::PathPool fresh;
+    llvm::SmallVector<std::uint32_t> shards;
+    auto loaded = index::ProjectIndex::from(buf.data(), buf.size(), fresh, shards);
+    ASSERT_TRUE(loaded.has_value());
+    ASSERT_EQ(loaded->symbols.size(), project.symbols.size());
+}
+
 TEST_CASE(FileIdsMapCorrectness) {
     index::TUIndex tu;
     ASSERT_TRUE(build_and_index(R"(


### PR DESCRIPTION
## What changed

The three index blob load sites (`ProjectIndex::from`, `MergedIndex::load`, `PreambleState::load`) verified flatbuffers with the default `Verifier` options, whose table budget is 1,000,000. A whole-project symbol table easily carries millions of tables on large workspaces (each symbol serializes as two tables), so a perfectly valid `ProjectIndex` blob written by the same binary fails verification on load. The failure is indistinguishable from a version mismatch, so it is reported as an old-format blob, the shard manifest comes back empty, and the startup sweep in `Indexer::load` then deletes every shard blob on disk — one restart discards hours of background indexing. Observed on a 4795-TU workspace where heavy TUs index 1.6M+ symbols.

The fix is a shared `blob_verifier` helper with a byte-proportional table budget: distinct tables occupy at least four bytes each, so `size / 4 + 1` admits every blob a writer can produce while keeping verification work bounded by blob size. All three sites now use it; `PreambleState::load` previously carried a local `1u << 26` budget for the same reason, which this replaces — a fixed constant only moves the wall. The load log message no longer claims "old-format" for what may be a verification failure.

## Tests

- New unit test `ProjectIndex.GiantIndexRoundTrip`: 600k synthetic symbols (≈1.2M tables, past the default budget) must round-trip. Verified red/green: fails without the fix, passes with it (~0.8s in RelWithDebInfo).
- The giant-scale case covers the ProjectIndex site; the MergedIndex/PreambleState sites share the same helper, so their existing normal-scale load tests exercise the changed code path.
- All four suites pass locally on RelWithDebInfo: unit 1168, integration 341, smoke 3/3, snap 395.