### PR TITLE
fix(server): shut down gracefully on SIGTERM

### DIFF
--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -1,5 +1,6 @@
 #include "server/transport/master_server.h"
 
+#include <csignal>
 #include <list>
 #include <memory>
 #include <string>
@@ -410,6 +411,11 @@ void MasterServer::schedule_shutdown() {
 }
 
 kota::task<> MasterServer::shutdown_and_cleanup() {
+    // Serving can end without an explicit shutdown trigger (transport EOF
+    // from a crashed editor); cancel the shutdown token here so every
+    // token-bound task — the SIGTERM watcher in particular — unwinds and
+    // releases its loop handle, letting the loop drain after cleanup.
+    schedule_shutdown();
     bg_tasks.cancel();
     co_await bg_tasks.join();
     // Quiesce in-flight compilation and indexing first so the persisted
@@ -645,6 +651,22 @@ static kota::task<> serve_peer(kota::ipc::JsonPeer& peer, kota::task<> acceptor)
     co_await kota::when_any(peer.run(), std::move(acceptor));
 }
 
+/// Route SIGTERM into the same shutdown path as the LSP exit notification,
+/// so an editor teardown or system stop still writes the shutdown save
+/// instead of losing it to default termination.
+static kota::task<> shutdown_on_sigterm(MasterServer& server) {
+    auto sig = kota::signal::create(server.loop);
+    if(!sig || sig->start(SIGTERM)) {
+        LOG_WARN("SIGTERM watcher unavailable; hard termination will skip the shutdown save");
+        co_return;
+    }
+    auto fired = co_await kota::with_token(sig->wait(), server.shutdown_token());
+    if(!fired.has_value())
+        co_return;
+    LOG_INFO("SIGTERM received, shutting down");
+    server.schedule_shutdown();
+}
+
 int run_serve_mode(const ServerOptions& opts, const char* self_path) {
     logging::stderr_logger("master", logging::options);
 
@@ -669,6 +691,8 @@ int run_serve_mode(const ServerOptions& opts, const char* self_path) {
     kota::event_loop loop;
     MasterServer server(loop, self_path);
     std::list<Connection> connections;
+
+    loop.schedule(shutdown_on_sigterm(server));
 
     if(mode == ServerMode::Pipe) {
         auto transport = kota::ipc::StreamTransport::open_stdio(loop);

--- a/tests/integration/lifecycle/sigterm.test.ts
+++ b/tests/integration/lifecycle/sigterm.test.ts
@@ -1,0 +1,45 @@
+/// SIGTERM drives the same graceful shutdown as the LSP exit notification.
+///
+/// An editor teardown or system stop delivers SIGTERM, not an LSP shutdown
+/// handshake; without a handler the server dies before its shutdown save and
+/// the next startup treats the cache as garbage.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { expect, test } from "../fixtures.ts";
+
+test.skipIf(process.platform === "win32")("sigterm runs shutdown save", async ({ session }) => {
+    const workspace = session.tmpdir();
+    workspace.pinCacheDir();
+    workspace.write("main.cpp", "int add(int a, int b) { return a + b; }\n");
+    workspace.writeCDB(["main.cpp"]);
+
+    const client = session.spawn(workspace);
+    await client.initialize(workspace);
+    const [uri] = await client.openAndWait("main.cpp");
+    client.assertCleanCompile(uri);
+
+    // The manifest write after this removal can only come from the shutdown
+    // checkpoint (the periodic and commit-count triggers keep their own
+    // schedules), so its existence after exit proves the SIGTERM took the
+    // graceful path — the exit-code-0 gate inside terminate() proves it
+    // completed.
+    const manifest = path.join(workspace.cacheRoot(), "manifest.json");
+    fs.rmSync(manifest, { force: true });
+    await client.terminate();
+    expect(fs.existsSync(manifest), "SIGTERM must run the shutdown save").toBe(true);
+});
+
+test("server exits on client eof", async ({ session }) => {
+    const workspace = session.tmpdir();
+    workspace.write("main.cpp", "int main() { return 0; }\n");
+    workspace.writeCDB(["main.cpp"]);
+
+    const client = session.spawn(workspace);
+    await client.initialize(workspace);
+
+    // The server must notice EOF and exit cleanly instead of idling
+    // forever on a still-armed watcher handle.
+    client.disconnect();
+    await client.assertExitedCleanly();
+});

--- a/tools/client/client.ts
+++ b/tools/client/client.ts
@@ -488,6 +488,25 @@ export class CliceClient {
         }
     }
 
+    /// Drop the transport without the shutdown handshake, as a crashed
+    /// editor would: dispose() alone leaves the child's stdin open, so the
+    /// server would never observe EOF.
+    disconnect(): void {
+        this.dispose();
+        this.child.stdin.end();
+    }
+
+    /// Terminate with SIGTERM and hold the same clean-exit gate as
+    /// shutdown(): the server must run its shutdown save and exit 0.
+    async terminate(): Promise<void> {
+        this.child.kill("SIGTERM");
+        try {
+            await this.assertExitedCleanly();
+        } finally {
+            this.dispose();
+        }
+    }
+
     /// The clean-exit gate every session must pass.
     async assertExitedCleanly(timeout = 10_000): Promise<void> {
         const failures: string[] = [];


### PR DESCRIPTION
## What changed

The master registered no signal handlers, so SIGTERM — what an editor teardown, window close timeout, or system stop actually delivers — killed the process before the shutdown save. Everything the save covers was lost: freshly built index shards, the compilation cache, and the store manifest checkpoint. Worse, the next startup's orphan sweep treats blobs the (never-written) manifest does not name as garbage, so a hard termination not only loses the session's work but poisons what earlier sessions persisted.

`clice serve` now arms a `kota::signal` watcher on the event loop that routes SIGTERM into `schedule_shutdown()` — exactly the path the LSP exit notification takes, so the full `shutdown_and_cleanup()` sequence (quiesce, index save, cache save, worker pool stop, store checkpoint) runs before exit. On Windows the registration is accepted by libuv and simply never fires.

While testing this, a second gap surfaced: serving can also end with no explicit shutdown trigger at all (transport EOF from a crashed editor), and nothing on that path cancelled the shutdown token, which would leave token-bound tasks — the new watcher included — holding live loop handles and the process idling forever. `shutdown_and_cleanup()` now cancels the token first, making every exit path equivalent.

## Tests

New `tests/integration/lifecycle/sigterm.test.ts` (with two small client additions, `terminate()` and `disconnect()`):

- `sigterm runs shutdown save`: SIGTERM must pass the same clean-exit gate as a graceful shutdown (exit code 0) and must write the store manifest, which within this test's lifetime only the shutdown checkpoint writes. Red/green verified: without the handler the server dies with a signal and no manifest.
- `server exits on client eof`: dropping the transport without the handshake must still end the process. Red/green verified: with the watcher but without the token cancel, the server hangs indefinitely.
- Skipped on Windows, where `SIGTERM` semantics do not exist (`child.kill` is an unconditional hard terminate).
- All four suites pass locally on RelWithDebInfo: unit 1168, integration 343, smoke 3/3, snap 395.