### PR TITLE
feat(bench): benchmark harness with per-TU profiler and perf logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@
 temp/
 .cache/
 
+# Materialized benchmark workloads (fetch_workload.py)
+benchmarks/workloads/
+
 .llvm*/
 .clice/
 compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,13 +234,15 @@ if(CLICE_ENABLE_TEST)
 endif()
 
 if(CLICE_ENABLE_BENCHMARK)
-    add_executable(scan_benchmark
-        "${PROJECT_SOURCE_DIR}/benchmarks/scan_benchmark.cpp"
-    )
-    target_include_directories(scan_benchmark PRIVATE
-        "${PROJECT_SOURCE_DIR}/src"
-    )
-    target_link_libraries(scan_benchmark PRIVATE clice::core kota::deco)
+    foreach(benchmark scan_benchmark pipeline_benchmark pch_chain_benchmark)
+        add_executable(${benchmark}
+            "${PROJECT_SOURCE_DIR}/benchmarks/${benchmark}.cpp"
+        )
+        target_include_directories(${benchmark} PRIVATE
+            "${PROJECT_SOURCE_DIR}/src"
+        )
+        target_link_libraries(${benchmark} PRIVATE clice::core kota::deco)
+    endforeach()
 endif()
 
 include("${PROJECT_SOURCE_DIR}/cmake/release.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,9 @@ if(CLICE_ENABLE_BENCHMARK)
             "${PROJECT_SOURCE_DIR}/src"
         )
         target_link_libraries(${benchmark} PRIVATE clice::core kota::deco)
+        # The benchmarks locate lib/clang next to their binary; an explicit
+        # `ninja <benchmark>` must not race or skip the resource copy.
+        add_dependencies(${benchmark} copy_clang_resource)
     endforeach()
 endif()
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -82,6 +82,23 @@ Breakdown of a real (non-benchmark) session from its logs:
 node tools/bench/perf_report.ts <logging_dir>/<session>/*.log --trace /tmp/trace.json
 ```
 
+Single-file stage comparison against clangd — pair `pipeline_benchmark`
+(one file selected via `--filter`) with `clangd --check`, which prints its
+preamble build and AST build times for the same TU without a server or
+background indexing in the way:
+
+```bash
+./build/RelWithDebInfo/bin/pipeline_benchmark --filter SemaExpr.cpp --runs 5 \
+    benchmarks/workloads/llvm/build/compile_commands.json
+clangd --check=benchmarks/workloads/llvm/clang/lib/Sema/SemaExpr.cpp \
+    --compile-commands-dir=benchmarks/workloads/llvm/build 2>&1 | grep -E "preamble|AST"
+```
+
+Read them side by side as: clangd "Built preamble in N s" vs our
+`pch_build`, clangd "Building AST" gap vs our `parse_pch`. Everything our
+`pch_build` spends beyond clangd's preamble number is the work clice adds
+to the critical path (TokenBuffer collection, preamble indexing).
+
 ## Method rules
 
 - **Fix the machine, compare on the machine.** Absolute numbers are not

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -22,15 +22,17 @@ your question:
    `-DCLICE_ENABLE_BENCHMARK=ON`, each answering one decision:
    - `scan_benchmark` — dependency-graph scan over a real CDB.
    - `pipeline_benchmark` — per-TU stage profile (preprocess with/without
-     TokenBuffer, parse, index build/serialize, preamble PCH build, reparse
-     over PCH), one result per file.
+     TokenBuffer, parse, index build/serialize, preamble PCH build incl.
+     preamble indexing, reparse over PCH incl. interactive indexing), one
+     result per file.
    - `pch_chain_benchmark` — monolithic vs chained PCH strategy (ported
      from PR #405).
 
 ## Building
 
 ```bash
-cmake -B build/RelWithDebInfo -DCLICE_ENABLE_BENCHMARK=ON  # plus the usual flags
+cmake -B build/RelWithDebInfo -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain.cmake -DCLICE_ENABLE_BENCHMARK=ON
 ninja -C build/RelWithDebInfo scan_benchmark pipeline_benchmark pch_chain_benchmark
 ```
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -67,6 +67,12 @@ stage per file — open it in [Perfetto](https://ui.perfetto.dev) to see the
 frontend-internal breakdown (preprocessing, parsing, Sema, PCH
 deserialization) that wall-clock stage timing cannot separate.
 
+`--log-level info` additionally surfaces the `[perf:index_detail]` lines
+from inside the index stages: semantics-table build vs projection vs
+finishing within `TUIndex::build`, and the path-rekeying copy vs the
+flatbuffers pack within `serialize`. The same lines appear in worker logs
+of a real session, so production runs decompose identically.
+
 E2E scenarios, clice vs clangd:
 
 ```bash

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -114,9 +114,9 @@ to the critical path (TokenBuffer collection, preamble indexing).
   `cold_start` wipes the cache dirs; everything else is warm. For component
   benchmarks the first run warms the OS file cache — use `--runs` and look
   at percentiles, not single samples.
-- **Idle machine.** No concurrent builds; on WSL2 specifically, do not run
-  ninja alongside a benchmark and expect page-cache-sensitive numbers to
-  wobble (WSL2 reclaims mmap'd cache aggressively).
+- **Idle machine.** No concurrent builds. On WSL2 specifically, do not run
+  ninja alongside a benchmark: page-cache-sensitive numbers wobble because
+  WSL2 reclaims mmap'd cache aggressively.
 - **One variable at a time.** The pipeline stages and the A/B knobs
   (`collect_tokens`, PCH on/off) exist so a comparison changes exactly one
   thing.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,123 @@
+# Benchmarks
+
+Performance work on clice runs on three layers. Pick the layer that answers
+your question:
+
+1. **Instrumentation** — _where does the time go in a real run?_ Every
+   server run emits `[perf:<topic>] key=value` log lines (see
+   `src/support/logging.h`) covering startup phases, per-file compiles,
+   PCH/PCM/index builds, cache hits, request latencies and index queries.
+   `tools/bench/perf_report.ts` aggregates any log into per-series
+   percentiles and can export a Chrome trace. This layer needs no special
+   build and works on logs users attach to issue reports.
+
+2. **Scenario harness** — _what does the user experience end to end?_
+   `tools/bench/bench.ts` drives a server over LSP through fixed scenarios
+   (cold start, warm start, edit loop, warm feature requests) on a real
+   workspace and reports client-observed percentiles. It is server-agnostic:
+   point it at clangd with `--server clangd` to A/B the same scenario.
+
+3. **Component benchmarks** — _which design alternative is faster?_
+   Standalone binaries in this directory, built with
+   `-DCLICE_ENABLE_BENCHMARK=ON`, each answering one decision:
+   - `scan_benchmark` — dependency-graph scan over a real CDB.
+   - `pipeline_benchmark` — per-TU stage profile (preprocess with/without
+     TokenBuffer, parse, index build/serialize, preamble PCH build, reparse
+     over PCH), one result per file.
+   - `pch_chain_benchmark` — monolithic vs chained PCH strategy (ported
+     from PR #405).
+
+## Building
+
+```bash
+cmake -B build/RelWithDebInfo -DCLICE_ENABLE_BENCHMARK=ON  # plus the usual flags
+ninja -C build/RelWithDebInfo scan_benchmark pipeline_benchmark pch_chain_benchmark
+```
+
+Always benchmark `RelWithDebInfo`; Debug numbers are meaningless.
+
+## Workloads
+
+Benchmarks against real projects must be pinned to be comparable.
+`workloads.json` records project + ref + configure command;
+`fetch_workload.py <name>` materializes one under `benchmarks/workloads/`
+(shallow clone + CMake configure — no build needed, only the
+compile_commands.json):
+
+```bash
+python benchmarks/fetch_workload.py llvm
+```
+
+clice's own CDB (`build/RelWithDebInfo/compile_commands.json`) doubles as
+an always-available medium workload.
+
+## Typical sessions
+
+Stage profile of the 100 largest TUs plus a Chrome trace of one:
+
+```bash
+./build/RelWithDebInfo/bin/pipeline_benchmark --limit 100 --json /tmp/pipeline.json \
+    benchmarks/workloads/llvm/build/compile_commands.json
+./build/RelWithDebInfo/bin/pipeline_benchmark --filter SemaExpr.cpp --runs 3 \
+    --time-trace /tmp/traces benchmarks/workloads/llvm/build/compile_commands.json
+```
+
+`--time-trace` writes clang's own `-ftime-trace` profile of the parse
+stage per file — open it in [Perfetto](https://ui.perfetto.dev) to see the
+frontend-internal breakdown (preprocessing, parsing, Sema, PCH
+deserialization) that wall-clock stage timing cannot separate.
+
+E2E scenarios, clice vs clangd:
+
+```bash
+node tools/bench/bench.ts --workspace benchmarks/workloads/llvm \
+    --file clang/lib/Sema/SemaExpr.cpp --json /tmp/clice.json
+node tools/bench/bench.ts --workspace benchmarks/workloads/llvm \
+    --file clang/lib/Sema/SemaExpr.cpp --server clangd --json /tmp/clangd.json
+```
+
+Breakdown of a real (non-benchmark) session from its logs:
+
+```bash
+node tools/bench/perf_report.ts <logging_dir>/<session>/*.log --trace /tmp/trace.json
+```
+
+## Method rules
+
+- **Fix the machine, compare on the machine.** Absolute numbers are not
+  comparable across hosts; run both sides of any A/B on the same machine in
+  the same session.
+- **Cold vs warm is a protocol, not an accident.** The harness's
+  `cold_start` wipes the cache dirs; everything else is warm. For component
+  benchmarks the first run warms the OS file cache — use `--runs` and look
+  at percentiles, not single samples.
+- **Idle machine.** No concurrent builds; on WSL2 specifically, do not run
+  ninja alongside a benchmark and expect page-cache-sensitive numbers to
+  wobble (WSL2 reclaims mmap'd cache aggressively).
+- **One variable at a time.** The pipeline stages and the A/B knobs
+  (`collect_tokens`, PCH on/off) exist so a comparison changes exactly one
+  thing.
+
+## Reference numbers
+
+Indicative magnitudes from past measured runs — **not** authoritative
+baselines (single machine, dated). Re-measure locally before drawing
+conclusions.
+
+**Interactive path** (WSL2, RelWithDebInfo, 2026-07; probe TU ≈ 150k
+semantic nodes over `<iostream>/<vector>/<string>`):
+
+| shape                                          | time                             |
+| ---------------------------------------------- | -------------------------------- |
+| parse, no PCH                                  | ~330 ms                          |
+| parse over warm preamble PCH (didChange path)  | ~50 ms                           |
+| TUIndex build, interactive (`interested_only`) | ~0.1–1.4 ms                      |
+| warm hover end-to-end (tiny project)           | ~0.9 ms (feature itself ~0.2 ms) |
+
+The didChange experience is parse-dominated; features and index are
+sub-millisecond next to it.
+
+**Monolithic vs chained PCH** (PR #405, LLVM 21 era, 70 stdlib headers):
+full chain build ~2× the monolithic build, but appending one header is
+~35× faster than the monolithic full rebuild, and AST-load overhead of the
+chain stays within +6% even under full deserialization.

--- a/benchmarks/fetch_workload.py
+++ b/benchmarks/fetch_workload.py
@@ -33,20 +33,39 @@ def head_commit(root: Path) -> str | None:
     return result.stdout.strip() if result.returncode == 0 else None
 
 
+def tracked_files_dirty(root: Path) -> bool:
+    """Untracked files are invisible here on purpose: the configure step
+    always leaves build output (including the CDB) untracked in the
+    checkout, so only tracked-file modifications are detectable drift."""
+    result = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=no"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode != 0 or result.stdout.strip() != ""
+
+
 def checkout(root: Path, workload: dict) -> bool:
     """Materialize the pinned ref; returns True when the tree changed.
 
     The marker file records which ref+commit a completed checkout
     produced: a fetch that died halfway, a ref bumped in workloads.json,
     or a checkout moved by hand all fail the comparison and are redone.
+    A matching marker with locally modified tracked files is hard-reset —
+    edits must not leak into a run the script reports as pinned.
     """
     marker = root / ".git" / "workload-ref"
     if (root / ".git").exists():
         head = head_commit(root)
         if head is not None and marker.exists():
             if marker.read_text() == f"{workload['ref']} {head}":
-                print(f"{root} already at {workload['ref']}")
-                return False
+                if not tracked_files_dirty(root):
+                    print(f"{root} already at {workload['ref']}")
+                    return False
+                print(f"{root} has local modifications; resetting")
+                run(["git", "reset", "--hard", "--quiet", "HEAD"], cwd=root)
+                return True
 
     root.mkdir(parents=True, exist_ok=True)
     run(["git", "init", "--quiet"], cwd=root)

--- a/benchmarks/fetch_workload.py
+++ b/benchmarks/fetch_workload.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Materialize a pinned benchmark workload from benchmarks/workloads.json.
+
+Usage:
+    python benchmarks/fetch_workload.py <name>
+
+Clones the workload's repository at its pinned ref into
+benchmarks/workloads/<name> (shallow) and runs the configure command to
+generate compile_commands.json. Both steps are skipped when already done,
+so re-running is cheap.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+BENCH_DIR = Path(__file__).resolve().parent
+
+
+def run(args: list[str], cwd: Path) -> None:
+    print(f"+ {' '.join(args)}")
+    subprocess.run(args, cwd=cwd, check=True)
+
+
+def main() -> int:
+    workloads = json.loads((BENCH_DIR / "workloads.json").read_text())["workloads"]
+
+    if len(sys.argv) != 2 or sys.argv[1] not in workloads:
+        names = ", ".join(sorted(workloads))
+        print(f"usage: fetch_workload.py <name>  (available: {names})")
+        return 1
+
+    name = sys.argv[1]
+    workload = workloads[name]
+    root = BENCH_DIR / "workloads" / name
+
+    if not (root / ".git").exists():
+        root.mkdir(parents=True, exist_ok=True)
+        run(["git", "init", "--quiet"], cwd=root)
+        run(["git", "remote", "add", "origin", workload["git"]], cwd=root)
+        run(
+            ["git", "fetch", "--depth", "1", "origin", workload["ref"]],
+            cwd=root,
+        )
+        run(["git", "checkout", "--quiet", "FETCH_HEAD"], cwd=root)
+    else:
+        print(f"{root} already cloned")
+
+    cdb = root / workload["cdb"]
+    if not cdb.exists():
+        run(workload["configure"], cwd=root)
+    else:
+        print(f"{cdb} already generated")
+
+    workspace = cdb.parent
+    print(f"\nworkload ready: {root}")
+    print(f"compile_commands.json: {cdb}")
+    print("suggested runs:")
+    print(f"  ./build/RelWithDebInfo/bin/scan_benchmark {cdb}")
+    print(f"  ./build/RelWithDebInfo/bin/pipeline_benchmark --limit 100 {cdb}")
+    scenario = workload.get("scenario")
+    if scenario:
+        print(
+            f"  node tools/bench/bench.ts --workspace {workspace}"
+            f" --file {root / scenario['file']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/fetch_workload.py
+++ b/benchmarks/fetch_workload.py
@@ -23,6 +23,42 @@ def run(args: list[str], cwd: Path) -> None:
     subprocess.run(args, cwd=cwd, check=True)
 
 
+def head_commit(root: Path) -> str | None:
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "HEAD"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def checkout(root: Path, workload: dict) -> bool:
+    """Materialize the pinned ref; returns True when the tree changed.
+
+    The marker file records which ref+commit a completed checkout
+    produced: a fetch that died halfway, a ref bumped in workloads.json,
+    or a checkout moved by hand all fail the comparison and are redone.
+    """
+    marker = root / ".git" / "workload-ref"
+    if (root / ".git").exists():
+        head = head_commit(root)
+        if head is not None and marker.exists():
+            if marker.read_text() == f"{workload['ref']} {head}":
+                print(f"{root} already at {workload['ref']}")
+                return False
+
+    root.mkdir(parents=True, exist_ok=True)
+    run(["git", "init", "--quiet"], cwd=root)
+    run(
+        ["git", "fetch", "--depth", "1", workload["git"], workload["ref"]],
+        cwd=root,
+    )
+    run(["git", "checkout", "--quiet", "FETCH_HEAD"], cwd=root)
+    marker.write_text(f"{workload['ref']} {head_commit(root)}")
+    return True
+
+
 def main() -> int:
     workloads = json.loads((BENCH_DIR / "workloads.json").read_text())["workloads"]
 
@@ -35,25 +71,14 @@ def main() -> int:
     workload = workloads[name]
     root = BENCH_DIR / "workloads" / name
 
-    if not (root / ".git").exists():
-        root.mkdir(parents=True, exist_ok=True)
-        run(["git", "init", "--quiet"], cwd=root)
-        run(["git", "remote", "add", "origin", workload["git"]], cwd=root)
-        run(
-            ["git", "fetch", "--depth", "1", "origin", workload["ref"]],
-            cwd=root,
-        )
-        run(["git", "checkout", "--quiet", "FETCH_HEAD"], cwd=root)
-    else:
-        print(f"{root} already cloned")
+    fresh = checkout(root, workload)
 
     cdb = root / workload["cdb"]
-    if not cdb.exists():
+    if fresh or not cdb.exists():
         run(workload["configure"], cwd=root)
     else:
         print(f"{cdb} already generated")
 
-    workspace = cdb.parent
     print(f"\nworkload ready: {root}")
     print(f"compile_commands.json: {cdb}")
     print("suggested runs:")
@@ -62,7 +87,7 @@ def main() -> int:
     scenario = workload.get("scenario")
     if scenario:
         print(
-            f"  node tools/bench/bench.ts --workspace {workspace}"
+            f"  node tools/bench/bench.ts --workspace {root}"
             f" --file {root / scenario['file']}"
         )
     return 0

--- a/benchmarks/pch_chain_benchmark.cpp
+++ b/benchmarks/pch_chain_benchmark.cpp
@@ -31,6 +31,7 @@
 #include "support/logging.h"
 
 #include "kota/deco/deco.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 
@@ -532,130 +533,138 @@ void bench_incremental(const std::vector<std::string>& headers, std::size_t base
     }
 }
 
-/// Sources for the AST load scenarios: light touches a couple of types
-/// (lazy PCH load, best case); heavy references symbols from as many
-/// headers as possible to force maximum PCH deserialization (worst case).
+/// Sources for the AST load scenarios: light touches a couple of scalar
+/// types (lazy PCH load, best case); heavy references symbols from every
+/// selected header to force maximum PCH deserialization (worst case).
+/// Both are built from the selected header prefix so that any accepted
+/// --chain-length yields a source that compiles cleanly.
 std::string make_light_source(const std::string& preamble) {
+    // <cstddef> and <cstdint> lead ALL_HEADERS, and --chain-length is at
+    // least 2, so these types exist for any prefix.
     return preamble + R"cpp(
 int main() {
-    std::vector<int> v = {1, 2, 3};
-    return v[0];
+    std::size_t n = sizeof(std::uint64_t);
+    return static_cast<int>(n);
 }
 )cpp";
 }
 
-std::string make_heavy_source(const std::string& preamble) {
-    return preamble + R"cpp(
-template <typename... Ts> void use(Ts&&...) {}
+/// One usage statement per header for the heavy source. Each snippet uses
+/// declarations only from its own header and headers EARLIER in
+/// ALL_HEADERS, so emitting the snippets of a contiguous prefix in header
+/// order yields a valid program. Headers with nothing to use have no
+/// entry (<iosfwd> and <codecvt> declare nothing to instantiate
+/// standalone; <expected> is empty under -std=c++20).
+const llvm::StringMap<llvm::StringRef> HEAVY_SNIPPETS = {
+    {"cstddef",            "std::size_t sz = 0; use(sz);"                            },
+    {"cstdint",            "std::uint64_t u64 = 0; use(u64);"                        },
+    {"climits",            "use(INT_MAX);"                                           },
+    {"cfloat",             "use(DBL_EPSILON);"                                       },
+    {"type_traits",        "static_assert(std::is_integral_v<int>);"                 },
+    {"concepts",           "static_assert(std::integral<int>);"                      },
+    {"compare",            "std::strong_ordering cmp = 1 <=> 2; use(cmp);"           },
+    {"initializer_list",   "auto il = {1, 2, 3}; use(il);"                           },
+    {"utility",            "auto pr = std::make_pair(1, 2); use(pr);"                },
+    {"tuple",              "auto tp = std::make_tuple(1, \"hello\", 3.14); use(tp);" },
+    {"optional",           "std::optional<int> opt = 42; use(opt);"                  },
+    {"variant",            "std::variant<int, double> var = 3.14; use(var);"         },
+    {"any",                "std::any a = 42; use(a);"                                },
+    {"bitset",             "std::bitset<64> bs(0xFF); use(bs);"                      },
+    {"bit",                "auto pc = std::popcount(42u); use(pc);"                  },
+    {"string_view",        "std::string_view sv = \"hello\"; use(sv);"               },
+    {"string",             "std::string s = \"world\"; use(s);"                      },
+    {"charconv",
+     "char buf[16]; auto res = std::to_chars(buf, buf + 16, 42); "
+     "use(res.ptr);"                                                                 },
+    {"format",             "auto fmt = std::format(\"{} {}\", s, 42); use(fmt);"     },
+    {"array",              "std::array<int, 3> arr = {1, 2, 3}; use(arr);"           },
+    {"vector",             "std::vector<std::string> vec = {\"a\", \"b\"}; use(vec);"},
+    {"deque",              "std::deque<int> dq = {1, 2}; use(dq);"                   },
+    {"list",               "std::list<int> lst = {1, 2}; use(lst);"                  },
+    {"forward_list",       "std::forward_list<int> fl = {1, 2}; use(fl);"            },
+    {"set",                "std::set<int> st = {1, 2, 3}; use(st);"                  },
+    {"map",                "std::map<std::string, int> mp = {{\"a\", 1}}; use(mp);"  },
+    {"unordered_set",      "std::unordered_set<int> us = {1, 2}; use(us);"           },
+    {"unordered_map",
+     "std::unordered_map<std::string, int> um = {{\"b\", 2}}; "
+     "use(um);"                                                                      },
+    {"stack",              "std::stack<int> stk; use(stk);"                          },
+    {"queue",              "std::queue<int> que; use(que);"                          },
+    {"span",               "std::span<const int> spn(arr); use(spn);"                },
+    {"iterator",           "use(std::distance(vec.begin(), vec.end()));"             },
+    {"ranges",             "auto rng = vec | std::views::take(1); use(rng);"         },
+    {"algorithm",          "std::sort(vec.begin(), vec.end());"                      },
+    {"numeric",
+     "auto sum = std::accumulate(arr.begin(), arr.end(), 0); "
+     "use(sum);"                                                                     },
+    {"memory",             "auto up = std::make_unique<int>(42); use(up);"           },
+    {"memory_resource",    "std::pmr::monotonic_buffer_resource mbr; use(mbr);"      },
+    {"scoped_allocator",
+     "std::scoped_allocator_adaptor<std::allocator<int>> saa; "
+     "use(saa);"                                                                     },
+    {"functional",
+     "std::function<int(int)> fn = [](int x) { return x * 2; }; "
+     "use(fn);"                                                                      },
+    {"ratio",              "using half = std::ratio<1, 2>; use(half::num);"          },
+    {"chrono",             "auto now = std::chrono::system_clock::now(); use(now);"  },
+    {"exception",          "use(std::uncaught_exceptions());"                        },
+    {"stdexcept",          "std::runtime_error re(\"test\"); use(re);"               },
+    {"system_error",
+     "auto ec = std::make_error_code(std::errc::invalid_argument); "
+     "use(ec);"                                                                      },
+    {"typeinfo",           "auto& ti = typeid(int); use(ti);"                        },
+    {"typeindex",          "std::type_index tidx(typeid(int)); use(tidx);"           },
+    {"source_location",    "auto loc = std::source_location::current(); use(loc);"   },
+    {"new",                "use(std::nothrow);"                                      },
+    {"limits",             "static_assert(std::numeric_limits<double>::is_iec559);"  },
+    {"numbers",            "constexpr auto pi = std::numbers::pi; use(pi);"          },
+    {"valarray",           "std::valarray<double> va = {1.0, 2.0, 3.0}; use(va);"    },
+    {"complex",            "std::complex<double> cx(1.0, 2.0); use(cx);"             },
+    {"random",             "std::mt19937 rng_eng(42); use(rng_eng);"                 },
+    {"ios",                "use(std::ios_base::app);"                                },
+    {"streambuf",          "std::streambuf* sb = nullptr; use(sb);"                  },
+    {"istream",            "std::istream* is = nullptr; use(is);"                    },
+    {"ostream",            "std::ostream* os = nullptr; use(os);"                    },
+    {"iostream",           "std::cout << 42;"                                        },
+    {"sstream",            "std::stringstream ss; ss << \"hello\"; use(ss);"         },
+    {"fstream",            "std::ifstream ifs; use(ifs);"                            },
+    {"cmath",              "auto sq = std::sqrt(2.0); use(sq);"                      },
+    {"cstdio",             "use(EOF);"                                               },
+    {"cstdlib",            "use(std::abs(-1));"                                      },
+    {"cstring",            "auto len = std::strlen(\"hello\"); use(len);"            },
+    {"ctime",              "auto t = std::time(nullptr); use(t);"                    },
+    {"cassert",            "assert(1 + 1 == 2);"                                     },
+    {"cerrno",             "use(errno);"                                             },
+    {"atomic",             "std::atomic<int> ai{0}; use(ai);"                        },
+    {"mutex",              "std::mutex mtx; use(mtx);"                               },
+    {"condition_variable", "std::condition_variable cv; use(cv);"                    },
+    {"thread",             "use(std::this_thread::get_id());"                        },
+    {"future",             "std::promise<int> prom; use(prom);"                      },
+    {"semaphore",          "std::counting_semaphore<1> sem(1); use(sem);"            },
+    {"latch",              "std::latch lat(1); use(lat);"                            },
+    {"barrier",            "std::barrier bar(1); use(bar);"                          },
+    {"stop_token",         "std::stop_source ssrc; use(ssrc);"                       },
+    {"shared_mutex",       "std::shared_mutex smtx; use(smtx);"                      },
+    {"regex",              "std::regex rx(\"hello.*\"); use(rx);"                    },
+    {"filesystem",         "auto cwd = std::filesystem::current_path(); use(cwd);"   },
+    {"locale",             "auto& lc = std::locale::classic(); use(lc);"             },
+};
 
-int main() {
-    // <cstddef> <cstdint> <climits> <cfloat>
-    std::size_t sz = 0; std::uint64_t u64 = 0;
-
-    // <type_traits> <concepts> <compare>
-    static_assert(std::is_integral_v<int>);
-    static_assert(std::integral<int>);
-    std::strong_ordering cmp = 1 <=> 2;
-
-    // <initializer_list> <utility> <tuple> <optional> <variant> <any> <expected>
-    auto il = {1, 2, 3};
-    auto pr = std::make_pair(1, 2);
-    auto tp = std::make_tuple(1, "hello", 3.14);
-    std::optional<int> opt = 42;
-    std::variant<int, double, std::string> var = "hello";
-    std::any a = 42;
-
-    // <bitset> <bit> <string_view> <string> <charconv> <format>
-    std::bitset<64> bs(0xFF);
-    auto pc = std::popcount(42u);
-    std::string_view sv = "hello";
-    std::string s = "world";
-    auto fmt = std::format("{} {}", s, 42);
-
-    // <array> <vector> <deque> <list> <forward_list>
-    std::array<int, 3> arr = {1, 2, 3};
-    std::vector<std::string> vec = {"a", "b"};
-    std::deque<int> dq = {1, 2};
-    std::list<int> lst = {1, 2};
-    std::forward_list<int> fl = {1, 2};
-
-    // <set> <map> <unordered_set> <unordered_map>
-    std::set<int> st = {1, 2, 3};
-    std::map<std::string, int> mp = {{"a", 1}};
-    std::unordered_set<int> us = {1, 2};
-    std::unordered_map<std::string, int> um = {{"b", 2}};
-
-    // <stack> <queue> <span>
-    std::stack<int> stk;
-    std::queue<int> que;
-    std::span<const int> spn(arr);
-
-    // <iterator> <ranges> <algorithm> <numeric>
-    auto it = vec.begin();
-    auto rng = vec | std::views::take(1);
-    std::sort(vec.begin(), vec.end());
-    auto sum = std::accumulate(arr.begin(), arr.end(), 0);
-
-    // <memory> <memory_resource> <scoped_allocator> <functional>
-    auto up = std::make_unique<int>(42);
-    auto sp = std::make_shared<std::string>("test");
-    std::function<int(int)> fn = [](int x) { return x * 2; };
-
-    // <ratio> <chrono>
-    using half = std::ratio<1, 2>;
-    auto now = std::chrono::system_clock::now();
-
-    // <exception> <stdexcept> <system_error>
-    try { throw std::runtime_error("test"); } catch(...) {}
-    auto ec = std::make_error_code(std::errc::invalid_argument);
-
-    // <typeinfo> <typeindex> <source_location>
-    auto& ti = typeid(int);
-    std::type_index tidx(ti);
-    auto loc = std::source_location::current();
-
-    // <new> <limits> <numbers> <valarray> <complex> <random>
-    static_assert(std::numeric_limits<double>::is_iec559);
-    constexpr auto pi = std::numbers::pi;
-    std::valarray<double> va = {1.0, 2.0, 3.0};
-    std::complex<double> cx(1.0, 2.0);
-    std::mt19937 rng_eng(42);
-
-    // <iosfwd> <ios> <streambuf> <istream> <ostream> <iostream> <sstream> <fstream>
-    std::stringstream ss;
-    ss << "hello " << 42;
-    std::cout << ss.str() << std::endl;
-
-    // <cmath> <cstdio> <cstdlib> <cstring> <ctime> <cassert> <cerrno>
-    auto sq = std::sqrt(2.0);
-    auto len = std::strlen("hello");
-    auto t = std::time(nullptr);
-    assert(sq > 1.0);
-
-    // <atomic> <mutex> <condition_variable> <thread> <future>
-    std::atomic<int> ai{0};
-    std::mutex mtx;
-    std::condition_variable cv;
-
-    // <semaphore> <latch> <barrier> <stop_token> <shared_mutex>
-    std::counting_semaphore<1> sem(1);
-    std::latch lat(1);
-
-    // <regex> <filesystem>
-    std::regex rx("hello.*");
-    auto cwd = std::filesystem::current_path();
-
-    // <locale> <codecvt>
-    auto& loc2 = std::locale::classic();
-
-    use(sz, u64, cmp, il, pr, tp, opt, var, a, bs, pc, sv, s, fmt,
-        arr, vec, dq, lst, fl, st, mp, us, um, stk, que, spn,
-        it, rng, sum, up, sp, fn, now, ec, ti, tidx, loc,
-        pi, va, cx, rng_eng, ss, sq, len, t, ai, mtx, cv,
-        sem, lat, rx, cwd, loc2);
-    return 0;
-}
-)cpp";
+std::string make_heavy_source(const std::string& preamble,
+                              const std::vector<std::string>& headers,
+                              std::size_t count) {
+    std::string source = preamble;
+    source += "\ntemplate <typename... Ts> void use(Ts&&...) {}\n\nint main() {\n";
+    for(std::size_t i = 0; i < count && i < headers.size(); i += 1) {
+        auto it = HEAVY_SNIPPETS.find(headers[i]);
+        if(it != HEAVY_SNIPPETS.end()) {
+            source += "    ";
+            source += it->second;
+            source += "\n";
+        }
+    }
+    source += "    return 0;\n}\n";
+    return source;
 }
 
 void bench_ast_load(const std::vector<std::string>& headers, std::size_t count, int runs) {
@@ -697,13 +706,13 @@ void bench_ast_load(const std::vector<std::string>& headers, std::size_t count, 
     std::string chain_pch = prev_pch;
 
     struct Scenario {
-        const char* name;
+        std::string name;
         std::string source;
     };
 
     Scenario scenarios[] = {
-        {"light (3 types)",     make_light_source(preamble)},
-        {"heavy (all headers)", make_heavy_source(preamble)},
+        {"light (2 types)", make_light_source(preamble)},
+        {std::format("heavy ({} headers)", count), make_heavy_source(preamble, headers, count)},
     };
 
     for(auto& [name, source]: scenarios) {
@@ -749,7 +758,7 @@ void bench_ast_load(const std::vector<std::string>& headers, std::size_t count, 
             double ratio = bench::percentile(chain_times, 0.5) / bench::percentile(mono_times, 0.5);
             std::println("  Ratio (chained/mono): {:.2f}x", ratio);
         } else if(chain_times.empty()) {
-            std::println("  Chained PCH: compilation FAILED (heavy source may have errors)");
+            std::println("  Chained PCH: compilation FAILED");
         }
     }
 }

--- a/benchmarks/pch_chain_benchmark.cpp
+++ b/benchmarks/pch_chain_benchmark.cpp
@@ -348,6 +348,7 @@ void bench_monolithic(const std::vector<std::string>& headers, std::size_t count
     }
 
     if(!times.empty()) {
+        std::ranges::sort(times);
         double mean =
             std::accumulate(times.begin(), times.end(), 0.0) / static_cast<double>(times.size());
         double median = bench::percentile(times, 0.5);
@@ -368,9 +369,7 @@ void bench_chained(const std::vector<std::string>& headers, std::size_t count, i
         bool success = false;
     };
 
-    TempTracker temps;
-
-    auto build_chain = [&](bool verbose) -> std::vector<LinkInfo> {
+    auto build_chain = [&](TempTracker& temps, bool verbose) -> std::vector<LinkInfo> {
         std::vector<LinkInfo> links;
         links.reserve(count);
 
@@ -418,8 +417,10 @@ void bench_chained(const std::vector<std::string>& headers, std::size_t count, i
         return links.size() == count && links.back().success;
     };
 
-    // First run: verbose, report per-link times.
-    auto links = build_chain(true);
+    // First run: verbose, report per-link times. Its chain must survive
+    // for the correctness check below.
+    TempTracker temps;
+    auto links = build_chain(temps, true);
 
     double total_ms = 0;
     for(auto& link: links) {
@@ -445,7 +446,11 @@ void bench_chained(const std::vector<std::string>& headers, std::size_t count, i
         totals.push_back(total_ms);
 
         for(int r = 1; r < runs; r += 1) {
-            auto chain = build_chain(false);
+            // A tracker per run: only the summed time survives the
+            // iteration, and a full standard-library chain of PCHs per run
+            // would otherwise pile up in the temp dir until exit.
+            TempTracker run_temps;
+            auto chain = build_chain(run_temps, false);
             if(!is_complete(chain)) {
                 std::println("  Run {}: chain incomplete, discarded", r + 1);
                 continue;
@@ -457,6 +462,7 @@ void bench_chained(const std::vector<std::string>& headers, std::size_t count, i
             totals.push_back(total);
         }
 
+        std::ranges::sort(totals);
         double mean =
             std::accumulate(totals.begin(), totals.end(), 0.0) / static_cast<double>(totals.size());
         double median = bench::percentile(totals, 0.5);
@@ -516,6 +522,8 @@ void bench_incremental(const std::vector<std::string>& headers, std::size_t base
     }
 
     if(!mono_times.empty() && !chain_times.empty()) {
+        std::ranges::sort(mono_times);
+        std::ranges::sort(chain_times);
         double mono_med = bench::percentile(mono_times, 0.5);
         double chain_med = bench::percentile(chain_times, 0.5);
         std::println("  Monolithic full rebuild:  median {:.1f}ms", mono_med);
@@ -721,6 +729,8 @@ void bench_ast_load(const std::vector<std::string>& headers, std::size_t count, 
                 chain_times.push_back(ms);
         }
 
+        std::ranges::sort(mono_times);
+        std::ranges::sort(chain_times);
         if(!mono_times.empty()) {
             double med = bench::percentile(mono_times, 0.5);
             std::println("  Monolithic PCH → compile:  median {:.1f}ms  (min {:.1f}, max {:.1f})",
@@ -820,6 +830,8 @@ void bench_end_to_end(const std::vector<std::string>& headers, std::size_t count
             chain_append_times.push_back(result.ms);
     }
 
+    std::ranges::sort(mono_rebuild_times);
+    std::ranges::sort(chain_append_times);
     if(!mono_rebuild_times.empty()) {
         std::println("    Monolithic full rebuild:  median {:.1f}ms",
                      bench::percentile(mono_rebuild_times, 0.5));

--- a/benchmarks/pch_chain_benchmark.cpp
+++ b/benchmarks/pch_chain_benchmark.cpp
@@ -237,8 +237,7 @@ struct PCHBuildResult {
 PCHBuildResult build_one_pch(const std::string& header_text,
                              const std::string& file_path,
                              const std::string& output_path,
-                             const std::string& prev_pch = "",
-                             std::uint32_t prev_bound = 0) {
+                             const std::string& prev_pch = "") {
     PCHBuildResult result;
 
     CompilationParams cp;
@@ -250,7 +249,11 @@ PCHBuildResult build_one_pch(const std::string& header_text,
     cp.add_remapped_file(file_path, header_text);
 
     if(!prev_pch.empty()) {
-        cp.pch = {prev_pch, prev_bound};
+        // Bound 0: PrecompiledPreambleBytes tells clang to skip the first N
+        // bytes of the current source, which is only correct when the PCH
+        // was built FROM the current file (monolithic preamble). Each chain
+        // link is a separate file, so nothing must be skipped.
+        cp.pch = {prev_pch, 0};
     }
 
     auto start = Clock::now();
@@ -283,8 +286,10 @@ PCHBuildResult build_one_pch(const std::string& header_text,
     return result;
 }
 
-/// Verify a PCH works by syntax-checking a test file against it.
-bool verify_pch(const std::string& pch_path, std::uint32_t preamble_bound) {
+/// Verify a PCH works by syntax-checking a test file against it. Bound 0:
+/// the verify source does not embed the PCH's preamble text, so no bytes
+/// of it may be skipped.
+bool verify_pch(const std::string& pch_path) {
     CompilationParams cp;
     cp.kind = CompilationKind::Content;
 
@@ -292,7 +297,7 @@ bool verify_pch(const std::string& pch_path, std::uint32_t preamble_bound) {
     auto args = make_source_args(file);
     cp.arguments = args.argv;
     cp.add_remapped_file(file, "static_assert(sizeof(int) > 0);\nint main() { return 0; }\n");
-    cp.pch = {pch_path, preamble_bound};
+    cp.pch = {pch_path, 0};
 
     auto unit = compile(cp);
     return unit.completed();
@@ -349,8 +354,7 @@ void bench_monolithic(const std::vector<std::string>& headers, std::size_t count
         times.push_back(result.ms);
         if(r == 0) {
             std::println("  Size: {} KB", result.size_bytes / 1024);
-            auto bound = static_cast<std::uint32_t>(preamble.size());
-            std::println("  Correctness: {}", verify_pch(pch_path, bound) ? "PASS" : "FAIL");
+            std::println("  Correctness: {}", verify_pch(pch_path) ? "PASS" : "FAIL");
         }
     }
 
@@ -391,12 +395,7 @@ void bench_chained(const std::vector<std::string>& headers, std::size_t count, i
             std::string file_path = temps.create("chain-link", "h");
             link.pch_path = temps.create("chain", "pch");
 
-            // For chained PCH the bound is always 0: PrecompiledPreambleBytes
-            // tells clang to skip the first N bytes of the current source,
-            // which is only correct when the PCH was built FROM the current
-            // file (monolithic preamble). Each chain link is a separate
-            // file, so nothing must be skipped.
-            auto result = build_one_pch(text, file_path, link.pch_path, prev_pch, 0);
+            auto result = build_one_pch(text, file_path, link.pch_path, prev_pch);
             link.build_ms = result.ms;
             link.success = result.success;
 
@@ -448,9 +447,8 @@ void bench_chained(const std::vector<std::string>& headers, std::size_t count, i
                  total_ms);
 
     if(!links.empty() && links.back().success) {
-        // bound=0: the chain PCH does not cover the verify file.
         std::println("  Final PCH correctness: {}",
-                     verify_pch(links.back().pch_path, 0) ? "PASS" : "FAIL");
+                     verify_pch(links.back().pch_path) ? "PASS" : "FAIL");
     }
 
     // Additional runs for timing statistics.
@@ -492,8 +490,7 @@ void bench_incremental(const std::vector<std::string>& headers, std::size_t base
         auto result = build_one_pch(text,
                                     temps.create("incr-base", "h"),
                                     temps.create("incr-base", "pch"),
-                                    prev_pch,
-                                    0);
+                                    prev_pch);
         if(!result.success) {
             std::println("  Base chain failed at link {} (<{}>)", i + 1, headers[i]);
             return;
@@ -523,7 +520,7 @@ void bench_incremental(const std::vector<std::string>& headers, std::size_t base
 
     for(int r = 0; r < runs; r += 1) {
         fs::remove(extra_pch);
-        auto result = build_one_pch(extra_text, extra_file, extra_pch, prev_pch, 0);
+        auto result = build_one_pch(extra_text, extra_file, extra_pch, prev_pch);
         if(result.success)
             chain_times.push_back(result.ms);
     }
@@ -687,8 +684,7 @@ void bench_ast_load(const std::vector<std::string>& headers, std::size_t count, 
         auto result = build_one_pch(text,
                                     temps.create("ast-chain", "h"),
                                     temps.create("ast-chain", "pch"),
-                                    prev_pch,
-                                    0);
+                                    prev_pch);
         if(!result.success) {
             std::println("  Chain build failed at link {} (<{}>): {}",
                          i + 1,
@@ -772,9 +768,7 @@ void bench_end_to_end(const std::vector<std::string>& headers, std::size_t count
         return;
     }
     std::println("    Build: {:.1f}ms", mono_result.ms);
-    std::println("    Verify: {}",
-                 verify_pch(mono_pch, static_cast<std::uint32_t>(mono_preamble.size())) ? "PASS"
-                                                                                        : "FAIL");
+    std::println("    Verify: {}", verify_pch(mono_pch) ? "PASS" : "FAIL");
 
     // Phase 2: background — split into a chain for future incremental use;
     // the user keeps editing and never waits for this.
@@ -788,8 +782,7 @@ void bench_end_to_end(const std::vector<std::string>& headers, std::size_t count
         auto result = build_one_pch(text,
                                     temps.create("e2e-chain", "h"),
                                     temps.create("e2e-chain", "pch"),
-                                    prev_pch,
-                                    0);
+                                    prev_pch);
         if(!result.success) {
             std::println("    Chain failed at link {} (<{}>): {}", i + 1, headers[i], result.error);
             return;
@@ -801,7 +794,7 @@ void bench_end_to_end(const std::vector<std::string>& headers, std::size_t count
     double split_ms = std::chrono::duration<double, std::milli>(split_end - split_start).count();
 
     std::println("    Split into {} links: {:.1f}ms", chain_pchs.size(), split_ms);
-    std::println("    Verify final link: {}", verify_pch(chain_pchs.back(), 0) ? "PASS" : "FAIL");
+    std::println("    Verify final link: {}", verify_pch(chain_pchs.back()) ? "PASS" : "FAIL");
 
     // Phase 3: user adds a new #include at the preamble end.
     std::println("\n  Phase 3: User adds #include <chrono> at preamble end");
@@ -823,8 +816,7 @@ void bench_end_to_end(const std::vector<std::string>& headers, std::size_t count
         auto result = build_one_pch(extra_text,
                                     temps.create("e2e-append", "h"),
                                     temps.create("e2e-append", "pch"),
-                                    chain_pchs.back(),
-                                    0);
+                                    chain_pchs.back());
         if(result.success)
             chain_append_times.push_back(result.ms);
     }
@@ -860,8 +852,7 @@ int main() {
         auto result = build_one_pch(extra_text,
                                     temps.create("e2e-final", "h"),
                                     temps.create("e2e-final", "pch"),
-                                    chain_pchs.back(),
-                                    0);
+                                    chain_pchs.back());
         if(result.success) {
             // bound=0: the chain PCH covers no bytes of the source file.
             double ms = compile_with_pch(full_source, source_file, result.path, 0);

--- a/benchmarks/pch_chain_benchmark.cpp
+++ b/benchmarks/pch_chain_benchmark.cpp
@@ -277,17 +277,26 @@ PCHBuildResult build_one_pch(const std::string& header_text,
     return result;
 }
 
-/// Verify a PCH works by syntax-checking a test file against it. Bound 0:
+std::string make_heavy_source(const std::string& preamble,
+                              const std::vector<std::string>& headers,
+                              std::size_t count);
+
+/// Verify a PCH by compiling code that uses representative declarations
+/// from every selected header WITHOUT re-including any of them (the heavy
+/// source over an empty preamble), so a loadable but incomplete PCH — a
+/// chain that dropped earlier links — fails instead of passing. Bound 0:
 /// the verify source does not embed the PCH's preamble text, so no bytes
 /// of it may be skipped.
-bool verify_pch(const std::string& pch_path) {
+bool verify_pch(const std::string& pch_path,
+                const std::vector<std::string>& headers,
+                std::size_t count) {
     CompilationParams cp;
     cp.kind = CompilationKind::Content;
 
     auto file = virtual_path("pch-verify.cpp");
     auto args = make_source_args(file);
     cp.arguments = args.argv;
-    cp.add_remapped_file(file, "static_assert(sizeof(int) > 0);\nint main() { return 0; }\n");
+    cp.add_remapped_file(file, make_heavy_source("", headers, count));
     cp.pch = {pch_path, 0};
 
     auto unit = compile(cp);
@@ -344,7 +353,8 @@ void bench_monolithic(const std::vector<std::string>& headers, std::size_t count
         times.push_back(result.ms);
         if(r == 0) {
             std::println("  Size: {} KB", result.size_bytes / 1024);
-            std::println("  Correctness: {}", verify_pch(pch_path) ? "PASS" : "FAIL");
+            std::println("  Correctness: {}",
+                         verify_pch(pch_path, headers, count) ? "PASS" : "FAIL");
         }
     }
 
@@ -439,7 +449,7 @@ void bench_chained(const std::vector<std::string>& headers, std::size_t count, i
 
     std::println("\n  Chain result: {} links, total {:.1f}ms", links.size(), total_ms);
     std::println("  Final PCH correctness: {}",
-                 verify_pch(links.back().pch_path) ? "PASS" : "FAIL");
+                 verify_pch(links.back().pch_path, headers, count) ? "PASS" : "FAIL");
 
     // Additional runs for timing statistics.
     if(runs > 1) {
@@ -784,7 +794,7 @@ void bench_end_to_end(const std::vector<std::string>& headers, std::size_t count
         return;
     }
     std::println("    Build: {:.1f}ms", mono_result.ms);
-    std::println("    Verify: {}", verify_pch(mono_pch) ? "PASS" : "FAIL");
+    std::println("    Verify: {}", verify_pch(mono_pch, headers, count) ? "PASS" : "FAIL");
 
     // Phase 2: background — split into a chain for future incremental use;
     // the user keeps editing and never waits for this.
@@ -810,7 +820,8 @@ void bench_end_to_end(const std::vector<std::string>& headers, std::size_t count
     double split_ms = std::chrono::duration<double, std::milli>(split_end - split_start).count();
 
     std::println("    Split into {} links: {:.1f}ms", chain_pchs.size(), split_ms);
-    std::println("    Verify final link: {}", verify_pch(chain_pchs.back()) ? "PASS" : "FAIL");
+    std::println("    Verify final link: {}",
+                 verify_pch(chain_pchs.back(), headers, count) ? "PASS" : "FAIL");
 
     // Phase 3: user adds a new #include at the preamble end. <cinttypes>
     // is deliberately outside ALL_HEADERS: appending a header already in

--- a/benchmarks/pch_chain_benchmark.cpp
+++ b/benchmarks/pch_chain_benchmark.cpp
@@ -262,17 +262,18 @@ PCHBuildResult build_one_pch(const std::string& header_text,
     auto unit = compile(cp, pch_info);
     bool ok = unit.completed();
 
-    auto end = Clock::now();
-    result.ms = std::chrono::duration<double, std::milli>(end - start).count();
-
     if(!ok) {
+        result.ms = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
         auto errors = collect_errors(unit);
         result.error = errors.empty() ? "PCH compilation failed (no diagnostics)" : errors;
         return result;
     }
 
-    // Flush to disk by destroying the unit.
+    // The unit's destructor flushes the PCH to disk; that write is part of
+    // the build cost being compared, so destroy before stopping the clock.
     unit = CompilationUnit(nullptr);
+    result.ms = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
+
     if(!llvm::sys::fs::exists(output_path)) {
         result.error = "PCH file not written to disk";
         return result;
@@ -300,7 +301,9 @@ bool verify_pch(const std::string& pch_path) {
     cp.pch = {pch_path, 0};
 
     auto unit = compile(cp);
-    return unit.completed();
+    // completed() only covers frontend execution; a compile over a broken
+    // PCH still completes carrying ordinary error diagnostics.
+    return unit.completed() && collect_errors(unit).empty();
 }
 
 /// Compile a source file over a given PCH and report the wall-clock time,
@@ -319,7 +322,9 @@ double compile_with_pch(const std::string& source_text,
 
     auto start = Clock::now();
     auto unit = compile(cp);
-    bool ok = unit.completed();
+    // See verify_pch: an erroneous parse still reports completed(), and its
+    // timing must not enter the latency samples.
+    bool ok = unit.completed() && collect_errors(unit).empty();
     unit = CompilationUnit(nullptr);
     auto end = Clock::now();
 
@@ -416,40 +421,43 @@ void bench_chained(const std::vector<std::string>& headers, std::size_t count, i
                 }
             }
 
-            // A failed link is skipped; the chain continues over the
-            // previous PCH.
-            if(result.success) {
-                prev_pch = link.pch_path;
-            }
+            bool success = result.success;
             links.push_back(std::move(link));
+            // A partial chain must not masquerade as the requested one:
+            // stop here and let the caller discard the run.
+            if(!success) {
+                break;
+            }
+            prev_pch = links.back().pch_path;
         }
 
         return links;
     };
 
+    auto is_complete = [&](const std::vector<LinkInfo>& links) {
+        return links.size() == count && links.back().success;
+    };
+
     // First run: verbose, report per-link times.
     auto links = build_chain(true);
 
-    std::size_t passed = 0, failed = 0;
     double total_ms = 0;
     for(auto& link: links) {
         if(link.success) {
-            passed += 1;
             total_ms += link.build_ms;
-        } else {
-            failed += 1;
         }
     }
 
-    std::println("\n  Chain result: {} passed, {} failed, total {:.1f}ms",
-                 passed,
-                 failed,
-                 total_ms);
-
-    if(!links.empty() && links.back().success) {
-        std::println("  Final PCH correctness: {}",
-                     verify_pch(links.back().pch_path) ? "PASS" : "FAIL");
+    if(!is_complete(links)) {
+        std::println("\n  Chain INCOMPLETE ({}/{} links built) — no timing statistics",
+                     links.empty() ? 0 : links.size() - 1,
+                     count);
+        return;
     }
+
+    std::println("\n  Chain result: {} links, total {:.1f}ms", links.size(), total_ms);
+    std::println("  Final PCH correctness: {}",
+                 verify_pch(links.back().pch_path) ? "PASS" : "FAIL");
 
     // Additional runs for timing statistics.
     if(runs > 1) {
@@ -458,10 +466,13 @@ void bench_chained(const std::vector<std::string>& headers, std::size_t count, i
 
         for(int r = 1; r < runs; r += 1) {
             auto chain = build_chain(false);
+            if(!is_complete(chain)) {
+                std::println("  Run {}: chain incomplete, discarded", r + 1);
+                continue;
+            }
             double total = 0;
             for(auto& link: chain) {
-                if(link.success)
-                    total += link.build_ms;
+                total += link.build_ms;
             }
             totals.push_back(total);
         }
@@ -662,6 +673,8 @@ int main() {
 
 void bench_ast_load(const std::vector<std::string>& headers, std::size_t count, int runs) {
     std::println("\n=== AST LOAD LATENCY ({} headers, {} runs) ===", count, runs);
+    std::println("  (mono consumes the source with its preamble skipped via the bound;");
+    std::println("   the chain re-preprocesses the include lines under the imported PCH)");
 
     auto preamble = make_preamble(headers, count);
     auto preamble_bound = static_cast<std::uint32_t>(preamble.size());
@@ -719,7 +732,12 @@ void bench_ast_load(const std::vector<std::string>& headers, std::size_t count, 
         }
 
         for(int r = 0; r < runs; r += 1) {
-            double ms = compile_with_pch(source, source_file, chain_pch, preamble_bound);
+            // Bound 0: the chain PCH was built from separate per-header
+            // files, so no bytes of this source may be skipped (see
+            // build_one_pch). The chain therefore re-preprocesses the
+            // include lines — guard-skipped, but not free — which the mono
+            // side avoids entirely; the ratio includes that gap.
+            double ms = compile_with_pch(source, source_file, chain_pch, 0);
             if(ms >= 0)
                 chain_times.push_back(ms);
         }
@@ -796,9 +814,11 @@ void bench_end_to_end(const std::vector<std::string>& headers, std::size_t count
     std::println("    Split into {} links: {:.1f}ms", chain_pchs.size(), split_ms);
     std::println("    Verify final link: {}", verify_pch(chain_pchs.back()) ? "PASS" : "FAIL");
 
-    // Phase 3: user adds a new #include at the preamble end.
-    std::println("\n  Phase 3: User adds #include <chrono> at preamble end");
-    std::string extra_text = "#include <chrono>\n";
+    // Phase 3: user adds a new #include at the preamble end. <cinttypes>
+    // is deliberately outside ALL_HEADERS: appending a header already in
+    // the chain would measure a guarded-include no-op.
+    std::println("\n  Phase 3: User adds #include <cinttypes> at preamble end");
+    std::string extra_text = "#include <cinttypes>\n";
 
     // Strategy A: monolithic — full rebuild.
     std::vector<double> mono_rebuild_times;
@@ -833,14 +853,14 @@ void bench_end_to_end(const std::vector<std::string>& headers, std::size_t count
         }
     }
 
-    // Phase 4: verify the appended chain PCH works with real code.
+    // Phase 4: verify the appended chain PCH works with real code. The
+    // source only uses the appended header, so it stays valid for any
+    // --chain-length.
     std::println("\n  Phase 4: Correctness — compile real code with appended chain");
     std::string verify_source = R"cpp(
 int main() {
-    auto now = std::chrono::system_clock::now();
-    std::vector<std::string> v = {"hello"};
-    std::map<int, double> m = {{1, 3.14}};
-    return 0;
+    std::intmax_t value = std::imaxabs(-42);
+    return static_cast<int>(value - 42);
 }
 )cpp";
     std::string full_preamble = mono_preamble + extra_text;

--- a/benchmarks/pch_chain_benchmark.cpp
+++ b/benchmarks/pch_chain_benchmark.cpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 
+#include "stats.h"
 #include "command/argument_parser.h"
 #include "command/command.h"
 #include "compile/compilation.h"
@@ -213,18 +214,6 @@ ArgList make_source_args(const std::string& file) {
                    file};
 }
 
-std::string collect_errors(CompilationUnit& unit) {
-    std::string errors;
-    for(auto& diag: unit.diagnostics()) {
-        if(diag.id.level >= DiagnosticLevel::Error) {
-            if(!errors.empty())
-                errors += "; ";
-            errors += diag.message;
-        }
-    }
-    return errors;
-}
-
 struct PCHBuildResult {
     bool success = false;
     std::string path;
@@ -333,11 +322,6 @@ double compile_with_pch(const std::string& source_text,
     return std::chrono::duration<double, std::milli>(end - start).count();
 }
 
-double median_of(std::vector<double>& values) {
-    std::ranges::sort(values);
-    return values[values.size() / 2];
-}
-
 void bench_monolithic(const std::vector<std::string>& headers, std::size_t count, int runs) {
     std::println("=== MONOLITHIC PCH ({} headers, {} runs) ===", count, runs);
 
@@ -366,7 +350,7 @@ void bench_monolithic(const std::vector<std::string>& headers, std::size_t count
     if(!times.empty()) {
         double mean =
             std::accumulate(times.begin(), times.end(), 0.0) / static_cast<double>(times.size());
-        double median = median_of(times);
+        double median = bench::percentile(times, 0.5);
         std::println("  Min: {:.1f}ms  Median: {:.1f}ms  Mean: {:.1f}ms  Max: {:.1f}ms",
                      times.front(),
                      median,
@@ -379,7 +363,6 @@ void bench_chained(const std::vector<std::string>& headers, std::size_t count, i
     std::println("\n=== CHAINED PCH ({} headers, {} runs) ===", count, runs);
 
     struct LinkInfo {
-        std::string header;
         std::string pch_path;
         double build_ms = 0;
         bool success = false;
@@ -394,8 +377,6 @@ void bench_chained(const std::vector<std::string>& headers, std::size_t count, i
         std::string prev_pch;
         for(std::size_t i = 0; i < count && i < headers.size(); i += 1) {
             LinkInfo link;
-            link.header = headers[i];
-
             std::string text = "#include <" + headers[i] + ">\n";
             std::string file_path = temps.create("chain-link", "h");
             link.pch_path = temps.create("chain", "pch");
@@ -421,11 +402,10 @@ void bench_chained(const std::vector<std::string>& headers, std::size_t count, i
                 }
             }
 
-            bool success = result.success;
             links.push_back(std::move(link));
             // A partial chain must not masquerade as the requested one:
             // stop here and let the caller discard the run.
-            if(!success) {
+            if(!result.success) {
                 break;
             }
             prev_pch = links.back().pch_path;
@@ -450,7 +430,7 @@ void bench_chained(const std::vector<std::string>& headers, std::size_t count, i
 
     if(!is_complete(links)) {
         std::println("\n  Chain INCOMPLETE ({}/{} links built) — no timing statistics",
-                     links.empty() ? 0 : links.size() - 1,
+                     std::ranges::count_if(links, &LinkInfo::success),
                      count);
         return;
     }
@@ -479,7 +459,7 @@ void bench_chained(const std::vector<std::string>& headers, std::size_t count, i
 
         double mean =
             std::accumulate(totals.begin(), totals.end(), 0.0) / static_cast<double>(totals.size());
-        double median = median_of(totals);
+        double median = bench::percentile(totals, 0.5);
         std::println(
             "  Total chain build - Min: {:.1f}ms  Median: {:.1f}ms  Mean: {:.1f}ms  Max: {:.1f}ms",
             totals.front(),
@@ -524,8 +504,7 @@ void bench_incremental(const std::vector<std::string>& headers, std::size_t base
     }
 
     // Chained incremental: just append one more link.
-    std::string extra_hdr = (base_count < headers.size()) ? headers[base_count] : "version";
-    std::string extra_text = "#include <" + extra_hdr + ">\n";
+    std::string extra_text = "#include <" + headers[base_count] + ">\n";
     std::string extra_file = temps.create("incr-extra", "h");
     std::string extra_pch = temps.create("incr-extra", "pch");
 
@@ -537,8 +516,8 @@ void bench_incremental(const std::vector<std::string>& headers, std::size_t base
     }
 
     if(!mono_times.empty() && !chain_times.empty()) {
-        double mono_med = median_of(mono_times);
-        double chain_med = median_of(chain_times);
+        double mono_med = bench::percentile(mono_times, 0.5);
+        double chain_med = bench::percentile(chain_times, 0.5);
         std::println("  Monolithic full rebuild:  median {:.1f}ms", mono_med);
         std::println("  Chained append-one-link:  median {:.1f}ms", chain_med);
         std::println("  Speedup: {:.1f}x", mono_med / chain_med);
@@ -743,21 +722,21 @@ void bench_ast_load(const std::vector<std::string>& headers, std::size_t count, 
         }
 
         if(!mono_times.empty()) {
-            double med = median_of(mono_times);
+            double med = bench::percentile(mono_times, 0.5);
             std::println("  Monolithic PCH → compile:  median {:.1f}ms  (min {:.1f}, max {:.1f})",
                          med,
                          mono_times.front(),
                          mono_times.back());
         }
         if(!chain_times.empty()) {
-            double med = median_of(chain_times);
+            double med = bench::percentile(chain_times, 0.5);
             std::println("  Chained PCH    → compile:  median {:.1f}ms  (min {:.1f}, max {:.1f})",
                          med,
                          chain_times.front(),
                          chain_times.back());
         }
         if(!mono_times.empty() && !chain_times.empty()) {
-            double ratio = median_of(chain_times) / median_of(mono_times);
+            double ratio = bench::percentile(chain_times, 0.5) / bench::percentile(mono_times, 0.5);
             std::println("  Ratio (chained/mono): {:.2f}x", ratio);
         } else if(chain_times.empty()) {
             std::println("  Chained PCH: compilation FAILED (heavy source may have errors)");
@@ -843,13 +822,14 @@ void bench_end_to_end(const std::vector<std::string>& headers, std::size_t count
 
     if(!mono_rebuild_times.empty()) {
         std::println("    Monolithic full rebuild:  median {:.1f}ms",
-                     median_of(mono_rebuild_times));
+                     bench::percentile(mono_rebuild_times, 0.5));
     }
     if(!chain_append_times.empty()) {
-        double chain_med = median_of(chain_append_times);
+        double chain_med = bench::percentile(chain_append_times, 0.5);
         std::println("    Chained append 1 link:   median {:.1f}ms", chain_med);
         if(!mono_rebuild_times.empty()) {
-            std::println("    Speedup: {:.0f}x", median_of(mono_rebuild_times) / chain_med);
+            std::println("    Speedup: {:.0f}x",
+                         bench::percentile(mono_rebuild_times, 0.5) / chain_med);
         }
     }
 

--- a/benchmarks/pch_chain_benchmark.cpp
+++ b/benchmarks/pch_chain_benchmark.cpp
@@ -1,0 +1,944 @@
+/// Benchmark: monolithic PCH vs chained PCH using clice's compile() API.
+///
+/// Ported from PR #405. Answers the strategy question behind incremental
+/// preamble builds: what does a one-link-per-#include PCH chain cost to
+/// build (full and incremental) and to consume (AST load latency), against
+/// the monolithic preamble the server builds today?
+///
+/// Tests:
+///   1. Correctness of chained PCH across the C++ standard library headers
+///   2. Build time: monolithic (single PCH) vs chained (one per #include)
+///   3. Incremental rebuild: appending one header to an existing chain
+///   4. Compile-with-PCH latency for both strategies
+///   5. End-to-end: monolithic first, background split, incremental append
+///
+/// Usage:
+///   pch_chain_benchmark [--runs N] [--chain-length N]
+
+#include <algorithm>
+#include <chrono>
+#include <numeric>
+#include <print>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "command/argument_parser.h"
+#include "command/command.h"
+#include "compile/compilation.h"
+#include "support/filesystem.h"
+#include "support/logging.h"
+
+#include "kota/deco/deco.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+
+using namespace clice;
+using Clock = std::chrono::steady_clock;
+
+namespace {
+
+struct BenchmarkOptions {
+    DecoKV(names = {"--runs"}; help = "Repetitions per measurement"; required = false;)
+    <int> runs = 3;
+
+    DecoKV(names = {"--chain-length"}; help = "Number of headers in the chain (capped at all)";
+           required = false;)
+    <int> chain_length = 0;
+
+    DecoKV(names = {"--log-level"}; help = "Log level: trace, debug, info, warn, error, off";
+           required = false;)
+    <std::string> log_level = "off";
+
+    DecoFlag(names = {"-h", "--help"}; help = "Show help message"; required = false;)
+    help;
+};
+
+/// C++20 standard library headers in a dependency-friendly include order
+/// (basic types first, I/O last).
+const std::vector<std::string> ALL_HEADERS = {
+    "cstddef",
+    "cstdint",
+    "climits",
+    "cfloat",
+    "type_traits",
+    "concepts",
+    "compare",
+    "initializer_list",
+    "utility",
+    "tuple",
+    "optional",
+    "variant",
+    "any",
+    "expected",
+    "bitset",
+    "bit",
+    "string_view",
+    "string",
+    "charconv",
+    "format",
+    "array",
+    "vector",
+    "deque",
+    "list",
+    "forward_list",
+    "set",
+    "map",
+    "unordered_set",
+    "unordered_map",
+    "stack",
+    "queue",
+    "span",
+    "iterator",
+    "ranges",
+    "algorithm",
+    "numeric",
+    "memory",
+    "memory_resource",
+    "scoped_allocator",
+    "functional",
+    "ratio",
+    "chrono",
+    "exception",
+    "stdexcept",
+    "system_error",
+    "typeinfo",
+    "typeindex",
+    "source_location",
+    "new",
+    "limits",
+    "numbers",
+    "valarray",
+    "complex",
+    "random",
+    "iosfwd",
+    "ios",
+    "streambuf",
+    "istream",
+    "ostream",
+    "iostream",
+    "sstream",
+    "fstream",
+    "cmath",
+    "cstdio",
+    "cstdlib",
+    "cstring",
+    "ctime",
+    "cassert",
+    "cerrno",
+    "atomic",
+    "mutex",
+    "condition_variable",
+    "thread",
+    "future",
+    "semaphore",
+    "latch",
+    "barrier",
+    "stop_token",
+    "shared_mutex",
+    "regex",
+    "filesystem",
+    "locale",
+    "codecvt",
+};
+
+/// Generate preamble text for the first `count` headers.
+std::string make_preamble(const std::vector<std::string>& headers, std::size_t count) {
+    std::string text;
+    for(std::size_t i = 0; i < count && i < headers.size(); i += 1) {
+        text += "#include <" + headers[i] + ">\n";
+    }
+    return text;
+}
+
+/// Owns every temporary path a benchmark routine creates and removes them
+/// on scope exit, so failure paths can simply return.
+struct TempTracker {
+    std::vector<std::string> paths;
+
+    ~TempTracker() {
+        for(auto& path: paths) {
+            fs::remove(path);
+        }
+    }
+
+    std::string create(llvm::StringRef prefix, llvm::StringRef ext) {
+        auto result = fs::createTemporaryFile(prefix, ext);
+        if(!result) {
+            std::println(stderr, "Failed to create temp file");
+            std::exit(1);
+        }
+        paths.push_back(*result);
+        return *result;
+    }
+};
+
+/// A path inside the system temp dir for a buffer that is only ever
+/// remapped, never written.
+std::string virtual_path(llvm::StringRef name) {
+    llvm::SmallString<128> path;
+    llvm::sys::path::system_temp_directory(/*ErasedOnReboot=*/true, path);
+    llvm::sys::path::append(path, name);
+    return path.str().str();
+}
+
+/// Owns argument storage for one compile invocation.
+struct ArgList {
+    std::vector<std::string> storage;
+    std::vector<const char*> argv;
+
+    ArgList(std::initializer_list<std::string> args) : storage(args) {
+        for(auto& arg: storage) {
+            argv.push_back(arg.c_str());
+        }
+    }
+};
+
+ArgList make_pch_args(const std::string& file) {
+    return ArgList{"clang++",
+                   "-std=c++20",
+                   "-resource-dir",
+                   resource_dir().str(),
+                   "-x",
+                   "c++-header",
+                   file};
+}
+
+ArgList make_source_args(const std::string& file) {
+    return ArgList{"clang++",
+                   "-std=c++20",
+                   "-resource-dir",
+                   resource_dir().str(),
+                   "-fsyntax-only",
+                   file};
+}
+
+std::string collect_errors(CompilationUnit& unit) {
+    std::string errors;
+    for(auto& diag: unit.diagnostics()) {
+        if(diag.id.level >= DiagnosticLevel::Error) {
+            if(!errors.empty())
+                errors += "; ";
+            errors += diag.message;
+        }
+    }
+    return errors;
+}
+
+struct PCHBuildResult {
+    bool success = false;
+    std::string path;
+    double ms = 0;
+    std::uint64_t size_bytes = 0;
+    std::string error;
+};
+
+/// Build a single PCH (monolithic, or one chain link over `prev_pch`).
+PCHBuildResult build_one_pch(const std::string& header_text,
+                             const std::string& file_path,
+                             const std::string& output_path,
+                             const std::string& prev_pch = "",
+                             std::uint32_t prev_bound = 0) {
+    PCHBuildResult result;
+
+    CompilationParams cp;
+    cp.kind = CompilationKind::Preamble;
+    cp.output_file = output_path;
+
+    auto args = make_pch_args(file_path);
+    cp.arguments = args.argv;
+    cp.add_remapped_file(file_path, header_text);
+
+    if(!prev_pch.empty()) {
+        cp.pch = {prev_pch, prev_bound};
+    }
+
+    auto start = Clock::now();
+
+    PCHInfo pch_info;
+    auto unit = compile(cp, pch_info);
+    bool ok = unit.completed();
+
+    auto end = Clock::now();
+    result.ms = std::chrono::duration<double, std::milli>(end - start).count();
+
+    if(!ok) {
+        auto errors = collect_errors(unit);
+        result.error = errors.empty() ? "PCH compilation failed (no diagnostics)" : errors;
+        return result;
+    }
+
+    // Flush to disk by destroying the unit.
+    unit = CompilationUnit(nullptr);
+    if(!llvm::sys::fs::exists(output_path)) {
+        result.error = "PCH file not written to disk";
+        return result;
+    }
+
+    result.success = true;
+    result.path = output_path;
+    if(auto error = llvm::sys::fs::file_size(output_path, result.size_bytes)) {
+        result.size_bytes = 0;
+    }
+    return result;
+}
+
+/// Verify a PCH works by syntax-checking a test file against it.
+bool verify_pch(const std::string& pch_path, std::uint32_t preamble_bound) {
+    CompilationParams cp;
+    cp.kind = CompilationKind::Content;
+
+    auto file = virtual_path("pch-verify.cpp");
+    auto args = make_source_args(file);
+    cp.arguments = args.argv;
+    cp.add_remapped_file(file, "static_assert(sizeof(int) > 0);\nint main() { return 0; }\n");
+    cp.pch = {pch_path, preamble_bound};
+
+    auto unit = compile(cp);
+    return unit.completed();
+}
+
+/// Compile a source file over a given PCH and report the wall-clock time,
+/// or -1 on failure.
+double compile_with_pch(const std::string& source_text,
+                        const std::string& source_file,
+                        const std::string& pch_path,
+                        std::uint32_t preamble_bound) {
+    CompilationParams cp;
+    cp.kind = CompilationKind::Content;
+
+    auto args = make_source_args(source_file);
+    cp.arguments = args.argv;
+    cp.add_remapped_file(source_file, source_text);
+    cp.pch = {pch_path, preamble_bound};
+
+    auto start = Clock::now();
+    auto unit = compile(cp);
+    bool ok = unit.completed();
+    unit = CompilationUnit(nullptr);
+    auto end = Clock::now();
+
+    if(!ok)
+        return -1.0;
+    return std::chrono::duration<double, std::milli>(end - start).count();
+}
+
+double median_of(std::vector<double>& values) {
+    std::ranges::sort(values);
+    return values[values.size() / 2];
+}
+
+void bench_monolithic(const std::vector<std::string>& headers, std::size_t count, int runs) {
+    std::println("=== MONOLITHIC PCH ({} headers, {} runs) ===", count, runs);
+
+    TempTracker temps;
+    std::string preamble = make_preamble(headers, count);
+    std::string file_path = temps.create("mono-preamble", "h");
+    std::string pch_path = temps.create("mono", "pch");
+
+    std::vector<double> times;
+    times.reserve(runs);
+
+    for(int r = 0; r < runs; r += 1) {
+        fs::remove(pch_path);
+        auto result = build_one_pch(preamble, file_path, pch_path);
+        if(!result.success) {
+            std::println(stderr, "  Run {}: FAILED - {}", r + 1, result.error);
+            break;
+        }
+        times.push_back(result.ms);
+        if(r == 0) {
+            std::println("  Size: {} KB", result.size_bytes / 1024);
+            auto bound = static_cast<std::uint32_t>(preamble.size());
+            std::println("  Correctness: {}", verify_pch(pch_path, bound) ? "PASS" : "FAIL");
+        }
+    }
+
+    if(!times.empty()) {
+        double mean =
+            std::accumulate(times.begin(), times.end(), 0.0) / static_cast<double>(times.size());
+        double median = median_of(times);
+        std::println("  Min: {:.1f}ms  Median: {:.1f}ms  Mean: {:.1f}ms  Max: {:.1f}ms",
+                     times.front(),
+                     median,
+                     mean,
+                     times.back());
+    }
+}
+
+void bench_chained(const std::vector<std::string>& headers, std::size_t count, int runs) {
+    std::println("\n=== CHAINED PCH ({} headers, {} runs) ===", count, runs);
+
+    struct LinkInfo {
+        std::string header;
+        std::string pch_path;
+        double build_ms = 0;
+        bool success = false;
+    };
+
+    TempTracker temps;
+
+    auto build_chain = [&](bool verbose) -> std::vector<LinkInfo> {
+        std::vector<LinkInfo> links;
+        links.reserve(count);
+
+        std::string prev_pch;
+        for(std::size_t i = 0; i < count && i < headers.size(); i += 1) {
+            LinkInfo link;
+            link.header = headers[i];
+
+            std::string text = "#include <" + headers[i] + ">\n";
+            std::string file_path = temps.create("chain-link", "h");
+            link.pch_path = temps.create("chain", "pch");
+
+            // For chained PCH the bound is always 0: PrecompiledPreambleBytes
+            // tells clang to skip the first N bytes of the current source,
+            // which is only correct when the PCH was built FROM the current
+            // file (monolithic preamble). Each chain link is a separate
+            // file, so nothing must be skipped.
+            auto result = build_one_pch(text, file_path, link.pch_path, prev_pch, 0);
+            link.build_ms = result.ms;
+            link.success = result.success;
+
+            if(verbose) {
+                if(result.success) {
+                    std::println("  [{:3}/{}] <{:25}> {:7.1f}ms  {:5} KB",
+                                 i + 1,
+                                 count,
+                                 headers[i],
+                                 result.ms,
+                                 result.size_bytes / 1024);
+                } else {
+                    std::println("  [{:3}/{}] <{:25}> FAILED: {}",
+                                 i + 1,
+                                 count,
+                                 headers[i],
+                                 result.error);
+                }
+            }
+
+            // A failed link is skipped; the chain continues over the
+            // previous PCH.
+            if(result.success) {
+                prev_pch = link.pch_path;
+            }
+            links.push_back(std::move(link));
+        }
+
+        return links;
+    };
+
+    // First run: verbose, report per-link times.
+    auto links = build_chain(true);
+
+    std::size_t passed = 0, failed = 0;
+    double total_ms = 0;
+    for(auto& link: links) {
+        if(link.success) {
+            passed += 1;
+            total_ms += link.build_ms;
+        } else {
+            failed += 1;
+        }
+    }
+
+    std::println("\n  Chain result: {} passed, {} failed, total {:.1f}ms",
+                 passed,
+                 failed,
+                 total_ms);
+
+    if(!links.empty() && links.back().success) {
+        // bound=0: the chain PCH does not cover the verify file.
+        std::println("  Final PCH correctness: {}",
+                     verify_pch(links.back().pch_path, 0) ? "PASS" : "FAIL");
+    }
+
+    // Additional runs for timing statistics.
+    if(runs > 1) {
+        std::vector<double> totals;
+        totals.push_back(total_ms);
+
+        for(int r = 1; r < runs; r += 1) {
+            auto chain = build_chain(false);
+            double total = 0;
+            for(auto& link: chain) {
+                if(link.success)
+                    total += link.build_ms;
+            }
+            totals.push_back(total);
+        }
+
+        double mean =
+            std::accumulate(totals.begin(), totals.end(), 0.0) / static_cast<double>(totals.size());
+        double median = median_of(totals);
+        std::println(
+            "  Total chain build - Min: {:.1f}ms  Median: {:.1f}ms  Mean: {:.1f}ms  Max: {:.1f}ms",
+            totals.front(),
+            median,
+            mean,
+            totals.back());
+    }
+}
+
+void bench_incremental(const std::vector<std::string>& headers, std::size_t base_count, int runs) {
+    std::println("\n=== INCREMENTAL REBUILD (add 1 header to {} existing) ===", base_count);
+
+    TempTracker temps;
+
+    // Build base chain.
+    std::string prev_pch;
+    for(std::size_t i = 0; i < base_count && i < headers.size(); i += 1) {
+        std::string text = "#include <" + headers[i] + ">\n";
+        auto result = build_one_pch(text,
+                                    temps.create("incr-base", "h"),
+                                    temps.create("incr-base", "pch"),
+                                    prev_pch,
+                                    0);
+        if(!result.success) {
+            std::println("  Base chain failed at link {} (<{}>)", i + 1, headers[i]);
+            return;
+        }
+        prev_pch = result.path;
+    }
+
+    // Monolithic rebuild for comparison.
+    std::string mono_preamble = make_preamble(headers, base_count + 1);
+    std::string mono_file = temps.create("incr-mono", "h");
+    std::string mono_pch = temps.create("incr-mono", "pch");
+
+    std::vector<double> mono_times, chain_times;
+
+    for(int r = 0; r < runs; r += 1) {
+        fs::remove(mono_pch);
+        auto result = build_one_pch(mono_preamble, mono_file, mono_pch);
+        if(result.success)
+            mono_times.push_back(result.ms);
+    }
+
+    // Chained incremental: just append one more link.
+    std::string extra_hdr = (base_count < headers.size()) ? headers[base_count] : "version";
+    std::string extra_text = "#include <" + extra_hdr + ">\n";
+    std::string extra_file = temps.create("incr-extra", "h");
+    std::string extra_pch = temps.create("incr-extra", "pch");
+
+    for(int r = 0; r < runs; r += 1) {
+        fs::remove(extra_pch);
+        auto result = build_one_pch(extra_text, extra_file, extra_pch, prev_pch, 0);
+        if(result.success)
+            chain_times.push_back(result.ms);
+    }
+
+    if(!mono_times.empty() && !chain_times.empty()) {
+        double mono_med = median_of(mono_times);
+        double chain_med = median_of(chain_times);
+        std::println("  Monolithic full rebuild:  median {:.1f}ms", mono_med);
+        std::println("  Chained append-one-link:  median {:.1f}ms", chain_med);
+        std::println("  Speedup: {:.1f}x", mono_med / chain_med);
+    }
+}
+
+/// Sources for the AST load scenarios: light touches a couple of types
+/// (lazy PCH load, best case); heavy references symbols from as many
+/// headers as possible to force maximum PCH deserialization (worst case).
+std::string make_light_source(const std::string& preamble) {
+    return preamble + R"cpp(
+int main() {
+    std::vector<int> v = {1, 2, 3};
+    return v[0];
+}
+)cpp";
+}
+
+std::string make_heavy_source(const std::string& preamble) {
+    return preamble + R"cpp(
+template <typename... Ts> void use(Ts&&...) {}
+
+int main() {
+    // <cstddef> <cstdint> <climits> <cfloat>
+    std::size_t sz = 0; std::uint64_t u64 = 0;
+
+    // <type_traits> <concepts> <compare>
+    static_assert(std::is_integral_v<int>);
+    static_assert(std::integral<int>);
+    std::strong_ordering cmp = 1 <=> 2;
+
+    // <initializer_list> <utility> <tuple> <optional> <variant> <any> <expected>
+    auto il = {1, 2, 3};
+    auto pr = std::make_pair(1, 2);
+    auto tp = std::make_tuple(1, "hello", 3.14);
+    std::optional<int> opt = 42;
+    std::variant<int, double, std::string> var = "hello";
+    std::any a = 42;
+
+    // <bitset> <bit> <string_view> <string> <charconv> <format>
+    std::bitset<64> bs(0xFF);
+    auto pc = std::popcount(42u);
+    std::string_view sv = "hello";
+    std::string s = "world";
+    auto fmt = std::format("{} {}", s, 42);
+
+    // <array> <vector> <deque> <list> <forward_list>
+    std::array<int, 3> arr = {1, 2, 3};
+    std::vector<std::string> vec = {"a", "b"};
+    std::deque<int> dq = {1, 2};
+    std::list<int> lst = {1, 2};
+    std::forward_list<int> fl = {1, 2};
+
+    // <set> <map> <unordered_set> <unordered_map>
+    std::set<int> st = {1, 2, 3};
+    std::map<std::string, int> mp = {{"a", 1}};
+    std::unordered_set<int> us = {1, 2};
+    std::unordered_map<std::string, int> um = {{"b", 2}};
+
+    // <stack> <queue> <span>
+    std::stack<int> stk;
+    std::queue<int> que;
+    std::span<const int> spn(arr);
+
+    // <iterator> <ranges> <algorithm> <numeric>
+    auto it = vec.begin();
+    auto rng = vec | std::views::take(1);
+    std::sort(vec.begin(), vec.end());
+    auto sum = std::accumulate(arr.begin(), arr.end(), 0);
+
+    // <memory> <memory_resource> <scoped_allocator> <functional>
+    auto up = std::make_unique<int>(42);
+    auto sp = std::make_shared<std::string>("test");
+    std::function<int(int)> fn = [](int x) { return x * 2; };
+
+    // <ratio> <chrono>
+    using half = std::ratio<1, 2>;
+    auto now = std::chrono::system_clock::now();
+
+    // <exception> <stdexcept> <system_error>
+    try { throw std::runtime_error("test"); } catch(...) {}
+    auto ec = std::make_error_code(std::errc::invalid_argument);
+
+    // <typeinfo> <typeindex> <source_location>
+    auto& ti = typeid(int);
+    std::type_index tidx(ti);
+    auto loc = std::source_location::current();
+
+    // <new> <limits> <numbers> <valarray> <complex> <random>
+    static_assert(std::numeric_limits<double>::is_iec559);
+    constexpr auto pi = std::numbers::pi;
+    std::valarray<double> va = {1.0, 2.0, 3.0};
+    std::complex<double> cx(1.0, 2.0);
+    std::mt19937 rng_eng(42);
+
+    // <iosfwd> <ios> <streambuf> <istream> <ostream> <iostream> <sstream> <fstream>
+    std::stringstream ss;
+    ss << "hello " << 42;
+    std::cout << ss.str() << std::endl;
+
+    // <cmath> <cstdio> <cstdlib> <cstring> <ctime> <cassert> <cerrno>
+    auto sq = std::sqrt(2.0);
+    auto len = std::strlen("hello");
+    auto t = std::time(nullptr);
+    assert(sq > 1.0);
+
+    // <atomic> <mutex> <condition_variable> <thread> <future>
+    std::atomic<int> ai{0};
+    std::mutex mtx;
+    std::condition_variable cv;
+
+    // <semaphore> <latch> <barrier> <stop_token> <shared_mutex>
+    std::counting_semaphore<1> sem(1);
+    std::latch lat(1);
+
+    // <regex> <filesystem>
+    std::regex rx("hello.*");
+    auto cwd = std::filesystem::current_path();
+
+    // <locale> <codecvt>
+    auto& loc2 = std::locale::classic();
+
+    use(sz, u64, cmp, il, pr, tp, opt, var, a, bs, pc, sv, s, fmt,
+        arr, vec, dq, lst, fl, st, mp, us, um, stk, que, spn,
+        it, rng, sum, up, sp, fn, now, ec, ti, tidx, loc,
+        pi, va, cx, rng_eng, ss, sq, len, t, ai, mtx, cv,
+        sem, lat, rx, cwd, loc2);
+    return 0;
+}
+)cpp";
+}
+
+void bench_ast_load(const std::vector<std::string>& headers, std::size_t count, int runs) {
+    std::println("\n=== AST LOAD LATENCY ({} headers, {} runs) ===", count, runs);
+
+    auto preamble = make_preamble(headers, count);
+    auto preamble_bound = static_cast<std::uint32_t>(preamble.size());
+
+    TempTracker temps;
+
+    // Build monolithic PCH.
+    std::string mono_hdr = temps.create("ast-mono", "h");
+    std::string mono_pch = temps.create("ast-mono", "pch");
+    auto mono_result = build_one_pch(preamble, mono_hdr, mono_pch);
+    if(!mono_result.success) {
+        std::println("  Monolithic PCH build failed");
+        return;
+    }
+
+    // Build chained PCH.
+    std::string prev_pch;
+    for(std::size_t i = 0; i < count && i < headers.size(); i += 1) {
+        std::string text = "#include <" + headers[i] + ">\n";
+        auto result = build_one_pch(text,
+                                    temps.create("ast-chain", "h"),
+                                    temps.create("ast-chain", "pch"),
+                                    prev_pch,
+                                    0);
+        if(!result.success) {
+            std::println("  Chain build failed at link {} (<{}>): {}",
+                         i + 1,
+                         headers[i],
+                         result.error);
+            return;
+        }
+        prev_pch = result.path;
+    }
+    std::string chain_pch = prev_pch;
+
+    struct Scenario {
+        const char* name;
+        std::string source;
+    };
+
+    Scenario scenarios[] = {
+        {"light (3 types)",     make_light_source(preamble)},
+        {"heavy (all headers)", make_heavy_source(preamble)},
+    };
+
+    for(auto& [name, source]: scenarios) {
+        std::println("\n  --- {} ---", name);
+        auto source_file = virtual_path("ast-load-test.cpp");
+
+        std::vector<double> mono_times, chain_times;
+
+        for(int r = 0; r < runs; r += 1) {
+            double ms = compile_with_pch(source, source_file, mono_pch, preamble_bound);
+            if(ms >= 0)
+                mono_times.push_back(ms);
+        }
+
+        for(int r = 0; r < runs; r += 1) {
+            double ms = compile_with_pch(source, source_file, chain_pch, preamble_bound);
+            if(ms >= 0)
+                chain_times.push_back(ms);
+        }
+
+        if(!mono_times.empty()) {
+            double med = median_of(mono_times);
+            std::println("  Monolithic PCH → compile:  median {:.1f}ms  (min {:.1f}, max {:.1f})",
+                         med,
+                         mono_times.front(),
+                         mono_times.back());
+        }
+        if(!chain_times.empty()) {
+            double med = median_of(chain_times);
+            std::println("  Chained PCH    → compile:  median {:.1f}ms  (min {:.1f}, max {:.1f})",
+                         med,
+                         chain_times.front(),
+                         chain_times.back());
+        }
+        if(!mono_times.empty() && !chain_times.empty()) {
+            double ratio = median_of(chain_times) / median_of(mono_times);
+            std::println("  Ratio (chained/mono): {:.2f}x", ratio);
+        } else if(chain_times.empty()) {
+            std::println("  Chained PCH: compilation FAILED (heavy source may have errors)");
+        }
+    }
+}
+
+void bench_end_to_end(const std::vector<std::string>& headers, std::size_t count, int runs) {
+    std::println("\n=== END-TO-END: monolithic → background split → incremental ===");
+    if(count < 2) {
+        std::println("  Need at least 2 headers");
+        return;
+    }
+
+    TempTracker temps;
+
+    // Phase 1: user opens a file — build the monolithic PCH they wait for.
+    std::println("\n  Phase 1: Monolithic PCH (what the user waits for)");
+    std::string mono_preamble = make_preamble(headers, count);
+    std::string mono_hdr = temps.create("e2e-mono", "h");
+    std::string mono_pch = temps.create("e2e-mono", "pch");
+
+    auto mono_result = build_one_pch(mono_preamble, mono_hdr, mono_pch);
+    if(!mono_result.success) {
+        std::println("    FAILED: {}", mono_result.error);
+        return;
+    }
+    std::println("    Build: {:.1f}ms", mono_result.ms);
+    std::println("    Verify: {}",
+                 verify_pch(mono_pch, static_cast<std::uint32_t>(mono_preamble.size())) ? "PASS"
+                                                                                        : "FAIL");
+
+    // Phase 2: background — split into a chain for future incremental use;
+    // the user keeps editing and never waits for this.
+    std::println("\n  Phase 2: Background chain split (async, user doesn't wait)");
+    std::string prev_pch;
+    std::vector<std::string> chain_pchs;
+
+    auto split_start = Clock::now();
+    for(std::size_t i = 0; i < count && i < headers.size(); i += 1) {
+        std::string text = "#include <" + headers[i] + ">\n";
+        auto result = build_one_pch(text,
+                                    temps.create("e2e-chain", "h"),
+                                    temps.create("e2e-chain", "pch"),
+                                    prev_pch,
+                                    0);
+        if(!result.success) {
+            std::println("    Chain failed at link {} (<{}>): {}", i + 1, headers[i], result.error);
+            return;
+        }
+        prev_pch = result.path;
+        chain_pchs.push_back(result.path);
+    }
+    auto split_end = Clock::now();
+    double split_ms = std::chrono::duration<double, std::milli>(split_end - split_start).count();
+
+    std::println("    Split into {} links: {:.1f}ms", chain_pchs.size(), split_ms);
+    std::println("    Verify final link: {}", verify_pch(chain_pchs.back(), 0) ? "PASS" : "FAIL");
+
+    // Phase 3: user adds a new #include at the preamble end.
+    std::println("\n  Phase 3: User adds #include <chrono> at preamble end");
+    std::string extra_text = "#include <chrono>\n";
+
+    // Strategy A: monolithic — full rebuild.
+    std::vector<double> mono_rebuild_times;
+    for(int r = 0; r < runs; r += 1) {
+        auto result = build_one_pch(mono_preamble + extra_text,
+                                    temps.create("e2e-rebuild", "h"),
+                                    temps.create("e2e-rebuild", "pch"));
+        if(result.success)
+            mono_rebuild_times.push_back(result.ms);
+    }
+
+    // Strategy B: chained — append one link to the cached chain.
+    std::vector<double> chain_append_times;
+    for(int r = 0; r < runs; r += 1) {
+        auto result = build_one_pch(extra_text,
+                                    temps.create("e2e-append", "h"),
+                                    temps.create("e2e-append", "pch"),
+                                    chain_pchs.back(),
+                                    0);
+        if(result.success)
+            chain_append_times.push_back(result.ms);
+    }
+
+    if(!mono_rebuild_times.empty()) {
+        std::println("    Monolithic full rebuild:  median {:.1f}ms",
+                     median_of(mono_rebuild_times));
+    }
+    if(!chain_append_times.empty()) {
+        double chain_med = median_of(chain_append_times);
+        std::println("    Chained append 1 link:   median {:.1f}ms", chain_med);
+        if(!mono_rebuild_times.empty()) {
+            std::println("    Speedup: {:.0f}x", median_of(mono_rebuild_times) / chain_med);
+        }
+    }
+
+    // Phase 4: verify the appended chain PCH works with real code.
+    std::println("\n  Phase 4: Correctness — compile real code with appended chain");
+    std::string verify_source = R"cpp(
+int main() {
+    auto now = std::chrono::system_clock::now();
+    std::vector<std::string> v = {"hello"};
+    std::map<int, double> m = {{1, 3.14}};
+    return 0;
+}
+)cpp";
+    std::string full_preamble = mono_preamble + extra_text;
+    auto full_bound = static_cast<std::uint32_t>(full_preamble.size());
+    std::string full_source = full_preamble + verify_source;
+    auto source_file = virtual_path("e2e-verify.cpp");
+
+    {
+        auto result = build_one_pch(extra_text,
+                                    temps.create("e2e-final", "h"),
+                                    temps.create("e2e-final", "pch"),
+                                    chain_pchs.back(),
+                                    0);
+        if(result.success) {
+            // bound=0: the chain PCH covers no bytes of the source file.
+            double ms = compile_with_pch(full_source, source_file, result.path, 0);
+            std::println("    Compile with appended chain PCH: {}",
+                         ms >= 0 ? std::format("PASS ({:.0f}ms)", ms) : "FAIL");
+        } else {
+            std::println("    Build appended chain: FAILED");
+        }
+    }
+
+    {
+        auto result = build_one_pch(full_preamble,
+                                    temps.create("e2e-vfull", "h"),
+                                    temps.create("e2e-vfull", "pch"));
+        if(result.success) {
+            double ms = compile_with_pch(full_source, source_file, result.path, full_bound);
+            std::println("    Compile with monolithic PCH:     {}",
+                         ms >= 0 ? std::format("PASS ({:.0f}ms)", ms) : "FAIL");
+        }
+    }
+}
+
+}  // namespace
+
+int main(int argc, const char** argv) {
+    auto args = kota::deco::util::argvify(argc, argv);
+    auto result = kota::deco::cli::parse<BenchmarkOptions>(args);
+
+    if(!result.has_value()) {
+        std::println(stderr, "Error: {}", result.error().message);
+        return 1;
+    }
+
+    auto& opts = result->options;
+
+    if(opts.help.value_or(false)) {
+        std::ostringstream oss;
+        kota::deco::cli::write_usage_for<BenchmarkOptions>(oss, "pch_chain_benchmark [OPTIONS]");
+        std::print("{}", oss.str());
+        return 0;
+    }
+
+    auto level = spdlog::level::from_str(*opts.log_level);
+    clice::logging::options.level = level;
+    clice::logging::stderr_logger("pch_chain_benchmark", clice::logging::options);
+
+    int runs = *opts.runs;
+    if(runs <= 0) {
+        std::println(stderr, "Error: --runs must be positive (got {})", runs);
+        return 1;
+    }
+
+    std::size_t chain_length = ALL_HEADERS.size();
+    if(*opts.chain_length > 0) {
+        chain_length = std::min(static_cast<std::size_t>(*opts.chain_length), chain_length);
+    }
+    if(chain_length < 2) {
+        std::println(stderr, "Error: --chain-length must be at least 2");
+        return 1;
+    }
+
+    if(resource_dir().empty()) {
+        std::println(stderr, "Cannot find the clang resource dir next to this binary.");
+        return 1;
+    }
+
+    std::println("PCH Chain Benchmark");
+    std::println("  Resource dir: {}", resource_dir());
+    std::println("  Chain length: {}", chain_length);
+    std::println("  Runs: {}", runs);
+    std::println("");
+
+    bench_monolithic(ALL_HEADERS, chain_length, runs);
+    bench_chained(ALL_HEADERS, chain_length, runs);
+    bench_incremental(ALL_HEADERS, chain_length - 1, runs);
+    bench_ast_load(ALL_HEADERS, chain_length, runs);
+    bench_end_to_end(ALL_HEADERS, chain_length, runs);
+
+    return 0;
+}

--- a/benchmarks/pipeline_benchmark.cpp
+++ b/benchmarks/pipeline_benchmark.cpp
@@ -1,0 +1,486 @@
+/// Per-TU profile of the compile pipeline on a real compilation database:
+/// how long each stage a language-server pass consists of takes, one result
+/// per file.
+///
+/// Stages, mirroring the server's own build shapes:
+///   read               source file I/O
+///   preprocess         PreprocessOnlyAction, TokenBuffer off
+///   preprocess_tokens  PreprocessOnlyAction, TokenBuffer on (delta = TokenBuffer cost)
+///   parse              full parse without PCH + TUIndex build + serialize
+///                      (the background-index worker shape)
+///   pch_build          preamble PCH build incl. disk flush (first didOpen shape)
+///   parse_pch          full parse over the PCH (the didChange shape)
+///
+/// Usage:
+///   pipeline_benchmark [OPTIONS] <compile_commands.json>
+///
+/// Example:
+///   ./build/RelWithDebInfo/bin/pipeline_benchmark build/RelWithDebInfo/compile_commands.json
+///   ./build/RelWithDebInfo/bin/pipeline_benchmark --filter compiler.cpp --runs 5 \
+///       --time-trace /tmp/traces <cdb>
+
+#include <algorithm>
+#include <print>
+#include <ranges>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "command/command.h"
+#include "command/toolchain.h"
+#include "compile/compilation.h"
+#include "index/tu_index.h"
+#include "support/filesystem.h"
+#include "support/logging.h"
+#include "support/timer.h"
+#include "syntax/scan.h"
+
+#include "kota/codec/json/json.h"
+#include "kota/deco/deco.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/TimeProfiler.h"
+
+using namespace clice;
+
+namespace {
+
+struct BenchmarkOptions {
+    DecoKV(names = {"--log-level"}; help = "Log level: trace, debug, info, warn, error, off";
+           required = false;)
+    <std::string> log_level = "off";
+
+    DecoKV(names = {"--filter"}; help = "Only profile files whose path contains this substring";
+           required = false;)
+    <std::string> filter;
+
+    DecoKV(names = {"--limit"}; help = "Profile at most N files (0 = all)"; required = false;)
+    <int> limit = 0;
+
+    DecoKV(names = {"--runs"}; help = "Repetitions per stage, the minimum is reported";
+           required = false;)
+    <int> runs = 1;
+
+    DecoKV(names = {"--json"}; help = "Write per-file results as JSON to this path";
+           required = false;)
+    <std::string> json_path;
+
+    DecoKV(names = {"--time-trace"};
+           help = "Write a Chrome trace of each file's parse stage into this directory";
+           required = false;)
+    <std::string> time_trace_dir;
+
+    DecoFlag(names = {"-h", "--help"}; help = "Show help message"; required = false;)
+    help;
+
+    DecoInput(meta_var = "CDB"; help = "Path to compile_commands.json"; required = false;)
+    <std::string> cdb_path;
+};
+
+/// One file, one result. A stage that did not run stays at -1 (e.g. the
+/// PCH stages of a file with an empty preamble, or everything after a
+/// failed stage).
+struct FileResult {
+    std::string file;
+    std::string error;
+
+    double read_ms = -1;
+    double preprocess_ms = -1;
+    double preprocess_tokens_ms = -1;
+    double parse_ms = -1;
+    double index_ms = -1;
+    double index_serialize_ms = -1;
+    double pch_build_ms = -1;
+    double parse_pch_ms = -1;
+
+    std::uint64_t index_bytes = 0;
+    std::uint64_t pch_bytes = 0;
+    std::uint64_t symbols = 0;
+    std::uint32_t preamble_bound = 0;
+};
+
+struct BenchmarkOutput {
+    std::string cdb;
+    std::vector<FileResult> files;
+};
+
+CompilationParams make_params(CompilationKind kind,
+                              const std::vector<const char*>& arguments,
+                              llvm::StringRef file,
+                              llvm::StringRef content) {
+    CompilationParams params;
+    params.kind = kind;
+    params.arguments = arguments;
+    params.add_remapped_file(file, content);
+    return params;
+}
+
+std::string collect_errors(CompilationUnit& unit) {
+    std::string errors;
+    for(auto& diag: unit.diagnostics()) {
+        if(diag.id.level >= DiagnosticLevel::Error) {
+            if(!errors.empty())
+                errors += "; ";
+            errors += diag.message;
+        }
+    }
+    return errors;
+}
+
+/// Run `stage` `runs` times and keep the fastest wall-clock time. The
+/// stage reports failure by returning false; timing of a failed run is
+/// discarded.
+template <typename Stage>
+bool run_stage(int runs, double& out_ms, Stage stage) {
+    double best = -1;
+    for(int i = 0; i < runs; i += 1) {
+        ScopedTimer timer;
+        if(!stage()) {
+            return false;
+        }
+        auto ms = timer.ms_f();
+        if(best < 0 || ms < best) {
+            best = ms;
+        }
+    }
+    out_ms = best;
+    return true;
+}
+
+FileResult profile_file(llvm::StringRef file,
+                        const std::vector<const char*>& arguments,
+                        int runs,
+                        llvm::StringRef time_trace_dir) {
+    FileResult result;
+    result.file = file.str();
+
+    std::string content;
+    bool ok = run_stage(runs, result.read_ms, [&] {
+        auto read = fs::read(file);
+        if(!read) {
+            result.error = "read failed: " + read.error().message();
+            return false;
+        }
+        content = std::move(*read);
+        return true;
+    });
+    if(!ok) {
+        return result;
+    }
+
+    for(bool collect_tokens: {false, true}) {
+        auto& out_ms = collect_tokens ? result.preprocess_tokens_ms : result.preprocess_ms;
+        ok = run_stage(runs, out_ms, [&] {
+            auto params = make_params(CompilationKind::Preprocess, arguments, file, content);
+            params.collect_tokens = collect_tokens;
+            auto unit = preprocess(params);
+            if(!unit.completed()) {
+                result.error = "preprocess failed: " + collect_errors(unit);
+                return false;
+            }
+            return true;
+        });
+        if(!ok) {
+            return result;
+        }
+    }
+
+    // The background-index worker shape: plain parse, then index build and
+    // serialization on the same unit. When a trace directory is given the
+    // profiler window covers all three; clang only emits events during the
+    // parse, and the trace must be written after the unit is destroyed —
+    // EndSourceFile runs in the unit's destructor.
+    bool tracing = !time_trace_dir.empty();
+    if(tracing) {
+        llvm::timeTraceProfilerInitialize(/*TimeTraceGranularity=*/500, "pipeline_benchmark");
+    }
+    ok = run_stage(tracing ? 1 : runs, result.parse_ms, [&] {
+        auto params = make_params(CompilationKind::Indexing, arguments, file, content);
+        auto unit = compile(params);
+        if(!unit.completed()) {
+            result.error = "parse failed: " + collect_errors(unit);
+            return false;
+        }
+
+        ScopedTimer index_timer;
+        auto tu_index = index::TUIndex::build(unit);
+        result.index_ms = index_timer.ms_f();
+        result.symbols = tu_index.symbols.size();
+
+        ScopedTimer serialize_timer;
+        std::string serialized;
+        llvm::raw_string_ostream os(serialized);
+        tu_index.serialize(os);
+        result.index_serialize_ms = serialize_timer.ms_f();
+        result.index_bytes = serialized.size();
+        return true;
+    });
+    if(tracing) {
+        llvm::SmallString<128> trace_path{time_trace_dir};
+        llvm::sys::path::append(trace_path, llvm::sys::path::filename(file));
+        trace_path += ".json";
+        if(auto error = llvm::timeTraceProfilerWrite(trace_path, file)) {
+            LOG_WARN("Failed to write time trace {}: {}", trace_path, error);
+        }
+        llvm::timeTraceProfilerCleanup();
+    }
+    if(!ok) {
+        // The parse timing subsumes index build; a parse that failed halfway
+        // still leaves the earlier stage numbers meaningful, so report them.
+        return result;
+    }
+
+    // The interactive shapes: build the preamble PCH (first didOpen), then
+    // parse the full file over it (every didChange).
+    result.preamble_bound = compute_preamble_bound(content);
+    if(result.preamble_bound == 0) {
+        return result;
+    }
+
+    auto pch_path = fs::createTemporaryFile("pipeline-bench", "pch");
+    if(!pch_path) {
+        result.error = "failed to create temporary PCH file";
+        return result;
+    }
+
+    ok = run_stage(runs, result.pch_build_ms, [&] {
+        CompilationParams params;
+        params.kind = CompilationKind::Preamble;
+        params.arguments = arguments;
+        params.add_remapped_file(file, content, result.preamble_bound);
+        params.output_file = *pch_path;
+
+        PCHInfo pch_info;
+        auto unit = compile(params, pch_info);
+        if(!unit.completed()) {
+            result.error = "pch build failed: " + collect_errors(unit);
+            return false;
+        }
+        // The PCH is flushed to disk by the unit's destructor; the stage
+        // timing must include it, so destroy explicitly.
+        unit = CompilationUnit(nullptr);
+        return true;
+    });
+    if(!ok) {
+        fs::remove(*pch_path);
+        return result;
+    }
+
+    if(auto error = llvm::sys::fs::file_size(*pch_path, result.pch_bytes)) {
+        result.pch_bytes = 0;
+    }
+
+    run_stage(runs, result.parse_pch_ms, [&] {
+        auto params = make_params(CompilationKind::Content, arguments, file, content);
+        params.pch = {*pch_path, result.preamble_bound};
+        auto unit = compile(params);
+        if(!unit.completed()) {
+            result.error = "parse with pch failed: " + collect_errors(unit);
+            return false;
+        }
+        return true;
+    });
+
+    fs::remove(*pch_path);
+    return result;
+}
+
+void print_file(const FileResult& result) {
+    auto cell = [](double ms) {
+        return ms < 0 ? std::string("      -") : std::format("{:>7.1f}", ms);
+    };
+    std::println("  {} {} {} {} {} {} {}  {}",
+                 cell(result.preprocess_ms),
+                 cell(result.preprocess_tokens_ms),
+                 cell(result.parse_ms),
+                 cell(result.index_ms),
+                 cell(result.pch_build_ms),
+                 cell(result.parse_pch_ms),
+                 std::format("{:>8}", result.symbols),
+                 result.file);
+}
+
+struct StageStats {
+    llvm::StringRef name;
+    std::vector<double> values;
+
+    void add(double ms) {
+        if(ms >= 0) {
+            values.push_back(ms);
+        }
+    }
+
+    double percentile(double p) {
+        auto index = static_cast<std::size_t>(p * static_cast<double>(values.size() - 1));
+        return values[index];
+    }
+};
+
+void print_summary(std::vector<FileResult>& results) {
+    StageStats stats[] = {
+        {"read"},
+        {"preprocess"},
+        {"preprocess_tokens"},
+        {"parse"},
+        {"index"},
+        {"index_serialize"},
+        {"pch_build"},
+        {"parse_pch"},
+    };
+    for(auto& result: results) {
+        stats[0].add(result.read_ms);
+        stats[1].add(result.preprocess_ms);
+        stats[2].add(result.preprocess_tokens_ms);
+        stats[3].add(result.parse_ms);
+        stats[4].add(result.index_ms);
+        stats[5].add(result.index_serialize_ms);
+        stats[6].add(result.pch_build_ms);
+        stats[7].add(result.parse_pch_ms);
+    }
+
+    std::println("");
+    std::println("  Stage summary (ms){:>14} {:>8} {:>8} {:>8} {:>8}",
+                 "files",
+                 "p50",
+                 "p90",
+                 "p99",
+                 "max");
+    for(auto& stage: stats) {
+        if(stage.values.empty()) {
+            continue;
+        }
+        std::ranges::sort(stage.values);
+        std::println("    {:<17}{:>13} {:>8.1f} {:>8.1f} {:>8.1f} {:>8.1f}",
+                     stage.name.str(),
+                     stage.values.size(),
+                     stage.percentile(0.5),
+                     stage.percentile(0.9),
+                     stage.percentile(0.99),
+                     stage.values.back());
+    }
+
+    auto slowest = results | std::views::filter([](auto& r) { return r.parse_ms >= 0; }) |
+                   std::ranges::to<std::vector>();
+    std::ranges::sort(slowest, std::greater{}, &FileResult::parse_ms);
+    std::println("");
+    std::println("  Slowest TUs by parse time");
+    for(auto& result: slowest | std::views::take(10)) {
+        std::println("    {:>8.1f}ms  {}", result.parse_ms, result.file);
+    }
+
+    auto failed = std::ranges::count_if(results, [](auto& r) { return !r.error.empty(); });
+    if(failed > 0) {
+        std::println("");
+        std::println("  {} file(s) had a failing stage (see JSON `error` fields)", failed);
+    }
+}
+
+}  // namespace
+
+int main(int argc, const char** argv) {
+    auto args = kota::deco::util::argvify(argc, argv);
+    auto result = kota::deco::cli::parse<BenchmarkOptions>(args);
+
+    if(!result.has_value()) {
+        std::println(stderr, "Error: {}", result.error().message);
+        return 1;
+    }
+
+    auto& opts = result->options;
+
+    if(opts.help.value_or(false) || !opts.cdb_path.has_value()) {
+        std::ostringstream oss;
+        kota::deco::cli::write_usage_for<BenchmarkOptions>(oss,
+                                                           "pipeline_benchmark [OPTIONS] <cdb>");
+        std::print("{}", oss.str());
+        return opts.help.value_or(false) ? 0 : 1;
+    }
+
+    auto level = spdlog::level::from_str(*opts.log_level);
+    clice::logging::options.level = level;
+    clice::logging::stderr_logger("pipeline_benchmark", clice::logging::options);
+
+    auto runs = *opts.runs;
+    if(runs <= 0) {
+        std::println(stderr, "Error: --runs must be positive (got {})", runs);
+        return 1;
+    }
+
+    if(opts.time_trace_dir.has_value()) {
+        if(auto error = llvm::sys::fs::create_directories(*opts.time_trace_dir)) {
+            std::println(stderr, "Error: cannot create {}: {}", *opts.time_trace_dir, error);
+            return 1;
+        }
+    }
+
+    CompilationDatabase cdb;
+    Toolchain toolchain;
+    auto count = cdb.load(*opts.cdb_path);
+    if(!count) {
+        std::println(stderr, "Error: failed to load {}", *opts.cdb_path);
+        return 1;
+    }
+    std::println("CDB loaded: {} entries", *count);
+
+    // One profile per file: entries are sorted by path id, and a file with
+    // several commands (multi-config CDB) is profiled under the first one,
+    // like the server picks.
+    std::vector<llvm::StringRef> files;
+    for(auto& entry: cdb.get_entries()) {
+        auto path = cdb.resolve_path(entry.file);
+        if(opts.filter.has_value() && !path.contains(*opts.filter)) {
+            continue;
+        }
+        if(!files.empty() && files.back() == path) {
+            continue;
+        }
+        files.push_back(path);
+        if(*opts.limit > 0 && files.size() == static_cast<std::size_t>(*opts.limit)) {
+            break;
+        }
+    }
+    std::println("Profiling {} file(s), {} run(s) per stage\n", files.size(), runs);
+
+    std::println("  {:>7} {:>7} {:>7} {:>7} {:>7} {:>7} {:>8}  file",
+                 "pp",
+                 "pp+tok",
+                 "parse",
+                 "index",
+                 "pch",
+                 "reparse",
+                 "symbols");
+
+    BenchmarkOutput output;
+    output.cdb = *opts.cdb_path;
+    for(auto file: files) {
+        auto commands = cdb.lookup(file);
+        if(commands.empty()) {
+            continue;
+        }
+        toolchain.resolve_or_warn(commands[0]);
+        auto arguments = commands[0].to_argv();
+
+        auto file_result = profile_file(file, arguments, runs, opts.time_trace_dir.value_or(""));
+        print_file(file_result);
+        output.files.push_back(std::move(file_result));
+    }
+
+    print_summary(output.files);
+
+    if(opts.json_path.has_value()) {
+        auto json = kota::codec::json::to_string(output);
+        if(!json) {
+            std::println(stderr, "Failed to serialize results");
+            return 1;
+        }
+        if(auto write = fs::write(*opts.json_path, *json); !write) {
+            std::println(stderr,
+                         "Failed to write {}: {}",
+                         *opts.json_path,
+                         write.error().message());
+            return 1;
+        }
+        std::println("\nResults written to {}", *opts.json_path);
+    }
+
+    return 0;
+}

--- a/benchmarks/pipeline_benchmark.cpp
+++ b/benchmarks/pipeline_benchmark.cpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 
+#include "stats.h"
 #include "command/command.h"
 #include "command/toolchain.h"
 #include "compile/compilation.h"
@@ -114,18 +115,6 @@ CompilationParams make_params(CompilationKind kind,
     params.arguments = arguments;
     params.add_remapped_file(file, content);
     return params;
-}
-
-std::string collect_errors(CompilationUnit& unit) {
-    std::string errors;
-    for(auto& diag: unit.diagnostics()) {
-        if(diag.id.level >= DiagnosticLevel::Error) {
-            if(!errors.empty())
-                errors += "; ";
-            errors += diag.message;
-        }
-    }
-    return errors;
 }
 
 /// Run `stage` `runs` times and keep the fastest wall-clock time. The
@@ -329,11 +318,6 @@ struct StageStats {
             values.push_back(ms);
         }
     }
-
-    double percentile(double p) {
-        auto index = static_cast<std::size_t>(p * static_cast<double>(values.size() - 1));
-        return values[index];
-    }
 };
 
 void print_summary(std::vector<FileResult>& results) {
@@ -369,13 +353,12 @@ void print_summary(std::vector<FileResult>& results) {
         if(stage.values.empty()) {
             continue;
         }
-        std::ranges::sort(stage.values);
         std::println("    {:<17}{:>13} {:>8.1f} {:>8.1f} {:>8.1f} {:>8.1f}",
                      stage.name.str(),
                      stage.values.size(),
-                     stage.percentile(0.5),
-                     stage.percentile(0.9),
-                     stage.percentile(0.99),
+                     bench::percentile(stage.values, 0.5),
+                     bench::percentile(stage.values, 0.9),
+                     bench::percentile(stage.values, 0.99),
                      stage.values.back());
     }
 

--- a/benchmarks/pipeline_benchmark.cpp
+++ b/benchmarks/pipeline_benchmark.cpp
@@ -201,16 +201,23 @@ FileResult profile_file(llvm::StringRef file,
             return false;
         }
 
+        // Like the stage itself, keep the fastest run for the sub-timings.
+        auto keep_min = [](double& slot, double ms) {
+            if(slot < 0 || ms < slot) {
+                slot = ms;
+            }
+        };
+
         ScopedTimer index_timer;
         auto tu_index = index::TUIndex::build(unit);
-        result.index_ms = index_timer.ms_f();
+        keep_min(result.index_ms, index_timer.ms_f());
         result.symbols = tu_index.symbols.size();
 
         ScopedTimer serialize_timer;
         std::string serialized;
         llvm::raw_string_ostream os(serialized);
         tu_index.serialize(os);
-        result.index_serialize_ms = serialize_timer.ms_f();
+        keep_min(result.index_serialize_ms, serialize_timer.ms_f());
         result.index_bytes = serialized.size();
         return true;
     });

--- a/benchmarks/pipeline_benchmark.cpp
+++ b/benchmarks/pipeline_benchmark.cpp
@@ -39,6 +39,7 @@
 #include "kota/deco/deco.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/TimeProfiler.h"
+#include "llvm/Support/xxhash.h"
 
 using namespace clice;
 
@@ -53,7 +54,8 @@ struct BenchmarkOptions {
            required = false;)
     <std::string> filter;
 
-    DecoKV(names = {"--limit"}; help = "Profile at most N files (0 = all)"; required = false;)
+    DecoKV(names = {"--limit"}; help = "Profile only the N largest files by source size (0 = all)";
+           required = false;)
     <int> limit = 0;
 
     DecoKV(names = {"--runs"}; help = "Repetitions per stage, the minimum is reported";
@@ -167,6 +169,14 @@ FileResult profile_file(llvm::StringRef file,
         return result;
     }
 
+    // One unmeasured preprocess warms the OS caches for every header the
+    // TU touches; without it the first measured variant pays the cold-cache
+    // cost and the tokens-vs-no-tokens delta is polluted.
+    {
+        auto params = make_params(CompilationKind::Preprocess, arguments, file, content);
+        preprocess(params);
+    }
+
     for(bool collect_tokens: {false, true}) {
         auto& out_ms = collect_tokens ? result.preprocess_tokens_ms : result.preprocess_ms;
         ok = run_stage(runs, out_ms, [&] {
@@ -223,8 +233,12 @@ FileResult profile_file(llvm::StringRef file,
     });
     if(tracing) {
         llvm::SmallString<128> trace_path{time_trace_dir};
-        llvm::sys::path::append(trace_path, llvm::sys::path::filename(file));
-        trace_path += ".json";
+        // Duplicate basenames are common in large projects; a full-path
+        // hash keeps one trace per TU.
+        llvm::sys::path::append(trace_path,
+                                std::format("{}.{:08x}.json",
+                                            llvm::sys::path::filename(file).str(),
+                                            static_cast<std::uint32_t>(llvm::xxh3_64bits(file))));
         if(auto error = llvm::timeTraceProfilerWrite(trace_path, file)) {
             LOG_WARN("Failed to write time trace {}: {}", trace_path, error);
         }
@@ -441,8 +455,24 @@ int main(int argc, const char** argv) {
             continue;
         }
         files.push_back(path);
-        if(*opts.limit > 0 && files.size() == static_cast<std::size_t>(*opts.limit)) {
-            break;
+    }
+
+    // --limit keeps the N largest TUs by main-file size — a coarse but
+    // stable proxy for TU weight — rather than an arbitrary CDB prefix.
+    if(*opts.limit > 0 && files.size() > static_cast<std::size_t>(*opts.limit)) {
+        std::vector<std::pair<std::uint64_t, llvm::StringRef>> sized;
+        sized.reserve(files.size());
+        for(auto path: files) {
+            std::uint64_t size = 0;
+            if(auto error = llvm::sys::fs::file_size(path, size)) {
+                size = 0;
+            }
+            sized.emplace_back(size, path);
+        }
+        std::ranges::stable_sort(sized, std::greater{}, [](auto& pair) { return pair.first; });
+        files.clear();
+        for(auto& [size, path]: sized | std::views::take(*opts.limit)) {
+            files.push_back(path);
         }
     }
     std::println("Profiling {} file(s), {} run(s) per stage\n", files.size(), runs);

--- a/benchmarks/pipeline_benchmark.cpp
+++ b/benchmarks/pipeline_benchmark.cpp
@@ -8,8 +8,10 @@
 ///   preprocess_tokens  PreprocessOnlyAction, TokenBuffer on (delta = TokenBuffer cost)
 ///   parse              full parse without PCH + TUIndex build + serialize
 ///                      (the background-index worker shape)
-///   pch_build          preamble PCH build incl. disk flush (first didOpen shape)
-///   parse_pch          full parse over the PCH (the didChange shape)
+///   pch_build          preamble PCH build + preamble index/state blob incl.
+///                      disk writes (first didOpen shape)
+///   parse_pch          full parse over the PCH + interactive index build +
+///                      serialize (the didChange shape)
 ///
 /// Usage:
 ///   pipeline_benchmark [OPTIONS] <compile_commands.json>
@@ -30,6 +32,8 @@
 #include "command/command.h"
 #include "command/toolchain.h"
 #include "compile/compilation.h"
+#include "feature/feature.h"
+#include "index/preamble_state.h"
 #include "index/tu_index.h"
 #include "support/filesystem.h"
 #include "support/logging.h"
@@ -172,8 +176,12 @@ FileResult profile_file(llvm::StringRef file,
             auto params = make_params(CompilationKind::Preprocess, arguments, file, content);
             params.collect_tokens = collect_tokens;
             auto unit = preprocess(params);
-            if(!unit.completed()) {
-                result.error = "preprocess failed: " + collect_errors(unit);
+            // completed() only covers frontend execution; missing headers,
+            // bad flags and ordinary source errors surface as diagnostics
+            // on a completed unit, and such a run's timing must not enter
+            // the samples (same for every acceptance check below).
+            if(auto errors = collect_errors(unit); !unit.completed() || !errors.empty()) {
+                result.error = "preprocess failed: " + errors;
                 return false;
             }
             return true;
@@ -195,8 +203,8 @@ FileResult profile_file(llvm::StringRef file,
     ok = run_stage(tracing ? 1 : runs, result.parse_ms, [&] {
         auto params = make_params(CompilationKind::Indexing, arguments, file, content);
         auto unit = compile(params);
-        if(!unit.completed()) {
-            result.error = "parse failed: " + collect_errors(unit);
+        if(auto errors = collect_errors(unit); !unit.completed() || !errors.empty()) {
+            result.error = "parse failed: " + errors;
             return false;
         }
 
@@ -247,11 +255,17 @@ FileResult profile_file(llvm::StringRef file,
     }
 
     auto pch_path = fs::createTemporaryFile("pipeline-bench", "pch");
-    if(!pch_path) {
-        result.error = "failed to create temporary PCH file";
+    auto state_path = fs::createTemporaryFile("pipeline-bench", "idx");
+    if(!pch_path || !state_path) {
+        result.error = "failed to create temporary PCH files";
         return result;
     }
+    auto remove_pch_files = [&] {
+        fs::remove(*pch_path);
+        fs::remove(*state_path);
+    };
 
+    std::vector<std::uint8_t> open_conditionals;
     ok = run_stage(runs, result.pch_build_ms, [&] {
         CompilationParams params;
         params.kind = CompilationKind::Preamble;
@@ -261,17 +275,39 @@ FileResult profile_file(llvm::StringRef file,
 
         PCHInfo pch_info;
         auto unit = compile(params, pch_info);
-        if(!unit.completed()) {
-            result.error = "pch build failed: " + collect_errors(unit);
+        if(auto errors = collect_errors(unit); !unit.completed() || !errors.empty()) {
+            result.error = "pch build failed: " + errors;
             return false;
         }
-        // The PCH is flushed to disk by the unit's destructor; the stage
-        // timing must include it, so destroy explicitly.
+
+        // The production PCH pass (stateless worker) also builds the
+        // preamble's full index, document links and inactive regions and
+        // writes the PreambleState blob next to the PCH before reporting
+        // success; the stage must carry that cost to match a didOpen.
+        auto tu_index = index::TUIndex::build(unit);
+        auto links = feature::document_links(unit);
+        auto inactive = feature::inactive_regions(unit, {}, 0, result.preamble_bound);
+        open_conditionals = std::move(inactive.open_stack);
+        std::string blob;
+        llvm::raw_string_ostream os(blob);
+        index::PreambleState::serialize(unit,
+                                        std::move(tu_index),
+                                        links,
+                                        inactive.regions,
+                                        open_conditionals,
+                                        os);
+
+        // The PCH is flushed to disk by the unit's destructor; the blob
+        // write follows it, like the worker's on-disk ordering contract.
         unit = CompilationUnit(nullptr);
+        if(auto write = fs::write(*state_path, blob); !write) {
+            result.error = "preamble state write failed: " + write.error().message();
+            return false;
+        }
         return true;
     });
     if(!ok) {
-        fs::remove(*pch_path);
+        remove_pch_files();
         return result;
     }
 
@@ -283,14 +319,24 @@ FileResult profile_file(llvm::StringRef file,
         auto params = make_params(CompilationKind::Content, arguments, file, content);
         params.pch = {*pch_path, result.preamble_bound};
         auto unit = compile(params);
-        if(!unit.completed()) {
-            result.error = "parse with pch failed: " + collect_errors(unit);
+        if(auto errors = collect_errors(unit); !unit.completed() || !errors.empty()) {
+            result.error = "parse with pch failed: " + errors;
             return false;
         }
+
+        // The didChange pass (stateful worker) also computes inactive
+        // regions and builds and serializes the interested-only index
+        // before replying; include them so parse and parse_pch bound the
+        // same work.
+        feature::inactive_regions(unit, open_conditionals, result.preamble_bound);
+        auto tu_index = index::TUIndex::build(unit, /*interested_only=*/true);
+        std::string serialized;
+        llvm::raw_string_ostream os(serialized);
+        tu_index.serialize(os);
         return true;
     });
 
-    fs::remove(*pch_path);
+    remove_pch_files();
     return result;
 }
 
@@ -353,6 +399,7 @@ void print_summary(std::vector<FileResult>& results) {
         if(stage.values.empty()) {
             continue;
         }
+        std::ranges::sort(stage.values);
         std::println("    {:<17}{:>13} {:>8.1f} {:>8.1f} {:>8.1f} {:>8.1f}",
                      stage.name.str(),
                      stage.values.size(),

--- a/benchmarks/scan_benchmark.cpp
+++ b/benchmarks/scan_benchmark.cpp
@@ -74,7 +74,7 @@ void export_graph_json(const PathPool& path_pool,
     }
 
     GraphExport export_data;
-    for(std::uint32_t id = 0; id < path_pool.paths.size(); id++) {
+    for(std::uint32_t id = 0; id < path_pool.paths.size(); id += 1) {
         auto inc_ids = graph.get_all_includes(id);
         if(inc_ids.empty()) {
             continue;
@@ -174,7 +174,7 @@ void print_report(const ScanReport& report) {
                      "Prefetch",
                      "DirList",
                      "DirHits");
-        for(std::size_t i = 0; i < report.wave_stats.size(); i++) {
+        for(std::size_t i = 0; i < report.wave_stats.size(); i += 1) {
             auto& ws = report.wave_stats[i];
             std::println("    {:>5} {:>8} {:>8} {:>8} {:>8} {:>8} {:>10} {:>10}",
                          i,
@@ -271,7 +271,12 @@ int main(int argc, const char** argv) {
 
     CompilationDatabase cdb;
     Toolchain toolchain;
-    auto count = cdb.load(cdb_path);
+    auto loaded = cdb.load(cdb_path);
+    if(!loaded) {
+        std::println(stderr, "Error: failed to load {}", cdb_path);
+        return 1;
+    }
+    auto count = *loaded;
 
     auto t1 = std::chrono::steady_clock::now();
     auto load_ms = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
@@ -285,7 +290,7 @@ int main(int argc, const char** argv) {
         for(auto& entry: cdb.get_entries()) {
             unique_contexts.insert(entry.info.ptr);
             unique_canonicals.insert(entry.info->canonical.ptr);
-            canonical_hist[entry.info->canonical.ptr]++;
+            canonical_hist[entry.info->canonical.ptr] += 1;
         }
         double dedup_ratio =
             unique_contexts.empty() ? 0.0 : static_cast<double>(count) / unique_contexts.size();
@@ -307,7 +312,7 @@ int main(int argc, const char** argv) {
                               &std::pair<int, const CanonicalCommand*>::first);
 
             // Show top-5 canonical commands.
-            for(int i = 0; i < std::min(5, (int)sorted.size()); i++) {
+            for(int i = 0; i < std::min(5, (int)sorted.size()); i += 1) {
                 auto [cnt, cmd] = sorted[i];
                 std::println("  canonical[{}] ({} files, {} args):", i, cnt, cmd->arguments.size());
                 for(auto arg: cmd->arguments)
@@ -330,7 +335,7 @@ int main(int argc, const char** argv) {
                 auto* b = sorted[1].second;
                 std::println("  --- Canonical diff (top-1 vs top-2) ---");
                 auto max_len = std::max(a->arguments.size(), b->arguments.size());
-                for(std::size_t i = 0; i < max_len; i++) {
+                for(std::size_t i = 0; i < max_len; i += 1) {
                     llvm::StringRef av = i < a->arguments.size() ? a->arguments[i] : "<missing>";
                     llvm::StringRef bv = i < b->arguments.size() ? b->arguments[i] : "<missing>";
                     if(av != bv)
@@ -355,7 +360,7 @@ int main(int argc, const char** argv) {
     phase1_times.reserve(runs);
     phase2_times.reserve(runs);
 
-    for(int i = 0; i < runs; i++) {
+    for(int i = 0; i < runs; i += 1) {
         // True cold start: rebuild CDB (clears toolchain & config caches),
         // reset PathPool and DependencyGraph.
         cdb = CompilationDatabase{};

--- a/benchmarks/stats.h
+++ b/benchmarks/stats.h
@@ -1,17 +1,20 @@
 #pragma once
 
 #include <algorithm>
+#include <cassert>
 #include <vector>
 
 namespace clice::bench {
 
-/// Percentile over a sample by the same nearest-rank formula the TS side
-/// uses (tools/bench/perf.ts computeStats): index = floor(p * (n - 1)) on
-/// the sorted values. Sorts in place; the sample must be non-empty.
-inline double percentile(std::vector<double>& values, double p) {
-    std::ranges::sort(values);
-    auto index = static_cast<std::size_t>(p * static_cast<double>(values.size() - 1));
-    return values[index];
+/// Percentile over an ascending-sorted sample by the same nearest-rank
+/// formula the TS side uses (tools/bench/perf.ts computeStats): index =
+/// floor(p * (n - 1)). Takes the sample pre-sorted and non-empty: sorting
+/// in place here would make call sites that read front()/back() in the
+/// same argument list depend on argument evaluation order.
+inline double percentile(const std::vector<double>& sorted, double p) {
+    assert(!sorted.empty() && std::ranges::is_sorted(sorted));
+    auto index = static_cast<std::size_t>(p * static_cast<double>(sorted.size() - 1));
+    return sorted[index];
 }
 
 }  // namespace clice::bench

--- a/benchmarks/stats.h
+++ b/benchmarks/stats.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+namespace clice::bench {
+
+/// Percentile over a sample by the same nearest-rank formula the TS side
+/// uses (tools/bench/perf.ts computeStats): index = floor(p * (n - 1)) on
+/// the sorted values. Sorts in place; the sample must be non-empty.
+inline double percentile(std::vector<double>& values, double p) {
+    std::ranges::sort(values);
+    auto index = static_cast<std::size_t>(p * static_cast<double>(values.size() - 1));
+    return values[index];
+}
+
+}  // namespace clice::bench

--- a/benchmarks/workloads.json
+++ b/benchmarks/workloads.json
@@ -19,8 +19,7 @@
       ],
       "cdb": "build/compile_commands.json",
       "scenario": {
-        "file": "clang/lib/Sema/SemaExpr.cpp",
-        "position": "0:0"
+        "file": "clang/lib/Sema/SemaExpr.cpp"
       }
     }
   }

--- a/benchmarks/workloads.json
+++ b/benchmarks/workloads.json
@@ -1,0 +1,27 @@
+{
+  "_comment": "Pinned real-project workloads for reproducible benchmarks. fetch_workload.py materializes one under benchmarks/workloads/<name>: shallow clone at the SHA, then the configure command generates compile_commands.json (no build needed). The scenario block feeds tools/bench/bench.ts defaults.",
+  "workloads": {
+    "llvm": {
+      "description": "llvm-project at the release the prebuilt LLVM packages track. Large workload: ~4500 clang+llvm TUs, heavy templates, deep include graphs.",
+      "git": "https://github.com/llvm/llvm-project.git",
+      "ref": "llvmorg-22.1.8",
+      "configure": [
+        "cmake",
+        "-S",
+        "llvm",
+        "-B",
+        "build",
+        "-G",
+        "Ninja",
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+        "-DLLVM_ENABLE_PROJECTS=clang"
+      ],
+      "cdb": "build/compile_commands.json",
+      "scenario": {
+        "file": "clang/lib/Sema/SemaExpr.cpp",
+        "position": "0:0"
+      }
+    }
+  }
+}

--- a/src/compile/compilation.cpp
+++ b/src/compile/compilation.cpp
@@ -456,4 +456,16 @@ CompilationUnit complete(CompilationParams& params, clang::CodeCompleteConsumer*
                      });
 }
 
+std::string collect_errors(CompilationUnit& unit) {
+    std::string errors;
+    for(auto& diag: unit.diagnostics()) {
+        if(diag.id.level >= DiagnosticLevel::Error) {
+            if(!errors.empty())
+                errors += "; ";
+            errors += diag.message;
+        }
+    }
+    return errors;
+}
+
 }  // namespace clice

--- a/src/compile/compilation.cpp
+++ b/src/compile/compilation.cpp
@@ -282,7 +282,7 @@ CompilationStatus CompilationUnitRef::Self::run_clang(
     }
 
     std::optional<clang::syntax::TokenCollector> token_collector;
-    if(!instance.hasCodeCompletionConsumer()) {
+    if(params.collect_tokens && !instance.hasCodeCompletionConsumer()) {
         /// It is not necessary to collect tokens if we are running code completion.
         /// And in fact will cause assertion failure.
         token_collector.emplace(instance.getPreprocessor());

--- a/src/compile/compilation.h
+++ b/src/compile/compilation.h
@@ -71,6 +71,10 @@ struct CompilationParams {
     /// Whether to run clang-tidy.
     bool clang_tidy = false;
 
+    /// Whether to collect the syntax::TokenBuffer during the run. Features
+    /// need it; measurement paths turn it off to isolate its cost.
+    bool collect_tokens = true;
+
     /// Output file path.
     llvm::SmallString<128> output_file;
 

--- a/src/compile/compilation.h
+++ b/src/compile/compilation.h
@@ -129,4 +129,7 @@ CompilationUnit compile(CompilationParams& params, PCMInfo& out);
 /// Run code completion at the given location.
 CompilationUnit complete(CompilationParams& params, clang::CodeCompleteConsumer* consumer);
 
+/// Error-level diagnostics of a finished compilation, joined with "; ".
+std::string collect_errors(CompilationUnit& unit);
+
 }  // namespace clice

--- a/src/index/tu_index.cpp
+++ b/src/index/tu_index.cpp
@@ -9,6 +9,8 @@
 #include "semantic/display.h"
 #include "semantic/semantics.h"
 #include "semantic/types.h"
+#include "support/logging.h"
+#include "support/timer.h"
 
 #include "llvm/Support/SHA256.h"
 #include "llvm/Support/xxhash.h"
@@ -504,6 +506,7 @@ public:
     }
 
     void build() {
+        ScopedTimer semantics_timer;
         /// The interested-only shape is the one features share, cached on the
         /// unit; the whole-TU shape is transient — projected and dropped.
         /// Both phases below share the one build.
@@ -512,11 +515,15 @@ public:
             full.emplace(Semantics::build(unit, false));
         }
         const Semantics& semantics = interested_only ? unit.semantics() : *full;
+        auto semantics_ms = semantics_timer.ms_f();
 
+        ScopedTimer project_timer;
         project_semantics(semantics);
 
         index_modules(semantics);
+        auto project_ms = project_timer.ms_f();
 
+        ScopedTimer finish_timer;
         // Build the include graph from what the index actually recorded:
         // every fid keying `file_indices` gets its include chain resolved
         // through the SourceManager, so the lookups below cannot miss.
@@ -559,6 +566,13 @@ public:
         }
 
         result.file_indices.erase(unit.interested_file());
+
+        LOG_PERF("index_detail",
+                 "op=build scope={} semantics_ms={:.2f} project_ms={:.2f} finish_ms={:.2f}",
+                 interested_only ? "interested" : "full",
+                 semantics_ms,
+                 project_ms,
+                 finish_timer.ms_f());
     }
 
 private:
@@ -643,14 +657,21 @@ void TUIndex::serialize(llvm::raw_ostream& os) {
     /// header contexts), last-wins. A deserialized index has no FileID-keyed
     /// state at all — its path-keyed rows already are the persisted form, so
     /// re-serializing must not wipe them.
+    ScopedTimer copy_timer;
     if(!file_indices.empty()) {
         path_file_indices.clear();
         for(auto& [fid, file_index]: file_indices) {
             path_file_indices[graph.path_id(fid)] = file_index;
         }
     }
+    auto copy_ms = copy_timer.ms_f();
 
+    ScopedTimer pack_timer;
     serialize_blob(*this, os);
+    LOG_PERF("index_detail",
+             "op=serialize copy_ms={:.2f} pack_ms={:.2f}",
+             copy_ms,
+             pack_timer.ms_f());
 }
 
 std::optional<TUIndex> TUIndex::from(llvm::StringRef data) {

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -1401,7 +1401,7 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
     if(!co_await ensure_compiled(session)) {
         co_return serde_raw{"null"};
     }
-    auto wait_ms = timer.ms();
+    auto wait_ms = timer.ms_f();
 
     if(session->generation != gen) {
         co_return serde_raw{"null"};
@@ -1472,7 +1472,12 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
             publish_recovered(session);
         }
     }
-    LOG_PERF("request", "kind={} file={} wait_ms={} total_ms={}", kind, path, wait_ms, timer.ms());
+    LOG_PERF("request",
+             "kind={} file={} wait_ms={:.2f} total_ms={:.2f}",
+             kind,
+             path,
+             wait_ms,
+             timer.ms_f());
     co_return std::move(result.value());
 }
 
@@ -1490,7 +1495,7 @@ kota::task<std::vector<feature::DocumentLink>, kota::ipc::Error>
     if(session->generation != gen) {
         co_return std::vector<feature::DocumentLink>{};
     }
-    auto wait_ms = timer.ms();
+    auto wait_ms = timer.ms_f();
 
     if(session->quarantine.kind_blocked(document_link_evidence)) {
         co_return kota::outcome_error(
@@ -1599,7 +1604,7 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
         co_return kota::outcome_error(
             kota::ipc::Error{worker::dispatch_errc::worker_unavailable, "Document is quarantined"});
     }
-    auto wait_ms = timer.ms();
+    auto wait_ms = timer.ms_f();
 
     if(session->generation != gen) {
         co_return serde_raw{"null"};
@@ -1646,7 +1651,12 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
             publish_recovered(session);
         }
     }
-    LOG_PERF("request", "kind={} file={} wait_ms={} total_ms={}", kind, path, wait_ms, timer.ms());
+    LOG_PERF("request",
+             "kind={} file={} wait_ms={:.2f} total_ms={:.2f}",
+             kind,
+             path,
+             wait_ms,
+             timer.ms_f());
     co_return std::move(result.value().result_json);
 }
 

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -1207,7 +1207,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
 
         auto version = session->version;
 
-        LOG_PERF("request", "kind=Compile file={} total_ms={}", file_path, timer.ms());
+        LOG_PERF("request", "kind=Compile file={} total_ms={:.2f}", file_path, timer.ms_f());
         // The preamble's share lives with the PCH; the compile result
         // covers the content past the bound. Publish both.
         auto inactive = std::move(pch_inactive);
@@ -1539,10 +1539,10 @@ kota::task<std::vector<feature::DocumentLink>, kota::ipc::Error>
         publish_recovered(session);
     }
     LOG_PERF("request",
-             "kind=DocumentLink file={} wait_ms={} total_ms={}",
+             "kind=DocumentLink file={} wait_ms={:.2f} total_ms={:.2f}",
              path,
              wait_ms,
-             timer.ms());
+             timer.ms_f());
     co_return std::move(result.value());
 }
 
@@ -1722,7 +1722,7 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
             publish_recovered(session);
         }
     }
-    LOG_PERF("request", "kind=Format file={} total_ms={}", path, timer.ms());
+    LOG_PERF("request", "kind=Format file={} total_ms={:.2f}", path, timer.ms_f());
     co_return std::move(result.value().result_json);
 }
 

--- a/src/server/service/query.cpp
+++ b/src/server/service/query.cpp
@@ -284,8 +284,16 @@ std::vector<protocol::Location> IndexQuery::query_relations(llvm::StringRef path
                                                             Session* session) {
     ScopedTimer timer;
     auto hit = resolve_cursor(path, position, session);
-    if(hit.hash == 0)
+    if(hit.hash == 0) {
+        // Misses (whitespace, comments, unindexed positions) are normal
+        // inputs; their latency belongs in the series like any hit's.
+        LOG_PERF("index_query",
+                 "kind=relations rel={} path={} results=0 elapsed_ms={:.2f}",
+                 kota::meta::enum_name(static_cast<RelationKind::Kind>(kind), "Invalid"),
+                 path,
+                 timer.ms_f());
         return {};
+    }
 
     std::vector<protocol::Location> locations;
 
@@ -877,9 +885,12 @@ std::vector<protocol::SymbolInformation> IndexQuery::search_symbols(llvm::String
         }
         return true;
     });
+    // The query is arbitrary LSP input; its length is logged instead of its
+    // text, which could contain newlines or `key=` fragments and corrupt
+    // the key/value record.
     LOG_PERF("index_query",
-             "kind=search query={} results={} elapsed_ms={:.2f}",
-             query,
+             "kind=search query_len={} results={} elapsed_ms={:.2f}",
+             query.size(),
              results.size(),
              timer.ms_f());
     return results;

--- a/src/server/service/query.cpp
+++ b/src/server/service/query.cpp
@@ -16,10 +16,13 @@
 #include "server/state/session.h"
 #include "server/state/session_store.h"
 #include "support/filesystem.h"
+#include "support/logging.h"
+#include "support/timer.h"
 
 #include "kota/ipc/lsp/position.h"
 #include "kota/ipc/lsp/protocol.h"
 #include "kota/ipc/lsp/uri.h"
+#include "kota/meta/enum.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Path.h"
@@ -279,6 +282,7 @@ std::vector<protocol::Location> IndexQuery::query_relations(llvm::StringRef path
                                                             const protocol::Position& position,
                                                             RelationKind kind,
                                                             Session* session) {
+    ScopedTimer timer;
     auto hit = resolve_cursor(path, position, session);
     if(hit.hash == 0)
         return {};
@@ -358,6 +362,12 @@ std::vector<protocol::Location> IndexQuery::query_relations(llvm::StringRef path
         });
 
     dedup_locations(locations);
+    LOG_PERF("index_query",
+             "kind=relations rel={} path={} results={} elapsed_ms={:.2f}",
+             kota::meta::enum_name(static_cast<RelationKind::Kind>(kind), "Invalid"),
+             path,
+             locations.size(),
+             timer.ms_f());
     return locations;
 }
 
@@ -800,6 +810,7 @@ std::vector<protocol::TypeHierarchyItem> IndexQuery::find_subtypes(index::Symbol
 
 std::vector<protocol::SymbolInformation> IndexQuery::search_symbols(llvm::StringRef query,
                                                                     std::size_t max_results) {
+    ScopedTimer timer;
     std::string query_lower = query.lower();
 
     auto is_indexable_kind = [](SymbolKind sk) {
@@ -866,6 +877,11 @@ std::vector<protocol::SymbolInformation> IndexQuery::search_symbols(llvm::String
         }
         return true;
     });
+    LOG_PERF("index_query",
+             "kind=search query={} results={} elapsed_ms={:.2f}",
+             query,
+             results.size(),
+             timer.ms_f());
     return results;
 }
 

--- a/src/server/worker/stateful_worker.cpp
+++ b/src/server/worker/stateful_worker.cpp
@@ -124,9 +124,12 @@ class StatefulWorker {
         auto doc = it->second;
         touch_lru(path);
 
+        ScopedTimer timer;
         co_await doc->ast_ready.wait();
         co_await doc->strand.lock();
         StrandGuard strand_guard{doc->strand};
+        auto acquire_ms = timer.ms_f();
+        double compute_ms = 0;
 
         // The frame stays alive until fn returns even when the handler is
         // cancelled mid-await, so the by-reference captures are safe; the
@@ -140,10 +143,19 @@ class StatefulWorker {
                 }
                 if(!doc->has_ast || (!doc->unit.completed() && !doc->unit.fatal_error()))
                     return std::move(missing);
-                return fn(*doc);
+                ScopedTimer compute_timer;
+                auto value = fn(*doc);
+                compute_ms = compute_timer.ms_f();
+                return value;
             },
             [&] { cancelled.store(true, std::memory_order_relaxed); });
 
+        LOG_PERF("query",
+                 "path={} acquire_ms={:.2f} compute_ms={:.2f} total_ms={:.2f}",
+                 path.str(),
+                 acquire_ms,
+                 compute_ms,
+                 timer.ms_f());
         co_return result.value();
     }
 

--- a/src/server/worker/stateful_worker.cpp
+++ b/src/server/worker/stateful_worker.cpp
@@ -113,8 +113,10 @@ class StatefulWorker {
 
     /// Look up document, wait for AST, lock strand, run fn(doc) on thread pool, unlock.
     /// Returns `missing` if the document is not found or its AST unusable.
+    /// `kind` discriminates the perf series: query kinds have very
+    /// different costs and must not collapse into one distribution.
     template <typename R, typename F>
-    kota::task<R> with_ast_or(llvm::StringRef path, R missing, F&& fn) {
+    kota::task<R> with_ast_or(llvm::StringRef kind, llvm::StringRef path, R missing, F&& fn) {
         auto it = documents.find(path);
         if(it == documents.end()) {
             co_return std::move(missing);
@@ -151,7 +153,8 @@ class StatefulWorker {
             [&] { cancelled.store(true, std::memory_order_relaxed); });
 
         LOG_PERF("query",
-                 "path={} acquire_ms={:.2f} compute_ms={:.2f} total_ms={:.2f}",
+                 "kind={} path={} acquire_ms={:.2f} compute_ms={:.2f} total_ms={:.2f}",
+                 kind.str(),
                  path.str(),
                  acquire_ms,
                  compute_ms,
@@ -161,8 +164,11 @@ class StatefulWorker {
 
     /// Returns "null" if document not found or AST not usable.
     template <typename F>
-    kota::task<kota::codec::RawValue> with_ast(llvm::StringRef path, F&& fn) {
-        co_return co_await with_ast_or(path, kota::codec::RawValue{"null"}, std::forward<F>(fn));
+    kota::task<kota::codec::RawValue> with_ast(llvm::StringRef kind, llvm::StringRef path, F&& fn) {
+        co_return co_await with_ast_or(kind,
+                                       path,
+                                       kota::codec::RawValue{"null"},
+                                       std::forward<F>(fn));
     }
 
 public:
@@ -344,6 +350,7 @@ void StatefulWorker::register_handlers() {
     peer.on_request([this](RequestContext& ctx, const worker::DocumentLinkParams& params)
                         -> RequestResult<worker::DocumentLinkParams> {
         co_return co_await with_ast_or(
+            "DocumentLink",
             params.path,
             std::vector<feature::DocumentLink>{},
             [&](DocumentEntry& doc) { return feature::document_links(doc.unit); });
@@ -375,25 +382,26 @@ void StatefulWorker::register_handlers() {
         [this](RequestContext& ctx,
                const worker::QueryParams& params) -> RequestResult<worker::QueryParams> {
             using K = worker::QueryKind;
+            auto kind = kota::meta::enum_name(params.kind, "Unknown");
             switch(params.kind) {
                 case K::Hover:
-                    co_return co_await with_ast(params.path, [&](DocumentEntry& doc) {
+                    co_return co_await with_ast(kind, params.path, [&](DocumentEntry& doc) {
                         auto result = feature::hover(doc.unit, params.offset, params.config.hover);
                         return result ? to_raw(*result) : kota::codec::RawValue{"null"};
                     });
                 case K::GoToDefinition:
                     // Include directives only; symbol definitions are served
                     // from the index by the master.
-                    co_return co_await with_ast(params.path, [&](DocumentEntry& doc) {
+                    co_return co_await with_ast(kind, params.path, [&](DocumentEntry& doc) {
                         return to_raw(feature::include_definition(doc.unit, params.offset));
                     });
                 case K::SemanticTokens:
-                    co_return co_await with_ast(params.path, [&](DocumentEntry& doc) {
+                    co_return co_await with_ast(kind, params.path, [&](DocumentEntry& doc) {
                         return to_raw(
                             feature::semantic_tokens(doc.unit, feature::PositionEncoding::UTF16));
                     });
                 case K::InlayHints:
-                    co_return co_await with_ast(params.path, [&](DocumentEntry& doc) {
+                    co_return co_await with_ast(kind, params.path, [&](DocumentEntry& doc) {
                         auto range = params.range;
                         if(range.begin == static_cast<uint32_t>(-1))
                             range = LocalSourceRange{0, static_cast<uint32_t>(doc.text.size())};
@@ -403,12 +411,12 @@ void StatefulWorker::register_handlers() {
                                                            feature::PositionEncoding::UTF16));
                     });
                 case K::FoldingRange:
-                    co_return co_await with_ast(params.path, [&](DocumentEntry& doc) {
+                    co_return co_await with_ast(kind, params.path, [&](DocumentEntry& doc) {
                         return to_raw(
                             feature::folding_ranges(doc.unit, feature::PositionEncoding::UTF16));
                     });
                 case K::DocumentSymbol:
-                    co_return co_await with_ast(params.path, [&](DocumentEntry& doc) {
+                    co_return co_await with_ast(kind, params.path, [&](DocumentEntry& doc) {
                         return to_raw(
                             feature::document_symbols(doc.unit, feature::PositionEncoding::UTF16));
                     });

--- a/src/server/worker/stateful_worker.cpp
+++ b/src/server/worker/stateful_worker.cpp
@@ -20,6 +20,7 @@
 #include "kota/ipc/codec/bincode.h"
 #include "kota/ipc/peer.h"
 #include "kota/ipc/transport.h"
+#include "kota/meta/enum.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -154,8 +155,8 @@ class StatefulWorker {
 
         LOG_PERF("query",
                  "kind={} path={} acquire_ms={:.2f} compute_ms={:.2f} total_ms={:.2f}",
-                 kind.str(),
-                 path.str(),
+                 kind,
+                 path,
                  acquire_ms,
                  compute_ms,
                  timer.ms_f());

--- a/src/server/worker/stateless_worker.cpp
+++ b/src/server/worker/stateless_worker.cpp
@@ -128,6 +128,7 @@ static worker::BuildResult handle_build_pch(const worker::BuildParams& params,
 
     PCHInfo pch_info;
     auto unit = compile(cp, pch_info);
+    auto compile_ms = timer.ms();
     // A cancelled parse reports !completed(); the extra check catches a
     // cancellation landing between the parse and the serialization, whose
     // blob nobody will read. The tmp file is removed like any failed build.
@@ -139,12 +140,16 @@ static worker::BuildResult handle_build_pch(const worker::BuildParams& params,
         errors = collect_errors(unit);
 
     std::string blob;
+    ScopedTimer index_timer;
     if(success) {
         blob = serialize_preamble_state(unit, params.preamble_bound);
     }
+    auto index_ms = index_timer.ms();
 
     // Destroy CompilationUnit to flush PCH to disk.
+    ScopedTimer flush_timer;
     unit = CompilationUnit(nullptr);
+    auto flush_ms = flush_timer.ms();
 
     // Write the blob strictly after the PCH flush: the CacheStore's
     // restart adoption validates a pair by "aux not older than primary"
@@ -163,7 +168,13 @@ static worker::BuildResult handle_build_pch(const worker::BuildParams& params,
     }
 
     if(success) {
-        LOG_INFO("BuildPCH done: file={}, output={}, {}ms", params.file, tmp_path, timer.ms());
+        LOG_PERF("build",
+                 "kind=pch file={} compile_ms={} preamble_index_ms={} flush_ms={} total_ms={}",
+                 params.file,
+                 compile_ms,
+                 index_ms,
+                 flush_ms,
+                 timer.ms());
         worker::BuildResult result;
         result.success = true;
         result.output_path = tmp_path;
@@ -209,6 +220,7 @@ static worker::BuildResult handle_build_pcm(const worker::BuildParams& params,
 
     PCMInfo pcm_info;
     auto unit = compile(cp, pcm_info);
+    auto compile_ms = timer.ms();
     bool success = unit.completed() && !stop->load(std::memory_order_relaxed);
     auto build_at = unit.build_at().count();
 
@@ -220,10 +232,17 @@ static worker::BuildResult handle_build_pcm(const worker::BuildParams& params,
     // buffer-derived artifact — module units are ordinary disk files with
     // CDB entries, so their symbols should flow through the normal
     // background-indexing path (no per-blob pair needed).
+    ScopedTimer flush_timer;
     unit = CompilationUnit(nullptr);
+    auto flush_ms = flush_timer.ms();
 
     if(success) {
-        LOG_INFO("BuildPCM done: module={}, {}ms", params.module_name, timer.ms());
+        LOG_PERF("build",
+                 "kind=pcm module={} compile_ms={} flush_ms={} total_ms={}",
+                 params.module_name,
+                 compile_ms,
+                 flush_ms,
+                 timer.ms());
         worker::BuildResult result;
         result.success = true;
         result.output_path = tmp_path;
@@ -257,6 +276,7 @@ static worker::BuildResult handle_index(const worker::BuildParams& params,
     cp.stop = stop;
 
     auto unit = compile(cp);
+    auto compile_ms = timer.ms();
     if(!unit.completed()) {
         LOG_WARN("Index failed: file={}, {}ms", params.file, timer.ms());
         return {false, "Index compilation failed"};
@@ -267,14 +287,25 @@ static worker::BuildResult handle_index(const worker::BuildParams& params,
     if(stop->load(std::memory_order_relaxed)) {
         return {false, "Index cancelled"};
     }
+    ScopedTimer index_timer;
     auto tu_index = index::TUIndex::build(unit);
+    auto index_ms = index_timer.ms();
+
+    ScopedTimer serialize_timer;
     std::string serialized;
     llvm::raw_string_ostream os(serialized);
     tu_index.serialize(os);
+    auto serialize_ms = serialize_timer.ms();
 
-    LOG_INFO("Index done: file={}, {} symbols, {}ms",
+    LOG_PERF("build",
+             "kind=index file={} symbols={} bytes={} compile_ms={} index_ms={} serialize_ms={} "
+             "total_ms={}",
              params.file,
              tu_index.symbols.size(),
+             serialized.size(),
+             compile_ms,
+             index_ms,
+             serialize_ms,
              timer.ms());
     worker::BuildResult result;
     result.success = true;

--- a/src/server/worker/stateless_worker.cpp
+++ b/src/server/worker/stateless_worker.cpp
@@ -41,19 +41,6 @@ struct ScopedNice {
 using kota::ipc::RequestResult;
 using RequestContext = kota::ipc::BincodePeer::RequestContext;
 
-/// Extract error messages from compilation diagnostics.
-static std::string collect_errors(CompilationUnit& unit) {
-    std::string errors;
-    for(auto& diag: unit.diagnostics()) {
-        if(diag.id.level >= DiagnosticLevel::Error) {
-            if(!errors.empty())
-                errors += "; ";
-            errors += diag.message;
-        }
-    }
-    return errors;
-}
-
 /// Serialize the preamble's PreambleState blob (full index + document
 /// links + inactive regions) into a string. Runs while the freshly
 /// parsed AST is still in memory — the only moment the preamble's index
@@ -179,8 +166,10 @@ static worker::BuildResult handle_build_pch(const worker::BuildParams& params,
 
     if(success) {
         LOG_PERF("build",
-                 "kind=pch file={} compile_ms={} preamble_index_ms={} flush_ms={} total_ms={}",
+                 "kind=pch file={} output={} compile_ms={} preamble_index_ms={} flush_ms={} "
+                 "total_ms={}",
                  params.file,
+                 tmp_path,
                  compile_ms,
                  index_ms,
                  flush_ms,

--- a/src/server/worker/stateless_worker.cpp
+++ b/src/server/worker/stateless_worker.cpp
@@ -301,15 +301,25 @@ static worker::BuildResult handle_index(const worker::BuildParams& params,
     tu_index.serialize(os);
     auto serialize_ms = serialize_timer.ms();
 
+    // AST teardown for a large TU is material work that belongs to this
+    // task: sample the total only after the unit and index are gone, so
+    // the logged span covers everything that blocks the worker.
+    auto symbol_count = tu_index.symbols.size();
+    ScopedTimer teardown_timer;
+    tu_index = index::TUIndex();
+    unit = CompilationUnit(nullptr);
+    auto teardown_ms = teardown_timer.ms();
+
     LOG_PERF("build",
              "kind=index file={} symbols={} bytes={} compile_ms={} index_ms={} serialize_ms={} "
-             "total_ms={}",
+             "teardown_ms={} total_ms={}",
              params.file,
-             tu_index.symbols.size(),
+             symbol_count,
              serialized.size(),
              compile_ms,
              index_ms,
              serialize_ms,
+             teardown_ms,
              timer.ms());
     worker::BuildResult result;
     result.success = true;

--- a/src/server/worker/stateless_worker.cpp
+++ b/src/server/worker/stateless_worker.cpp
@@ -61,9 +61,13 @@ static std::string collect_errors(CompilationUnit& unit) {
 /// happens separately, after the PCH itself is flushed.
 static std::string serialize_preamble_state(CompilationUnit& unit, std::uint32_t preamble_bound) {
     auto tu_index = index::TUIndex::build(unit);
+
+    ScopedTimer links_timer;
     auto links = feature::document_links(unit);
     auto inactive = feature::inactive_regions(unit, {}, 0, preamble_bound);
+    auto links_ms = links_timer.ms_f();
 
+    ScopedTimer blob_timer;
     std::string blob;
     llvm::raw_string_ostream os(blob);
     index::PreambleState::serialize(unit,
@@ -72,6 +76,11 @@ static std::string serialize_preamble_state(CompilationUnit& unit, std::uint32_t
                                     inactive.regions,
                                     inactive.open_stack,
                                     os);
+    LOG_PERF("index_detail",
+             "op=preamble links_ms={:.2f} blob_ms={:.2f} bytes={}",
+             links_ms,
+             blob_timer.ms_f(),
+             blob.size());
     return blob;
 }
 

--- a/src/server/worker/stateless_worker.cpp
+++ b/src/server/worker/stateless_worker.cpp
@@ -156,6 +156,7 @@ static worker::BuildResult handle_build_pch(const worker::BuildParams& params,
     // failure, never a user-code problem — must not be downgraded to an
     // expected build failure.
     bool internal_error = false;
+    ScopedTimer state_write_timer;
     if(success) {
         if(auto error = write_preamble_state(blob, params.index_output_path)) {
             success = false;
@@ -163,16 +164,18 @@ static worker::BuildResult handle_build_pch(const worker::BuildParams& params,
             errors = std::move(*error);
         }
     }
+    auto state_write_ms = state_write_timer.ms();
 
     if(success) {
         LOG_PERF("build",
                  "kind=pch file={} output={} compile_ms={} preamble_index_ms={} flush_ms={} "
-                 "total_ms={}",
+                 "state_write_ms={} total_ms={}",
                  params.file,
                  tmp_path,
                  compile_ms,
                  index_ms,
                  flush_ms,
+                 state_write_ms,
                  timer.ms());
         worker::BuildResult result;
         result.success = true;

--- a/src/server/worker/stateless_worker.cpp
+++ b/src/server/worker/stateless_worker.cpp
@@ -136,8 +136,9 @@ static worker::BuildResult handle_build_pch(const worker::BuildParams& params,
     cp.output_file = tmp_path;
 
     PCHInfo pch_info;
+    ScopedTimer compile_timer;
     auto unit = compile(cp, pch_info);
-    auto compile_ms = timer.ms();
+    auto compile_ms = compile_timer.ms();
     // A cancelled parse reports !completed(); the extra check catches a
     // cancellation landing between the parse and the serialization, whose
     // blob nobody will read. The tmp file is removed like any failed build.
@@ -228,8 +229,9 @@ static worker::BuildResult handle_build_pcm(const worker::BuildParams& params,
     cp.output_file = tmp_path;
 
     PCMInfo pcm_info;
+    ScopedTimer compile_timer;
     auto unit = compile(cp, pcm_info);
-    auto compile_ms = timer.ms();
+    auto compile_ms = compile_timer.ms();
     bool success = unit.completed() && !stop->load(std::memory_order_relaxed);
     auto build_at = unit.build_at().count();
 
@@ -284,8 +286,9 @@ static worker::BuildResult handle_index(const worker::BuildParams& params,
     }
     cp.stop = stop;
 
+    ScopedTimer compile_timer;
     auto unit = compile(cp);
-    auto compile_ms = timer.ms();
+    auto compile_ms = compile_timer.ms();
     if(!unit.completed()) {
         LOG_WARN("Index failed: file={}, {}ms", params.file, timer.ms());
         return {false, "Index compilation failed"};

--- a/src/support/logging.h
+++ b/src/support/logging.h
@@ -65,9 +65,15 @@
 /// "[perf:<topic>] key=value ..." at info level, e.g.
 /// `grep 'perf:index' master.log`. Topics in use: "index" (per-file and
 /// phase timings), "cache" (hit/miss with reason), "startup" (phase
-/// durations), "request" (per-request latency: wait_ms = time until a
-/// worker was ready, total_ms = end-to-end). Use stable key=value pairs and
-/// `_ms` suffixes for durations — scripts aggregate these lines.
+/// durations), "request" (per-request latency on the master: wait_ms =
+/// time until a worker was ready, total_ms = end-to-end), "query"
+/// (worker-side share of a request: acquire_ms = AST wait + strand lock,
+/// compute_ms = the feature call itself), "build" (stateless-worker build
+/// tasks: kind=pch|pcm|index with per-stage splits — compile_ms, and per
+/// kind preamble_index_ms/flush_ms or index_ms/serialize_ms),
+/// "index_query" (master-side index lookups: kind=relations|search). Use
+/// stable key=value pairs and `_ms` suffixes for durations — scripts
+/// aggregate these lines (tools/bench/perf_report.ts).
 ///
 /// ## Process ownership
 /// The master logs to <logging_dir>/<session>/master.log and mirrors to

--- a/src/support/logging.h
+++ b/src/support/logging.h
@@ -71,9 +71,13 @@
 /// compute_ms = the feature call itself), "build" (stateless-worker build
 /// tasks: kind=pch|pcm|index with per-stage splits — compile_ms, and per
 /// kind preamble_index_ms/flush_ms or index_ms/serialize_ms),
-/// "index_query" (master-side index lookups: kind=relations|search). Use
-/// stable key=value pairs and `_ms` suffixes for durations — scripts
-/// aggregate these lines (tools/bench/perf_report.ts).
+/// "index_query" (master-side index lookups: kind=relations|search),
+/// "index_detail" (inside one index pass: op=build splits the semantics
+/// table from projection and finishing, op=serialize splits the path-id
+/// rekeying copy from the flatbuffers pack, op=preamble the document
+/// links and the PreambleState blob). Use stable key=value pairs and
+/// `_ms` suffixes for durations — scripts aggregate these lines
+/// (tools/bench/perf_report.ts).
 ///
 /// ## Process ownership
 /// The master logs to <logging_dir>/<session>/master.log and mirrors to

--- a/src/support/timer.h
+++ b/src/support/timer.h
@@ -13,6 +13,15 @@ struct ScopedTimer {
                    std::chrono::steady_clock::now() - start)
             .count();
     }
+
+    /// Fractional milliseconds for sub-millisecond stages (feature compute,
+    /// IPC hops); perf lines keep the `_ms` suffix convention.
+    double ms_f() const {
+        return std::chrono::duration_cast<std::chrono::microseconds>(
+                   std::chrono::steady_clock::now() - start)
+                   .count() /
+               1000.0;
+    }
 };
 
 }  // namespace clice

--- a/tests/tools/perf.test.ts
+++ b/tests/tools/perf.test.ts
@@ -46,9 +46,11 @@ test("summarize discriminates by kind and keeps only durations", () => {
                 "[perf:build] kind=pch file=/w/b.h compile_ms=300 total_ms=340",
                 "[perf:build] kind=index file=/w/a.cpp compile_ms=50 total_ms=60",
                 "[perf:startup] phase=dep_scan elapsed_ms=25",
+                "[perf:index_detail] op=serialize copy_ms=17.4 pack_ms=155.3",
             ].join("\n"),
         ),
     );
+    expect(summary["index_detail.serialize.pack_ms"]?.p50).toBe(155.3);
     expect(summary["build.pch.compile_ms"]?.count).toBe(2);
     expect(summary["build.pch.compile_ms"]?.max).toBe(300);
     expect(summary["build.index.total_ms"]?.count).toBe(1);

--- a/tests/tools/perf.test.ts
+++ b/tests/tools/perf.test.ts
@@ -69,6 +69,28 @@ test("stats percentiles", () => {
     expect(computeStats([])).toBeNull();
 });
 
+test("trace lanes preserve process and thread identity", () => {
+    const master = parsePerfLines(
+        "[2026-08-14 10:00:00.000] [info] [thread 1] [f:1] [perf:request] kind=Hover total_ms=4\n",
+        1,
+    );
+    const worker = parsePerfLines(
+        "[2026-08-14 10:00:00.050] [info] [thread 9] [f:2] [perf:query] kind=Hover total_ms=2\n",
+        2,
+    );
+    const trace = JSON.parse(toChromeTrace([...master, ...worker], { 2: "worker.log" })) as {
+        traceEvents: { ph: string; pid: number; tid: number; args: { name?: string } }[];
+    };
+    const meta = trace.traceEvents.find((e) => e.ph === "M")!;
+    expect(meta.pid).toBe(2);
+    expect(meta.args.name).toBe("worker.log");
+    const spans = trace.traceEvents.filter((e) => e.ph === "X");
+    expect(spans.map((e) => [e.pid, e.tid])).toEqual([
+        [1, 1],
+        [2, 9],
+    ]);
+});
+
 test("chrome trace reconstructs spans", () => {
     const events = parsePerfLines(
         [

--- a/tests/tools/perf.test.ts
+++ b/tests/tools/perf.test.ts
@@ -47,6 +47,10 @@ test("summarize discriminates by kind and keeps only durations", () => {
                 "[perf:build] kind=index file=/w/a.cpp compile_ms=50 total_ms=60",
                 "[perf:startup] phase=dep_scan elapsed_ms=25",
                 "[perf:index_detail] op=serialize copy_ms=17.4 pack_ms=155.3",
+                "[perf:index_detail] op=build scope=full semantics_ms=80 finish_ms=5",
+                "[perf:index_detail] op=build scope=interested semantics_ms=8 finish_ms=1",
+                "[perf:index_query] kind=relations rel=Definition path=/w/a.cpp elapsed_ms=3",
+                "[perf:index_query] kind=relations rel=Reference path=/w/a.cpp elapsed_ms=7",
             ].join("\n"),
         ),
     );
@@ -55,6 +59,12 @@ test("summarize discriminates by kind and keeps only durations", () => {
     expect(summary["build.pch.compile_ms"]?.max).toBe(300);
     expect(summary["build.index.total_ms"]?.count).toBe(1);
     expect(summary["startup.dep_scan.elapsed_ms"]?.p50).toBe(25);
+    // The secondary scope/rel discriminators keep materially different
+    // operations in separate series.
+    expect(summary["index_detail.build.full.semantics_ms"]?.p50).toBe(80);
+    expect(summary["index_detail.build.interested.semantics_ms"]?.p50).toBe(8);
+    expect(summary["index_query.relations.Definition.elapsed_ms"]?.p50).toBe(3);
+    expect(summary["index_query.relations.Reference.elapsed_ms"]?.p50).toBe(7);
     // Non-duration keys (file=, kind=) never become series.
     expect(Object.keys(summary).every((name) => name.endsWith("_ms"))).toBe(true);
 });

--- a/tests/tools/perf.test.ts
+++ b/tests/tools/perf.test.ts
@@ -1,0 +1,91 @@
+/// Tests for the perf-line parser (tools/bench/perf.ts) that turns
+/// `[perf:<topic>] key=value` log lines into series and Chrome traces.
+
+import { expect, test } from "vitest";
+import { computeStats, parsePerfLines, summarize, toChromeTrace } from "@clice/tools/bench/perf";
+
+const LINE =
+    "[2026-08-14 10:00:01.500] [info] [thread 7] [indexer.cpp:793] " +
+    "[perf:index] progress=3/10 file=/w/a.cpp bytes=1024 index_ms=12.5 merge_ms=3";
+
+test("perf line parsing", () => {
+    const events = parsePerfLines(`noise\n${LINE}\nmore noise\n`);
+    expect(events).toHaveLength(1);
+    const event = events[0]!;
+    expect(event.topic).toBe("index");
+    expect(event.ts).toBe(Date.parse("2026-08-14T10:00:01.500"));
+    expect(event.values).toEqual({
+        progress: "3/10",
+        file: "/w/a.cpp",
+        bytes: 1024,
+        index_ms: 12.5,
+        merge_ms: 3,
+    });
+});
+
+test("perf line without timestamp", () => {
+    const events = parsePerfLines("[perf:startup] phase=cdb_load entries=42 elapsed_ms=7\n");
+    expect(events).toHaveLength(1);
+    expect(events[0]!.ts).toBeNull();
+    expect(events[0]!.values["elapsed_ms"]).toBe(7);
+});
+
+test("values may contain spaces", () => {
+    const events = parsePerfLines(
+        "[perf:index_query] kind=search query=foo bar results=2 elapsed_ms=0.42\n",
+    );
+    expect(events[0]!.values["query"]).toBe("foo bar");
+    expect(events[0]!.values["results"]).toBe(2);
+});
+
+test("summarize discriminates by kind and keeps only durations", () => {
+    const summary = summarize(
+        parsePerfLines(
+            [
+                "[perf:build] kind=pch file=/w/a.h compile_ms=100 total_ms=120",
+                "[perf:build] kind=pch file=/w/b.h compile_ms=300 total_ms=340",
+                "[perf:build] kind=index file=/w/a.cpp compile_ms=50 total_ms=60",
+                "[perf:startup] phase=dep_scan elapsed_ms=25",
+            ].join("\n"),
+        ),
+    );
+    expect(summary["build.pch.compile_ms"]?.count).toBe(2);
+    expect(summary["build.pch.compile_ms"]?.max).toBe(300);
+    expect(summary["build.index.total_ms"]?.count).toBe(1);
+    expect(summary["startup.dep_scan.elapsed_ms"]?.p50).toBe(25);
+    // Non-duration keys (file=, kind=) never become series.
+    expect(Object.keys(summary).every((name) => name.endsWith("_ms"))).toBe(true);
+});
+
+test("stats percentiles", () => {
+    const stats = computeStats([5, 1, 3, 2, 4])!;
+    expect(stats.count).toBe(5);
+    expect(stats.min).toBe(1);
+    expect(stats.p50).toBe(3);
+    expect(stats.max).toBe(5);
+    expect(stats.mean).toBe(3);
+    expect(computeStats([])).toBeNull();
+});
+
+test("chrome trace reconstructs spans", () => {
+    const events = parsePerfLines(
+        [
+            "[2026-08-14 10:00:00.000] [info] [t] [f:1] [perf:startup] phase=dep_scan elapsed_ms=40",
+            // No total_ms/elapsed_ms duration — not representable as a span.
+            "[2026-08-14 10:00:00.100] [info] [t] [f:2] [perf:cache] ns=pch event=hit key=k",
+            // No timestamp — cannot be placed on the timeline.
+            "[perf:startup] phase=index_load elapsed_ms=5",
+        ].join("\n"),
+    );
+    const trace = JSON.parse(toChromeTrace(events)) as {
+        traceEvents: { name: string; ph: string; ts: number; dur: number }[];
+    };
+    expect(trace.traceEvents).toHaveLength(1);
+    const span = trace.traceEvents[0]!;
+    expect(span.name).toBe("startup.dep_scan");
+    expect(span.ph).toBe("X");
+    // Stamped at span end: 40ms duration ending at the base timestamp, in
+    // microseconds relative to the earliest stamped event.
+    expect(span.ts).toBe(-40_000);
+    expect(span.dur).toBe(40_000);
+});

--- a/tools/bench/bench.ts
+++ b/tools/bench/bench.ts
@@ -353,10 +353,7 @@ async function runStartScenario(opts: Options, file: string): Promise<ScenarioRe
     const bench = new Bench(opts);
 
     const start = nowMs();
-    const client = CliceClient.start(opts.binary, { args: serverArgs(opts) });
-    await client.initialize(new Workspace(opts.workspace), {
-        initializationOptions: initializationOptions(),
-    });
+    const client = await startServer(opts);
     bench.record("initialize", nowMs() - start);
 
     await bench.measure("open_to_diagnostics", () => client.openAndWait(file, 300_000));
@@ -476,14 +473,15 @@ async function main(): Promise<void> {
     const cdb = findCdb(opts.workspace);
     opts.cdbDir = path.dirname(cdb);
     const file = opts.file !== null ? path.resolve(opts.workspace, opts.file) : firstCdbEntry(cdb);
+    const cpus = os.cpus();
 
     const result: BenchResult = {
         env: {
             platform: process.platform,
             release: os.release(),
             arch: process.arch,
-            cpus: os.cpus().length,
-            cpuModel: os.cpus()[0]?.model ?? "unknown",
+            cpus: cpus.length,
+            cpuModel: cpus[0]?.model ?? "unknown",
             node: process.version,
             server: opts.server,
             binary: opts.binary,

--- a/tools/bench/bench.ts
+++ b/tools/bench/bench.ts
@@ -33,7 +33,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { parseArgs } from "node:util";
 import { fileURLToPath } from "node:url";
-import { CliceClient, logFiles } from "../client/client.ts";
+import { CliceClient, logFiles, withTimeout } from "../client/client.ts";
 import { Workspace } from "../client/workspace.ts";
 import { computeStats, parsePerfLines, summarize, type Stats } from "./perf.ts";
 
@@ -339,8 +339,8 @@ class Bench {
     }
 }
 
-/// clice runs `serve` and discovers the CDB itself; clangd needs the CDB
-/// directory spelled out.
+/// clice takes the CDB via initialization options; clangd needs the CDB
+/// directory spelled out on the command line.
 function serverArgs(opts: Options): string[] {
     return opts.server === "clice"
         ? ["serve"]
@@ -352,9 +352,14 @@ function serverArgs(opts: Options): string[] {
 /// run the server's real defaults (stateful 2, stateless cores/2, tracker
 /// 3s/30s, from src/server/state/config.h) including the background
 /// activity those loops generate.
-function initializationOptions(): Record<string, unknown> {
+function initializationOptions(opts: Options): Record<string, unknown> {
     return {
         project: {
+            // Pin clice to the CDB selected for the comparison: a workspace
+            // clice.toml may configure compile_commands_paths elsewhere,
+            // while the clangd run always receives opts.cdbDir — the A/B
+            // must open the file under the same compilation command.
+            compile_commands_paths: [opts.cdbDir],
             stateful_worker_count: 2,
             stateless_worker_count: Math.max(Math.floor(os.cpus().length / 2), 2),
         },
@@ -368,7 +373,7 @@ function initializationOptions(): Record<string, unknown> {
 async function startServer(opts: Options): Promise<CliceClient> {
     const client = CliceClient.start(opts.binary, { args: serverArgs(opts) });
     await client.initialize(new Workspace(opts.workspace), {
-        initializationOptions: initializationOptions(),
+        initializationOptions: initializationOptions(opts),
     });
     return client;
 }
@@ -393,6 +398,13 @@ async function shutdownServer(client: CliceClient, opts: Options): Promise<void>
 }
 
 /// Server start → initialize response → first diagnostics of the main file.
+///
+/// The hover poke that triggers compilation on clice stays off the timed
+/// path: diagnostics publish when compilation settles and the hover is
+/// computed afterward, so awaiting its response first (as openAndWait
+/// does) would fold hover computation into every sample. The sample ends
+/// at the diagnostics notification; the poke is drained after the clock
+/// stops.
 async function runStartScenario(opts: Options, file: string): Promise<ScenarioResult> {
     const bench = new Bench(opts);
 
@@ -400,7 +412,14 @@ async function runStartScenario(opts: Options, file: string): Promise<ScenarioRe
     const client = await startServer(opts);
     bench.record("initialize", nowMs() - start);
 
-    await bench.measure("open_to_diagnostics", () => client.openAndWait(file, 300_000));
+    let poke: Promise<unknown> = Promise.resolve();
+    await bench.measure("open_to_diagnostics", async () => {
+        const [uri] = client.open(file);
+        const arrived = client.armDiagnostics(uri);
+        poke = client.hoverAt(uri, 0, 0);
+        await withTimeout(arrived, 300_000, `diagnostics ${uri}`);
+    });
+    await poke;
 
     const result = bench.result(client);
     await shutdownServer(client, opts);
@@ -437,10 +456,16 @@ async function runEditLoop(opts: Options, file: string): Promise<ScenarioResult>
 
     for (let i = 1; i <= opts.edits; i += 1) {
         const comment = `// bench edit ${i}`;
+        // See runStartScenario: the sample ends at the diagnostics
+        // notification, with the triggering hover drained off the clock.
+        let poke: Promise<unknown> = Promise.resolve();
         await bench.measure("edit_to_diagnostics", async () => {
+            const arrived = client.armDiagnostics(uri);
             client.changeRange(uri, i, { start: end, end }, `\n${comment}`);
-            await client.waitForRecompile(uri, 300_000);
+            poke = client.hoverAt(uri, 0, 0);
+            await withTimeout(arrived, 300_000, `diagnostics ${uri}`);
         });
+        await poke;
         end = { line: end.line + 1, character: comment.length };
     }
 

--- a/tools/bench/bench.ts
+++ b/tools/bench/bench.ts
@@ -164,22 +164,66 @@ function parseOptions(): Options {
     };
 }
 
+/// Overwrite comment and string/char literal bytes with spaces, keeping
+/// offsets and newlines intact, so position derivation only ever sees
+/// code. Raw string literals are treated as ordinary strings — good
+/// enough for a probe heuristic with a --position override.
+function blankNonCode(text: string): string {
+    const out = text.split("");
+    const blank = (index: number): void => {
+        if (index < out.length && out[index] !== "\n") {
+            out[index] = " ";
+        }
+    };
+    let i = 0;
+    while (i < text.length) {
+        const two = text.slice(i, i + 2);
+        if (two === "//") {
+            while (i < text.length && text[i] !== "\n") {
+                blank(i);
+                i += 1;
+            }
+        } else if (two === "/*") {
+            while (i < text.length && text.slice(i, i + 2) !== "*/") {
+                blank(i);
+                i += 1;
+            }
+            blank(i);
+            blank(i + 1);
+            i += 2;
+        } else if (text[i] === '"' || text[i] === "'") {
+            const quote = text[i];
+            blank(i);
+            i += 1;
+            // An unterminated literal ends at the newline (blank keeps it).
+            while (i < text.length && text[i] !== quote && text[i] !== "\n") {
+                blank(i);
+                if (text[i] === "\\") {
+                    blank(i + 1);
+                    i += 1;
+                }
+                i += 1;
+            }
+            blank(i);
+            i += 1;
+        } else {
+            i += 1;
+        }
+    }
+    return out.join("");
+}
+
 /// Derive a symbol-bearing probe position: the first call-like identifier
-/// outside comment/preprocessor lines. The old 0:0 default usually landed
-/// on a license comment, so the positional features took their
-/// empty-result fast paths and measured nothing.
+/// in code text — comments, string/char literals and preprocessor lines
+/// do not count. The old 0:0 default usually landed on a license comment,
+/// so the positional features took their empty-result fast paths and
+/// measured nothing.
 function derivePosition(file: string): { line: number; character: number } {
     const keywords = new Set(["if", "for", "while", "switch", "return", "sizeof", "catch"]);
-    const lines = fs.readFileSync(file, "utf8").split("\n");
+    const lines = blankNonCode(fs.readFileSync(file, "utf8")).split("\n");
     for (let line = 0; line < lines.length; line += 1) {
         const text = lines[line] ?? "";
-        const trimmed = text.trimStart();
-        if (
-            trimmed.startsWith("//") ||
-            trimmed.startsWith("/*") ||
-            trimmed.startsWith("*") ||
-            trimmed.startsWith("#")
-        ) {
+        if (text.trimStart().startsWith("#")) {
             continue;
         }
         for (const match of text.matchAll(/\b([A-Za-z_]\w+)\s*\(/g)) {
@@ -430,7 +474,15 @@ async function runWarmRequests(opts: Options, file: string): Promise<ScenarioRes
     for (const request of Object.values(requests)) {
         await request();
     }
-    bench.perfWindowStart = Date.now();
+    // Log timestamps truncate to milliseconds, so a boundary read in the
+    // same millisecond as the last warmup's perf line cannot separate the
+    // two. Park until the wall clock leaves the warmup millisecond: every
+    // warmup event is stamped <= boundary, every measured one >= boundary+1.
+    const boundary = Date.now();
+    while (Date.now() <= boundary) {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    bench.perfWindowStart = boundary + 1;
 
     for (const [name, request] of Object.entries(requests)) {
         for (let i = 0; i < opts.repeats; i += 1) {

--- a/tools/bench/bench.ts
+++ b/tools/bench/bench.ts
@@ -15,7 +15,8 @@
 ///   --binary <path>          server executable (default: clice from
 ///                            build/RelWithDebInfo/bin, clangd from PATH)
 ///   --file <rel>             file to open/edit (default: first CDB entry)
-///   --position <line:char>   position for warm requests (default 0:0)
+///   --position <line:char>   position for warm requests (default: derived
+///                            from the file's first call-like identifier)
 ///   --scenario <name>        cold_start | warm_start | edit_loop |
 ///                            warm_requests; repeatable (default: all)
 ///   --edits <N>              edit_loop iterations (default 10)
@@ -23,8 +24,9 @@
 ///   --json <path>            write the full results as JSON
 ///
 /// The workspace must contain a compile_commands.json. cold_start wipes
-/// the workspace's .clice cache dir (and clangd's .cache) first; the other
-/// scenarios reuse whatever state the previous scenarios left, in order.
+/// the selected server's cache first (clice's .clice dir, clangd's
+/// .cache/clangd); the other scenarios reuse whatever state the previous
+/// scenarios left, in order.
 
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -47,7 +49,8 @@ interface Options {
     /// Directory holding compile_commands.json; resolved in main().
     cdbDir: string;
     file: string | null;
-    position: { line: number; character: number };
+    /// null = derive a symbol-bearing position from the file content.
+    position: { line: number; character: number } | null;
     scenarios: ScenarioName[];
     edits: number;
     repeats: number;
@@ -91,7 +94,7 @@ function parseOptions(): Options {
             binary: { type: "string" },
             workspace: { type: "string" },
             file: { type: "string" },
-            position: { type: "string", default: "0:0" },
+            position: { type: "string" },
             scenario: { type: "string", multiple: true },
             edits: { type: "string", default: "10" },
             repeats: { type: "string", default: "50" },
@@ -124,11 +127,27 @@ function parseOptions(): Options {
         return name as ScenarioName;
     });
 
-    const [lineText, charText] = values.position.split(":");
-    const line = Number(lineText);
-    const character = Number(charText);
-    if (!Number.isInteger(line) || !Number.isInteger(character)) {
-        fail(`bad --position '${values.position}' (expected line:char)`);
+    let position: { line: number; character: number } | null = null;
+    if (values.position !== undefined) {
+        const parts = values.position.split(":");
+        const line = Number(parts[0]);
+        const character = Number(parts[1]);
+        if (
+            parts.length !== 2 ||
+            !Number.isInteger(line) ||
+            line < 0 ||
+            !Number.isInteger(character) ||
+            character < 0
+        ) {
+            fail(`bad --position '${values.position}' (expected line:char)`);
+        }
+        position = { line, character };
+    }
+
+    const edits = Number(values.edits);
+    const repeats = Number(values.repeats);
+    if (!Number.isInteger(edits) || edits < 0 || !Number.isInteger(repeats) || repeats < 0) {
+        fail("--edits and --repeats must be non-negative integers");
     }
 
     return {
@@ -137,12 +156,40 @@ function parseOptions(): Options {
         workspace: path.resolve(values.workspace),
         cdbDir: "",
         file: values.file ?? null,
-        position: { line, character },
+        position,
         scenarios,
-        edits: Number(values.edits),
-        repeats: Number(values.repeats),
+        edits,
+        repeats,
         jsonPath: values.json ?? null,
     };
+}
+
+/// Derive a symbol-bearing probe position: the first call-like identifier
+/// outside comment/preprocessor lines. The old 0:0 default usually landed
+/// on a license comment, so the positional features took their
+/// empty-result fast paths and measured nothing.
+function derivePosition(file: string): { line: number; character: number } {
+    const keywords = new Set(["if", "for", "while", "switch", "return", "sizeof", "catch"]);
+    const lines = fs.readFileSync(file, "utf8").split("\n");
+    for (let line = 0; line < lines.length; line += 1) {
+        const text = lines[line] ?? "";
+        const trimmed = text.trimStart();
+        if (
+            trimmed.startsWith("//") ||
+            trimmed.startsWith("/*") ||
+            trimmed.startsWith("*") ||
+            trimmed.startsWith("#")
+        ) {
+            continue;
+        }
+        for (const match of text.matchAll(/\b([A-Za-z_]\w+)\s*\(/g)) {
+            const name = match[1];
+            if (name !== undefined && !keywords.has(name)) {
+                return { line, character: match.index };
+            }
+        }
+    }
+    fail(`cannot derive a symbol-bearing position in ${file}; pass --position`);
 }
 
 /// Locate the CDB the way clice does: workspace root first, then any
@@ -193,6 +240,10 @@ class Bench {
     /// scenario spawns a fresh server, so files beyond this set are exactly
     /// this scenario's session logs.
     priorLogs: Set<string>;
+    /// When set (epoch ms), server-side perf events stamped before this
+    /// point are dropped: they belong to setup/warmup work the client
+    /// series deliberately excludes.
+    perfWindowStart: number | null = null;
     opts: Options;
 
     constructor(opts: Options) {
@@ -225,11 +276,17 @@ class Bench {
         const result: ScenarioResult = { measurements };
         if (this.opts.server === "clice") {
             const fresh = logFiles(this.opts.workspace).filter((f) => !this.priorLogs.has(f));
-            const text =
+            // One pid per log file: master and workers are separate
+            // processes and keep separate trace lanes.
+            let events =
                 fresh.length > 0
-                    ? fresh.map((f) => fs.readFileSync(f, "utf8")).join("\n")
-                    : client.drainedStderr().toString("utf8");
-            const perf = summarize(parsePerfLines(text));
+                    ? fresh.flatMap((f, i) => parsePerfLines(fs.readFileSync(f, "utf8"), i + 1))
+                    : parsePerfLines(client.drainedStderr().toString("utf8"));
+            const windowStart = this.perfWindowStart;
+            if (windowStart !== null) {
+                events = events.filter((e) => e.ts !== null && e.ts >= windowStart);
+            }
+            const perf = summarize(events);
             if (Object.keys(perf).length > 0) {
                 result.perf = perf;
             }
@@ -246,14 +303,20 @@ function serverArgs(opts: Options): string[] {
         : ["--background-index", `--compile-commands-dir=${opts.cdbDir}`];
 }
 
-/// CliceClient.initialize defaults worker counts to 1 for cheap tests; a
-/// benchmark must run the server's real defaults (stateful 2, stateless
-/// cores/2, from src/server/state/config.cpp).
+/// CliceClient.initialize defaults worker counts to 1 and zeroes the
+/// tracker polling loops for cheap deterministic tests; a benchmark must
+/// run the server's real defaults (stateful 2, stateless cores/2, tracker
+/// 3s/30s, from src/server/state/config.h) including the background
+/// activity those loops generate.
 function initializationOptions(): Record<string, unknown> {
     return {
         project: {
             stateful_worker_count: 2,
             stateless_worker_count: Math.max(Math.floor(os.cpus().length / 2), 2),
+        },
+        tracker: {
+            cdb_poll_seconds: 3,
+            workspace_poll_seconds: 30,
         },
     };
 }
@@ -304,12 +367,17 @@ async function runStartScenario(opts: Options, file: string): Promise<ScenarioRe
 }
 
 async function runColdStart(opts: Options, file: string): Promise<ScenarioResult> {
-    // clice caches in the workspace's .clice (pinned by the client's
-    // initialize); clangd keeps its index under .cache next to the
-    // workspace root and the CDB directory.
-    for (const dir of [".clice", ".cache"]) {
-        fs.rmSync(path.join(opts.workspace, dir), { recursive: true, force: true });
-        fs.rmSync(path.join(opts.cdbDir, dir), { recursive: true, force: true });
+    // Wipe only the selected server's cache: clice keeps everything in the
+    // workspace's .clice (pinned by the client's initialize); clangd keeps
+    // its index under .cache/clangd next to the workspace root and the CDB
+    // directory. The rest of a real project's .cache belongs to other
+    // tools and must survive.
+    if (opts.server === "clice") {
+        fs.rmSync(path.join(opts.workspace, ".clice"), { recursive: true, force: true });
+    } else {
+        for (const dir of new Set([opts.workspace, opts.cdbDir])) {
+            fs.rmSync(path.join(dir, ".cache", "clangd"), { recursive: true, force: true });
+        }
     }
     return runStartScenario(opts, file);
 }
@@ -319,14 +387,20 @@ async function runEditLoop(opts: Options, file: string): Promise<ScenarioResult>
     const client = await startServer(opts);
     const [uri, content] = await client.openAndWait(file, 300_000);
 
+    // Append at the end of the TU: every edit invalidates the main file
+    // but not the preamble — the interactive path the server optimizes.
+    // Sent as a ranged insertion like a real editor; a full-document
+    // replacement would add whole-file serialization to every sample.
+    const lines = content.split("\n");
+    let end = { line: lines.length - 1, character: lines[lines.length - 1]?.length ?? 0 };
+
     for (let i = 1; i <= opts.edits; i += 1) {
-        // Append at the end of the TU: every edit invalidates the main file
-        // but not the preamble — the interactive path the server optimizes.
-        const edited = `${content}\n// bench edit ${i}\n`;
+        const comment = `// bench edit ${i}`;
         await bench.measure("edit_to_diagnostics", async () => {
-            client.change(uri, i, edited);
+            client.changeRange(uri, i, { start: end, end }, `\n${comment}`);
             await client.waitForRecompile(uri, 300_000);
         });
+        end = { line: end.line + 1, character: comment.length };
     }
 
     const result = bench.result(client);
@@ -338,7 +412,11 @@ async function runWarmRequests(opts: Options, file: string): Promise<ScenarioRes
     const bench = new Bench(opts);
     const client = await startServer(opts);
     const [uri] = await client.openAndWait(file, 300_000);
-    const { line, character } = opts.position;
+    const position = opts.position ?? derivePosition(file);
+    if (opts.position === null) {
+        console.log(`derived probe position ${position.line}:${position.character}`);
+    }
+    const { line, character } = position;
 
     const requests: Record<string, () => Promise<unknown>> = {
         hover: () => client.hoverAt(uri, line, character),
@@ -349,9 +427,15 @@ async function runWarmRequests(opts: Options, file: string): Promise<ScenarioRes
         semantic_tokens: () => client.semanticTokensFull(uri),
     };
 
-    for (const [name, request] of Object.entries(requests)) {
-        // One unmeasured warmup absorbs lazy first-request work.
+    // One unmeasured warmup per request absorbs lazy first-request work.
+    // All warmups run before the measurement window opens, so the
+    // server-side series carry exactly --repeats events per kind.
+    for (const request of Object.values(requests)) {
         await request();
+    }
+    bench.perfWindowStart = Date.now();
+
+    for (const [name, request] of Object.entries(requests)) {
         for (let i = 0; i < opts.repeats; i += 1) {
             await bench.measure(name, request);
         }

--- a/tools/bench/bench.ts
+++ b/tools/bench/bench.ts
@@ -360,8 +360,14 @@ function initializationOptions(opts: Options): Record<string, unknown> {
             // while the clangd run always receives opts.cdbDir — the A/B
             // must open the file under the same compilation command.
             compile_commands_paths: [opts.cdbDir],
+            // Pin logs to where result() reads them (logFiles searches
+            // <workspace>/.clice/logs); a clice.toml logging_dir would
+            // otherwise send the worker perf lines elsewhere.
+            logging_dir: path.join(opts.workspace, ".clice", "logs"),
             stateful_worker_count: 2,
-            stateless_worker_count: Math.max(Math.floor(os.cpus().length / 2), 2),
+            // availableParallelism respects cpusets and container CPU
+            // quotas; os.cpus() is the host's full list.
+            stateless_worker_count: Math.max(Math.floor(os.availableParallelism() / 2), 2),
         },
         tracker: {
             cdb_poll_seconds: 3,

--- a/tools/bench/bench.ts
+++ b/tools/bench/bench.ts
@@ -1,0 +1,415 @@
+/// E2E benchmark harness: drive a language server over LSP through fixed
+/// scenarios on a real workspace and report client-observed latencies.
+///
+/// The harness is server-agnostic at the LSP level, so the same scenarios
+/// run against clice and clangd for A/B comparison. For clice it
+/// additionally parses the `[perf:*]` lines mirrored to stderr into a
+/// server-side breakdown (see perf.ts).
+///
+/// Usage:
+///   node tools/bench/bench.ts --workspace <dir> [options]
+///
+/// Options:
+///   --server clice|clangd    which server to drive (default clice)
+///   --binary <path>          server executable (default: clice from
+///                            build/RelWithDebInfo/bin, clangd from PATH)
+///   --file <rel>             file to open/edit (default: first CDB entry)
+///   --position <line:char>   position for warm requests (default 0:0)
+///   --scenario <name>        cold_start | warm_start | edit_loop |
+///                            warm_requests; repeatable (default: all)
+///   --edits <N>              edit_loop iterations (default 10)
+///   --repeats <N>            warm request repetitions (default 50)
+///   --json <path>            write the full results as JSON
+///
+/// The workspace must contain a compile_commands.json. cold_start wipes
+/// the workspace's .clice cache dir (and clangd's .cache) first; the other
+/// scenarios reuse whatever state the previous scenarios left, in order.
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { parseArgs } from "node:util";
+import { fileURLToPath } from "node:url";
+import { CliceClient } from "../client/client.ts";
+import { Workspace } from "../client/workspace.ts";
+import { computeStats, parsePerfLines, summarize, type Stats } from "./perf.ts";
+
+const REPO_ROOT = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+
+const ALL_SCENARIOS = ["cold_start", "warm_start", "edit_loop", "warm_requests"] as const;
+type ScenarioName = (typeof ALL_SCENARIOS)[number];
+
+interface Options {
+    server: "clice" | "clangd";
+    binary: string;
+    workspace: string;
+    /// Directory holding compile_commands.json; resolved in main().
+    cdbDir: string;
+    file: string | null;
+    position: { line: number; character: number };
+    scenarios: ScenarioName[];
+    edits: number;
+    repeats: number;
+    jsonPath: string | null;
+}
+
+interface ScenarioResult {
+    /// Client-observed latency series, milliseconds.
+    measurements: Record<string, Stats>;
+    /// Server-side breakdown from `[perf:*]` stderr lines (clice only).
+    perf?: Record<string, Stats>;
+}
+
+interface BenchResult {
+    env: {
+        platform: string;
+        release: string;
+        arch: string;
+        cpus: number;
+        cpuModel: string;
+        node: string;
+        server: string;
+        binary: string;
+        date: string;
+    };
+    workspace: string;
+    file: string;
+    scenarios: Partial<Record<ScenarioName, ScenarioResult>>;
+}
+
+function fail(message: string): never {
+    console.error(`error: ${message}`);
+    process.exit(1);
+}
+
+function parseOptions(): Options {
+    const { values } = parseArgs({
+        options: {
+            server: { type: "string", default: "clice" },
+            binary: { type: "string" },
+            workspace: { type: "string" },
+            file: { type: "string" },
+            position: { type: "string", default: "0:0" },
+            scenario: { type: "string", multiple: true },
+            edits: { type: "string", default: "10" },
+            repeats: { type: "string", default: "50" },
+            json: { type: "string" },
+            help: { type: "boolean", default: false },
+        },
+    });
+
+    if (values.help || values.workspace === undefined) {
+        console.log("Usage: node tools/bench/bench.ts --workspace <dir> [options]");
+        console.log("See the header of tools/bench/bench.ts for the option list.");
+        process.exit(values.help ? 0 : 1);
+    }
+
+    const server = values.server;
+    if (server !== "clice" && server !== "clangd") {
+        fail(`unknown server '${server}' (expected clice or clangd)`);
+    }
+
+    const binary =
+        values.binary ??
+        (server === "clice"
+            ? path.join(REPO_ROOT, "build", "RelWithDebInfo", "bin", "clice")
+            : "clangd");
+
+    const scenarios = (values.scenario ?? [...ALL_SCENARIOS]).map((name) => {
+        if (!(ALL_SCENARIOS as readonly string[]).includes(name)) {
+            fail(`unknown scenario '${name}'`);
+        }
+        return name as ScenarioName;
+    });
+
+    const [lineText, charText] = values.position.split(":");
+    const line = Number(lineText);
+    const character = Number(charText);
+    if (!Number.isInteger(line) || !Number.isInteger(character)) {
+        fail(`bad --position '${values.position}' (expected line:char)`);
+    }
+
+    return {
+        server,
+        binary,
+        workspace: path.resolve(values.workspace),
+        cdbDir: "",
+        file: values.file ?? null,
+        position: { line, character },
+        scenarios,
+        edits: Number(values.edits),
+        repeats: Number(values.repeats),
+        jsonPath: values.json ?? null,
+    };
+}
+
+/// Locate the CDB the way clice does: workspace root first, then any
+/// first-level subdirectory (e.g. build/).
+function findCdb(workspace: string): string {
+    const candidates = [workspace];
+    for (const entry of fs.readdirSync(workspace, { withFileTypes: true })) {
+        if (entry.isDirectory()) {
+            candidates.push(path.join(workspace, entry.name));
+        }
+    }
+    for (const dir of candidates) {
+        const cdb = path.join(dir, "compile_commands.json");
+        if (fs.existsSync(cdb)) {
+            return cdb;
+        }
+    }
+    fail(`no compile_commands.json under ${workspace} or its direct subdirectories`);
+}
+
+function firstCdbEntry(cdbPath: string): string {
+    const entries = JSON.parse(fs.readFileSync(cdbPath, "utf8")) as {
+        file: string;
+        directory?: string;
+    }[];
+    const first = entries[0];
+    if (first === undefined) {
+        fail(`empty compile_commands.json at ${cdbPath}`);
+    }
+    return path.isAbsolute(first.file)
+        ? first.file
+        : path.join(first.directory ?? path.dirname(cdbPath), first.file);
+}
+
+function nowMs(): number {
+    return Number(process.hrtime.bigint()) / 1e6;
+}
+
+async function timed(fn: () => Promise<unknown>): Promise<number> {
+    const start = nowMs();
+    await fn();
+    return nowMs() - start;
+}
+
+class Bench {
+    series = new Map<string, number[]>();
+
+    record(name: string, ms: number): void {
+        const list = this.series.get(name) ?? [];
+        list.push(ms);
+        this.series.set(name, list);
+    }
+
+    async measure(name: string, fn: () => Promise<unknown>): Promise<void> {
+        this.record(name, await timed(fn));
+    }
+
+    result(client: CliceClient, server: string): ScenarioResult {
+        const measurements: Record<string, Stats> = {};
+        for (const [name, values] of this.series) {
+            const stats = computeStats(values);
+            if (stats !== null) {
+                measurements[name] = stats;
+            }
+        }
+        const result: ScenarioResult = { measurements };
+        if (server === "clice") {
+            const perf = summarize(parsePerfLines(client.drainedStderr().toString("utf8")));
+            if (Object.keys(perf).length > 0) {
+                result.perf = perf;
+            }
+        }
+        return result;
+    }
+}
+
+/// clice runs `serve` and discovers the CDB itself; clangd needs the CDB
+/// directory spelled out.
+function serverArgs(opts: Options): string[] {
+    return opts.server === "clice"
+        ? ["serve"]
+        : ["--background-index", `--compile-commands-dir=${opts.cdbDir}`];
+}
+
+/// CliceClient.initialize defaults worker counts to 1 for cheap tests; a
+/// benchmark must run the server's real defaults (stateful 2, stateless
+/// cores/2, from src/server/state/config.cpp).
+function initializationOptions(): Record<string, unknown> {
+    return {
+        project: {
+            stateful_worker_count: 2,
+            stateless_worker_count: Math.max(Math.floor(os.cpus().length / 2), 2),
+        },
+    };
+}
+
+async function startServer(opts: Options): Promise<CliceClient> {
+    const client = CliceClient.start(opts.binary, { args: serverArgs(opts) });
+    await client.initialize(new Workspace(opts.workspace), {
+        initializationOptions: initializationOptions(),
+    });
+    return client;
+}
+
+async function shutdownServer(client: CliceClient, opts: Options): Promise<void> {
+    if (opts.server === "clice") {
+        await client.shutdown();
+        return;
+    }
+    // clangd exits on its own protocol; skip clice's clean-exit gate
+    // (drop report, anomaly scan) which does not apply to it.
+    try {
+        await client.sendRequest("shutdown");
+        await client.sendNotification("exit");
+    } finally {
+        client.disposed = true;
+        setTimeout(() => {
+            client.child.kill("SIGKILL");
+        }, 5_000).unref();
+        await client.exited;
+    }
+}
+
+/// Server start → initialize response → first diagnostics of the main file.
+async function runStartScenario(opts: Options, file: string): Promise<ScenarioResult> {
+    const bench = new Bench();
+
+    const start = nowMs();
+    const client = CliceClient.start(opts.binary, { args: serverArgs(opts) });
+    await client.initialize(new Workspace(opts.workspace), {
+        initializationOptions: initializationOptions(),
+    });
+    bench.record("initialize", nowMs() - start);
+
+    await bench.measure("open_to_diagnostics", () => client.openAndWait(file, 300_000));
+
+    const result = bench.result(client, opts.server);
+    await shutdownServer(client, opts);
+    return result;
+}
+
+async function runColdStart(opts: Options, file: string): Promise<ScenarioResult> {
+    // clice caches in the workspace's .clice (pinned by the client's
+    // initialize); clangd keeps its index under .cache next to the
+    // workspace root and the CDB directory.
+    for (const dir of [".clice", ".cache"]) {
+        fs.rmSync(path.join(opts.workspace, dir), { recursive: true, force: true });
+        fs.rmSync(path.join(opts.cdbDir, dir), { recursive: true, force: true });
+    }
+    return runStartScenario(opts, file);
+}
+
+async function runEditLoop(opts: Options, file: string): Promise<ScenarioResult> {
+    const bench = new Bench();
+    const client = await startServer(opts);
+    const [uri, content] = await client.openAndWait(file, 300_000);
+
+    for (let i = 1; i <= opts.edits; i += 1) {
+        // Append at the end of the TU: every edit invalidates the main file
+        // but not the preamble — the interactive path the server optimizes.
+        const edited = `${content}\n// bench edit ${i}\n`;
+        await bench.measure("edit_to_diagnostics", async () => {
+            client.change(uri, i, edited);
+            await client.waitForRecompile(uri, 300_000);
+        });
+    }
+
+    const result = bench.result(client, opts.server);
+    await shutdownServer(client, opts);
+    return result;
+}
+
+async function runWarmRequests(opts: Options, file: string): Promise<ScenarioResult> {
+    const bench = new Bench();
+    const client = await startServer(opts);
+    const [uri] = await client.openAndWait(file, 300_000);
+    const { line, character } = opts.position;
+
+    const requests: Record<string, () => Promise<unknown>> = {
+        hover: () => client.hoverAt(uri, line, character),
+        definition: () => client.definitionAt(uri, line, character),
+        references: () => client.referencesAt(uri, line, character),
+        completion: () => client.completionAt(uri, line, character),
+        document_symbol: () => client.documentSymbols(uri),
+        semantic_tokens: () => client.semanticTokensFull(uri),
+    };
+
+    for (const [name, request] of Object.entries(requests)) {
+        // One unmeasured warmup absorbs lazy first-request work.
+        await request();
+        for (let i = 0; i < opts.repeats; i += 1) {
+            await bench.measure(name, request);
+        }
+    }
+
+    const result = bench.result(client, opts.server);
+    await shutdownServer(client, opts);
+    return result;
+}
+
+function printScenario(name: string, result: ScenarioResult): void {
+    console.log(`\n=== ${name} ===`);
+    const rows = Object.entries(result.measurements);
+    console.log(
+        `  ${"series".padEnd(24)} ${"count".padStart(6)} ${"p50".padStart(9)} ` +
+            `${"p90".padStart(9)} ${"p99".padStart(9)} ${"max".padStart(9)}`,
+    );
+    for (const [series, stats] of rows) {
+        console.log(
+            `  ${series.padEnd(24)} ${String(stats.count).padStart(6)} ` +
+                `${stats.p50.toFixed(2).padStart(9)} ${stats.p90.toFixed(2).padStart(9)} ` +
+                `${stats.p99.toFixed(2).padStart(9)} ${stats.max.toFixed(2).padStart(9)}`,
+        );
+    }
+    if (result.perf !== undefined) {
+        console.log("  server-side breakdown ([perf:*], ms):");
+        for (const [series, stats] of Object.entries(result.perf)) {
+            console.log(
+                `    ${series.padEnd(38)} n=${String(stats.count).padStart(5)} ` +
+                    `p50=${stats.p50.toFixed(2).padStart(9)} max=${stats.max.toFixed(2).padStart(9)}`,
+            );
+        }
+    }
+}
+
+async function main(): Promise<void> {
+    const opts = parseOptions();
+    const cdb = findCdb(opts.workspace);
+    opts.cdbDir = path.dirname(cdb);
+    const file = opts.file !== null ? path.resolve(opts.workspace, opts.file) : firstCdbEntry(cdb);
+
+    const result: BenchResult = {
+        env: {
+            platform: process.platform,
+            release: os.release(),
+            arch: process.arch,
+            cpus: os.cpus().length,
+            cpuModel: os.cpus()[0]?.model ?? "unknown",
+            node: process.version,
+            server: opts.server,
+            binary: opts.binary,
+            date: new Date().toISOString(),
+        },
+        workspace: opts.workspace,
+        file,
+        scenarios: {},
+    };
+
+    console.log(`server: ${opts.server} (${opts.binary})`);
+    console.log(`workspace: ${opts.workspace}`);
+    console.log(`file: ${file}`);
+
+    const runners: Record<ScenarioName, () => Promise<ScenarioResult>> = {
+        cold_start: () => runColdStart(opts, file),
+        warm_start: () => runStartScenario(opts, file),
+        edit_loop: () => runEditLoop(opts, file),
+        warm_requests: () => runWarmRequests(opts, file),
+    };
+
+    for (const name of opts.scenarios) {
+        const scenario = await runners[name]();
+        result.scenarios[name] = scenario;
+        printScenario(name, scenario);
+    }
+
+    if (opts.jsonPath !== null) {
+        fs.writeFileSync(opts.jsonPath, JSON.stringify(result, null, 2));
+        console.log(`\nresults written to ${opts.jsonPath}`);
+    }
+}
+
+await main();

--- a/tools/bench/bench.ts
+++ b/tools/bench/bench.ts
@@ -3,8 +3,9 @@
 ///
 /// The harness is server-agnostic at the LSP level, so the same scenarios
 /// run against clice and clangd for A/B comparison. For clice it
-/// additionally parses the `[perf:*]` lines mirrored to stderr into a
-/// server-side breakdown (see perf.ts).
+/// additionally parses the session's `[perf:*]` log lines — master and
+/// worker files under <workspace>/.clice/logs — into a server-side
+/// breakdown (see perf.ts).
 ///
 /// Usage:
 ///   node tools/bench/bench.ts --workspace <dir> [options]
@@ -30,7 +31,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { parseArgs } from "node:util";
 import { fileURLToPath } from "node:url";
-import { CliceClient } from "../client/client.ts";
+import { CliceClient, logFiles } from "../client/client.ts";
 import { Workspace } from "../client/workspace.ts";
 import { computeStats, parsePerfLines, summarize, type Stats } from "./perf.ts";
 
@@ -56,7 +57,8 @@ interface Options {
 interface ScenarioResult {
     /// Client-observed latency series, milliseconds.
     measurements: Record<string, Stats>;
-    /// Server-side breakdown from `[perf:*]` stderr lines (clice only).
+    /// Server-side breakdown from the session's `[perf:*]` log lines
+    /// (clice only).
     perf?: Record<string, Stats>;
 }
 
@@ -187,6 +189,16 @@ async function timed(fn: () => Promise<unknown>): Promise<number> {
 
 class Bench {
     series = new Map<string, number[]>();
+    /// Log files that existed before this scenario's server ran; every
+    /// scenario spawns a fresh server, so files beyond this set are exactly
+    /// this scenario's session logs.
+    priorLogs: Set<string>;
+    opts: Options;
+
+    constructor(opts: Options) {
+        this.opts = opts;
+        this.priorLogs = new Set(opts.server === "clice" ? logFiles(opts.workspace) : []);
+    }
 
     record(name: string, ms: number): void {
         const list = this.series.get(name) ?? [];
@@ -198,7 +210,11 @@ class Bench {
         this.record(name, await timed(fn));
     }
 
-    result(client: CliceClient, server: string): ScenarioResult {
+    /// Server-side breakdown from the session's log files — the worker
+    /// processes' `[perf:build]`/`[perf:query]` lines only exist there
+    /// (workers never mirror to stderr). Captured stderr, which carries the
+    /// master's lines, is the fallback when no log files appeared.
+    result(client: CliceClient): ScenarioResult {
         const measurements: Record<string, Stats> = {};
         for (const [name, values] of this.series) {
             const stats = computeStats(values);
@@ -207,8 +223,13 @@ class Bench {
             }
         }
         const result: ScenarioResult = { measurements };
-        if (server === "clice") {
-            const perf = summarize(parsePerfLines(client.drainedStderr().toString("utf8")));
+        if (this.opts.server === "clice") {
+            const fresh = logFiles(this.opts.workspace).filter((f) => !this.priorLogs.has(f));
+            const text =
+                fresh.length > 0
+                    ? fresh.map((f) => fs.readFileSync(f, "utf8")).join("\n")
+                    : client.drainedStderr().toString("utf8");
+            const perf = summarize(parsePerfLines(text));
             if (Object.keys(perf).length > 0) {
                 result.perf = perf;
             }
@@ -266,7 +287,7 @@ async function shutdownServer(client: CliceClient, opts: Options): Promise<void>
 
 /// Server start → initialize response → first diagnostics of the main file.
 async function runStartScenario(opts: Options, file: string): Promise<ScenarioResult> {
-    const bench = new Bench();
+    const bench = new Bench(opts);
 
     const start = nowMs();
     const client = CliceClient.start(opts.binary, { args: serverArgs(opts) });
@@ -277,7 +298,7 @@ async function runStartScenario(opts: Options, file: string): Promise<ScenarioRe
 
     await bench.measure("open_to_diagnostics", () => client.openAndWait(file, 300_000));
 
-    const result = bench.result(client, opts.server);
+    const result = bench.result(client);
     await shutdownServer(client, opts);
     return result;
 }
@@ -294,7 +315,7 @@ async function runColdStart(opts: Options, file: string): Promise<ScenarioResult
 }
 
 async function runEditLoop(opts: Options, file: string): Promise<ScenarioResult> {
-    const bench = new Bench();
+    const bench = new Bench(opts);
     const client = await startServer(opts);
     const [uri, content] = await client.openAndWait(file, 300_000);
 
@@ -308,13 +329,13 @@ async function runEditLoop(opts: Options, file: string): Promise<ScenarioResult>
         });
     }
 
-    const result = bench.result(client, opts.server);
+    const result = bench.result(client);
     await shutdownServer(client, opts);
     return result;
 }
 
 async function runWarmRequests(opts: Options, file: string): Promise<ScenarioResult> {
-    const bench = new Bench();
+    const bench = new Bench(opts);
     const client = await startServer(opts);
     const [uri] = await client.openAndWait(file, 300_000);
     const { line, character } = opts.position;
@@ -336,7 +357,7 @@ async function runWarmRequests(opts: Options, file: string): Promise<ScenarioRes
         }
     }
 
-    const result = bench.result(client, opts.server);
+    const result = bench.result(client);
     await shutdownServer(client, opts);
     return result;
 }

--- a/tools/bench/perf.ts
+++ b/tools/bench/perf.ts
@@ -157,8 +157,15 @@ export function toChromeTrace(
         traceEvents.push({ name: "process_name", ph: "M", pid: Number(pid), args: { name } });
     }
     // Events concatenate from multiple log files in file order, so the
-    // first stamped event is not necessarily the earliest.
-    const base = Math.min(...events.filter((e) => e.ts !== null).map((e) => e.ts ?? 0), Infinity);
+    // first stamped event is not necessarily the earliest. No spread into
+    // Math.min: a long session's event count exceeds the engine's
+    // argument-count limit.
+    let base = Infinity;
+    for (const event of events) {
+        if (event.ts !== null && event.ts < base) {
+            base = event.ts;
+        }
+    }
     for (const event of events) {
         if (event.ts === null) {
             continue;

--- a/tools/bench/perf.ts
+++ b/tools/bench/perf.ts
@@ -92,15 +92,31 @@ export function computeStats(values: number[]): Stats | null {
     };
 }
 
+/// Discriminated name for an event: `<topic>[.<kind>][.<detail>]`. The kind
+/// is the event's `kind`, `phase`, or `op` value; the detail is its `scope`
+/// or `rel` value — mirroring how the topics in logging.h use those fields
+/// to distinguish materially different operations (`index_detail op=build
+/// scope=full` vs `scope=interested`, `index_query kind=relations
+/// rel=Definition` vs `rel=Reference`).
+function eventName(event: PerfEvent): string {
+    const parts = [event.topic];
+    const kind = event.values["kind"] ?? event.values["phase"] ?? event.values["op"];
+    if (kind !== undefined) {
+        parts.push(String(kind));
+    }
+    const detail = event.values["scope"] ?? event.values["rel"];
+    if (detail !== undefined) {
+        parts.push(String(detail));
+    }
+    return parts.join(".");
+}
+
 /// Group events into duration series. Every numeric `*_ms` key becomes a
-/// series named `<topic>[.<kind>].<key>`, where the kind discriminator is
-/// the event's `kind`, `phase`, or `op` value when present — mirroring how the
-/// topics in logging.h use those fields.
+/// series named `<eventName>.<key>`.
 function aggregate(events: PerfEvent[]): Map<string, number[]> {
     const series = new Map<string, number[]>();
     for (const event of events) {
-        const kind = event.values["kind"] ?? event.values["phase"] ?? event.values["op"];
-        const prefix = kind === undefined ? event.topic : `${event.topic}.${String(kind)}`;
+        const prefix = eventName(event);
         for (const [key, value] of Object.entries(event.values)) {
             if (typeof value !== "number" || !key.endsWith("_ms")) {
                 continue;
@@ -174,10 +190,8 @@ export function toChromeTrace(
         if (typeof duration !== "number") {
             continue;
         }
-        const kind = event.values["kind"] ?? event.values["phase"] ?? event.values["op"];
-        const name = kind === undefined ? event.topic : `${event.topic}.${String(kind)}`;
         traceEvents.push({
-            name,
+            name: eventName(event),
             cat: event.topic,
             ph: "X",
             ts: (event.ts - base - duration) * 1000,

--- a/tools/bench/perf.ts
+++ b/tools/bench/perf.ts
@@ -28,13 +28,13 @@ export function parsePerfLines(text: string): PerfEvent[] {
             continue;
         }
         const values: Record<string, string | number> = {};
-        for (const pair of rest.split(" ")) {
-            const eq = pair.indexOf("=");
-            if (eq <= 0) {
+        // A value runs until the next ` key=` boundary, not the next space:
+        // paths and workspace-symbol queries may contain spaces.
+        for (const pair of rest.matchAll(/(\w+)=((?:(?!\s\w+=).)*)/g)) {
+            const [, key, raw] = pair;
+            if (key === undefined || raw === undefined) {
                 continue;
             }
-            const key = pair.slice(0, eq);
-            const raw = pair.slice(eq + 1);
             const num = Number(raw);
             values[key] = raw !== "" && Number.isFinite(num) ? num : raw;
         }
@@ -83,7 +83,7 @@ export function computeStats(values: number[]): Stats | null {
 /// series named `<topic>[.<kind>].<key>`, where the kind discriminator is
 /// the event's `kind` or `phase` value when present — mirroring how the
 /// topics in logging.h use those fields.
-export function aggregate(events: PerfEvent[]): Map<string, number[]> {
+function aggregate(events: PerfEvent[]): Map<string, number[]> {
     const series = new Map<string, number[]>();
     for (const event of events) {
         const kind = event.values["kind"] ?? event.values["phase"];

--- a/tools/bench/perf.ts
+++ b/tools/bench/perf.ts
@@ -81,12 +81,12 @@ export function computeStats(values: number[]): Stats | null {
 
 /// Group events into duration series. Every numeric `*_ms` key becomes a
 /// series named `<topic>[.<kind>].<key>`, where the kind discriminator is
-/// the event's `kind` or `phase` value when present — mirroring how the
+/// the event's `kind`, `phase`, or `op` value when present — mirroring how the
 /// topics in logging.h use those fields.
 function aggregate(events: PerfEvent[]): Map<string, number[]> {
     const series = new Map<string, number[]>();
     for (const event of events) {
-        const kind = event.values["kind"] ?? event.values["phase"];
+        const kind = event.values["kind"] ?? event.values["phase"] ?? event.values["op"];
         const prefix = typeof kind === "string" ? `${event.topic}.${kind}` : event.topic;
         for (const [key, value] of Object.entries(event.values)) {
             if (typeof value !== "number" || !key.endsWith("_ms")) {
@@ -138,7 +138,7 @@ export function toChromeTrace(events: PerfEvent[]): string {
         if (typeof duration !== "number") {
             continue;
         }
-        const kind = event.values["kind"] ?? event.values["phase"];
+        const kind = event.values["kind"] ?? event.values["phase"] ?? event.values["op"];
         const name = typeof kind === "string" ? `${event.topic}.${kind}` : event.topic;
         traceEvents.push({
             name,

--- a/tools/bench/perf.ts
+++ b/tools/bench/perf.ts
@@ -5,10 +5,15 @@
 
 /// One `[perf:topic]` line: string keys kept verbatim, numeric values
 /// parsed. `ts` is the log line's timestamp in epoch milliseconds when the
-/// line carried one (stderr mirrors and log files do).
+/// line carried one (stderr mirrors and log files do). `pid`/`tid` are the
+/// trace lanes: the caller assigns one `pid` per source log (master and
+/// each worker are separate processes), `tid` is the line's `[thread N]`
+/// value; both default to 1 for stderr-only sources.
 export interface PerfEvent {
     topic: string;
     ts: number | null;
+    pid: number;
+    tid: number;
     values: Record<string, string | number>;
 }
 
@@ -16,7 +21,9 @@ export interface PerfEvent {
 const LINE_PATTERN =
     /^(?:\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3})\] )?.*?\[perf:([\w-]+)\] (.*)$/;
 
-export function parsePerfLines(text: string): PerfEvent[] {
+const THREAD_PATTERN = /\[thread (\d+)\]/;
+
+export function parsePerfLines(text: string, pid = 1): PerfEvent[] {
     const events: PerfEvent[] = [];
     for (const line of text.split("\n")) {
         const match = LINE_PATTERN.exec(line);
@@ -29,7 +36,10 @@ export function parsePerfLines(text: string): PerfEvent[] {
         }
         const values: Record<string, string | number> = {};
         // A value runs until the next ` key=` boundary, not the next space:
-        // paths and workspace-symbol queries may contain spaces.
+        // paths may contain spaces. This boundary is the format's contract —
+        // producers must not put arbitrary user text into perf lines (the
+        // workspace-symbol query is logged as query_len for this reason);
+        // the remaining values are filesystem paths and enum names.
         for (const pair of rest.matchAll(/(\w+)=((?:(?!\s\w+=).)*)/g)) {
             const [, key, raw] = pair;
             if (key === undefined || raw === undefined) {
@@ -38,11 +48,14 @@ export function parsePerfLines(text: string): PerfEvent[] {
             const num = Number(raw);
             values[key] = raw !== "" && Number.isFinite(num) ? num : raw;
         }
+        const thread = THREAD_PATTERN.exec(line);
         events.push({
             topic,
             // The log stamp has no timezone; Date.parse reads it as local
             // time, which is what the producing process used.
             ts: stamp !== undefined ? Date.parse(stamp.replace(" ", "T")) : null,
+            pid,
+            tid: thread?.[1] !== undefined ? Number(thread[1]) : 1,
             values,
         });
     }
@@ -123,12 +136,26 @@ interface TraceEvent {
     args: Record<string, string | number>;
 }
 
+interface TraceMetadataEvent {
+    name: "process_name";
+    ph: "M";
+    pid: number;
+    args: { name: string };
+}
+
 /// Convert perf events to Chrome "Trace Event" JSON (load in Perfetto or
 /// chrome://tracing). A perf line is emitted when its span ends and carries
 /// the duration, so the span is reconstructed as [ts - dur, ts]. Lines
-/// without a timestamp are skipped.
-export function toChromeTrace(events: PerfEvent[]): string {
-    const traceEvents: TraceEvent[] = [];
+/// without a timestamp are skipped. `processNames` labels the pid lanes
+/// (typically the source log file names).
+export function toChromeTrace(
+    events: PerfEvent[],
+    processNames: Record<number, string> = {},
+): string {
+    const traceEvents: (TraceEvent | TraceMetadataEvent)[] = [];
+    for (const [pid, name] of Object.entries(processNames)) {
+        traceEvents.push({ name: "process_name", ph: "M", pid: Number(pid), args: { name } });
+    }
     const base = events.find((e) => e.ts !== null)?.ts ?? 0;
     for (const event of events) {
         if (event.ts === null) {
@@ -146,8 +173,8 @@ export function toChromeTrace(events: PerfEvent[]): string {
             ph: "X",
             ts: (event.ts - base - duration) * 1000,
             dur: duration * 1000,
-            pid: 1,
-            tid: 1,
+            pid: event.pid,
+            tid: event.tid,
             args: event.values,
         });
     }

--- a/tools/bench/perf.ts
+++ b/tools/bench/perf.ts
@@ -1,0 +1,155 @@
+/// Parser and aggregator for clice's `[perf:<topic>] key=value` log lines
+/// (see src/support/logging.h). Consumed by bench.ts for the server-side
+/// breakdown of a benchmark run and by perf_report.ts for offline log
+/// analysis.
+
+/// One `[perf:topic]` line: string keys kept verbatim, numeric values
+/// parsed. `ts` is the log line's timestamp in epoch milliseconds when the
+/// line carried one (stderr mirrors and log files do).
+export interface PerfEvent {
+    topic: string;
+    ts: number | null;
+    values: Record<string, string | number>;
+}
+
+/// `[2026-08-14 12:34:56.789] [info] [thread 1] [file.cpp:42] [perf:x] k=v`
+const LINE_PATTERN =
+    /^(?:\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3})\] )?.*?\[perf:([\w-]+)\] (.*)$/;
+
+export function parsePerfLines(text: string): PerfEvent[] {
+    const events: PerfEvent[] = [];
+    for (const line of text.split("\n")) {
+        const match = LINE_PATTERN.exec(line);
+        if (match === null) {
+            continue;
+        }
+        const [, stamp, topic, rest] = match;
+        if (topic === undefined || rest === undefined) {
+            continue;
+        }
+        const values: Record<string, string | number> = {};
+        for (const pair of rest.split(" ")) {
+            const eq = pair.indexOf("=");
+            if (eq <= 0) {
+                continue;
+            }
+            const key = pair.slice(0, eq);
+            const raw = pair.slice(eq + 1);
+            const num = Number(raw);
+            values[key] = raw !== "" && Number.isFinite(num) ? num : raw;
+        }
+        events.push({
+            topic,
+            // The log stamp has no timezone; Date.parse reads it as local
+            // time, which is what the producing process used.
+            ts: stamp !== undefined ? Date.parse(stamp.replace(" ", "T")) : null,
+            values,
+        });
+    }
+    return events;
+}
+
+export interface Stats {
+    count: number;
+    min: number;
+    p50: number;
+    p90: number;
+    p99: number;
+    max: number;
+    mean: number;
+    sum: number;
+}
+
+export function computeStats(values: number[]): Stats | null {
+    if (values.length === 0) {
+        return null;
+    }
+    const sorted = [...values].sort((a, b) => a - b);
+    const at = (p: number): number => sorted[Math.floor(p * (sorted.length - 1))] ?? 0;
+    const sum = sorted.reduce((a, b) => a + b, 0);
+    return {
+        count: sorted.length,
+        min: sorted[0] ?? 0,
+        p50: at(0.5),
+        p90: at(0.9),
+        p99: at(0.99),
+        max: sorted[sorted.length - 1] ?? 0,
+        mean: sum / sorted.length,
+        sum,
+    };
+}
+
+/// Group events into duration series. Every numeric `*_ms` key becomes a
+/// series named `<topic>[.<kind>].<key>`, where the kind discriminator is
+/// the event's `kind` or `phase` value when present — mirroring how the
+/// topics in logging.h use those fields.
+export function aggregate(events: PerfEvent[]): Map<string, number[]> {
+    const series = new Map<string, number[]>();
+    for (const event of events) {
+        const kind = event.values["kind"] ?? event.values["phase"];
+        const prefix = typeof kind === "string" ? `${event.topic}.${kind}` : event.topic;
+        for (const [key, value] of Object.entries(event.values)) {
+            if (typeof value !== "number" || !key.endsWith("_ms")) {
+                continue;
+            }
+            const name = `${prefix}.${key}`;
+            const list = series.get(name) ?? [];
+            list.push(value);
+            series.set(name, list);
+        }
+    }
+    return series;
+}
+
+export function summarize(events: PerfEvent[]): Record<string, Stats> {
+    const summary: Record<string, Stats> = {};
+    for (const [name, values] of aggregate(events)) {
+        const stats = computeStats(values);
+        if (stats !== null) {
+            summary[name] = stats;
+        }
+    }
+    return summary;
+}
+
+interface TraceEvent {
+    name: string;
+    cat: string;
+    ph: "X";
+    ts: number;
+    dur: number;
+    pid: number;
+    tid: number;
+    args: Record<string, string | number>;
+}
+
+/// Convert perf events to Chrome "Trace Event" JSON (load in Perfetto or
+/// chrome://tracing). A perf line is emitted when its span ends and carries
+/// the duration, so the span is reconstructed as [ts - dur, ts]. Lines
+/// without a timestamp are skipped.
+export function toChromeTrace(events: PerfEvent[]): string {
+    const traceEvents: TraceEvent[] = [];
+    const base = events.find((e) => e.ts !== null)?.ts ?? 0;
+    for (const event of events) {
+        if (event.ts === null) {
+            continue;
+        }
+        const duration = event.values["total_ms"] ?? event.values["elapsed_ms"];
+        if (typeof duration !== "number") {
+            continue;
+        }
+        const kind = event.values["kind"] ?? event.values["phase"];
+        const name = typeof kind === "string" ? `${event.topic}.${kind}` : event.topic;
+        traceEvents.push({
+            name,
+            cat: event.topic,
+            ph: "X",
+            ts: (event.ts - base - duration) * 1000,
+            dur: duration * 1000,
+            pid: 1,
+            tid: 1,
+            args: event.values,
+        });
+    }
+    return JSON.stringify({ traceEvents, displayTimeUnit: "ms" });
+}

--- a/tools/bench/perf.ts
+++ b/tools/bench/perf.ts
@@ -100,7 +100,7 @@ function aggregate(events: PerfEvent[]): Map<string, number[]> {
     const series = new Map<string, number[]>();
     for (const event of events) {
         const kind = event.values["kind"] ?? event.values["phase"] ?? event.values["op"];
-        const prefix = typeof kind === "string" ? `${event.topic}.${kind}` : event.topic;
+        const prefix = kind === undefined ? event.topic : `${event.topic}.${String(kind)}`;
         for (const [key, value] of Object.entries(event.values)) {
             if (typeof value !== "number" || !key.endsWith("_ms")) {
                 continue;
@@ -156,7 +156,9 @@ export function toChromeTrace(
     for (const [pid, name] of Object.entries(processNames)) {
         traceEvents.push({ name: "process_name", ph: "M", pid: Number(pid), args: { name } });
     }
-    const base = events.find((e) => e.ts !== null)?.ts ?? 0;
+    // Events concatenate from multiple log files in file order, so the
+    // first stamped event is not necessarily the earliest.
+    const base = Math.min(...events.filter((e) => e.ts !== null).map((e) => e.ts ?? 0), Infinity);
     for (const event of events) {
         if (event.ts === null) {
             continue;
@@ -166,7 +168,7 @@ export function toChromeTrace(
             continue;
         }
         const kind = event.values["kind"] ?? event.values["phase"] ?? event.values["op"];
-        const name = typeof kind === "string" ? `${event.topic}.${kind}` : event.topic;
+        const name = kind === undefined ? event.topic : `${event.topic}.${String(kind)}`;
         traceEvents.push({
             name,
             cat: event.topic,

--- a/tools/bench/perf_report.ts
+++ b/tools/bench/perf_report.ts
@@ -1,0 +1,56 @@
+/// Offline report over clice's `[perf:*]` log lines: aggregate a real
+/// run's master/worker logs into per-series latency stats, optionally
+/// exporting a Chrome trace for Perfetto.
+///
+/// Usage:
+///   node tools/bench/perf_report.ts <logfile>... [--trace out.json]
+///
+/// Log files live under the server's logging dir (master.log and the
+/// per-worker logs); any text with perf lines works, including captured
+/// stderr.
+
+import * as fs from "node:fs";
+import { parseArgs } from "node:util";
+import { parsePerfLines, summarize, toChromeTrace, type PerfEvent } from "./perf.ts";
+
+const { values, positionals } = parseArgs({
+    options: {
+        trace: { type: "string" },
+        help: { type: "boolean", default: false },
+    },
+    allowPositionals: true,
+});
+
+if (values.help || positionals.length === 0) {
+    console.log("Usage: node tools/bench/perf_report.ts <logfile>... [--trace out.json]");
+    process.exit(values.help ? 0 : 1);
+}
+
+const events: PerfEvent[] = [];
+for (const file of positionals) {
+    events.push(...parsePerfLines(fs.readFileSync(file, "utf8")));
+}
+
+if (events.length === 0) {
+    console.log("no [perf:*] lines found");
+    process.exit(0);
+}
+
+console.log(`${events.length} perf events`);
+console.log(
+    `${"series".padEnd(44)} ${"count".padStart(6)} ${"p50".padStart(9)} ` +
+        `${"p90".padStart(9)} ${"max".padStart(9)} ${"sum".padStart(10)}`,
+);
+const summary = Object.entries(summarize(events)).sort((a, b) => b[1].sum - a[1].sum);
+for (const [series, stats] of summary) {
+    console.log(
+        `${series.padEnd(44)} ${String(stats.count).padStart(6)} ` +
+            `${stats.p50.toFixed(2).padStart(9)} ${stats.p90.toFixed(2).padStart(9)} ` +
+            `${stats.max.toFixed(2).padStart(9)} ${stats.sum.toFixed(0).padStart(10)}`,
+    );
+}
+
+if (values.trace !== undefined) {
+    fs.writeFileSync(values.trace, toChromeTrace(events));
+    console.log(`\nChrome trace written to ${values.trace} (open in Perfetto)`);
+}

--- a/tools/bench/perf_report.ts
+++ b/tools/bench/perf_report.ts
@@ -34,7 +34,11 @@ const processNames: Record<number, string> = {};
 positionals.forEach((file, index) => {
     const pid = index + 1;
     processNames[pid] = path.basename(file);
-    events.push(...parsePerfLines(fs.readFileSync(file, "utf8"), pid));
+    // No spread into push: a long session yields enough events to blow
+    // the engine's argument-count limit.
+    for (const event of parsePerfLines(fs.readFileSync(file, "utf8"), pid)) {
+        events.push(event);
+    }
 });
 
 if (events.length === 0) {

--- a/tools/bench/perf_report.ts
+++ b/tools/bench/perf_report.ts
@@ -10,6 +10,7 @@
 /// stderr.
 
 import * as fs from "node:fs";
+import * as path from "node:path";
 import { parseArgs } from "node:util";
 import { parsePerfLines, summarize, toChromeTrace, type PerfEvent } from "./perf.ts";
 
@@ -26,10 +27,15 @@ if (values.help || positionals.length === 0) {
     process.exit(values.help ? 0 : 1);
 }
 
+// One trace pid per input log: master and workers are separate processes,
+// and their concurrent activity must land on separate lanes.
 const events: PerfEvent[] = [];
-for (const file of positionals) {
-    events.push(...parsePerfLines(fs.readFileSync(file, "utf8")));
-}
+const processNames: Record<number, string> = {};
+positionals.forEach((file, index) => {
+    const pid = index + 1;
+    processNames[pid] = path.basename(file);
+    events.push(...parsePerfLines(fs.readFileSync(file, "utf8"), pid));
+});
 
 if (events.length === 0) {
     console.log("no [perf:*] lines found");
@@ -51,6 +57,6 @@ for (const [series, stats] of summary) {
 }
 
 if (values.trace !== undefined) {
-    fs.writeFileSync(values.trace, toChromeTrace(events));
+    fs.writeFileSync(values.trace, toChromeTrace(events, processNames));
     console.log(`\nChrome trace written to ${values.trace} (open in Perfetto)`);
 }

--- a/tools/client/client.ts
+++ b/tools/client/client.ts
@@ -681,6 +681,14 @@ export class CliceClient {
         });
     }
 
+    /// Incremental didChange: replace `range` with `text`.
+    changeRange(uri: string, version: number, range: proto.Range, text: string): void {
+        void this.sendNotification(proto.DidChangeTextDocumentNotification.type, {
+            textDocument: { uri, version },
+            contentChanges: [{ range, text }],
+        });
+    }
+
     save(uri: string, text?: string): void {
         void this.sendNotification(proto.DidSaveTextDocumentNotification.type, {
             textDocument: { uri },

--- a/tools/client/client.ts
+++ b/tools/client/client.ts
@@ -127,7 +127,9 @@ export async function findFreePort(): Promise<number> {
 const ANOMALY_PATTERN = /\[anomaly:([A-Za-z]+)\]/;
 const CRASH_TRACE_MARKER = "=== CRASH STACK TRACE ===";
 
-function logFiles(root: string | null): string[] {
+/// All .log files under <workspace>/.clice/logs — one directory per server
+/// session, master and worker logs side by side.
+export function logFiles(root: string | null): string[] {
     if (root === null) {
         return [];
     }

--- a/tools/client/workspace.ts
+++ b/tools/client/workspace.ts
@@ -30,7 +30,13 @@ export interface CDBOptions {
 }
 
 export class Workspace {
-    constructor(readonly root: string) {}
+    // Not a constructor parameter property: those don't survive Node's
+    // strip-only TS mode, and bench.ts runs this file under plain node.
+    readonly root: string;
+
+    constructor(root: string) {
+        this.root = root;
+    }
 
     /// A fresh temp-directory workspace. Removal is the creator's business —
     /// the session fixture registers it for teardown.

--- a/tools/package.json
+++ b/tools/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./bench/perf": "./bench/perf.ts",
     "./client": "./client/client.ts",
     "./workspace": "./client/workspace.ts",
     "./session": "./client/session.ts",

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -18,5 +18,5 @@
     "allowImportingTsExtensions": true,
     "skipLibCheck": true
   },
-  "include": ["client/**/*.ts", "snap/**/*.ts", "protocol/**/*.ts", "*.ts"]
+  "include": ["bench/**/*.ts", "client/**/*.ts", "snap/**/*.ts", "protocol/**/*.ts", "*.ts"]
 }


### PR DESCRIPTION
## What changed

First step of the performance-baseline effort for the large-project reports: make "where does the time go" measurable and reproducible, on three layers.

**1. Instrumentation — every real run now carries a complete timing account.**
- Worker-side request split: new `[perf:query]` topic (`acquire_ms` = AST wait + strand lock, `compute_ms` = the feature itself), and master `[perf:request]` lines gain sub-millisecond precision (`ScopedTimer::ms_f`).
- Stateless-worker build tasks emit `[perf:build]` with per-stage splits: PCH = compile / preamble-index / disk-flush / preamble-state sidecar write, index = compile / TUIndex build / serialize / teardown (replacing the old info-level "done" lines).
- Index internals get their own `[perf:index_detail]` topic (visible at info level): TUIndex build splits into semantics table / projection / graph+dedup finish, serialize into the path-rekey copy vs the flatbuffers pack, and the preamble state into links vs blob with byte counts — fine-grained enough to localize an index regression without re-instrumenting.
- Master index queries emit `[perf:index_query]` (`kind=relations|search`).
- `CompilationParams.collect_tokens` gates the `TokenBuffer` collection so its cost is measurable in isolation.

**2. Benchmark binaries (`-DCLICE_ENABLE_BENCHMARK=ON`).**
- `pipeline_benchmark` (new): per-TU stage profile over a real `compile_commands.json` — preprocess with/without TokenBuffer, plain parse + index build/serialize (the background-index shape), preamble PCH build and reparse over the PCH, both mirroring the worker code paths (PCH includes the preamble-state sidecar, the reparse runs the interested-only index). One JSON result per file, slowest-TU ranking, and `--time-trace` passes clang's own `-ftime-trace` through per file for the frontend-internal breakdown.
- `pch_chain_benchmark`: port of #405 (monolithic vs chained PCH) onto the current API and LLVM 22; supersedes that PR. Port fixes a latent bug in the original: the monolithic `verify_pch` passed a preamble bound larger than the verify source, making clang skip past the buffer end. Verification now compiles a heavy source against the full chain content, with a negative control.
- `scan_benchmark`: repaired after the `CompilationDatabase::load` signature change (it does not build on main), and brought up to house style.

**3. E2E scenario harness (`tools/bench/`).**
- `bench.ts` drives a server over LSP through fixed scenarios — cold start, warm start, edit loop, warm feature requests — and reports client-observed percentiles. Server-agnostic: `--server clangd` runs the identical scenarios against clangd (same LLVM 22 major, ships in the pixi env) for direct A/B.
- For clice it merges the session's master **and worker** log files into a server-side breakdown, so a cold start decomposes end to end (e.g. didOpen 436 ms = PCH build 387 ms = compile 300 + preamble index 82 + flush 2, + pipeline). Timed paths are decoupled from the warm-up pokes, and the harness pins what could skew an A/B: the CDB directory and the log location override any workspace `clice.toml`, and worker counts derive from the parallelism actually available to the process.
- `perf_report.ts` aggregates any log offline and exports Chrome-trace JSON for Perfetto.
- `workloads.json` + `fetch_workload.py` pin real-project workloads by ref (LLVM at `llvmorg-22.1.8`) so numbers are comparable across machines and time; `benchmarks/README.md` documents the methodology, platform caveats, and indicative reference numbers. Measured results deliberately stay out of the repo.

Findings from the first measurement pass and the follow-up optimization directions are tracked in #606.

## Tests

- All four suites pass locally on RelWithDebInfo (unit 1187, integration 348, smoke 3, snap 395), `npm run check` clean, `pixi run format` applied.
- New `tests/tools/perf.test.ts` pins the perf-line parser (timestamps, kind/phase series, values containing spaces, Chrome-trace span reconstruction).
- Each benchmark binary and both harness sides (clice, clangd) smoke-ran locally on real CDBs; the `-ftime-trace` output loads in Perfetto.
