### PR TITLE
feat(server): foreground-aware background indexing budget

### DIFF
--- a/src/server/compiler/compile_graph.cpp
+++ b/src/server/compiler/compile_graph.cpp
@@ -103,6 +103,9 @@ void CompileGraph::release(std::uint32_t path_id) {
     auto& unit = units.find(path_id)->second;
     assert(unit.refcount > 0 && "released more interest than acquired");
     unit.refcount -= 1;
+    if(unit.refcount == 0) {
+        unit.foreground = false;
+    }
 
     // No interest left in an in-flight round. The drop is often transient —
     // a stale round's edges being re-acquired by the retry that re-resolves
@@ -189,9 +192,15 @@ kota::task<> CompileGraph::unit_body(std::uint32_t path_id,
 
     // Acquire edge references on all direct dependencies. This must stay
     // synchronous: no suspension between refcount++ and guard registration.
+    // A foreground unit passes its class down: the user waits on the whole
+    // chain, not just the root.
+    auto foreground = unit.foreground;
     for(auto dep_id: deps) {
         acquire(dep_id);
         guard.acquired.push_back(dep_id);
+        if(foreground) {
+            units.find(dep_id)->second.foreground = true;
+        }
     }
 
     if(!deps.empty()) {
@@ -208,7 +217,9 @@ kota::task<> CompileGraph::unit_body(std::uint32_t path_id,
         }
     }
 
-    bool ok = co_await dispatch(path_id);
+    // Re-look up the class: a foreground requester may have joined while
+    // the dependency waits above were suspended.
+    bool ok = co_await dispatch(path_id, units.find(path_id)->second.foreground);
 
     // Synchronous tail: nothing can interleave between dispatch resuming us
     // and co_return, so the checks below are atomic.
@@ -263,14 +274,17 @@ kota::task<bool> CompileGraph::await_unit(std::uint32_t path_id,
     }
 }
 
-kota::task<bool> CompileGraph::compile(std::uint32_t path_id) {
+kota::task<bool> CompileGraph::compile(std::uint32_t path_id, bool foreground) {
     // Request scope: one root reference, dropped when the requester exits or
     // its frame is cancelled.
     RefGuard scope(*this, {path_id});
+    if(foreground) {
+        units.find(path_id)->second.foreground = true;
+    }
     co_return co_await await_unit(path_id, std::nullopt);
 }
 
-kota::task<bool> CompileGraph::compile_deps(std::uint32_t path_id) {
+kota::task<bool> CompileGraph::compile_deps(std::uint32_t path_id, bool foreground) {
     ensure_resolved(path_id);
 
     // Copy deps — the map may rehash while this frame is suspended.
@@ -282,6 +296,11 @@ kota::task<bool> CompileGraph::compile_deps(std::uint32_t path_id) {
     // Request scope: root references on each direct dependency (path_id
     // itself is never dispatched here).
     RefGuard scope(*this, deps);
+    if(foreground) {
+        for(auto dep_id: deps) {
+            units.find(dep_id)->second.foreground = true;
+        }
+    }
 
     std::vector<kota::task<bool>> waits;
     waits.reserve(deps.size());

--- a/src/server/compiler/compile_graph.cpp
+++ b/src/server/compiler/compile_graph.cpp
@@ -193,13 +193,14 @@ kota::task<> CompileGraph::unit_body(std::uint32_t path_id,
     // Acquire edge references on all direct dependencies. This must stay
     // synchronous: no suspension between refcount++ and guard registration.
     // A foreground unit passes its class down: the user waits on the whole
-    // chain, not just the root.
+    // chain, not just the root — and a dep discovered here may already be
+    // running with a resolved closure of its own, so the mark must recurse.
     auto foreground = unit.foreground;
     for(auto dep_id: deps) {
         acquire(dep_id);
         guard.acquired.push_back(dep_id);
         if(foreground) {
-            units.find(dep_id)->second.foreground = true;
+            mark_foreground(dep_id);
         }
     }
 

--- a/src/server/compiler/compile_graph.cpp
+++ b/src/server/compiler/compile_graph.cpp
@@ -279,12 +279,31 @@ kota::task<bool> CompileGraph::await_unit(std::uint32_t path_id,
     }
 }
 
+void CompileGraph::mark_foreground(std::uint32_t path_id) {
+    auto& unit = units[path_id];
+    unit.path_id = path_id;
+    // Already-marked doubles as the cycle/shared-dep visit guard.
+    if(unit.foreground) {
+        return;
+    }
+    unit.foreground = true;
+    // A late join must upgrade the whole resolved closure, not just the
+    // root: a dependency already spawned at Low re-reads its class when a
+    // preempted round retries, and without the closure mark that retry
+    // would stay Low — cancellable by the very foreground waiting on it.
+    // Copy: recursion inserts units and may rehash the map.
+    auto deps = unit.dependencies;
+    for(auto dep_id: deps) {
+        mark_foreground(dep_id);
+    }
+}
+
 kota::task<bool> CompileGraph::compile(std::uint32_t path_id, bool foreground) {
     // Request scope: one root reference, dropped when the requester exits or
     // its frame is cancelled.
     RefGuard scope(*this, {path_id});
     if(foreground) {
-        units.find(path_id)->second.foreground = true;
+        mark_foreground(path_id);
     }
     co_return co_await await_unit(path_id, std::nullopt);
 }
@@ -303,7 +322,7 @@ kota::task<bool> CompileGraph::compile_deps(std::uint32_t path_id, bool foregrou
     RefGuard scope(*this, deps);
     if(foreground) {
         for(auto dep_id: deps) {
-            units.find(dep_id)->second.foreground = true;
+            mark_foreground(dep_id);
         }
     }
 

--- a/src/server/compiler/compile_graph.cpp
+++ b/src/server/compiler/compile_graph.cpp
@@ -219,12 +219,15 @@ kota::task<> CompileGraph::unit_body(std::uint32_t path_id,
 
     // Re-look up the class: a foreground requester may have joined while
     // the dependency waits above were suspended.
-    bool ok = co_await dispatch(path_id, units.find(path_id)->second.foreground);
+    auto outcome = co_await dispatch(path_id, units.find(path_id)->second.foreground);
 
     // Synchronous tail: nothing can interleave between dispatch resuming us
     // and co_return, so the checks below are atomic.
-    if(!ok) {
-        guard.outcome = CompileUnit::Outcome::Failed;
+    if(outcome != CompileUnit::Outcome::Success) {
+        // Failed propagates to waiters; Stale (the scheduler preempted the
+        // build) makes them respawn the round, re-reading the interest
+        // class — a foreground joiner's retry dispatches at High.
+        guard.outcome = outcome;
         co_return;
     }
 
@@ -268,7 +271,9 @@ kota::task<bool> CompileGraph::await_unit(std::uint32_t path_id,
             case CompileUnit::Outcome::Failed: co_return false;
             // The round was cancelled and produced no result; we still hold
             // interest, so drive a new round. Each retry consumes one
-            // staleness event — without further updates this terminates.
+            // staleness event (an update, or one scheduler preemption of
+            // the dispatch, whose retry queues for a pool slot rather than
+            // spinning) — this terminates once the events stop.
             case CompileUnit::Outcome::Stale: break;
         }
     }

--- a/src/server/compiler/compile_graph.h
+++ b/src/server/compiler/compile_graph.h
@@ -13,10 +13,13 @@ namespace clice {
 
 struct CompileUnit {
     /// Result of one compilation round, observed by waiters after the
-    /// round's completion event fires.
+    /// round's completion event fires. Also the dispatch callback's return
+    /// type: a dispatch reports Stale when the scheduler preempted its
+    /// build — no verdict on the unit, waiters retry.
     enum class Outcome : std::uint8_t {
-        /// The round was cancelled (file update or loss of interest) and its
-        /// result discarded; waiters that still hold interest retry.
+        /// The round was cancelled (file update, loss of interest, or a
+        /// scheduler-preempted build) and its result discarded; waiters
+        /// that still hold interest retry.
         Stale,
         Success,
         /// Dispatch failed or a dependency cycle was detected; waiters
@@ -103,8 +106,13 @@ struct CompileUnit {
 class CompileGraph {
 public:
     /// Performs the actual compilation (e.g. produce PCM file); `foreground`
-    /// carries the unit's interest class into the build's priority.
-    using dispatch_fn = std::function<kota::task<bool>(std::uint32_t path_id, bool foreground)>;
+    /// carries the unit's interest class into the build's priority. Stale
+    /// reports a scheduler-preempted build: the round ends without a
+    /// verdict and waiters respawn it — a foreground joiner's retry then
+    /// re-dispatches at High instead of surfacing the preemption as a
+    /// failure.
+    using dispatch_fn =
+        std::function<kota::task<CompileUnit::Outcome>(std::uint32_t path_id, bool foreground)>;
 
     /// Returns the dependency path_ids for a given path_id (called lazily on first compile).
     using resolve_fn = std::function<llvm::SmallVector<std::uint32_t>(std::uint32_t path_id)>;

--- a/src/server/compiler/compile_graph.h
+++ b/src/server/compiler/compile_graph.h
@@ -51,6 +51,14 @@ struct CompileUnit {
     /// compiling cancels this unit's round. Not a lifetime count.
     std::uint32_t refcount = 0;
 
+    /// A foreground requester holds (or held) interest in this round: the
+    /// dispatch sends the build at High priority so a waiting user request
+    /// is not throttled behind background indexing. Sticky while any
+    /// interest remains — clearing with the foreground requester alone
+    /// would drop an in-flight retry back to Low mid-wait — and reset when
+    /// the interest count returns to zero.
+    bool foreground = false;
+
     /// A zero-interest cancellation check is already queued for this unit.
     bool zero_check_pending = false;
 
@@ -94,20 +102,23 @@ struct CompileUnit {
 ///   dependency cycle) propagates to waiters without retry.
 class CompileGraph {
 public:
-    /// Performs the actual compilation (e.g. produce PCM file).
-    using dispatch_fn = std::function<kota::task<bool>(std::uint32_t path_id)>;
+    /// Performs the actual compilation (e.g. produce PCM file); `foreground`
+    /// carries the unit's interest class into the build's priority.
+    using dispatch_fn = std::function<kota::task<bool>(std::uint32_t path_id, bool foreground)>;
 
     /// Returns the dependency path_ids for a given path_id (called lazily on first compile).
     using resolve_fn = std::function<llvm::SmallVector<std::uint32_t>(std::uint32_t path_id)>;
 
     CompileGraph(kota::event_loop& loop, dispatch_fn dispatch, resolve_fn resolve);
 
-    /// Compile a unit and all its transitive dependencies.
-    kota::task<bool> compile(std::uint32_t path_id);
+    /// Compile a unit and all its transitive dependencies. `foreground`
+    /// marks the chain's dispatches High-priority (a user request waits on
+    /// them); background callers leave it unset.
+    kota::task<bool> compile(std::uint32_t path_id, bool foreground = false);
 
     /// Compile all transitive module dependencies of path_id, but NOT path_id itself.
     /// Used for non-module files (plain .cpp) that import modules.
-    kota::task<bool> compile_deps(std::uint32_t path_id);
+    kota::task<bool> compile_deps(std::uint32_t path_id, bool foreground = false);
 
     /// Mark path_id and all transitive dependents as dirty,
     /// cancelling any in-progress compilations (their results are stale).

--- a/src/server/compiler/compile_graph.h
+++ b/src/server/compiler/compile_graph.h
@@ -169,6 +169,10 @@ private:
     /// Interest +1; creates the unit if needed.
     void acquire(std::uint32_t path_id);
 
+    /// Mark a unit and its resolved dependency closure foreground; units
+    /// resolved later inherit through the edge propagation in unit_body.
+    void mark_foreground(std::uint32_t path_id);
+
     /// Interest -1; schedules a zero-interest cancellation check when it
     /// drops to zero mid-compile.
     void release(std::uint32_t path_id);

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -269,10 +269,11 @@ void Compiler::init_compile_graph() {
     };
 
     // Dispatch: sends BuildPCM request to a stateless worker.
-    auto dispatch = [this](std::uint32_t path_id, bool foreground) -> kota::task<bool> {
+    using Outcome = CompileUnit::Outcome;
+    auto dispatch = [this](std::uint32_t path_id, bool foreground) -> kota::task<Outcome> {
         auto mod_it = workspace.path_to_module.find(path_id);
         if(mod_it == workspace.path_to_module.end())
-            co_return false;
+            co_return Outcome::Failed;
 
         // Copy out of the map before any suspension below: while a PCM build
         // is awaited, a concurrent didSave can insert into (or erase from)
@@ -289,7 +290,7 @@ void Compiler::init_compile_graph() {
 
         if(!workspace.store) {
             LOG_WARN("BuildPCM skipped for module {}: cache store is unavailable", module_name);
-            co_return false;
+            co_return Outcome::Failed;
         }
 
         // Deterministic content-addressed PCM key over the source path and
@@ -315,7 +316,7 @@ void Compiler::init_compile_graph() {
             } else {
                 workspace.pcm_paths[path_id] = pcm_it->second.path;
                 LOG_PERF("cache", "ns=pcm event=hit key={} module={}", pcm_key, module_name);
-                co_return true;
+                co_return Outcome::Success;
             }
         }
         LOG_PERF("cache",
@@ -336,7 +337,7 @@ void Compiler::init_compile_graph() {
             LOG_WARN("PCM build for module {} refused: key {} keeps crashing workers",
                      module_name,
                      budget_key);
-            co_return false;
+            co_return Outcome::Failed;
         }
 
         bp.module_name = module_name;
@@ -354,6 +355,13 @@ void Compiler::init_compile_graph() {
             [this, &budget_key](const kota::ipc::protocol::Error&) {
                 workspace.build_crashes.on_crash(budget_key);
             });
+        // A scheduler preemption (foreground reclaim, memory pressure) is
+        // no verdict on the unit: report the round stale so waiters drive
+        // a retry instead of failing their whole chain.
+        if(!result.has_value() && result.error().code == worker::dispatch_errc::cancelled) {
+            LOG_INFO("BuildPCM preempted for module {}, will retry", module_name);
+            co_return Outcome::Stale;
+        }
         if(!result.has_value() || !result.value().success) {
             if(expected_build_failure(result)) {
                 LOG_WARN("BuildPCM failed for module {}: {}",
@@ -365,7 +373,7 @@ void Compiler::init_compile_graph() {
                             module_name,
                             build_failure_message(result));
             }
-            co_return false;
+            co_return Outcome::Failed;
         }
 
         // Commit on the thread pool: it fsyncs the freshly written PCM.
@@ -373,7 +381,7 @@ void Compiler::init_compile_graph() {
             co_await kota::queue([&] { return workspace.store->commit(std::move(pending)); });
         if(!committed.has_value() || !committed.value().has_value()) {
             LOG_WARN("Failed to commit PCM for module {}", module_name);
-            co_return false;
+            co_return Outcome::Failed;
         }
 
         workspace.build_crashes.on_land(budget_key);
@@ -393,7 +401,7 @@ void Compiler::init_compile_graph() {
         if(on_indexing_needed)
             on_indexing_needed();
 
-        co_return true;
+        co_return Outcome::Success;
     };
 
     workspace.compile_graph =

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -269,7 +269,7 @@ void Compiler::init_compile_graph() {
     };
 
     // Dispatch: sends BuildPCM request to a stateless worker.
-    auto dispatch = [this](std::uint32_t path_id) -> kota::task<bool> {
+    auto dispatch = [this](std::uint32_t path_id, bool foreground) -> kota::task<bool> {
         auto mod_it = workspace.path_to_module.find(path_id);
         if(mod_it == workspace.path_to_module.end())
             co_return false;
@@ -282,6 +282,7 @@ void Compiler::init_compile_graph() {
         auto file_path = std::string(workspace.path_pool.resolve(path_id));
 
         worker::BuildParams bp;
+        bp.priority = foreground ? worker::Priority::High : worker::Priority::Low;
         bp.kind = worker::BuildKind::BuildPCM;
         bp.file = file_path;
         contexts.resolve_command(file_path, bp.directory, bp.arguments);
@@ -716,10 +717,14 @@ kota::task<bool> Compiler::ensure_deps(Session& session,
     // scope unwinds the wait and releases this request's interest in the
     // dependency graph, without touching the shared compilations themselves.
     auto compile_deps = [&](std::uint32_t pid) -> kota::task<bool> {
+        // A user request waits on these builds: dispatch them High so the
+        // background budget cannot throttle its own foreground.
         if(!scope) {
-            co_return co_await workspace.compile_graph->compile_deps(pid);
+            co_return co_await workspace.compile_graph->compile_deps(pid, /*foreground=*/true);
         }
-        auto result = co_await kota::with_token(workspace.compile_graph->compile_deps(pid), *scope);
+        auto result = co_await kota::with_token(
+            workspace.compile_graph->compile_deps(pid, /*foreground=*/true),
+            *scope);
         co_return result.has_value() && *result;
     };
 

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -1310,6 +1310,68 @@ auto Indexer::note_dispatch_failure(std::uint32_t server_path_id,
     return RequeueVerdict::Requeued;
 }
 
+kota::task<> Indexer::run_round_feeder(kota::task_group<>& workers,
+                                       RoundState& round,
+                                       std::size_t round_end,
+                                       std::size_t total,
+                                       std::size_t& dispatched) {
+    while(index_queue_pos < round_end) {
+        if(pause_depth > 0)
+            co_await resume_event.wait();
+
+        // With no schedulable worker but revival pending, a dispatch would
+        // only convert the queue slot into an instant worker_unavailable
+        // failure; park until a slot returns to service. With revival off
+        // such failures are terminal and take the normal failure path.
+        while(pool.revives_slots() && pool.schedulable_stateless() == 0) {
+            capacity_event.reset();
+            co_await capacity_event.wait();
+        }
+
+        // Feed at most twice the pool's low budget: deep enough that
+        // workers never idle waiting for the feeder, shallow enough that
+        // the pool queue holds little when a pause or budget cut lands.
+        // The floor keeps the window alive when the budget reads zero (a
+        // pool that has not started yet); without it the feeder would wait
+        // on task_done with nothing in flight to ever set it.
+        while(round.inflight >= std::max<std::size_t>(2 * pool.effective_low_limit(), 2)) {
+            round.task_done.reset();
+            co_await round.task_done.wait();
+        }
+
+        auto server_path_id = index_queue[index_queue_pos];
+        index_queue_pos += 1;
+        pending_ids.erase(server_path_id);
+        // No open-session or hash-freshness shortcut here: index_one is the
+        // single decision point for skipping (it knows the pending reason;
+        // a hash check alone cannot see a file's own edit), and the
+        // completion clear in run_index_task retires the pending state with
+        // the ticket honored. A second, reason-blind copy of these checks
+        // here is exactly what once erased ContentChanged state early and
+        // let a stale shard keep serving.
+
+        // A queued slot with no pending entry was cleared mid-batch: the
+        // file was removed from disk after being enqueued (clear_pending),
+        // so there is nothing to index — skip the slot. Every other slot
+        // has an entry, because enqueue writes it before the queue push.
+        auto pending_it = reindex_reasons.find(server_path_id);
+        if(pending_it == reindex_reasons.end()) {
+            continue;
+        }
+
+        dispatched += 1;
+        round.inflight += 1;
+        auto ticket = pending_it->second.ticket;
+        // A member coroutine, not an immediately-invoked capturing lambda:
+        // a lambda's captures live in the lambda object, which dies at the
+        // end of this statement — anything read after the first suspension
+        // would dangle. Coroutine parameters are copied into the frame.
+        workers.spawn(run_index_task(server_path_id, ticket, dispatched, total, round));
+    }
+
+    LOG_DEBUG("Background indexing: all {} tasks spawned, waiting for completion", dispatched);
+}
+
 kota::task<> Indexer::run_index_task(std::uint32_t server_path_id,
                                      std::uint64_t ticket,
                                      std::size_t index,
@@ -1380,58 +1442,13 @@ kota::task<> Indexer::run_background_indexing() {
     ScopedTimer timer;
     kota::task_group<> workers(loop);
 
-    while(index_queue_pos < round_end) {
-        if(pause_depth > 0)
-            co_await resume_event.wait();
-
-        // With no schedulable worker but revival pending, a dispatch would
-        // only convert the queue slot into an instant worker_unavailable
-        // failure; park until a slot returns to service. With revival off
-        // such failures are terminal and take the normal failure path.
-        while(pool.revives_slots() && pool.schedulable_stateless() == 0) {
-            capacity_event.reset();
-            co_await capacity_event.wait();
-        }
-
-        // Feed at most twice the pool's low budget: deep enough that
-        // workers never idle waiting for the feeder, shallow enough that
-        // the pool queue holds little when a pause or budget cut lands.
-        while(round.inflight >= std::max<std::size_t>(2 * pool.effective_low_limit(), 2)) {
-            round.task_done.reset();
-            co_await round.task_done.wait();
-        }
-
-        auto server_path_id = index_queue[index_queue_pos];
-        index_queue_pos += 1;
-        pending_ids.erase(server_path_id);
-        // No open-session or hash-freshness shortcut here: index_one is the
-        // single decision point for skipping (it knows the pending reason;
-        // a hash check alone cannot see a file's own edit), and the
-        // completion clear in run_index_task retires the pending state with
-        // the ticket honored. A second, reason-blind copy of these checks
-        // here is exactly what once erased ContentChanged state early and
-        // let a stale shard keep serving.
-
-        // A queued slot with no pending entry was cleared mid-batch: the
-        // file was removed from disk after being enqueued (clear_pending),
-        // so there is nothing to index — skip the slot. Every other slot
-        // has an entry, because enqueue writes it before the queue push.
-        auto pending_it = reindex_reasons.find(server_path_id);
-        if(pending_it == reindex_reasons.end()) {
-            continue;
-        }
-
-        dispatched += 1;
-        round.inflight += 1;
-        auto ticket = pending_it->second.ticket;
-        // A member coroutine, not an immediately-invoked capturing lambda:
-        // a lambda's captures live in the lambda object, which dies at the
-        // end of this statement — anything read after the first suspension
-        // would dangle. Coroutine parameters are copied into the frame.
-        workers.spawn(run_index_task(server_path_id, ticket, dispatched, total, round));
-    }
-
-    LOG_DEBUG("Background indexing: all {} tasks spawned, waiting for completion", dispatched);
+    // The dispatch loop runs as a child of `workers`, so this frame's only
+    // suspension while children live is the join below: a shutdown cancel
+    // cascades through the join into the group, and the feeder plus every
+    // in-flight task unwind before `workers` is destroyed. Parking the
+    // feeder's waits on this frame instead would let the cancel finalize
+    // the frame — destroying the group with children still in flight.
+    workers.spawn(run_round_feeder(workers, round, round_end, total, dispatched));
     co_await workers.join();
 
     // Skipped files bump `completed` without a Report emit; refresh the

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -131,6 +131,16 @@ std::string serialize_cdb_snapshot(Workspace& workspace,
 
 }  // namespace
 
+Indexer::Indexer(kota::event_loop& loop,
+                 Workspace& workspace,
+                 WorkerPool& pool,
+                 ContextResolver& contexts,
+                 const SessionStore& sessions) :
+    loop(loop), bg_tasks(loop), workspace(workspace), pool(pool), contexts(contexts),
+    sessions(sessions) {
+    capacity_conn = pool.on_stateless_capacity.connect([this] { capacity_event.set(); });
+}
+
 bool Indexer::merge(const void* tu_index_data, std::size_t size) {
     // Zero-copy consumption: the wire stays serialized; a new variant's
     // blob bytes are sliced out and installed or merged without decoding
@@ -1304,7 +1314,7 @@ kota::task<> Indexer::run_index_task(std::uint32_t server_path_id,
                                      std::uint64_t ticket,
                                      std::size_t index,
                                      std::size_t total,
-                                     std::size_t& completed) {
+                                     RoundState& round) {
     co_await index_one(server_path_id, ticket, index, total);
     // The pending window ends with the index attempt, success or not. On
     // failure the last-known rows resume serving — deliberately: keeping
@@ -1317,9 +1327,11 @@ kota::task<> Indexer::run_index_task(std::uint32_t server_path_id,
        it != reindex_reasons.end() && it->second.ticket == ticket) {
         reindex_reasons.erase(it);
     }
-    ++completed;
+    round.completed += 1;
+    round.inflight -= 1;
+    round.task_done.set();
     progress_data.stage = Progress::Stage::Report;
-    progress_data.completed = completed;
+    progress_data.completed = round.completed;
     on_progress_changed.emit();
 }
 
@@ -1347,9 +1359,15 @@ kota::task<> Indexer::run_background_indexing() {
         index_queue.end(),
         [this](std::uint32_t id) { return workspace.path_to_module.contains(id); });
 
-    auto total = index_queue.size() - index_queue_pos;
+    // This round consumes [index_queue_pos, round_end) only. Anything
+    // appended during the round — including its own failures' requeues —
+    // waits for the next round; consuming a requeue in the round that
+    // produced it is what let a worker outage spin the dispatch loop
+    // against instant failures (#611).
+    auto round_end = index_queue.size();
+    auto total = round_end - index_queue_pos;
     std::size_t dispatched = 0;
-    std::size_t completed = 0;
+    RoundState round;
 
     // Announce the round; a progress reporter reads the counts from
     // progress() and owns the LSP token's begin/report/end handshake. With
@@ -1362,11 +1380,29 @@ kota::task<> Indexer::run_background_indexing() {
     ScopedTimer timer;
     kota::task_group<> workers(loop);
 
-    while(index_queue_pos < index_queue.size()) {
+    while(index_queue_pos < round_end) {
         if(pause_depth > 0)
             co_await resume_event.wait();
 
-        auto server_path_id = index_queue[index_queue_pos++];
+        // With no schedulable worker but revival pending, a dispatch would
+        // only convert the queue slot into an instant worker_unavailable
+        // failure; park until a slot returns to service. With revival off
+        // such failures are terminal and take the normal failure path.
+        while(pool.revives_slots() && pool.schedulable_stateless() == 0) {
+            capacity_event.reset();
+            co_await capacity_event.wait();
+        }
+
+        // Feed at most twice the pool's low budget: deep enough that
+        // workers never idle waiting for the feeder, shallow enough that
+        // the pool queue holds little when a pause or budget cut lands.
+        while(round.inflight >= std::max<std::size_t>(2 * pool.effective_low_limit(), 2)) {
+            round.task_done.reset();
+            co_await round.task_done.wait();
+        }
+
+        auto server_path_id = index_queue[index_queue_pos];
+        index_queue_pos += 1;
         pending_ids.erase(server_path_id);
         // No open-session or hash-freshness shortcut here: index_one is the
         // single decision point for skipping (it knows the pending reason;
@@ -1385,13 +1421,14 @@ kota::task<> Indexer::run_background_indexing() {
             continue;
         }
 
-        ++dispatched;
+        dispatched += 1;
+        round.inflight += 1;
         auto ticket = pending_it->second.ticket;
         // A member coroutine, not an immediately-invoked capturing lambda:
         // a lambda's captures live in the lambda object, which dies at the
         // end of this statement — anything read after the first suspension
         // would dangle. Coroutine parameters are copied into the frame.
-        workers.spawn(run_index_task(server_path_id, ticket, dispatched, total, completed));
+        workers.spawn(run_index_task(server_path_id, ticket, dispatched, total, round));
     }
 
     LOG_DEBUG("Background indexing: all {} tasks spawned, waiting for completion", dispatched);
@@ -1399,14 +1436,14 @@ kota::task<> Indexer::run_background_indexing() {
 
     // Skipped files bump `completed` without a Report emit; refresh the
     // materialized count so a subscriber waking up on End reads the truth.
-    progress_data.completed = completed;
+    progress_data.completed = round.completed;
     progress_data.stage = Progress::Stage::End;
     progress_data.dispatched = dispatched;
     on_progress_changed.emit();
 
     // Safe point to compact: no dispatch loop holds an index into the queue.
-    // Files enqueued while we awaited the workers keep the queue alive for
-    // the next scheduled round.
+    // Files enqueued or requeued past the round snapshot keep the queue
+    // alive for the next scheduled round.
     if(index_queue_pos >= index_queue.size()) {
         assert(pending_ids.empty() && "drained queue must have no pending ids");
         assert(reindex_reasons.empty() && "drained queue must have no pending reasons");
@@ -1427,10 +1464,10 @@ kota::task<> Indexer::run_background_indexing() {
     // one's in-flight batch, racing same-key blob writes on the pool.
     indexing_active = false;
 
-    // Files enqueued while the round was joining its workers saw their
-    // schedule() no-op against indexing_active; without this kick they
-    // would wait for the next external event — and a content-changed
-    // pending file's rows stay skipped for that whole wait.
+    // Files enqueued or requeued while the round ran saw their schedule()
+    // no-op against indexing_active; without this kick they would wait for
+    // the next external event — and a content-changed pending file's rows
+    // stay skipped for that whole wait.
     if(index_queue_pos < index_queue.size()) {
         schedule();
     }

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -1316,27 +1316,39 @@ kota::task<> Indexer::run_round_feeder(kota::task_group<>& workers,
                                        std::size_t total,
                                        std::size_t& dispatched) {
     while(index_queue_pos < round_end) {
-        if(pause_depth > 0)
-            co_await resume_event.wait();
+        // Every wait loops back to re-check ALL gates: a pause arriving
+        // while parked on capacity (or a capacity loss while parked on the
+        // pause) must not let one slot slip through on wake-up.
+        while(true) {
+            if(pause_depth > 0) {
+                co_await resume_event.wait();
+                continue;
+            }
 
-        // With no schedulable worker but revival pending, a dispatch would
-        // only convert the queue slot into an instant worker_unavailable
-        // failure; park until a slot returns to service. With revival off
-        // such failures are terminal and take the normal failure path.
-        while(pool.revives_slots() && pool.schedulable_stateless() == 0) {
-            capacity_event.reset();
-            co_await capacity_event.wait();
-        }
+            // With no schedulable worker but revival pending, a dispatch
+            // would only convert the queue slot into an instant
+            // worker_unavailable failure; park until a slot returns to
+            // service. With revival off such failures are terminal and
+            // take the normal failure path.
+            if(pool.revives_slots() && pool.schedulable_stateless() == 0) {
+                capacity_event.reset();
+                co_await capacity_event.wait();
+                continue;
+            }
 
-        // Feed at most twice the pool's low budget: deep enough that
-        // workers never idle waiting for the feeder, shallow enough that
-        // the pool queue holds little when a pause or budget cut lands.
-        // The floor keeps the window alive when the budget reads zero (a
-        // pool that has not started yet); without it the feeder would wait
-        // on task_done with nothing in flight to ever set it.
-        while(round.inflight >= std::max<std::size_t>(2 * pool.effective_low_limit(), 2)) {
-            round.task_done.reset();
-            co_await round.task_done.wait();
+            // Feed at most twice the pool's low budget: deep enough that
+            // workers never idle waiting for the feeder, shallow enough
+            // that the pool queue holds little when a pause or budget cut
+            // lands. The floor keeps the window alive when the budget
+            // reads zero (a pool that has not started yet); without it
+            // the feeder would wait on task_done with nothing in flight
+            // to ever set it.
+            if(round.inflight >= std::max<std::size_t>(2 * pool.effective_low_limit(), 2)) {
+                round.task_done.reset();
+                co_await round.task_done.wait();
+                continue;
+            }
+            break;
         }
 
         auto server_path_id = index_queue[index_queue_pos];

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -1074,7 +1074,7 @@ kota::task<> Indexer::stop() {
     co_await bg_tasks.join();
 }
 
-void Indexer::schedule() {
+void Indexer::schedule(bool immediate) {
     if(!workspace.config.project.enable_indexing.value || indexing_active || indexing_scheduled)
         return;
     indexing_scheduled = true;
@@ -1082,8 +1082,13 @@ void Indexer::schedule() {
     if(!index_idle_timer) {
         index_idle_timer = std::make_shared<kota::timer>(kota::timer::create(loop));
     }
+    // The idle timeout exists to batch edit storms into one round; a
+    // follow-up round for work requeued during the round just ended has
+    // already been batched by that round and starts right away — a crashed
+    // file's retry must not owe an extra idle window on top of the round
+    // boundary it already waited out.
     index_idle_timer->start(
-        std::chrono::milliseconds(workspace.config.project.idle_timeout_ms.value));
+        std::chrono::milliseconds(immediate ? 0 : workspace.config.project.idle_timeout_ms.value));
 
     if(!bg_tasks.spawn(run_background_indexing())) {
         indexing_scheduled = false;
@@ -1498,7 +1503,7 @@ kota::task<> Indexer::run_background_indexing() {
     // the next external event — and a content-changed pending file's rows
     // stay skipped for that whole wait.
     if(index_queue_pos < index_queue.size()) {
-        schedule();
+        schedule(/*immediate=*/true);
     }
 }
 

--- a/src/server/compiler/indexer.h
+++ b/src/server/compiler/indexer.h
@@ -65,9 +65,7 @@ public:
             Workspace& workspace,
             WorkerPool& pool,
             ContextResolver& contexts,
-            const SessionStore& sessions) :
-        loop(loop), bg_tasks(loop), workspace(workspace), pool(pool), contexts(contexts),
-        sessions(sessions) {}
+            const SessionStore& sessions);
 
     /// Whether open files' disk snapshots are indexed like closed ones.
     /// Off by default: the LSP side never reads an open file's shard (its
@@ -403,7 +401,26 @@ private:
     std::size_t pause_depth = 0;
     kota::event resume_event{true};
 
+    /// Set by on_stateless_capacity: wakes a round parked on "no schedulable
+    /// stateless worker" the moment a slot (re)enters service.
+    kota::event capacity_event{false};
+    Signal<>::Connection capacity_conn;
+
     Progress progress_data;
+
+    /// A round's shared counters, living on run_background_indexing's frame,
+    /// which outlives every spawned task (it joins them before returning).
+    struct RoundState {
+        std::size_t completed = 0;
+
+        /// Dispatched tasks not yet finished; the feeder caps this at twice
+        /// the pool's low budget so the pool queue stays shallow enough for
+        /// pause and budget changes to bite.
+        std::size_t inflight = 0;
+
+        /// Set whenever a task finishes, waking a feeder waiting out the cap.
+        kota::event task_done{false};
+    };
 
     kota::task<> run_background_indexing();
     kota::task<> index_one(std::uint32_t server_path_id,
@@ -412,14 +429,12 @@ private:
                            std::size_t total);
 
     /// One dispatched unit of a background round: index the file, then end
-    /// its pending window (ticket-guarded) and report progress. `completed`
-    /// refers into run_background_indexing's frame, which outlives every
-    /// spawned task (it joins them before returning).
+    /// its pending window (ticket-guarded) and report progress.
     kota::task<> run_index_task(std::uint32_t server_path_id,
                                 std::uint64_t ticket,
                                 std::size_t index,
                                 std::size_t total,
-                                std::size_t& completed);
+                                RoundState& round);
 };
 
 }  // namespace clice

--- a/src/server/compiler/indexer.h
+++ b/src/server/compiler/indexer.h
@@ -413,9 +413,7 @@ private:
     struct RoundState {
         std::size_t completed = 0;
 
-        /// Dispatched tasks not yet finished; the feeder caps this at twice
-        /// the pool's low budget so the pool queue stays shallow enough for
-        /// pause and budget changes to bite.
+        /// Dispatched tasks not yet finished.
         std::size_t inflight = 0;
 
         /// Set whenever a task finishes, waking a feeder waiting out the cap.
@@ -423,6 +421,16 @@ private:
     };
 
     kota::task<> run_background_indexing();
+
+    /// The round's dispatch loop, spawned as a child of `workers` so that a
+    /// shutdown cancel reaches it through the round frame's join — see the
+    /// spawn site. Consumes [index_queue_pos, round_end) and spawns one
+    /// run_index_task per live slot, bounded by the feeder window.
+    kota::task<> run_round_feeder(kota::task_group<>& workers,
+                                  RoundState& round,
+                                  std::size_t round_end,
+                                  std::size_t total,
+                                  std::size_t& dispatched);
     kota::task<> index_one(std::uint32_t server_path_id,
                            std::uint64_t ticket,
                            std::size_t index,

--- a/src/server/compiler/indexer.h
+++ b/src/server/compiler/indexer.h
@@ -133,7 +133,9 @@ public:
     }
 
     /// Schedule background indexing (respects idle timeout and dedup).
-    void schedule();
+    /// `immediate` skips the idle batching window — used by the round tail
+    /// for work requeued during the round that just ended.
+    void schedule(bool immediate = false);
 
     /// Merge a TUIndex result: intern FileVersions, replace the TU's
     /// manifest, and write row blobs only for variants no shard stores yet

--- a/src/server/protocol/worker.h
+++ b/src/server/protocol/worker.h
@@ -269,6 +269,19 @@ struct CancelCompileParams {
     std::string path;
 };
 
+/// Interrupt a stateless worker's in-flight build. Sent by the pool's
+/// cooperative cancel instead of wire-cancelling the build request: the
+/// worker flips the build's stop flag so clang abandons the parse at the
+/// next declaration, while the request still runs to a normal (cancelled)
+/// reply. The sender keeps awaiting that reply, so the slot stays busy —
+/// and the cancel-grace deadline stays armed — until the process is
+/// actually free; a wire cancel would resume the sender immediately and
+/// hand the slot out while the worker is still stuck in the old parse.
+/// Carries no build identity: the pool dispatches at most one build per
+/// worker at a time, and pipe ordering pins any follow-up build behind
+/// the cancel.
+struct CancelBuildParams {};
+
 }  // namespace clice::worker
 
 namespace kota::ipc::protocol {
@@ -310,6 +323,11 @@ struct NotificationTraits<clice::worker::EvictedParams> {
 template <>
 struct NotificationTraits<clice::worker::CancelCompileParams> {
     constexpr inline static std::string_view method = "clice/worker/cancelCompile";
+};
+
+template <>
+struct NotificationTraits<clice::worker::CancelBuildParams> {
+    constexpr inline static std::string_view method = "clice/worker/cancelBuild";
 };
 
 }  // namespace kota::ipc::protocol

--- a/src/server/protocol/worker.h
+++ b/src/server/protocol/worker.h
@@ -192,9 +192,6 @@ enum class BuildKind : uint8_t {
 ///   - SignatureHelp: + text, version, offset, pch, pcms
 ///   - Format:        + text, format_range (optional)
 struct BuildParams {
-    // FIXME: BuildPCM dispatched via compile_graph defaults to Low, which can
-    // starve interactive dep-resolution (hover/completion) behind indexing.
-    // Consider routing module-dep builds as High when triggered by a user request.
     Priority priority = Priority::Low;
     BuildKind kind;
     std::string file;

--- a/src/server/transport/agent_client.cpp
+++ b/src/server/transport/agent_client.cpp
@@ -67,6 +67,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
     peer.on_request(
         [&srv](RequestContext&,
                const CompileCommandParams& params) -> RequestResult<CompileCommandParams> {
+            srv.pool.foreground_pulse();
             std::string directory;
             std::vector<std::string> arguments;
             srv.contexts.resolve_command(params.path, directory, arguments);
@@ -80,6 +81,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
 
     peer.on_request([&srv](RequestContext&,
                            const ProjectFilesParams& params) -> RequestResult<ProjectFilesParams> {
+        srv.pool.foreground_pulse();
         auto& ws = srv.workspace;
         auto filter = params.filter.value_or("all");
 
@@ -140,6 +142,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
 
     peer.on_request(
         [&srv](RequestContext&, const FileDepsParams& params) -> RequestResult<FileDepsParams> {
+            srv.pool.foreground_pulse();
             auto& ws = srv.workspace;
             // find() applies the canonical spelling; a native uppercase-drive
             // path from an agentic client must hit the same ID.
@@ -227,6 +230,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
     peer.on_request(
         [&srv](RequestContext&,
                const ImpactAnalysisParams& params) -> RequestResult<ImpactAnalysisParams> {
+            srv.pool.foreground_pulse();
             auto& ws = srv.workspace;
             auto pool_id = ws.path_pool.find(params.path);
             if(!pool_id)
@@ -264,6 +268,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
 
     peer.on_request([&srv](RequestContext&,
                            const SymbolSearchParams& params) -> RequestResult<SymbolSearchParams> {
+        srv.pool.foreground_pulse();
         srv.on_agentic_query();
         auto max = params.max_results.value_or(100);
         std::string query_lower = llvm::StringRef(params.query).lower();
@@ -308,6 +313,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
 
     peer.on_request(
         [&srv](RequestContext&, const ReadSymbolParams& params) -> RequestResult<ReadSymbolParams> {
+            srv.pool.foreground_pulse();
             srv.on_agentic_query();
             auto resolved = resolve_unique(params, srv.agent_query);
             if(!resolved)
@@ -332,6 +338,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
     peer.on_request(
         [&srv](RequestContext&,
                const DocumentSymbolsParams& params) -> RequestResult<DocumentSymbolsParams> {
+            srv.pool.foreground_pulse();
             srv.on_agentic_query();
             auto is_document_level = [](SymbolKind kind) {
                 return kind == SymbolKind::Namespace || kind == SymbolKind::Class ||
@@ -394,6 +401,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
 
     peer.on_request(
         [&srv](RequestContext&, const DefinitionParams& params) -> RequestResult<DefinitionParams> {
+            srv.pool.foreground_pulse();
             srv.on_agentic_query();
             auto resolved = resolve_unique(
                 ReadSymbolParams{params.name, params.path, params.line, params.symbol_id},
@@ -422,6 +430,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
 
     peer.on_request([&srv](RequestContext&,
                            const ReferencesParams& params) -> RequestResult<ReferencesParams> {
+        srv.pool.foreground_pulse();
         srv.on_agentic_query();
         auto resolved = resolve_unique(
             ReadSymbolParams{params.name, params.path, params.line, params.symbol_id},
@@ -459,6 +468,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
 
     peer.on_request(
         [&srv](RequestContext&, const CallGraphParams& params) -> RequestResult<CallGraphParams> {
+            srv.pool.foreground_pulse();
             srv.on_agentic_query();
             auto resolved = resolve_unique(
                 ReadSymbolParams{params.name, params.path, params.line, params.symbol_id},
@@ -522,6 +532,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
     peer.on_request(
         [&srv](RequestContext&,
                const TypeHierarchyParams& params) -> RequestResult<TypeHierarchyParams> {
+            srv.pool.foreground_pulse();
             srv.on_agentic_query();
             auto resolved = resolve_unique(
                 ReadSymbolParams{params.name, params.path, params.line, params.symbol_id},
@@ -581,6 +592,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
         });
 
     peer.on_request([&srv](RequestContext&, const StatusParams&) -> RequestResult<StatusParams> {
+        srv.pool.foreground_pulse();
         // The progress numbers describe the current round — or the last
         // one, retained after it ends; the live queue is compacted between
         // rounds and would read as "nothing was ever indexed".

--- a/src/server/transport/lsp_client.cpp
+++ b/src/server/transport/lsp_client.cpp
@@ -89,6 +89,7 @@ void LSPClient::register_lifecycle() {
 
     peer.on_request([this](RequestContext& ctx, const protocol::InitializeParams& params)
                         -> RequestResult<protocol::InitializeParams> {
+        this->server.pool.foreground_pulse();
         auto& srv = this->server;
         if(srv.lifecycle != ServerLifecycle::Uninitialized) {
             co_return kota::outcome_error(protocol::Error{"Server already initialized"});
@@ -218,6 +219,7 @@ void LSPClient::register_lifecycle() {
     peer.on_request(
         [this](RequestContext& ctx,
                const protocol::ShutdownParams& params) -> RequestResult<protocol::ShutdownParams> {
+            this->server.pool.foreground_pulse();
             this->server.lifecycle = ServerLifecycle::ShuttingDown;
             LOG_INFO("Shutdown requested");
             co_return nullptr;
@@ -331,6 +333,7 @@ void LSPClient::register_document_sync() {
 
 void LSPClient::register_language_features() {
     peer.on_request([this](RequestContext& ctx, const protocol::HoverParams& params) -> RawResult {
+        this->server.pool.foreground_pulse();
         auto& srv = this->server;
         auto [path, path_id, session] =
             resolve_uri(params.text_document_position_params.text_document.uri);
@@ -343,6 +346,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request(
         [this](RequestContext& ctx, const protocol::SemanticTokensParams& params) -> RawResult {
+            this->server.pool.foreground_pulse();
             auto& srv = this->server;
             auto [path, path_id, session] = resolve_uri(params.text_document.uri);
             if(!session)
@@ -352,6 +356,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request(
         [this](RequestContext& ctx, const protocol::InlayHintParams& params) -> RawResult {
+            this->server.pool.foreground_pulse();
             auto& srv = this->server;
             auto [path, path_id, session] = resolve_uri(params.text_document.uri);
             if(!session)
@@ -361,6 +366,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request(
         [this](RequestContext& ctx, const protocol::FoldingRangeParams& params) -> RawResult {
+            this->server.pool.foreground_pulse();
             auto& srv = this->server;
             auto [path, path_id, session] = resolve_uri(params.text_document.uri);
             if(!session)
@@ -370,6 +376,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request(
         [this](RequestContext& ctx, const protocol::DocumentSymbolParams& params) -> RawResult {
+            this->server.pool.foreground_pulse();
             auto& srv = this->server;
             auto [path, path_id, session] = resolve_uri(params.text_document.uri);
             if(!session)
@@ -379,6 +386,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request(
         [this](RequestContext& ctx, const protocol::DocumentLinkParams& params) -> RawResult {
+            this->server.pool.foreground_pulse();
             auto [path, path_id, session] = resolve_uri(params.text_document.uri);
             if(!session)
                 co_return kota::outcome_error(document_not_open());
@@ -390,6 +398,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request(
         [this](RequestContext& ctx, const protocol::CodeActionParams& params) -> RawResult {
+            this->server.pool.foreground_pulse();
             auto& srv = this->server;
             auto [path, path_id, session] = resolve_uri(params.text_document.uri);
             if(!session)
@@ -399,6 +408,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request([this](RequestContext& ctx,
                            const protocol::DefinitionParams& params) -> RawResult {
+        this->server.pool.foreground_pulse();
         auto& uri = params.text_document_position_params.text_document.uri;
         auto& pos = params.text_document_position_params.position;
         auto [path, path_id, session] = resolve_uri(uri);
@@ -410,6 +420,7 @@ void LSPClient::register_language_features() {
     // returned as [] — never an error.
     peer.on_request(
         [this](RequestContext& ctx, const protocol::ReferenceParams& params) -> RawResult {
+            this->server.pool.foreground_pulse();
             auto& uri = params.text_document_position_params.text_document.uri;
             auto& pos = params.text_document_position_params.position;
             auto [path, path_id, session] = resolve_uri(uri);
@@ -421,6 +432,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request(
         [this](RequestContext& ctx, const protocol::TypeDefinitionParams& params) -> RawResult {
+            this->server.pool.foreground_pulse();
             auto& uri = params.text_document_position_params.text_document.uri;
             auto& pos = params.text_document_position_params.position;
             auto [path, path_id, session] = resolve_uri(uri);
@@ -429,6 +441,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request(
         [this](RequestContext& ctx, const protocol::ImplementationParams& params) -> RawResult {
+            this->server.pool.foreground_pulse();
             auto& uri = params.text_document_position_params.text_document.uri;
             auto& pos = params.text_document_position_params.position;
             auto [path, path_id, session] = resolve_uri(uri);
@@ -437,6 +450,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request(
         [this](RequestContext& ctx, const protocol::DeclarationParams& params) -> RawResult {
+            this->server.pool.foreground_pulse();
             auto& uri = params.text_document_position_params.text_document.uri;
             auto& pos = params.text_document_position_params.position;
             auto [path, path_id, session] = resolve_uri(uri);
@@ -445,6 +459,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request([this](RequestContext& ctx,
                            const protocol::CompletionParams& params) -> RawResult {
+        this->server.pool.foreground_pulse();
         auto& srv = this->server;
         auto [path, path_id, session] =
             resolve_uri(params.text_document_position_params.text_document.uri);
@@ -462,6 +477,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request(
         [this](RequestContext& ctx, const protocol::SignatureHelpParams& params) -> RawResult {
+            this->server.pool.foreground_pulse();
             auto& srv = this->server;
             auto [path, path_id, session] =
                 resolve_uri(params.text_document_position_params.text_document.uri);
@@ -475,6 +491,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request(
         [this](RequestContext& ctx, const protocol::DocumentFormattingParams& params) -> RawResult {
+            this->server.pool.foreground_pulse();
             auto& srv = this->server;
             auto [path, path_id, session] = resolve_uri(params.text_document.uri);
             if(!session)
@@ -484,6 +501,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request([this](RequestContext& ctx,
                            const protocol::DocumentRangeFormattingParams& params) -> RawResult {
+        this->server.pool.foreground_pulse();
         auto& srv = this->server;
         auto [path, path_id, session] = resolve_uri(params.text_document.uri);
         if(!session)
@@ -493,6 +511,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request([this](RequestContext& ctx,
                            const protocol::CallHierarchyPrepareParams& params) -> RawResult {
+        this->server.pool.foreground_pulse();
         auto& uri = params.text_document_position_params.text_document.uri;
         auto& pos = params.text_document_position_params.position;
         auto [path, path_id, session] = resolve_uri(uri);
@@ -501,6 +520,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request([this](RequestContext& ctx,
                            const protocol::CallHierarchyIncomingCallsParams& params) -> RawResult {
+        this->server.pool.foreground_pulse();
         auto [path, path_id, session] = resolve_uri(params.item.uri);
         co_return co_await this->server.features.call_hierarchy_incoming(session,
                                                                          path,
@@ -509,6 +529,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request([this](RequestContext& ctx,
                            const protocol::CallHierarchyOutgoingCallsParams& params) -> RawResult {
+        this->server.pool.foreground_pulse();
         auto [path, path_id, session] = resolve_uri(params.item.uri);
         co_return co_await this->server.features.call_hierarchy_outgoing(session,
                                                                          path,
@@ -517,6 +538,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request([this](RequestContext& ctx,
                            const protocol::TypeHierarchyPrepareParams& params) -> RawResult {
+        this->server.pool.foreground_pulse();
         auto& uri = params.text_document_position_params.text_document.uri;
         auto& pos = params.text_document_position_params.position;
         auto [path, path_id, session] = resolve_uri(uri);
@@ -525,6 +547,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request([this](RequestContext& ctx,
                            const protocol::TypeHierarchySupertypesParams& params) -> RawResult {
+        this->server.pool.foreground_pulse();
         auto [path, path_id, session] = resolve_uri(params.item.uri);
         co_return co_await this->server.features.type_hierarchy_supertypes(session,
                                                                            path,
@@ -533,6 +556,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request([this](RequestContext& ctx,
                            const protocol::TypeHierarchySubtypesParams& params) -> RawResult {
+        this->server.pool.foreground_pulse();
         auto [path, path_id, session] = resolve_uri(params.item.uri);
         co_return co_await this->server.features.type_hierarchy_subtypes(session,
                                                                          path,
@@ -541,6 +565,7 @@ void LSPClient::register_language_features() {
 
     peer.on_request(
         [this](RequestContext& ctx, const protocol::WorkspaceSymbolParams& params) -> RawResult {
+            this->server.pool.foreground_pulse();
             co_return co_await this->server.features.workspace_symbol(params.query);
         });
 }
@@ -551,6 +576,7 @@ void LSPClient::register_extensions() {
     peer.on_request(
         "clice/queryContext",
         [this](RequestContext& ctx, const ext::QueryContextParams& params) -> RawResult {
+            this->server.pool.foreground_pulse();
             auto [path, path_id, session] = resolve_uri(params.uri);
             co_return to_raw(this->server.contexts.query_contexts(path, path_id, params));
         });
@@ -558,6 +584,7 @@ void LSPClient::register_extensions() {
     peer.on_request(
         "clice/currentContext",
         [this](RequestContext& ctx, const ext::CurrentContextParams& params) -> RawResult {
+            this->server.pool.foreground_pulse();
             auto [path, path_id, session] = resolve_uri(params.uri);
             co_return to_raw(this->server.contexts.current_context(path, session.get(), params));
         });
@@ -565,6 +592,7 @@ void LSPClient::register_extensions() {
     peer.on_request(
         "clice/switchContext",
         [this](RequestContext& ctx, const ext::SwitchContextParams& params) -> RawResult {
+            this->server.pool.foreground_pulse();
             auto [path, path_id, session] = resolve_uri(params.uri);
             auto [context_path, context_path_id, context_session] = resolve_uri(params.context_uri);
             // The session reset lives inside switch_context (single owner,

--- a/src/server/transport/lsp_client.cpp
+++ b/src/server/transport/lsp_client.cpp
@@ -234,6 +234,7 @@ void LSPClient::register_document_sync() {
         auto& srv = this->server;
         if(past_shutdown(srv.lifecycle))
             return;
+        srv.pool.foreground_pulse();
 
         auto [path, path_id, session] = resolve_uri(params.text_document.uri);
 
@@ -263,6 +264,7 @@ void LSPClient::register_document_sync() {
         auto& srv = this->server;
         if(past_shutdown(srv.lifecycle))
             return;
+        srv.pool.foreground_pulse();
 
         auto [path, path_id, session] = resolve_uri(params.text_document.uri);
         if(!session) {
@@ -318,6 +320,7 @@ void LSPClient::register_document_sync() {
         // ready reads the saved disk content anyway.
         if(srv.lifecycle != ServerLifecycle::Ready)
             return;
+        srv.pool.foreground_pulse();
 
         auto [path, path_id, session] = resolve_uri(params.text_document.uri);
         srv.dispatch(FileEvent::buffer_saved(path_id));

--- a/src/server/worker/stateless_worker.cpp
+++ b/src/server/worker/stateless_worker.cpp
@@ -407,7 +407,21 @@ int run_stateless_worker_mode(const std::string& worker_name, const std::string&
         return 1;
     }
 
+    // Stop flag of the most recent build request, published before its
+    // pool-thread hop so a CancelBuild aimed at it still lands. Never
+    // cleared: the master sends CancelBuild only while it awaits that
+    // build's reply, and pipe ordering pins any follow-up build behind the
+    // cancel, so a set can only ever hit the stale build's flag.
+    std::shared_ptr<std::atomic_bool> build_stop;
+
     kota::ipc::BincodePeer peer(loop, std::move(*transport_result));
+
+    peer.on_notification([&build_stop](const worker::CancelBuildParams&) {
+        LOG_DEBUG("CancelBuild notification received");
+        if(build_stop) {
+            build_stop->store(true, std::memory_order_relaxed);
+        }
+    });
 
     peer.on_request([&](RequestContext& ctx,
                         const worker::BuildParams& params) -> RequestResult<worker::BuildParams> {
@@ -419,6 +433,7 @@ int run_stateless_worker_mode(const std::string& worker_name, const std::string&
         // even the parse itself stops instead of running to completion for
         // a result nobody will read.
         auto stop = std::make_shared<std::atomic_bool>(false);
+        build_stop = stop;
         auto result = co_await kota::queue(
             [&]() -> worker::BuildResult {
                 if(stop->load(std::memory_order_relaxed)) {

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -179,6 +179,8 @@ bool WorkerPool::spawn_worker(bool stateful) {
     if(stateful)
         install_evict_handler(workers[index], index);
     worker_tasks.spawn(monitor_worker(index, stateful));
+    if(!stateful)
+        on_stateless_capacity.emit();
     return true;
 }
 
@@ -207,8 +209,10 @@ bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
         install_evict_handler(w, index);
     worker_tasks.spawn(monitor_worker(index, stateful));
 
-    if(!stateful)
+    if(!stateful) {
         try_dispatch_pending();
+        on_stateless_capacity.emit();
+    }
 
     LOG_INFO("Worker {} restarted (crash streak {})", w.name, w.crash_streak);
     return true;

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -681,6 +681,8 @@ std::size_t WorkerPool::claim_stateless(std::size_t index, worker::Priority prio
     auto& w = stateless_workers[index];
     w.busy = true;
     w.low_priority = priority == worker::Priority::Low;
+    next_claim_epoch += 1;
+    w.claim_epoch = next_claim_epoch;
     return index;
 }
 
@@ -802,21 +804,7 @@ kota::task<> WorkerPool::monitor_loop() {
         co_await kota::sleep(std::chrono::milliseconds(3000), loop);
 
         tick_foreground();
-
-        // A cancelled low request that ignored its stop flag past the grace
-        // window is stuck inside one declaration; reclaim the process.
-        auto now = std::chrono::steady_clock::now();
-        for(std::size_t i = 0; i < stateless_workers.size(); i += 1) {
-            auto& w = stateless_workers[i];
-            if(w.state == SlotState::Alive && w.busy &&
-               w.cancel_requested_at != std::chrono::steady_clock::time_point{} &&
-               now - w.cancel_requested_at > cancel_grace) {
-                LOG_WARN("Worker {} ignored a cooperative cancel; killing it", w.name);
-                w.preempted = true;
-                reset_streak_if_healthy(w);
-                mark_worker_dead(i, false, true);
-            }
-        }
+        tick_cancel_grace();
 
         auto mem = kota::sys::memory();
         if(mem.total == 0)
@@ -861,19 +849,50 @@ void WorkerPool::tick_foreground() {
     try_dispatch_pending();
 }
 
+void WorkerPool::tick_cancel_grace() {
+    // A cancelled low request that ignored its stop flag past the grace
+    // window is stuck inside one declaration; reclaim the process.
+    auto now = std::chrono::steady_clock::now();
+    for(std::size_t i = 0; i < stateless_workers.size(); i += 1) {
+        auto& w = stateless_workers[i];
+        if(w.state == SlotState::Alive && w.busy &&
+           w.cancel_requested_at != std::chrono::steady_clock::time_point{} &&
+           now - w.cancel_requested_at > cancel_grace) {
+            LOG_WARN("Worker {} ignored a cooperative cancel; killing it", w.name);
+            w.preempted = true;
+            reset_streak_if_healthy(w);
+            mark_worker_dead(i, false, true);
+        }
+    }
+}
+
 void WorkerPool::cancel_low_priority(std::size_t count) {
-    std::size_t cancelled = 0;
     // Newest claim first: the youngest compile has the least work to lose,
-    // and always starting from index 0 would starve the same slot's file.
-    for(std::size_t i = stateless_workers.size(); i > 0 && cancelled < count;) {
-        i -= 1;
+    // and a fixed scan order would keep sacrificing the same slot's file.
+    llvm::SmallVector<std::size_t> victims;
+    for(std::size_t i = 0; i < stateless_workers.size(); i += 1) {
         auto& w = stateless_workers[i];
         if(w.state != SlotState::Alive || !w.busy || !w.low_priority)
             continue;
         if(w.cancel_requested_at != std::chrono::steady_clock::time_point{})
             continue;
-        if(w.preempt_source)
-            w.preempt_source->cancel();
+        // A claim whose sender has not resumed yet has no cancellation
+        // source installed; skip it entirely — stamping it would leave a
+        // request that never saw a cancel to be grace-killed as if it had
+        // ignored one. The invariant: a stamped slot was really cancelled.
+        if(!w.preempt_source)
+            continue;
+        victims.push_back(i);
+    }
+    std::ranges::sort(victims, std::greater{}, [this](std::size_t i) {
+        return stateless_workers[i].claim_epoch;
+    });
+    std::size_t cancelled = 0;
+    for(auto i: victims) {
+        if(cancelled >= count)
+            break;
+        auto& w = stateless_workers[i];
+        w.preempt_source->cancel();
         w.cancel_requested_at = std::chrono::steady_clock::now();
         cancelled += 1;
     }
@@ -963,8 +982,12 @@ void WorkerPool::tick_scaling(double available_ratio) {
     // for high-priority requests: the reserved slot stays idle, so busy
     // never equals alive, but the pool is effectively saturated for
     // low-priority (indexing) work.
+    // A zeroed low budget (severe memory pressure) is deliberate shutdown,
+    // not saturation: counting it would let the scaler re-admit low work
+    // past the memory controller's recovery threshold.
+    auto low_budget = effective_low_limit();
     bool saturated = (alive > 0 && busy == alive && has_queued) ||
-                     (low_busy_count() >= effective_low_limit() && !low_queue.empty());
+                     (low_budget > 0 && low_busy_count() >= low_budget && !low_queue.empty());
 
     if(saturated) {
         saturated_cycles += 1;

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -703,11 +703,11 @@ kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority prio
 
         // A queued High request needs a process, not just CPU: with every
         // slot busy, cooperatively cancel one low compile so a slot frees
-        // at the next declaration boundary instead of at end-of-TU. Slots
-        // already asked stay asked (cancel_low_priority skips them), so
+        // at the next declaration boundary instead of at end-of-TU. The
+        // deficit already counts slots asked and highs queued, so
         // re-entering this loop cannot over-cancel.
         if(priority == P::High && pick_idle_stateless() == SIZE_MAX)
-            cancel_low_priority(1);
+            cancel_low_priority(low_reclaim_deficit(1));
 
         // Queue up and suspend until try_dispatch_pending() claims a worker
         // for us or wakes us to observe pool death. The destructor covers
@@ -824,14 +824,30 @@ void WorkerPool::note_foreground() {
     if(foreground_active)
         return;
     foreground_active = true;
+    if(auto deficit = low_reclaim_deficit()) {
+        LOG_INFO("Foreground active: low budget -> {}, cancelling {} in-flight",
+                 effective_low_limit(),
+                 deficit);
+        cancel_low_priority(deficit);
+    }
+}
+
+std::size_t WorkerPool::low_reclaim_deficit(std::size_t pending_high) {
     auto cap = effective_low_limit();
     auto busy_low = low_busy_count();
-    if(busy_low > cap) {
-        LOG_INFO("Foreground active: low budget -> {}, cancelling {} in-flight",
-                 cap,
-                 busy_low - cap);
-        cancel_low_priority(busy_low - cap);
+    std::size_t need = busy_low > cap ? busy_low - cap : 0;
+    // Queued High requests each need a freed process; with a slot idle the
+    // queue is a transient the next dispatch drains without a sacrifice.
+    auto high_need = high_queue.size() + pending_high;
+    if(high_need > 0 && pick_idle_stateless() == SIZE_MAX) {
+        need = std::max(need, high_need);
     }
+    auto asked = static_cast<std::size_t>(
+        std::ranges::count_if(stateless_workers, [](const WorkerProcess& w) {
+            return w.state == SlotState::Alive && w.busy && w.low_priority &&
+                   w.cancel_requested_at != std::chrono::steady_clock::time_point{};
+        }));
+    return need > asked ? need - asked : 0;
 }
 
 void WorkerPool::tick_foreground() {
@@ -879,7 +895,8 @@ void WorkerPool::cancel_low_priority(std::size_t count) {
         // A claim whose sender has not resumed yet has no cancellation
         // source installed; skip it entirely — stamping it would leave a
         // request that never saw a cancel to be grace-killed as if it had
-        // ignored one. The invariant: a stamped slot was really cancelled.
+        // ignored one. The demand is not dropped: the sender re-checks the
+        // deficit when it arms and gives the claim back on the spot.
         if(!w.preempt_source)
             continue;
         victims.push_back(i);
@@ -893,6 +910,8 @@ void WorkerPool::cancel_low_priority(std::size_t count) {
             break;
         auto& w = stateless_workers[i];
         w.preempt_source->cancel();
+        if(w.peer)
+            w.peer->send_notification(worker::CancelBuildParams{});
         w.cancel_requested_at = std::chrono::steady_clock::now();
         cancelled += 1;
     }
@@ -1098,13 +1117,10 @@ void WorkerPool::preempt_low_priority(std::size_t count) {
         if(w.state != SlotState::Alive || !w.busy || !w.low_priority)
             continue;
 
-        // Signal the sender first, then take the slot out of rotation and
-        // kill the process — the kill is what actually frees the memory.
-        // The kill fails the in-flight request, and the sender classifies
-        // that failure as preemption by consulting the source. Today the
-        // runtime only queues waiters on cancel/close (never resumes them
-        // inline), so either order behaves the same; cancelling first
-        // keeps the classification correct without depending on that.
+        // Mark the source before taking the slot out of rotation: the kill
+        // is what actually frees the memory and fails the in-flight
+        // request, and the sender classifies that failure as preemption by
+        // consulting the source.
         auto source = w.preempt_source;
         w.preempted = true;
         // The preempt respawn skips crash accounting, so credit a healthy

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -910,6 +910,11 @@ void WorkerPool::cancel_low_priority(std::size_t count) {
             break;
         auto& w = stateless_workers[i];
         w.preempt_source->cancel();
+        // An Alive slot always holds a peer in production (mark_worker_dead
+        // drops the peer and the Alive state in one step); the conditional
+        // exists for fixture-built slots. Either way the source above makes
+        // the sender observe cancelled, and a slot that dies before the
+        // grace expires has its stamp cleared by the respawn.
         if(w.peer)
             w.peer->send_notification(worker::CancelBuildParams{});
         w.cancel_requested_at = std::chrono::steady_clock::now();

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -81,6 +81,12 @@ std::size_t WorkerPool::low_busy_count() const {
     });
 }
 
+std::size_t WorkerPool::high_busy_count() const {
+    return std::ranges::count_if(stateless_workers, [](const WorkerProcess& w) {
+        return w.state == SlotState::Alive && w.busy && !w.low_priority;
+    });
+}
+
 std::size_t WorkerPool::stateless_capacity() const {
     return std::ranges::count_if(stateless_workers, [](const WorkerProcess& w) {
         return w.state != SlotState::Dead && w.state != SlotState::Retired && !w.retiring;
@@ -201,6 +207,7 @@ bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
     w.low_priority = false;
     w.retiring = false;
     w.preempted = false;
+    w.cancel_requested_at = {};
     w.spawn_time = std::chrono::steady_clock::now();
     // generation was bumped at death; crash_streak carries across restarts
     // until a healthy uptime resets it.
@@ -692,6 +699,14 @@ kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority prio
                 co_return claim_stateless(idx, priority);
         }
 
+        // A queued High request needs a process, not just CPU: with every
+        // slot busy, cooperatively cancel one low compile so a slot frees
+        // at the next declaration boundary instead of at end-of-TU. Slots
+        // already asked stay asked (cancel_low_priority skips them), so
+        // re-entering this loop cannot over-cancel.
+        if(priority == P::High && pick_idle_stateless() == SIZE_MAX)
+            cancel_low_priority(1);
+
         // Queue up and suspend until try_dispatch_pending() claims a worker
         // for us or wakes us to observe pool death. The destructor covers
         // cancellation while queued or between dispatch and resume.
@@ -721,6 +736,7 @@ void WorkerPool::release_stateless_slot(std::size_t worker_index) {
     w.busy = false;
     w.low_priority = false;
     w.preempt_source.reset();
+    w.cancel_requested_at = {};
     LOG_DEBUG("Release {} (busy={}, low_busy={})", w.name, busy_stateless(), low_busy_count());
     try_dispatch_pending();
 }
@@ -785,6 +801,23 @@ kota::task<> WorkerPool::monitor_loop() {
     while(true) {
         co_await kota::sleep(std::chrono::milliseconds(3000), loop);
 
+        tick_foreground();
+
+        // A cancelled low request that ignored its stop flag past the grace
+        // window is stuck inside one declaration; reclaim the process.
+        auto now = std::chrono::steady_clock::now();
+        for(std::size_t i = 0; i < stateless_workers.size(); i += 1) {
+            auto& w = stateless_workers[i];
+            if(w.state == SlotState::Alive && w.busy &&
+               w.cancel_requested_at != std::chrono::steady_clock::time_point{} &&
+               now - w.cancel_requested_at > cancel_grace) {
+                LOG_WARN("Worker {} ignored a cooperative cancel; killing it", w.name);
+                w.preempted = true;
+                reset_streak_if_healthy(w);
+                mark_worker_dead(i, false, true);
+            }
+        }
+
         auto mem = kota::sys::memory();
         if(mem.total == 0)
             continue;
@@ -796,6 +829,56 @@ kota::task<> WorkerPool::monitor_loop() {
         tick_memory(ratio);
         tick_scaling(ratio);
     }
+}
+
+void WorkerPool::note_foreground() {
+    last_fg_activity = std::chrono::steady_clock::now();
+    if(foreground_active)
+        return;
+    foreground_active = true;
+    auto cap = effective_low_limit();
+    auto busy_low = low_busy_count();
+    if(busy_low > cap) {
+        LOG_INFO("Foreground active: low budget -> {}, cancelling {} in-flight",
+                 cap,
+                 busy_low - cap);
+        cancel_low_priority(busy_low - cap);
+    }
+}
+
+void WorkerPool::tick_foreground() {
+    if(!foreground_active)
+        return;
+    if(foreground_busy()) {
+        last_fg_activity = std::chrono::steady_clock::now();
+        return;
+    }
+    if(std::chrono::steady_clock::now() - last_fg_activity < fg_hold)
+        return;
+    foreground_active = false;
+    LOG_DEBUG("Foreground idle: low budget -> {}", effective_low_limit());
+    // The reopened budget can admit queued low work right away.
+    try_dispatch_pending();
+}
+
+void WorkerPool::cancel_low_priority(std::size_t count) {
+    std::size_t cancelled = 0;
+    // Newest claim first: the youngest compile has the least work to lose,
+    // and always starting from index 0 would starve the same slot's file.
+    for(std::size_t i = stateless_workers.size(); i > 0 && cancelled < count;) {
+        i -= 1;
+        auto& w = stateless_workers[i];
+        if(w.state != SlotState::Alive || !w.busy || !w.low_priority)
+            continue;
+        if(w.cancel_requested_at != std::chrono::steady_clock::time_point{})
+            continue;
+        if(w.preempt_source)
+            w.preempt_source->cancel();
+        w.cancel_requested_at = std::chrono::steady_clock::now();
+        cancelled += 1;
+    }
+    if(cancelled > 0)
+        LOG_INFO("Cooperatively cancelled {} low-priority requests", cancelled);
 }
 
 void WorkerPool::tick_memory(double available_ratio) {
@@ -813,15 +896,17 @@ void WorkerPool::tick_memory(double available_ratio) {
         saturated_cycles,
         idle_cycles);
 
-    // Severe pressure: drop the low allowance to its floor and preempt all
-    // running low-priority work — killing the workers releases their memory
-    // immediately, and they respawn without crash accounting.
+    // Severe pressure: zero the low allowance and preempt all running
+    // low-priority work — killing the workers releases their memory
+    // immediately, and they respawn without crash accounting. Zero, not
+    // one: with any allowance left, the preemption's own dispatch kick
+    // would admit a fresh compile into the very pressure being relieved.
     if(available_ratio < 0.10) {
-        if(low_limit > 1) {
+        if(low_limit > 0) {
             if(w_max == 0 || low_limit > w_max)
                 w_max = low_limit;
-            low_limit = 1;
-            LOG_WARN("low_limit -> 1 (severe memory pressure: {:.0f}% available)",
+            low_limit = 0;
+            LOG_WARN("low_limit -> 0 (severe memory pressure: {:.0f}% available)",
                      available_ratio * 100);
         }
         if(auto busy_low = low_busy_count())
@@ -842,7 +927,11 @@ void WorkerPool::tick_memory(double available_ratio) {
                      low_limit,
                      available_ratio * 100);
         }
-    } else if(available_ratio > 0.40 && low_limit < max_low_limit()) {
+    } else if(available_ratio > 0.40 && low_limit < max_low_limit() && !foreground_active) {
+        // The foreground gate is anti-windup: while the cap masks the low
+        // budget, memory freed by the squeeze itself would otherwise walk
+        // the window back to its old peak, and the cap's falling edge would
+        // release that untested burst all at once.
         backoff_cooldown = 0;
         if(w_max > 0 && low_limit < w_max) {
             // CUBIC-style fast recovery: close half the gap to the last
@@ -888,7 +977,10 @@ void WorkerPool::tick_scaling(double available_ratio) {
         idle_cycles = 0;
     }
 
-    if(saturated_cycles >= scale_up_ticks && available_ratio > 0.30) {
+    // No scale-up while the foreground cap binds: the "saturation" is the
+    // cap doing its job, and new slots would feed the post-cap ramp-up, not
+    // the user.
+    if(saturated_cycles >= scale_up_ticks && available_ratio > 0.30 && !foreground_active) {
         if(scale_up_worker())
             saturated_cycles = 0;
     }

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -8,6 +8,7 @@
 #include <optional>
 
 #include "server/protocol/worker.h"
+#include "support/signal.h"
 
 #include "kota/async/async.h"
 #include "kota/ipc/codec/bincode.h"
@@ -178,6 +179,21 @@ public:
     bool revives_slots() const {
         return started && options.revive_after.count() > 0;
     }
+
+    /// Alive stateless slots that also accept new work: a retiring slot
+    /// stays alive to finish its request but is skipped by dispatch.
+    std::size_t schedulable_stateless() const;
+
+    /// The current low-priority concurrency budget. Public so the indexer's
+    /// feeder can size its in-flight window from it.
+    std::size_t effective_low_limit() const {
+        return std::min(low_limit, max_low_limit());
+    }
+
+    /// Emitted when a stateless slot (re)enters service — spawn, respawn,
+    /// revive, scale-up. The indexer's capacity gate wakes on it instead of
+    /// spinning dispatch attempts against a pool with no schedulable worker.
+    Signal<> on_stateless_capacity;
 
     /// Callback invoked when a worker process crashes.
     std::function<void(const WorkerCrashInfo&)> on_crash;
@@ -352,10 +368,6 @@ private:
     /// Stateless slots that can serve requests now.
     std::size_t alive_stateless() const;
 
-    /// Alive stateless slots that also accept new work: a retiring slot
-    /// stays alive to finish its request but is skipped by dispatch.
-    std::size_t schedulable_stateless() const;
-
     /// Alive stateless slots with a request in flight.
     std::size_t busy_stateless() const;
 
@@ -384,10 +396,6 @@ private:
     std::size_t max_low_limit() const {
         auto live = schedulable_stateless();
         return live > 1 ? live - 1 : live;
-    }
-
-    std::size_t effective_low_limit() const {
-        return std::min(low_limit, max_low_limit());
     }
 
     /// Wait for an idle stateless worker. Returns SIZE_MAX when no slot can

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -184,10 +184,20 @@ public:
     /// stays alive to finish its request but is skipped by dispatch.
     std::size_t schedulable_stateless() const;
 
-    /// The current low-priority concurrency budget. Public so the indexer's
-    /// feeder can size its in-flight window from it.
+    /// The current low-priority concurrency budget: the memory controller's
+    /// window, additionally clamped to the foreground cap while the user is
+    /// active. Public so the indexer's feeder can size its in-flight window
+    /// from it.
     std::size_t effective_low_limit() const {
-        return std::min(low_limit, max_low_limit());
+        return std::min(low_limit, foreground_active ? foreground_cap() : max_low_limit());
+    }
+
+    /// Foreground evidence from outside the pool: didOpen/didChange/didSave
+    /// and friends. Starts (or refreshes) the hold window; requests need no
+    /// call of their own — every stateful dispatch and every High stateless
+    /// dispatch notes itself, and in-flight ones hold the window open.
+    void foreground_pulse() {
+        note_foreground();
     }
 
     /// Emitted when a stateless slot (re)enters service — spawn, respawn,
@@ -271,6 +281,11 @@ private:
         /// Stateless only: cancels the in-flight low-priority request so its
         /// sender observes preemption instead of a bare transport error.
         std::shared_ptr<kota::cancellation_source> preempt_source;
+
+        /// When a cooperative cancel was requested of this slot's in-flight
+        /// low request; zero when none is outstanding. The monitor kills the
+        /// process if it blows past cancel_grace without returning.
+        std::chrono::steady_clock::time_point cancel_requested_at{};
     };
 
     kota::event_loop& loop;
@@ -387,16 +402,37 @@ private:
         return stateless_capacity() > 0;
     }
 
-    /// Reserve one worker for high-priority requests by capping low-priority
-    /// concurrency at one below the slots that can be scheduled right now.
-    /// A slot dying, awaiting respawn, or retiring cannot take new work;
-    /// counting it would let low-priority requests occupy every schedulable
-    /// worker. With a single schedulable worker this collapses to 1: both
-    /// priorities share it, and high wins only via queue ordering.
+    /// The low-priority ceiling with no foreground activity: every
+    /// schedulable slot. Foreground bursts reclaim capacity through the
+    /// foreground cap and the deficit cancel in acquire_stateless_slot
+    /// instead of a standing reservation, which would leave a slot idle
+    /// through every fully-idle stretch.
     std::size_t max_low_limit() const {
-        auto live = schedulable_stateless();
-        return live > 1 ? live - 1 : live;
+        return schedulable_stateless();
     }
+
+    /// The low budget while the user is active: a fixed share of the
+    /// configured capacity (not of the live slot count, which the scaler
+    /// moves and which would turn the share into a feedback loop).
+    std::size_t foreground_cap() const {
+        return std::max<std::size_t>(1, options.max_stateless * 3 / 10);
+    }
+
+    /// Rising edge of foreground activity: clamp the budget now and
+    /// cooperatively cancel the excess in-flight low work so the CPU frees
+    /// within a declaration boundary, not at end-of-TU.
+    void note_foreground();
+
+    /// Falling edge, driven by the monitor tick: leases gone and the hold
+    /// window expired reopen the idle budget.
+    void tick_foreground();
+
+    /// Cooperatively cancel up to `count` in-flight low-priority requests:
+    /// the wire cancellation trips the worker's stop flag, the compile
+    /// returns at the next declaration boundary, and the sender observes
+    /// dispatch_errc::cancelled — the process survives. A victim that
+    /// ignores the cancel past cancel_grace is killed by the monitor.
+    void cancel_low_priority(std::size_t count);
 
     /// Wait for an idle stateless worker. Returns SIZE_MAX when no slot can
     /// serve the request anymore (pool stopped or all slots given up).
@@ -477,6 +513,31 @@ private:
     /// processes respawn immediately without crash accounting.
     void preempt_low_priority(std::size_t count);
 
+    /// Foreground activity state: in-flight foreground work (stateful or
+    /// High stateless), or a pulse within fg_hold, keeps the low budget
+    /// clamped to foreground_cap(). Rising edges are synchronous
+    /// (note_foreground); the falling edge is evaluated by the monitor tick
+    /// so hot paths never read the clock.
+    bool foreground_active = false;
+    std::size_t stateful_inflight = 0;
+    std::chrono::steady_clock::time_point last_fg_activity{};
+
+    /// Whether foreground work is in flight right now — the hold window
+    /// only starts counting once this drains.
+    bool foreground_busy() const {
+        return stateful_inflight > 0 || !high_queue.empty() || high_busy_count() > 0;
+    }
+
+    /// Alive stateless slots busy with high-priority work.
+    std::size_t high_busy_count() const;
+
+    constexpr static std::chrono::seconds fg_hold{10};
+
+    /// Grace before a cooperatively cancelled low request's worker is
+    /// killed: covers a compile stuck inside one giant declaration, where
+    /// the stop flag is never polled.
+    constexpr static std::chrono::seconds cancel_grace{10};
+
     /// CUBIC-style fast recovery target: last low_limit before a reduction.
     std::size_t w_max = 0;
 
@@ -544,6 +605,19 @@ RequestResult<Params> WorkerPool::send_stateful(std::uint32_t path_id,
                                                 const Params& params,
                                                 kota::ipc::request_options opts,
                                                 Suspect suspect) {
+    // Every stateful request is user-facing: note the activity and hold the
+    // foreground window open for as long as it flies.
+    note_foreground();
+    stateful_inflight += 1;
+
+    struct InflightGuard {
+        std::size_t& count;
+
+        ~InflightGuard() {
+            count -= 1;
+        }
+    } inflight_guard{stateful_inflight};
+
     // An isolated probe only runs on a worker hosting no other document:
     // its crash must never take healthy sessions with it. With no such
     // worker available right now, the caller keeps the probe armed and
@@ -621,6 +695,11 @@ RequestResult<Params> WorkerPool::send_stateful(std::uint32_t path_id,
 template <typename Params>
 RequestResult<Params> WorkerPool::send_stateless(const Params& params,
                                                  kota::ipc::request_options opts) {
+    // High-priority stateless work (PCH, completion builds, foreground
+    // PCMs) is foreground by the priority taxonomy; while it runs or
+    // queues, foreground_busy() holds the window open.
+    if(params.priority == worker::Priority::High)
+        note_foreground();
     auto idx = co_await acquire_stateless_slot(params.priority);
     if(idx == SIZE_MAX) {
         co_return kota::outcome_error(kota::ipc::Error{worker::dispatch_errc::worker_unavailable,
@@ -643,12 +722,15 @@ RequestResult<Params> WorkerPool::send_stateless(const Params& params,
     }
 
     auto result = co_await peer->send_request(params, opts);
-    if(result.has_value())
-        co_return std::move(result);
-
+    // A cooperative cancel may still come back as a value — the worker
+    // returns a "cancelled" build result at its next stop poll — but the
+    // sender must observe cancelled either way, so the indexer requeues
+    // instead of recording a failure.
     if(preempt_src && preempt_src->cancelled())
         co_return kota::outcome_error(kota::ipc::Error{worker::dispatch_errc::cancelled,
-                                                       "Request preempted under memory pressure"});
+                                                       "Request preempted by the scheduler"});
+    if(result.has_value())
+        co_return std::move(result);
 
     // An error returned by the worker's handler leaves the worker healthy;
     // pass it through untouched.

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -280,8 +280,9 @@ private:
 
         std::chrono::steady_clock::time_point spawn_time{};
 
-        /// Stateless only: cancels the in-flight low-priority request so its
-        /// sender observes preemption instead of a bare transport error.
+        /// Stateless only: marks the in-flight low-priority request as
+        /// scheduler-cancelled so its sender classifies the eventual reply
+        /// (cooperative stop or kill) as preemption instead of a failure.
         std::shared_ptr<kota::cancellation_source> preempt_source;
 
         /// When a cooperative cancel was requested of this slot's in-flight
@@ -439,11 +440,23 @@ private:
     void tick_cancel_grace();
 
     /// Cooperatively cancel up to `count` in-flight low-priority requests:
-    /// the wire cancellation trips the worker's stop flag, the compile
-    /// returns at the next declaration boundary, and the sender observes
-    /// dispatch_errc::cancelled — the process survives. A victim that
-    /// ignores the cancel past cancel_grace is killed by the monitor.
+    /// a CancelBuild notification trips the worker's stop flag, the compile
+    /// returns at the next declaration boundary, and the sender — which
+    /// keeps awaiting the worker's own reply, so the slot stays busy until
+    /// the process is actually free — observes dispatch_errc::cancelled.
+    /// A victim that ignores the cancel past cancel_grace is killed by the
+    /// monitor.
     void cancel_low_priority(std::size_t count);
+
+    /// Low slots still owed to foreground/High demand beyond the cancels
+    /// already in flight: the excess over the clamped budget, or one per
+    /// queued High request while no slot is idle, minus the victims already
+    /// asked to stop. Evaluated at every demand edge AND at the Low arming
+    /// point in send_stateless — the cancel sweep must skip claims whose
+    /// sender has not armed a source yet, so the arming re-check is what
+    /// keeps demand from being dropped in that window. `pending_high`
+    /// counts a High requester about to queue itself.
+    std::size_t low_reclaim_deficit(std::size_t pending_high = 0);
 
     /// Wait for an idle stateless worker. Returns SIZE_MAX when no slot can
     /// serve the request anymore (pool stopped or all slots given up).
@@ -722,27 +735,32 @@ RequestResult<Params> WorkerPool::send_stateless(const Params& params,
     auto peer = stateless_workers[idx].peer;
     auto gen = stateless_workers[idx].generation;
 
-    // For low-priority requests, install a cancellation source so
-    // preempt_low_priority() can signal the preemption to this sender
-    // before the kill's transport error arrives.
     std::shared_ptr<kota::cancellation_source> preempt_src;
     if(params.priority == worker::Priority::Low) {
+        // Reclaim demand that arose while this claim's sender was parked
+        // (a foreground edge, a queued High) was skipped by the cancel
+        // sweep — an unarmed slot must never be stamped (see
+        // cancel_low_priority). Honor it here, before the request reaches
+        // the wire: giving the claim back costs nothing.
+        if(low_reclaim_deficit() > 0) {
+            co_return kota::outcome_error(kota::ipc::Error{worker::dispatch_errc::cancelled,
+                                                           "Request preempted by the scheduler"});
+        }
+        // The classification channel for scheduler-initiated cancels: the
+        // cooperative CancelBuild and the memory-preemption kill both mark
+        // it, and the sender consults it when the reply arrives.
         preempt_src = std::make_shared<kota::cancellation_source>();
         stateless_workers[idx].preempt_source = preempt_src;
-        // Known limitation: with a caller-provided token the scheduler's
-        // cancel cannot reach the worker (no token composition in kota) —
-        // the request is then only classified, not shortened, and a long
-        // one falls to the grace kill. Today's sole Low caller (the
-        // indexer) passes no token.
-        if(!opts.token)
-            opts.token = preempt_src->token();
     }
 
     auto result = co_await peer->send_request(params, opts);
-    // A cooperative cancel may still come back as a value — the worker
-    // returns a "cancelled" build result at its next stop poll — but the
-    // sender must observe cancelled either way, so the indexer requeues
-    // instead of recording a failure.
+    // A scheduler cancel comes back as whatever the worker produced — the
+    // cooperatively stopped build's own reply, or the killed process's
+    // transport error — never as a wire cancel: the sender deliberately
+    // awaits the real reply so the slot frees only once the process is
+    // actually idle again, keeping the grace deadline armed and the next
+    // request off a still-stuck worker. Either shape must surface as
+    // cancelled, so the indexer requeues instead of recording a failure.
     if(preempt_src && preempt_src->cancelled())
         co_return kota::outcome_error(kota::ipc::Error{worker::dispatch_errc::cancelled,
                                                        "Request preempted by the scheduler"});

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -101,9 +101,11 @@ enum class Suspect : std::uint8_t {
 /// Two kinds of workers are managed:
 ///   - Stateless workers execute independent build tasks (PCH/PCM builds,
 ///     indexing, completion, formatting) with two-level priority scheduling:
-///     one worker's worth of capacity is reserved for high-priority requests
-///     by capping low-priority concurrency at capacity - 1, and the cap
-///     shrinks further under memory pressure.
+///     low-priority concurrency is budgeted — the full schedulable capacity
+///     when the user is idle, a fixed share of the configured capacity while
+///     foreground activity is live, and less under memory pressure. A High
+///     request finding no idle slot cooperatively cancels one low build
+///     instead of waiting out a whole TU.
 ///   - Stateful workers keep per-document ASTs; each open document is pinned
 ///     to one worker (path_id affinity), balanced by document count.
 ///
@@ -286,6 +288,11 @@ private:
         /// low request; zero when none is outstanding. The monitor kills the
         /// process if it blows past cancel_grace without returning.
         std::chrono::steady_clock::time_point cancel_requested_at{};
+
+        /// Monotonic claim ordinal of the in-flight request. Victim
+        /// selection picks the largest — the actual newest claim; the slot
+        /// index says nothing about claim order once slots are reused.
+        std::uint64_t claim_epoch = 0;
     };
 
     kota::event_loop& loop;
@@ -423,9 +430,13 @@ private:
     /// within a declaration boundary, not at end-of-TU.
     void note_foreground();
 
-    /// Falling edge, driven by the monitor tick: leases gone and the hold
-    /// window expired reopen the idle budget.
+    /// Falling edge, driven by the monitor tick: foreground work drained
+    /// and the hold window expired reopen the idle budget.
     void tick_foreground();
+
+    /// Kill workers whose cooperatively cancelled request outlived
+    /// cancel_grace; driven by the monitor tick.
+    void tick_cancel_grace();
 
     /// Cooperatively cancel up to `count` in-flight low-priority requests:
     /// the wire cancellation trips the worker's stop flag, the compile
@@ -521,6 +532,7 @@ private:
     bool foreground_active = false;
     std::size_t stateful_inflight = 0;
     std::chrono::steady_clock::time_point last_fg_activity{};
+    std::uint64_t next_claim_epoch = 0;
 
     /// Whether foreground work is in flight right now — the hold window
     /// only starts counting once this drains.
@@ -717,6 +729,11 @@ RequestResult<Params> WorkerPool::send_stateless(const Params& params,
     if(params.priority == worker::Priority::Low) {
         preempt_src = std::make_shared<kota::cancellation_source>();
         stateless_workers[idx].preempt_source = preempt_src;
+        // Known limitation: with a caller-provided token the scheduler's
+        // cancel cannot reach the worker (no token composition in kota) —
+        // the request is then only classified, not shortened, and a long
+        // one falls to the grace kill. Today's sole Low caller (the
+        // indexer) passes no token.
         if(!opts.token)
             opts.token = preempt_src->token();
     }

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -754,6 +754,19 @@ RequestResult<Params> WorkerPool::send_stateless(const Params& params,
     }
 
     auto result = co_await peer->send_request(params, opts);
+    // The worker link broke mid-request: declare the slot dead now so a
+    // caller-side retry cannot land on the same corpse before the monitor
+    // observed the exit. This must precede the cancel classification — a
+    // cooperatively cancelled worker can die on its own inside the grace
+    // window, and returning early would release the slot still Alive.
+    bool transport_dead = !result.has_value() && worker::is_transport_error(result.error());
+    if(transport_dead && stateless_workers[idx].generation == gen) {
+        mark_worker_dead(idx, false, true);
+        // The dead worker's claim is gone; a queued low-priority waiter may
+        // now fit under the limit on another idle worker.
+        try_dispatch_pending();
+    }
+
     // A scheduler cancel comes back as whatever the worker produced — the
     // cooperatively stopped build's own reply, or the killed process's
     // transport error — never as a wire cancel: the sender deliberately
@@ -769,18 +782,9 @@ RequestResult<Params> WorkerPool::send_stateless(const Params& params,
 
     // An error returned by the worker's handler leaves the worker healthy;
     // pass it through untouched.
-    if(!worker::is_transport_error(result.error()))
+    if(!transport_dead)
         co_return std::move(result);
 
-    // The worker link broke mid-request: declare the slot dead now so a
-    // caller-side retry cannot land on the same corpse before the monitor
-    // observed the exit.
-    if(stateless_workers[idx].generation == gen) {
-        mark_worker_dead(idx, false, true);
-        // The dead worker's claim is gone; a queued low-priority waiter may
-        // now fit under the limit on another idle worker.
-        try_dispatch_pending();
-    }
     co_return kota::outcome_error(
         kota::ipc::Error{worker::dispatch_errc::worker_crashed,
                          "Stateless worker died during request: " + result.error().message,

--- a/tests/integration/lifecycle/crash_recovery.test.ts
+++ b/tests/integration/lifecycle/crash_recovery.test.ts
@@ -2,7 +2,9 @@
 ///
 /// Kills stateless workers while an indexing round is in flight and verifies the
 /// round still converges: in-flight files fail with worker_crashed, the indexer
-/// requeues them, and a follow-up round indexes every file.
+/// requeues them, and a follow-up round indexes every file. The second test
+/// darkens the whole pool (crash budget exhausted) and verifies the round parks
+/// until revival instead of spinning requeues (#611).
 
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -141,8 +143,8 @@ test.skipIf(process.platform !== "linux")(
         process.env["CLICE_ANOMALY_NO_TRAP"] = "1";
         let client;
         try {
-            client = session.spawn(workspace, {
-                allowAnomaly: true,
+            client = session.spawn(workspace, { allowAnomaly: true });
+            await client.initialize(workspace, {
                 initializationOptions: {
                     project: {
                         stateless_worker_count: 1,
@@ -152,18 +154,25 @@ test.skipIf(process.platform !== "linux")(
                     },
                 },
             });
-            await client.initialize(workspace);
         } finally {
             delete process.env["CLICE_ANOMALY_NO_TRAP"];
         }
 
         await client.openAndWait("main.cpp");
 
-        // Kill the slot on sight until its budget (3 consecutive fast
-        // crashes) is spent; respawn backoff caps at ~1s, so 8s of killing
-        // covers the initial worker and every respawn.
+        const logsDir = workspace.path(".clice/logs");
+        const masterLog = () =>
+            fs
+                .readdirSync(logsDir, { recursive: true, encoding: "utf8" })
+                .filter((name) => path.basename(name) === "master.log")
+                .map((name) => fs.readFileSync(path.join(logsDir, name), "utf8"))
+                .join("");
+
+        // Kill the slot on sight until the pool reports the budget as spent
+        // (a fast-crash streak past max_crash_streak); respawn backoff caps
+        // at ~1s, so a few seconds of killing cover every respawn.
         let kills = 0;
-        for (let i = 0; i < 40; i += 1) {
+        for (let i = 0; i < 150 && !masterLog().includes("exceeded crash budget"); i += 1) {
             for (const pid of statelessWorkerPids(client.child.pid!)) {
                 try {
                     process.kill(pid, "SIGKILL");
@@ -175,10 +184,19 @@ test.skipIf(process.platform !== "linux")(
             await sleep(200);
         }
         expect(kills, "no stateless worker was ever seen").toBeGreaterThanOrEqual(3);
+        expect(
+            masterLog().includes("exceeded crash budget"),
+            "the pool never went dark — the outage under test did not happen",
+        ).toBe(true);
 
         // Dark window: the master must stay responsive while the round is
-        // parked on the capacity signal.
-        const during = await indexedFunctions(client);
+        // parked on the capacity signal — fail loudly here instead of via
+        // the test timeout if it wedged.
+        const during = await Promise.race([
+            indexedFunctions(client),
+            sleep(15_000).then(() => null),
+        ]);
+        expect(during, "master unresponsive during the outage").not.toBeNull();
 
         // The revival cooldown (30s) re-arms the slot and the parked round
         // must resume and finish every file: crash requeues land past the
@@ -195,19 +213,13 @@ test.skipIf(process.platform !== "linux")(
         const missing = [...expected].filter((f) => !found.has(f)).sort();
         expect(
             [...expected].every((f) => found.has(f)),
-            `missing after outage (had ${during.size} during): ${JSON.stringify(missing)}`,
+            `missing after outage (had ${during?.size} during): ${JSON.stringify(missing)}`,
         ).toBe(true);
 
         // The spin itself: parked dispatch sends nothing, so the outage may
         // produce at most a handful of worker-unavailable requeues — the
         // incident produced them at an unbounded rate.
-        const logsDir = workspace.path(".clice/logs");
-        const requeues = fs
-            .readdirSync(logsDir, { recursive: true, encoding: "utf8" })
-            .filter((name) => path.basename(name) === "master.log")
-            .map((name) => fs.readFileSync(path.join(logsDir, name), "utf8"))
-            .join("")
-            .match(/No stateless workers available/g);
+        const requeues = masterLog().match(/No stateless workers available/g);
         expect((requeues ?? []).length).toBeLessThanOrEqual(FILE_COUNT);
     },
 );

--- a/tests/integration/lifecycle/crash_recovery.test.ts
+++ b/tests/integration/lifecycle/crash_recovery.test.ts
@@ -5,6 +5,7 @@
 /// requeues them, and a follow-up round indexes every file.
 
 import * as fs from "node:fs";
+import * as path from "node:path";
 import { sleep, type CliceClient } from "@clice/tools/client";
 import { expect, test } from "../fixtures.ts";
 
@@ -110,5 +111,103 @@ test.skipIf(process.platform !== "linux")(
             [...expected].every((f) => found.has(f)),
             `missing after crash: ${JSON.stringify(missing)}`,
         ).toBe(true);
+    },
+);
+
+// Regression for #611: with every stateless slot's crash budget burnt, the
+// dispatch loop must park until the pool revives a slot — not spin the same
+// requeued files through instant worker-unavailable failures (the incident
+// produced a ~986 GiB master.log with a [51294/1] progress numerator).
+test.skipIf(process.platform !== "linux")(
+    "pool outage parks indexing",
+    { timeout: 300_000 },
+    async ({ session }) => {
+        const workspace = session.tmpdir();
+        const files: string[] = [];
+        for (let i = 0; i < FILE_COUNT; i++) {
+            const name = `file_${i}.cpp`;
+            workspace.write(
+                name,
+                `#include <string>\n` +
+                    `int func_${i}() { return (int)std::string("${i}").size(); }\n`,
+            );
+            files.push(name);
+        }
+        workspace.write("main.cpp", "int main() { return 0; }\n");
+        workspace.writeCDB([...files, "main.cpp"]);
+
+        // One stateless slot only, so exhausting its crash budget darkens
+        // the whole pool. The kills surface as WorkerCrash anomalies.
+        process.env["CLICE_ANOMALY_NO_TRAP"] = "1";
+        let client;
+        try {
+            client = session.spawn(workspace, {
+                allowAnomaly: true,
+                initializationOptions: {
+                    project: {
+                        stateless_worker_count: 1,
+                        min_stateless_worker_count: 1,
+                        max_stateless_worker_count: 1,
+                        idle_timeout_ms: 10,
+                    },
+                },
+            });
+            await client.initialize(workspace);
+        } finally {
+            delete process.env["CLICE_ANOMALY_NO_TRAP"];
+        }
+
+        await client.openAndWait("main.cpp");
+
+        // Kill the slot on sight until its budget (3 consecutive fast
+        // crashes) is spent; respawn backoff caps at ~1s, so 8s of killing
+        // covers the initial worker and every respawn.
+        let kills = 0;
+        for (let i = 0; i < 40; i += 1) {
+            for (const pid of statelessWorkerPids(client.child.pid!)) {
+                try {
+                    process.kill(pid, "SIGKILL");
+                    kills += 1;
+                } catch {
+                    // Already reaped.
+                }
+            }
+            await sleep(200);
+        }
+        expect(kills, "no stateless worker was ever seen").toBeGreaterThanOrEqual(3);
+
+        // Dark window: the master must stay responsive while the round is
+        // parked on the capacity signal.
+        const during = await indexedFunctions(client);
+
+        // The revival cooldown (30s) re-arms the slot and the parked round
+        // must resume and finish every file: crash requeues land past the
+        // round snapshot, so no single file burns its budget.
+        const expected = new Set(Array.from({ length: FILE_COUNT }, (_, i) => `func_${i}`));
+        let found = new Set<string>();
+        for (let i = 0; i < 150; i += 1) {
+            found = await indexedFunctions(client);
+            if ([...expected].every((f) => found.has(f))) {
+                break;
+            }
+            await sleep(1_000);
+        }
+        const missing = [...expected].filter((f) => !found.has(f)).sort();
+        expect(
+            [...expected].every((f) => found.has(f)),
+            `missing after outage (had ${during.size} during): ${JSON.stringify(missing)}`,
+        ).toBe(true);
+
+        // The spin itself: parked dispatch sends nothing, so the outage may
+        // produce at most a handful of worker-unavailable requeues — the
+        // incident produced them at an unbounded rate.
+        const logsDir = workspace.path(".clice/logs");
+        const requeues = fs
+            .readdirSync(logsDir, { recursive: true, encoding: "utf8" })
+            .filter((name) => path.basename(name) === "master.log")
+            .map((name) => fs.readFileSync(path.join(logsDir, name), "utf8"))
+            .join("")
+            .match(/No stateless workers available/g);
+        expect((requeues ?? []).length).toBeLessThanOrEqual(FILE_COUNT);
     },
 );

--- a/tests/integration/lifecycle/crash_recovery.test.ts
+++ b/tests/integration/lifecycle/crash_recovery.test.ts
@@ -100,8 +100,11 @@ test.skipIf(process.platform !== "linux")(
         // requeued and indexed by a follow-up round: every function
         // eventually appears in the project index.
         const expected = new Set(Array.from({ length: FILE_COUNT }, (_, i) => `func_${i}`));
+        // Budgeted for the Debug/ASan CI runners: 20 single-worker ASan
+        // compiles plus a crash respawn and one round boundary for the
+        // requeued file measure ~130s there (~60s locally).
         let found = new Set<string>();
-        for (let i = 0; i < 120; i++) {
+        for (let i = 0; i < 180; i++) {
             found = await indexedFunctions(client);
             if ([...expected].every((f) => found.has(f))) {
                 break;

--- a/tests/unit/server/cancel_chain_tests.cpp
+++ b/tests/unit/server/cancel_chain_tests.cpp
@@ -92,6 +92,54 @@ TEST_CASE(HandlerCancelChainsThrough) {
     EXPECT_TRUE(observed_cancelled_reply);
 }
 
+// The scheduler's cooperative cancel of a stateless build takes the
+// CancelBuild-notification path, never a wire cancel: the sender keeps
+// awaiting the build's own reply (the slot must stay busy while the
+// worker is), and the notification trips the stop flag so that reply
+// arrives at the next declaration boundary instead of after the whole TU.
+TEST_CASE(CancelBuildStopsBuild) {
+    TempDir tmp;
+    std::string text;
+    text.reserve(1 << 22);
+    for(int i = 0; i < 200'000; i += 1) {
+        text += std::format("int v{};\n", i);
+    }
+    tmp.touch("probe.cpp", text);
+    auto src = tmp.path("probe.cpp");
+
+    WorkerHandle w;
+    ASSERT_TRUE(w.spawn());
+
+    bool test_done = false;
+    w.run([&]() -> kota::task<> {
+        worker::BuildParams bp;
+        bp.kind = worker::BuildKind::Index;
+        bp.file = src;
+        bp.directory = "/tmp";
+        bp.arguments = make_args(src);
+
+        auto build = [&]() -> kota::task<> {
+            auto result = co_await w.peer->send_request(bp);
+            // An uninterrupted worker would index all 200k decls and reply
+            // success; the stopped parse must not produce an index.
+            CO_ASSERT_TRUE(result.has_value());
+            EXPECT_FALSE(result.value().success);
+        };
+
+        kota::task_group<> group(w.loop);
+        group.spawn(build());
+
+        co_await kota::sleep(50, w.loop);
+        w.peer->send_notification(worker::CancelBuildParams{});
+        co_await group.join();
+
+        test_done = true;
+        w.peer->close_output();
+    });
+
+    ASSERT_TRUE(test_done);
+}
+
 };  // TEST_SUITE(CancelChain)
 
 }  // namespace

--- a/tests/unit/server/compile_graph_integration_tests.cpp
+++ b/tests/unit/server/compile_graph_integration_tests.cpp
@@ -20,7 +20,7 @@ CompileGraph::dispatch_fn make_dispatch(CompilationDatabase& cdb,
                                         PathPool& pool,
                                         DependencyGraph& graph,
                                         llvm::DenseMap<std::uint32_t, std::string>& pcm_paths) {
-    return [&](std::uint32_t path_id) -> kota::task<bool> {
+    return [&](std::uint32_t path_id, bool) -> kota::task<bool> {
         auto file_path = pool.resolve(path_id);
         auto results = cdb.lookup(file_path);
         if(results.empty()) {
@@ -1117,13 +1117,13 @@ TEST_CASE(shared_dep_import_switch) {
     kota::event shared_proceed;
     int shared_calls = 0;
     auto inner = default_dispatch();
-    auto dispatch = [&](std::uint32_t pid) -> kota::task<bool> {
+    auto dispatch = [&](std::uint32_t pid, bool) -> kota::task<bool> {
         if(pid == pid_shared) {
             shared_calls += 1;
             shared_started.set();
             co_await shared_proceed.wait();
         }
-        co_return co_await inner(pid);
+        co_return co_await inner(pid, false);
     };
 
     make_graph(std::move(dispatch), default_resolver());
@@ -1215,13 +1215,13 @@ TEST_CASE(shared_dep_fails_both) {
     kota::event shared_proceed;
     int shared_calls = 0;
     auto inner = default_dispatch();
-    auto dispatch = [&](std::uint32_t pid) -> kota::task<bool> {
+    auto dispatch = [&](std::uint32_t pid, bool) -> kota::task<bool> {
         if(pid == pid_shared) {
             shared_calls += 1;
             shared_started.set();
             co_await shared_proceed.wait();
         }
-        co_return co_await inner(pid);
+        co_return co_await inner(pid, false);
     };
 
     make_graph(std::move(dispatch), default_resolver());

--- a/tests/unit/server/compile_graph_integration_tests.cpp
+++ b/tests/unit/server/compile_graph_integration_tests.cpp
@@ -20,11 +20,11 @@ CompileGraph::dispatch_fn make_dispatch(CompilationDatabase& cdb,
                                         PathPool& pool,
                                         DependencyGraph& graph,
                                         llvm::DenseMap<std::uint32_t, std::string>& pcm_paths) {
-    return [&](std::uint32_t path_id, bool) -> kota::task<bool> {
+    return [&](std::uint32_t path_id, bool) -> kota::task<CompileUnit::Outcome> {
         auto file_path = pool.resolve(path_id);
         auto results = cdb.lookup(file_path);
         if(results.empty()) {
-            co_return false;
+            co_return CompileUnit::Outcome::Failed;
         }
         toolchain.resolve_or_warn(results[0]);
 
@@ -45,7 +45,7 @@ CompileGraph::dispatch_fn make_dispatch(CompilationDatabase& cdb,
 
         auto tmp = fs::createTemporaryFile("test-pcm", "pcm");
         if(!tmp) {
-            co_return false;
+            co_return CompileUnit::Outcome::Failed;
         }
         cp.output_file = *tmp;
 
@@ -54,9 +54,9 @@ CompileGraph::dispatch_fn make_dispatch(CompilationDatabase& cdb,
 
         if(unit.completed()) {
             pcm_paths[path_id] = std::string(cp.output_file);
-            co_return true;
+            co_return CompileUnit::Outcome::Success;
         }
-        co_return false;
+        co_return CompileUnit::Outcome::Failed;
     };
 }
 
@@ -1117,7 +1117,7 @@ TEST_CASE(shared_dep_import_switch) {
     kota::event shared_proceed;
     int shared_calls = 0;
     auto inner = default_dispatch();
-    auto dispatch = [&](std::uint32_t pid, bool) -> kota::task<bool> {
+    auto dispatch = [&](std::uint32_t pid, bool) -> kota::task<CompileUnit::Outcome> {
         if(pid == pid_shared) {
             shared_calls += 1;
             shared_started.set();
@@ -1215,7 +1215,7 @@ TEST_CASE(shared_dep_fails_both) {
     kota::event shared_proceed;
     int shared_calls = 0;
     auto inner = default_dispatch();
-    auto dispatch = [&](std::uint32_t pid, bool) -> kota::task<bool> {
+    auto dispatch = [&](std::uint32_t pid, bool) -> kota::task<CompileUnit::Outcome> {
         if(pid == pid_shared) {
             shared_calls += 1;
             shared_started.set();

--- a/tests/unit/server/compile_graph_tests.cpp
+++ b/tests/unit/server/compile_graph_tests.cpp
@@ -1134,6 +1134,56 @@ TEST_CASE(preempted_dep_retry_upgrades) {
     EXPECT_TRUE(dep_classes[1]);
 }
 
+TEST_CASE(late_resolve_upgrades_closure) {
+    // A foreground root still unresolved when marked resolves to a
+    // dependency already running as background: the closure behind that
+    // dependency must upgrade too, so the deep unit's preempted round
+    // retries foreground instead of staying cancellable Low.
+    kota::event started;
+    kota::event proceed;
+    int deep_calls = 0;
+    std::vector<bool> deep_classes;
+    auto dispatch = [&](std::uint32_t pid, bool foreground) -> kota::task<Outcome> {
+        if(pid == 3) {
+            deep_calls += 1;
+            deep_classes.push_back(foreground);
+            if(deep_calls == 1) {
+                started.set();
+                co_await proceed.wait();
+                co_return Outcome::Stale;
+            }
+        }
+        co_return Outcome::Success;
+    };
+    llvm::DenseMap<std::uint32_t, llvm::SmallVector<std::uint32_t>> adj;
+    adj[1] = {2};
+    adj[2] = {3};
+    make_graph(std::move(dispatch), static_resolver(std::move(adj)));
+
+    Request background;
+    bool fg_ok = false;
+    execute([&]() -> kota::task<> {
+        auto foreground_join = [&]() -> kota::task<> {
+            auto r = co_await graph->compile(1, /*foreground=*/true).catch_cancel();
+            fg_ok = r.has_value() && *r;
+        };
+        auto driver = [&]() -> kota::task<> {
+            co_await started.wait();
+            proceed.set();
+            co_return;
+        };
+        // The background request resolves 2 and parks 3 inside its first
+        // dispatch; the foreground request then joins at the unresolved 1.
+        co_await kota::when_all(run_request(2, background), foreground_join(), driver());
+    });
+
+    EXPECT_TRUE(background.result == true);
+    EXPECT_TRUE(fg_ok);
+    ASSERT_EQ(deep_calls, 2);
+    EXPECT_FALSE(deep_classes[0]);
+    EXPECT_TRUE(deep_classes[1]);
+}
+
 TEST_CASE(preempted_retry_upgrades_class) {
     // A foreground requester joining a Low round whose build the scheduler
     // then preempts must not eat the preemption as a failure: the respawn

--- a/tests/unit/server/compile_graph_tests.cpp
+++ b/tests/unit/server/compile_graph_tests.cpp
@@ -1086,6 +1086,54 @@ TEST_CASE(preempted_dispatch_retries) {
     });
 }
 
+TEST_CASE(preempted_dep_retry_upgrades) {
+    // A foreground requester joining a background root must upgrade the
+    // resolved dependency closure: the dependency's preempted round retries
+    // with the foreground class instead of staying cancellable Low.
+    kota::event started;
+    kota::event proceed;
+    int dep_calls = 0;
+    std::vector<bool> dep_classes;
+    auto dispatch = [&](std::uint32_t pid, bool foreground) -> kota::task<Outcome> {
+        if(pid == 2) {
+            dep_calls += 1;
+            dep_classes.push_back(foreground);
+            if(dep_calls == 1) {
+                started.set();
+                co_await proceed.wait();
+                co_return Outcome::Stale;
+            }
+        }
+        co_return Outcome::Success;
+    };
+    llvm::DenseMap<std::uint32_t, llvm::SmallVector<std::uint32_t>> adj;
+    adj[1] = {2};
+    make_graph(std::move(dispatch), static_resolver(std::move(adj)));
+
+    Request background;
+    bool fg_ok = false;
+    execute([&]() -> kota::task<> {
+        auto foreground_join = [&]() -> kota::task<> {
+            auto r = co_await graph->compile(1, /*foreground=*/true).catch_cancel();
+            fg_ok = r.has_value() && *r;
+        };
+        auto driver = [&]() -> kota::task<> {
+            co_await started.wait();
+            proceed.set();
+            co_return;
+        };
+        // The foreground request joins while the dependency's first round
+        // is parked inside its dispatch.
+        co_await kota::when_all(run_request(1, background), foreground_join(), driver());
+    });
+
+    EXPECT_TRUE(background.result == true);
+    EXPECT_TRUE(fg_ok);
+    ASSERT_EQ(dep_calls, 2);
+    EXPECT_FALSE(dep_classes[0]);
+    EXPECT_TRUE(dep_classes[1]);
+}
+
 TEST_CASE(preempted_retry_upgrades_class) {
     // A foreground requester joining a Low round whose build the scheduler
     // then preempts must not eat the preemption as a failure: the respawn

--- a/tests/unit/server/compile_graph_tests.cpp
+++ b/tests/unit/server/compile_graph_tests.cpp
@@ -31,27 +31,27 @@ CompileGraph::resolve_fn
 }
 
 CompileGraph::dispatch_fn instant_dispatch() {
-    return [](std::uint32_t) -> kota::task<bool> {
+    return [](std::uint32_t, bool) -> kota::task<bool> {
         co_return true;
     };
 }
 
 CompileGraph::dispatch_fn tracking_dispatch(std::vector<std::uint32_t>& compiled) {
-    return [&compiled](std::uint32_t path_id) -> kota::task<bool> {
+    return [&compiled](std::uint32_t path_id, bool) -> kota::task<bool> {
         compiled.push_back(path_id);
         co_return true;
     };
 }
 
 CompileGraph::dispatch_fn failing_dispatch() {
-    return [](std::uint32_t) -> kota::task<bool> {
+    return [](std::uint32_t, bool) -> kota::task<bool> {
         co_return false;
     };
 }
 
 /// Dispatch that fails only for specific path_ids.
 CompileGraph::dispatch_fn selective_dispatch(llvm::DenseSet<std::uint32_t> fail_ids) {
-    return [fail_ids = std::move(fail_ids)](std::uint32_t path_id) -> kota::task<bool> {
+    return [fail_ids = std::move(fail_ids)](std::uint32_t path_id, bool) -> kota::task<bool> {
         co_return !fail_ids.contains(path_id);
     };
 }
@@ -85,7 +85,7 @@ struct ManualDispatch {
     }
 
     CompileGraph::dispatch_fn fn() {
-        return [this](std::uint32_t path_id) -> kota::task<bool> {
+        return [this](std::uint32_t path_id, bool) -> kota::task<bool> {
             auto& g = gate(path_id);
             g.calls += 1;
             g.started.set();
@@ -441,7 +441,7 @@ TEST_CASE(compile_deps_resolve_once) {
 TEST_CASE(compile_deps_failure) {
     // A failing dependency fails the request; the root unit is never
     // dispatched on a failed preparation.
-    auto fail_and_track = [&](std::uint32_t path_id) -> kota::task<bool> {
+    auto fail_and_track = [&](std::uint32_t path_id, bool) -> kota::task<bool> {
         compiled.push_back(path_id);
         co_return false;
     };
@@ -1626,7 +1626,7 @@ TEST_CASE(shutdown_with_inflight) {
 
 TEST_CASE(randomized_stress) {
     kota::semaphore permits{0};
-    auto dispatch = [&](std::uint32_t) -> kota::task<bool> {
+    auto dispatch = [&](std::uint32_t, bool) -> kota::task<bool> {
         co_await permits.acquire();
         co_return true;
     };

--- a/tests/unit/server/compile_graph_tests.cpp
+++ b/tests/unit/server/compile_graph_tests.cpp
@@ -11,6 +11,8 @@ namespace {
 
 namespace ranges = std::ranges;
 
+using Outcome = CompileUnit::Outcome;
+
 /// A resolve_fn that always returns no dependencies.
 CompileGraph::resolve_fn no_deps() {
     return [](std::uint32_t) -> llvm::SmallVector<std::uint32_t> {
@@ -31,28 +33,28 @@ CompileGraph::resolve_fn
 }
 
 CompileGraph::dispatch_fn instant_dispatch() {
-    return [](std::uint32_t, bool) -> kota::task<bool> {
-        co_return true;
+    return [](std::uint32_t, bool) -> kota::task<Outcome> {
+        co_return Outcome::Success;
     };
 }
 
 CompileGraph::dispatch_fn tracking_dispatch(std::vector<std::uint32_t>& compiled) {
-    return [&compiled](std::uint32_t path_id, bool) -> kota::task<bool> {
+    return [&compiled](std::uint32_t path_id, bool) -> kota::task<Outcome> {
         compiled.push_back(path_id);
-        co_return true;
+        co_return Outcome::Success;
     };
 }
 
 CompileGraph::dispatch_fn failing_dispatch() {
-    return [](std::uint32_t, bool) -> kota::task<bool> {
-        co_return false;
+    return [](std::uint32_t, bool) -> kota::task<Outcome> {
+        co_return Outcome::Failed;
     };
 }
 
 /// Dispatch that fails only for specific path_ids.
 CompileGraph::dispatch_fn selective_dispatch(llvm::DenseSet<std::uint32_t> fail_ids) {
-    return [fail_ids = std::move(fail_ids)](std::uint32_t path_id, bool) -> kota::task<bool> {
-        co_return !fail_ids.contains(path_id);
+    return [fail_ids = std::move(fail_ids)](std::uint32_t path_id, bool) -> kota::task<Outcome> {
+        co_return fail_ids.contains(path_id) ? Outcome::Failed : Outcome::Success;
     };
 }
 
@@ -85,12 +87,12 @@ struct ManualDispatch {
     }
 
     CompileGraph::dispatch_fn fn() {
-        return [this](std::uint32_t path_id, bool) -> kota::task<bool> {
+        return [this](std::uint32_t path_id, bool) -> kota::task<Outcome> {
             auto& g = gate(path_id);
             g.calls += 1;
             g.started.set();
             co_await g.proceed.wait();
-            co_return g.result;
+            co_return g.result ? Outcome::Success : Outcome::Failed;
         };
     }
 };
@@ -441,9 +443,9 @@ TEST_CASE(compile_deps_resolve_once) {
 TEST_CASE(compile_deps_failure) {
     // A failing dependency fails the request; the root unit is never
     // dispatched on a failed preparation.
-    auto fail_and_track = [&](std::uint32_t path_id, bool) -> kota::task<bool> {
+    auto fail_and_track = [&](std::uint32_t path_id, bool) -> kota::task<Outcome> {
         compiled.push_back(path_id);
-        co_return false;
+        co_return Outcome::Failed;
     };
 
     make_graph(std::move(fail_and_track),
@@ -1064,6 +1066,70 @@ TEST_CASE(recompile_after_failure) {
     });
 }
 
+TEST_CASE(preempted_dispatch_retries) {
+    // A dispatch reporting Stale (the scheduler preempted its build) is no
+    // verdict: the waiter respawns the round instead of failing, and the
+    // request succeeds once a dispatch completes.
+    int calls = 0;
+    auto dispatch = [&](std::uint32_t, bool) -> kota::task<Outcome> {
+        calls += 1;
+        co_return calls == 1 ? Outcome::Stale : Outcome::Success;
+    };
+    make_graph(std::move(dispatch), no_deps());
+
+    execute([&]() -> kota::task<> {
+        auto result = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(result.has_value());
+        EXPECT_TRUE(*result);
+        EXPECT_EQ(calls, 2);
+        EXPECT_FALSE(graph->is_dirty(1));
+    });
+}
+
+TEST_CASE(preempted_retry_upgrades_class) {
+    // A foreground requester joining a Low round whose build the scheduler
+    // then preempts must not eat the preemption as a failure: the respawn
+    // re-reads the interest class, so the retry dispatches foreground.
+    kota::event started;
+    kota::event proceed;
+    int calls = 0;
+    std::vector<bool> classes;
+    auto dispatch = [&](std::uint32_t, bool foreground) -> kota::task<Outcome> {
+        calls += 1;
+        classes.push_back(foreground);
+        if(calls == 1) {
+            started.set();
+            co_await proceed.wait();
+            co_return Outcome::Stale;
+        }
+        co_return Outcome::Success;
+    };
+    make_graph(std::move(dispatch), no_deps());
+
+    Request background;
+    bool fg_ok = false;
+    execute([&]() -> kota::task<> {
+        auto foreground_join = [&]() -> kota::task<> {
+            auto r = co_await graph->compile(1, /*foreground=*/true).catch_cancel();
+            fg_ok = r.has_value() && *r;
+        };
+        auto driver = [&]() -> kota::task<> {
+            co_await started.wait();
+            proceed.set();
+            co_return;
+        };
+        // Start order matters: the foreground request joins the parked
+        // round before the driver releases its dispatch.
+        co_await kota::when_all(run_request(1, background), foreground_join(), driver());
+    });
+
+    EXPECT_TRUE(background.result == true);
+    EXPECT_TRUE(fg_ok);
+    ASSERT_EQ(calls, 2);
+    EXPECT_FALSE(classes[0]);
+    EXPECT_TRUE(classes[1]);
+}
+
 TEST_CASE(shared_dep_failure_propagates) {
     // One failing round of a shared dependency fails every consumer waiting
     // on it; the failing dispatch runs only once.
@@ -1626,9 +1692,9 @@ TEST_CASE(shutdown_with_inflight) {
 
 TEST_CASE(randomized_stress) {
     kota::semaphore permits{0};
-    auto dispatch = [&](std::uint32_t, bool) -> kota::task<bool> {
+    auto dispatch = [&](std::uint32_t, bool) -> kota::task<Outcome> {
         co_await permits.acquire();
-        co_return true;
+        co_return Outcome::Success;
     };
 
     make_graph(std::move(dispatch),

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -104,6 +104,16 @@ struct IndexerFixture {
         loop.schedule(task);
         loop.run();
     }
+
+    /// Run one background round to completion on the fixture's loop.
+    void run_round() {
+        auto body = [this]() -> kota::task<> {
+            co_await indexer.run_background_indexing();
+        };
+        auto task = body();
+        loop.schedule(task);
+        loop.run();
+    }
 };
 
 namespace {
@@ -1873,6 +1883,50 @@ TEST_CASE(ContentChangeResetsBudget) {
     ASSERT_EQ(int(f.fail(id, /*crashed=*/true)), int(IndexerFixture::Verdict::Requeued));
     f.indexer.enqueue(id, ReindexReason::DepsOnly);
     ASSERT_EQ(f.attempts(id), 1u);
+}
+
+TEST_CASE(RoundSnapshotBoundary) {
+    IndexerFixture f;
+    // Manual rounds: the tail schedule() must no-op so the boundary between
+    // the two rounds stays observable.
+    f.workspace.config.project.enable_indexing.value = false;
+
+    auto a = f.workspace.path_pool.intern("/fake/a.cpp");
+    auto b = f.workspace.path_pool.intern("/fake/b.cpp");
+    auto c = f.workspace.path_pool.intern("/fake/c.cpp");
+
+    f.indexer.enqueue(a, ReindexReason::ContentChanged);
+    f.indexer.enqueue(b, ReindexReason::ContentChanged);
+
+    // Grow the queue from inside the round: the first Report enqueues a
+    // third file, which must land past the round snapshot and wait for the
+    // next round instead of being consumed by this one.
+    bool grew = false;
+    Indexer::Progress first_end;
+    auto conn = f.indexer.on_progress_changed.connect([&] {
+        auto& progress = f.indexer.progress();
+        if(progress.stage == Indexer::Progress::Stage::Report && !grew) {
+            grew = true;
+            f.indexer.enqueue(c, ReindexReason::ContentChanged);
+        }
+        if(progress.stage == Indexer::Progress::Stage::End && first_end.total == 0) {
+            first_end = progress;
+        }
+    });
+
+    f.run_round();
+
+    ASSERT_TRUE(grew);
+    ASSERT_EQ(first_end.total, 2u);
+    ASSERT_EQ(first_end.dispatched, 2u);
+    ASSERT_EQ(first_end.completed, 2u);
+    ASSERT_EQ(f.indexer.pending_files(), 1u);
+
+    f.run_round();
+
+    ASSERT_EQ(f.indexer.pending_files(), 0u);
+    ASSERT_EQ(f.indexer.failed_files(), 3u);
+    ASSERT_TRUE(f.indexer.is_idle());
 }
 
 };  // TEST_SUITE(IndexerRequeue)

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -105,12 +105,15 @@ struct IndexerFixture {
         loop.run();
     }
 
+    /// One background round as a schedulable task, for tests that need to
+    /// interleave other tasks with it.
+    kota::task<> round_task() {
+        return indexer.run_background_indexing();
+    }
+
     /// Run one background round to completion on the fixture's loop.
     void run_round() {
-        auto body = [this]() -> kota::task<> {
-            co_await indexer.run_background_indexing();
-        };
-        auto task = body();
+        auto task = round_task();
         loop.schedule(task);
         loop.run();
     }
@@ -1926,6 +1929,42 @@ TEST_CASE(RoundSnapshotBoundary) {
 
     ASSERT_EQ(f.indexer.pending_files(), 0u);
     ASSERT_EQ(f.indexer.failed_files(), 3u);
+    ASSERT_TRUE(f.indexer.is_idle());
+}
+
+TEST_CASE(PauseResumesRound) {
+    IndexerFixture f;
+    f.workspace.config.project.enable_indexing.value = false;
+
+    auto a = f.workspace.path_pool.intern("/fake/a.cpp");
+    auto b = f.workspace.path_pool.intern("/fake/b.cpp");
+    f.indexer.enqueue(a, ReindexReason::ContentChanged);
+    f.indexer.enqueue(b, ReindexReason::ContentChanged);
+
+    // Pause from inside the round (the first Report), resume from a
+    // separately scheduled task: the feeder must park on the resume event
+    // and drain the rest of the round afterwards.
+    bool paused = false;
+    auto conn = f.indexer.on_progress_changed.connect([&] {
+        if(f.indexer.progress().stage == Indexer::Progress::Stage::Report && !paused) {
+            paused = true;
+            f.indexer.pause_indexing();
+        }
+    });
+
+    auto resume_body = [&]() -> kota::task<> {
+        co_await kota::yield();
+        f.indexer.resume_indexing();
+    };
+    auto round = f.round_task();
+    auto resumer = resume_body();
+    f.loop.schedule(round);
+    f.loop.schedule(resumer);
+    f.loop.run();
+
+    ASSERT_TRUE(paused);
+    ASSERT_EQ(f.indexer.pending_files(), 0u);
+    ASSERT_EQ(f.indexer.failed_files(), 2u);
     ASSERT_TRUE(f.indexer.is_idle());
 }
 

--- a/tests/unit/server/invalidator_tests.cpp
+++ b/tests/unit/server/invalidator_tests.cpp
@@ -87,7 +87,7 @@ TEST_CASE(CascadeSplitsOpenClosed) {
     deps[closed_user] = {mod};
     workspace.compile_graph = std::make_unique<CompileGraph>(
         loop,
-        [](std::uint32_t) -> kota::task<bool> { co_return true; },
+        [](std::uint32_t, bool) -> kota::task<bool> { co_return true; },
         [deps = std::move(deps)](std::uint32_t id) -> llvm::SmallVector<std::uint32_t> {
             auto it = deps.find(id);
             return it != deps.end() ? it->second : llvm::SmallVector<std::uint32_t>{};
@@ -660,7 +660,7 @@ TEST_CASE(CDBChangedCascadesModule) {
     deps[closed_user] = {mod};
     workspace.compile_graph = std::make_unique<CompileGraph>(
         loop,
-        [](std::uint32_t) -> kota::task<bool> { co_return true; },
+        [](std::uint32_t, bool) -> kota::task<bool> { co_return true; },
         [deps = std::move(deps)](std::uint32_t id) -> llvm::SmallVector<std::uint32_t> {
             auto it = deps.find(id);
             return it != deps.end() ? it->second : llvm::SmallVector<std::uint32_t>{};

--- a/tests/unit/server/invalidator_tests.cpp
+++ b/tests/unit/server/invalidator_tests.cpp
@@ -87,7 +87,9 @@ TEST_CASE(CascadeSplitsOpenClosed) {
     deps[closed_user] = {mod};
     workspace.compile_graph = std::make_unique<CompileGraph>(
         loop,
-        [](std::uint32_t, bool) -> kota::task<bool> { co_return true; },
+        [](std::uint32_t, bool) -> kota::task<CompileUnit::Outcome> {
+            co_return CompileUnit::Outcome::Success;
+        },
         [deps = std::move(deps)](std::uint32_t id) -> llvm::SmallVector<std::uint32_t> {
             auto it = deps.find(id);
             return it != deps.end() ? it->second : llvm::SmallVector<std::uint32_t>{};
@@ -660,7 +662,9 @@ TEST_CASE(CDBChangedCascadesModule) {
     deps[closed_user] = {mod};
     workspace.compile_graph = std::make_unique<CompileGraph>(
         loop,
-        [](std::uint32_t, bool) -> kota::task<bool> { co_return true; },
+        [](std::uint32_t, bool) -> kota::task<CompileUnit::Outcome> {
+            co_return CompileUnit::Outcome::Success;
+        },
         [deps = std::move(deps)](std::uint32_t id) -> llvm::SmallVector<std::uint32_t> {
             auto it = deps.find(id);
             return it != deps.end() ? it->second : llvm::SmallVector<std::uint32_t>{};

--- a/tests/unit/server/stateful_worker_tests.cpp
+++ b/tests/unit/server/stateful_worker_tests.cpp
@@ -47,7 +47,6 @@ TEST_CASE(CompileRequest) {
         CO_ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value().version, 1);
         test_done = true;
-        w.peer->close_output();
     });
 
     ASSERT_TRUE(test_done);
@@ -110,9 +109,13 @@ TEST_CASE(CancelledCompileFreesStrand) {
         // The strand must be free again: a second compile of the same
         // document completes instead of hanging behind the cancelled one's
         // never-released lock (the guard releases it when the cancelled
-        // handler's frame unwinds). Bounded so a regression is a clean,
-        // attributable failure instead of a CI-wide timeout.
+        // handler's frame unwinds). A held strand blocks a compile of any
+        // size, so the retry uses a trivial TU — re-parsing the 200k
+        // declarations here once blew the bound on a slow runner — and the
+        // bound makes a regression a clean, attributable failure instead
+        // of a CI-wide timeout.
         cp.version = 2;
+        cp.text = "int done;\n";
         kota::ipc::request_options retry_opts;
         retry_opts.timeout = std::chrono::milliseconds(30'000);
         auto retry = co_await w.peer->send_request(cp, retry_opts);
@@ -120,7 +123,6 @@ TEST_CASE(CancelledCompileFreesStrand) {
         EXPECT_EQ(retry.value().version, 2);
 
         test_done = true;
-        w.peer->close_output();
     });
 
     ASSERT_TRUE(test_done);
@@ -177,7 +179,6 @@ TEST_CASE(CancelNotificationInterruptsCompile) {
         EXPECT_TRUE(reply->tu_index_data.empty());
 
         test_done = true;
-        w.peer->close_output();
     });
 
     ASSERT_TRUE(test_done);
@@ -230,7 +231,6 @@ TEST_CASE(CancelledQueryFreesStrand) {
         CO_ASSERT_TRUE(retry.has_value());
 
         test_done = true;
-        w.peer->close_output();
     });
 
     ASSERT_TRUE(test_done);
@@ -254,7 +254,6 @@ TEST_CASE(HoverWithoutCompile) {
         // Should be "null" RawValue since document doesn't exist.
         EXPECT_EQ(result.value().data, std::string("null"));
         test_done = true;
-        w.peer->close_output();
     });
 
     ASSERT_TRUE(test_done);
@@ -296,7 +295,6 @@ TEST_CASE(CompileThenHover) {
         EXPECT_NE(hover_result.value().data, std::string("null"));
 
         test_done = true;
-        w.peer->close_output();
     });
 
     ASSERT_TRUE(test_done);
@@ -318,7 +316,6 @@ TEST_CASE(CodeActionReturnsEmpty) {
         // No document: the shared with_ast default is "null".
         EXPECT_EQ(result.value().data, std::string("[]"));
         test_done = true;
-        w.peer->close_output();
     });
 
     ASSERT_TRUE(test_done);
@@ -341,7 +338,6 @@ TEST_CASE(GoToDefinitionWithoutCompile) {
         // No document: the shared with_ast default is "null".
         EXPECT_EQ(result.value().data, std::string("null"));
         test_done = true;
-        w.peer->close_output();
     });
 
     ASSERT_TRUE(test_done);
@@ -362,7 +358,6 @@ TEST_CASE(SemanticTokensWithoutCompile) {
         CO_ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value().data, std::string("null"));
         test_done = true;
-        w.peer->close_output();
     });
 
     ASSERT_TRUE(test_done);
@@ -383,7 +378,6 @@ TEST_CASE(FoldingRangeWithoutCompile) {
         CO_ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value().data, std::string("null"));
         test_done = true;
-        w.peer->close_output();
     });
 
     ASSERT_TRUE(test_done);
@@ -404,7 +398,6 @@ TEST_CASE(DocumentSymbolWithoutCompile) {
         CO_ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value().data, std::string("null"));
         test_done = true;
-        w.peer->close_output();
     });
 
     ASSERT_TRUE(test_done);
@@ -424,7 +417,6 @@ TEST_CASE(DocumentLinkWithoutCompile) {
         CO_ASSERT_TRUE(result.has_value());
         EXPECT_TRUE(result.value().empty());
         test_done = true;
-        w.peer->close_output();
     });
 
     ASSERT_TRUE(test_done);
@@ -445,7 +437,6 @@ TEST_CASE(InlayHintsWithoutCompile) {
         CO_ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value().data, std::string("null"));
         test_done = true;
-        w.peer->close_output();
     });
 
     ASSERT_TRUE(test_done);
@@ -516,7 +507,6 @@ TEST_CASE(MultipleSequentialRequests) {
         EXPECT_TRUE(r5.has_value());
 
         test_done = true;
-        w.peer->close_output();
     });
 
     ASSERT_TRUE(test_done);
@@ -565,7 +555,6 @@ TEST_CASE(MultipleDocuments) {
         }
 
         test_done = true;
-        w.peer->close_output();
     });
 
     ASSERT_TRUE(test_done);
@@ -594,7 +583,6 @@ TEST_CASE(EvictNotification) {
         EXPECT_EQ(result.value().data, std::string("null"));
 
         test_done = true;
-        w.peer->close_output();
     });
 
     ASSERT_TRUE(test_done);
@@ -646,7 +634,6 @@ TEST_CASE(LowLimitDrivesEviction) {
         EXPECT_EQ(result.value().data, std::string("null"));
 
         test_done = true;
-        w.peer->close_output();
     });
 
     ASSERT_TRUE(test_done);
@@ -686,7 +673,6 @@ TEST_CASE(SpawnWithMemoryLimit) {
         EXPECT_TRUE(result.has_value());
 
         test_done = true;
-        w.peer->close_output();
     });
 
     ASSERT_TRUE(test_done);

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -94,6 +94,21 @@ struct WorkerPoolFixture {
                std::chrono::steady_clock::time_point{};
     }
 
+    std::size_t reclaim_deficit(std::size_t pending_high = 0) {
+        return pool.low_reclaim_deficit(pending_high);
+    }
+
+    /// Queue a fake High waiter, as acquire_stateless_slot would when no
+    /// slot is idle; the deficit counts it as demand.
+    void queue_high() {
+        auto pending = std::make_unique<WorkerPool::PendingStateless>(pool, worker::Priority::High);
+        pool.high_queue.push_back(pending.get());
+        pending->queue = &pool.high_queue;
+        queued_high.push_back(std::move(pending));
+    }
+
+    std::vector<std::unique_ptr<WorkerPool::PendingStateless>> queued_high;
+
     void set_max_crash_streak(unsigned n) {
         pool.options.max_crash_streak = n;
     }
@@ -1021,6 +1036,46 @@ TEST_CASE(CancelSkipsAskedSlots) {
 
     // The second ask must move on to the older claim instead of re-asking.
     EXPECT_TRUE(f.cancel_asked(0) && f.cancel_asked(1));
+}
+
+TEST_CASE(DeficitSurvivesUnarmedSweep) {
+    WorkerPoolFixture f;
+    for(int i = 0; i < 4; i += 1) {
+        f.add_stateless(true, true, true);
+    }
+    f.set_low_limit(8);
+    f.set_max_stateless(10);
+
+    // The rising edge finds only unarmed claims: the sweep stamps nothing,
+    // but the demand survives for the arming re-check to honor.
+    f.pool.foreground_pulse();
+    EXPECT_TRUE(!f.cancel_asked(0) && !f.cancel_asked(1) && !f.cancel_asked(2) &&
+                !f.cancel_asked(3));
+    EXPECT_EQ(f.reclaim_deficit(), 1u);
+
+    // Once a sender arms and the ask lands, the deficit is covered.
+    f.arm_cancel_source(3);
+    f.cancel_low(f.reclaim_deficit());
+    EXPECT_TRUE(f.cancel_asked(3));
+    EXPECT_EQ(f.reclaim_deficit(), 0u);
+}
+
+TEST_CASE(DeficitCountsQueuedHigh) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true, true);
+    f.set_low_limit(8);
+    f.set_max_stateless(10);
+
+    // Within budget and no High demand: nothing owed. A queued High with
+    // no idle slot owes one low even though the budget alone allows it.
+    EXPECT_EQ(f.reclaim_deficit(), 0u);
+    f.queue_high();
+    EXPECT_EQ(f.reclaim_deficit(), 1u);
+
+    // An ask already in flight covers the queued High.
+    f.arm_cancel_source(0);
+    f.cancel_low(1);
+    EXPECT_EQ(f.reclaim_deficit(), 0u);
 }
 
 };  // TEST_SUITE(WorkerPoolScheduling)

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -1400,6 +1400,12 @@ TEST_CASE(AIMDMinimum) {
     f.set_low_limit(1);
     f.apply_backoff();
     EXPECT_EQ(f.low_limit(), 1u);
+
+    // A zeroed budget is the memory controller's deliberate shutdown; a
+    // crash must not lift it back to 1 before recovery is observed.
+    f.set_low_limit(0);
+    f.apply_backoff();
+    EXPECT_EQ(f.low_limit(), 0u);
 }
 
 TEST_CASE(CrashAppliesBackoff) {
@@ -2020,6 +2026,54 @@ TEST_CASE(PreemptCancelsRequest) {
         }
         EXPECT_TRUE(f.worker_alive(0));
         EXPECT_EQ(f.crash_streak(0), 0u);
+
+        co_await f.stop();
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(CancelledCrashRetiresSlot) {
+    TempDir tmp;
+    tmp.touch("slow.cpp", "#include <vector>\n#include <string>\nint x = 1;\n");
+    auto src = tmp.path("slow.cpp");
+
+    WorkerPoolFixture f;
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        CO_ASSERT_TRUE(f.start(1, 0));
+        co_await kota::sleep(500);
+
+        worker::BuildParams params;
+        params.priority = worker::Priority::Low;
+        params.kind = worker::BuildKind::Index;
+        params.file = src;
+        params.directory = "/tmp";
+        params.arguments = make_args(src);
+
+        worker::protocol::integer code = 0;
+        kota::task_group<> group(f.loop);
+        auto sender = [&]() -> kota::task<> {
+            auto result = co_await f.pool.send_stateless(params);
+            if(!result.has_value())
+                code = result.error().code;
+        };
+        group.spawn(sender());
+        while(f.low_busy() == 0)
+            co_await kota::sleep(1);
+
+        // A cooperative cancel whose victim then dies on its own inside the
+        // grace window: the request still classifies as cancelled, but the
+        // slot must be retired with it — released as Alive it would take
+        // the next dispatch before the monitor observes the exit. The
+        // generation bump is the retirement evidence that survives an
+        // instant respawn.
+        auto gen = f.generation(0);
+        f.cancel_low(1);
+        f.kill_worker(0);
+        co_await group.join();
+        EXPECT_EQ(code, worker::dispatch_errc::cancelled);
+        EXPECT_NE(f.generation(0), gen);
 
         co_await f.stop();
         done = true;

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -53,6 +53,15 @@ struct WorkerPoolFixture {
         pool.low_limit = low;
     }
 
+    void cancel_low(std::size_t count) {
+        pool.cancel_low_priority(count);
+    }
+
+    bool cancel_asked(std::size_t idx) {
+        return pool.stateless_workers[idx].cancel_requested_at !=
+               std::chrono::steady_clock::time_point{};
+    }
+
     void set_max_crash_streak(unsigned n) {
         pool.options.max_crash_streak = n;
     }
@@ -831,9 +840,11 @@ TEST_CASE(EffectiveLimitClamped) {
     f.add_stateless();
     f.add_stateless();
     f.set_low_limit(8);
-    // Capacity 3 caps the effective allowance at 2 regardless of low_limit.
-    EXPECT_EQ(f.max_low_limit(), 2u);
-    EXPECT_EQ(f.effective_low_limit(), 2u);
+    // Capacity 3 caps the effective allowance regardless of low_limit; no
+    // standing reservation — foreground bursts reclaim slots through the
+    // foreground cap and the deficit cancel instead.
+    EXPECT_EQ(f.max_low_limit(), 3u);
+    EXPECT_EQ(f.effective_low_limit(), 3u);
 }
 
 TEST_CASE(LowCapCountsLive) {
@@ -846,10 +857,10 @@ TEST_CASE(LowCapCountsLive) {
     f.mark_dead(1);
 
     // A slot awaiting respawn is future capacity, not schedulable now: the
-    // reserve-one-for-high cap must not let low-priority work occupy both
-    // live workers for the whole respawn window.
-    EXPECT_EQ(f.max_low_limit(), 1u);
-    EXPECT_EQ(f.effective_low_limit(), 1u);
+    // ceiling must track the two live workers, not the three allocated
+    // slots, for the whole respawn window.
+    EXPECT_EQ(f.max_low_limit(), 2u);
+    EXPECT_EQ(f.effective_low_limit(), 2u);
 }
 
 TEST_CASE(LowCapSkipsRetiring) {
@@ -862,9 +873,56 @@ TEST_CASE(LowCapSkipsRetiring) {
     f.set_retiring(1);
 
     // A retiring slot is alive but takes no new work, so it must not
-    // count toward the schedulable pool the cap reserves from.
-    EXPECT_EQ(f.max_low_limit(), 1u);
-    EXPECT_EQ(f.effective_low_limit(), 1u);
+    // count toward the schedulable ceiling.
+    EXPECT_EQ(f.max_low_limit(), 2u);
+    EXPECT_EQ(f.effective_low_limit(), 2u);
+}
+
+TEST_CASE(ForegroundCapClampsBudget) {
+    WorkerPoolFixture f;
+    f.add_stateless();
+    f.add_stateless();
+    f.add_stateless();
+    f.add_stateless();
+    f.set_low_limit(8);
+    f.set_max_stateless(10);
+
+    // Idle: the full schedulable capacity, no standing reservation.
+    EXPECT_EQ(f.pool.effective_low_limit(), 4u);
+
+    // Active: 30% of the configured capacity, not of the live slot count.
+    f.pool.foreground_pulse();
+    EXPECT_EQ(f.pool.effective_low_limit(), 3u);
+}
+
+TEST_CASE(ForegroundCancelsExcess) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true, true);
+    f.add_stateless(true, true, true);
+    f.add_stateless(true, true, true);
+    f.add_stateless(true, true, true);
+    f.set_low_limit(4);
+    f.set_max_stateless(10);
+
+    // The rising edge cancels exactly the over-cap excess (4 busy − cap 3),
+    // newest slot first, cooperatively (slots stay alive).
+    f.pool.foreground_pulse();
+
+    EXPECT_TRUE(f.cancel_asked(3));
+    EXPECT_TRUE(!f.cancel_asked(0) && !f.cancel_asked(1) && !f.cancel_asked(2));
+    EXPECT_EQ(f.state(3), WorkerPoolFixture::SlotState::Alive);
+}
+
+TEST_CASE(CancelSkipsAskedSlots) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true, true);
+    f.add_stateless(true, true, true);
+
+    f.cancel_low(1);
+    f.cancel_low(1);
+
+    // The second ask must move on to the older slot instead of re-asking.
+    EXPECT_TRUE(f.cancel_asked(0) && f.cancel_asked(1));
 }
 
 };  // TEST_SUITE(WorkerPoolScheduling)
@@ -1364,9 +1422,9 @@ TEST_CASE(MaxLowLimitShrinks) {
 
     f.simulate_crash(0, false);
 
-    // Capacity dropped to 2; the derived ceiling reserves one for high and
-    // clamps the stored allowance of 2 down to it.
-    EXPECT_EQ(f.max_low_limit(), 1u);
+    // Capacity dropped to 2, so the ceiling tracks it; the crash AIMD
+    // independently walked the stored allowance down to 1.
+    EXPECT_EQ(f.max_low_limit(), 2u);
     EXPECT_EQ(f.effective_low_limit(), 1u);
 }
 
@@ -1427,8 +1485,10 @@ TEST_CASE(SevereMemoryTick) {
 
     f.tick_memory(0.05);
 
-    // Floor the allowance, remember the recovery target, kill the low work.
-    EXPECT_EQ(f.low_limit(), 1u);
+    // Zero the allowance, remember the recovery target, kill the low work.
+    // Zero, not one: any allowance left would let the preemption's own
+    // dispatch kick admit a fresh compile into the pressure being relieved.
+    EXPECT_EQ(f.low_limit(), 0u);
     EXPECT_EQ(f.w_max(), 2u);
     EXPECT_EQ(f.low_busy(), 0u);
     EXPECT_EQ(f.state(0), WorkerPoolFixture::SlotState::Dying);
@@ -1825,8 +1885,8 @@ TEST_CASE(ScaleUpKeepsLimit) {
         CO_ASSERT_TRUE(f.scale_up());
 
         // The new worker adds exactly one to the allowance; it must not
-        // reset the reduction back to the ceiling (which is now 3).
-        EXPECT_EQ(f.max_low_limit(), 3u);
+        // reset the reduction back to the ceiling (which is now 4).
+        EXPECT_EQ(f.max_low_limit(), 4u);
         EXPECT_EQ(f.low_limit(), 2u);
 
         co_await f.stop();

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -53,6 +53,38 @@ struct WorkerPoolFixture {
         pool.low_limit = low;
     }
 
+    /// Arm a busy slot with a live cancellation source, as a resumed
+    /// sender would; cancel_low_priority only victimizes armed slots.
+    std::shared_ptr<kota::cancellation_source> arm_cancel_source(std::size_t idx) {
+        auto source = std::make_shared<kota::cancellation_source>();
+        pool.stateless_workers[idx].preempt_source = source;
+        return source;
+    }
+
+    void tick_foreground() {
+        pool.tick_foreground();
+    }
+
+    /// Age the last foreground activity past the hold window.
+    void rewind_fg_activity() {
+        pool.last_fg_activity =
+            std::chrono::steady_clock::now() - WorkerPool::fg_hold - std::chrono::seconds(1);
+    }
+
+    /// Stamp a cooperative cancel as having happened past the grace window.
+    void expire_cancel_grace(std::size_t idx) {
+        pool.stateless_workers[idx].cancel_requested_at =
+            std::chrono::steady_clock::now() - WorkerPool::cancel_grace - std::chrono::seconds(1);
+    }
+
+    void tick_cancel_grace() {
+        pool.tick_cancel_grace();
+    }
+
+    void set_claim_epoch(std::size_t idx, std::uint64_t epoch) {
+        pool.stateless_workers[idx].claim_epoch = epoch;
+    }
+
     void cancel_low(std::size_t count) {
         pool.cancel_low_priority(count);
     }
@@ -903,25 +935,91 @@ TEST_CASE(ForegroundCancelsExcess) {
     f.add_stateless(true, true, true);
     f.set_low_limit(4);
     f.set_max_stateless(10);
+    std::vector<std::shared_ptr<kota::cancellation_source>> sources;
+    for(std::size_t i = 0; i < 4; i += 1) {
+        f.set_claim_epoch(i, i + 1);
+        sources.push_back(f.arm_cancel_source(i));
+    }
 
     // The rising edge cancels exactly the over-cap excess (4 busy − cap 3),
-    // newest slot first, cooperatively (slots stay alive).
+    // newest claim first, cooperatively (slots stay alive).
     f.pool.foreground_pulse();
 
     EXPECT_TRUE(f.cancel_asked(3));
+    EXPECT_TRUE(sources[3]->cancelled());
     EXPECT_TRUE(!f.cancel_asked(0) && !f.cancel_asked(1) && !f.cancel_asked(2));
+    EXPECT_TRUE(!sources[0]->cancelled() && !sources[1]->cancelled());
     EXPECT_EQ(f.state(3), WorkerPoolFixture::SlotState::Alive);
+}
+
+TEST_CASE(ForegroundHoldExpires) {
+    WorkerPoolFixture f;
+    f.add_stateless();
+    f.add_stateless();
+    f.set_low_limit(8);
+    f.set_max_stateless(10);
+
+    f.pool.foreground_pulse();
+    EXPECT_EQ(f.pool.effective_low_limit(), 3u);
+
+    // Still inside the hold window: the tick keeps the clamp.
+    f.tick_foreground();
+    EXPECT_EQ(f.pool.effective_low_limit(), 3u);
+
+    // Rewind the last activity past the hold: the tick reopens the budget.
+    f.rewind_fg_activity();
+    f.tick_foreground();
+    EXPECT_EQ(f.pool.effective_low_limit(), 2u);
+}
+
+TEST_CASE(GraceKillReclaims) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true, true);
+    f.arm_cancel_source(0);
+    f.cancel_low(1);
+
+    // Within the grace window the worker lives on.
+    f.tick_cancel_grace();
+    EXPECT_EQ(f.state(0), WorkerPoolFixture::SlotState::Alive);
+
+    // Past it, the stuck process is reclaimed like a memory preemption:
+    // no crash accounting, immediate respawn.
+    f.expire_cancel_grace(0);
+    f.tick_cancel_grace();
+    EXPECT_EQ(f.state(0), WorkerPoolFixture::SlotState::Dying);
+}
+
+TEST_CASE(CancelSkipsUnarmedSlots) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true, true);
+    f.add_stateless(true, true, true);
+    f.set_claim_epoch(0, 1);
+    f.set_claim_epoch(1, 2);
+    // Slot 1 was claimed but its sender has not resumed: no source yet.
+    auto armed = f.arm_cancel_source(0);
+
+    f.cancel_low(2);
+
+    // Only the armed slot may be stamped — stamping the un-asked one would
+    // get a request that never saw a cancel grace-killed.
+    EXPECT_TRUE(f.cancel_asked(0));
+    EXPECT_TRUE(armed->cancelled());
+    EXPECT_TRUE(!f.cancel_asked(1));
 }
 
 TEST_CASE(CancelSkipsAskedSlots) {
     WorkerPoolFixture f;
     f.add_stateless(true, true, true);
     f.add_stateless(true, true, true);
+    f.set_claim_epoch(0, 1);
+    f.set_claim_epoch(1, 2);
+    f.arm_cancel_source(0);
+    f.arm_cancel_source(1);
 
     f.cancel_low(1);
     f.cancel_low(1);
 
-    // The second ask must move on to the older slot instead of re-asking.
+    // The second ask must move on to the older claim instead of re-asking.
     EXPECT_TRUE(f.cancel_asked(0) && f.cancel_asked(1));
 }
 

--- a/tests/unit/server/worker_test_helpers.h
+++ b/tests/unit/server/worker_test_helpers.h
@@ -115,10 +115,17 @@ struct WorkerHandle {
     }
 
     /// Run a coroutine on the event loop and return when it completes.
+    /// Closes the worker's input afterwards — including when the body
+    /// unwound early through a failed CO_ASSERT — so the IO pump drains
+    /// and a failing test reports instead of hanging the suite.
     template <typename F>
     void run(F&& coro_factory) {
+        auto body = [](WorkerHandle& self, F factory) -> kota::task<> {
+            co_await factory();
+            self.peer->close_output();
+        };
         loop.schedule(peer->run());
-        loop.schedule(coro_factory());
+        loop.schedule(body(*this, std::forward<F>(coro_factory)));
         loop.run();
     }
 };


### PR DESCRIPTION
## Related issue

Fixes #611. Also the scheduler half of the "background indexing starves the foreground" complaints (#602's storm becomes budget-bounded; its cascade semantics are a separate issue).

## What changed

Background indexing could take every stateless worker and the machine with it: the dispatch loop spawned the whole queue upfront, requeues fed back into the same round (the #611 busy-loop, `[51294/1]` progress and a ~986 GiB log in the wild), and nothing about user activity ever shrank the background budget.

**Indexing rounds (scheduler mechanics)**

- A round now snapshots its queue range at start and consumes only that range; requeues and new enqueues land past the snapshot and wait for the next round. Progress numerators can no longer outrun their totals.
- With every stateless slot dead but revivable, the round parks on a new `WorkerPool::on_stateless_capacity` signal instead of spinning instant `worker_unavailable` failures — the #611 fix proper.
- Dispatch is pull-based: at most twice the current low-priority budget is in flight, so the pool queue stays shallow enough for pauses and budget cuts to take effect. The dispatch loop runs as a child of the round's task group, so a shutdown cancel cascades through the round's join and never destroys the group with live children.

**Foreground-aware budget**

- The pool now tracks foreground activity: every stateful dispatch and High stateless dispatch notes it, LSP/agent request ingress and didOpen/didChange/didSave pulse it, and in-flight foreground work holds it; a 10 s hold after the last evidence ends it (test-only `clice/internal/*` probes deliberately do not count).
- Low-priority budget: with no foreground activity, the full schedulable capacity (the old permanent reserve-one-slot rule is gone); while the user is active, 30% of the configured worker capacity; less under memory pressure, and zero under severe pressure — previously the floor of one slot let the post-preemption dispatch kick admit a fresh compile into the very pressure being relieved.
- Reclaim is cooperative, not lethal: over-budget low builds get a wire cancellation, clang exits at the next declaration boundary via the existing stop flag, and the file requeues for the next round. A worker that ignores the cancel past a 10 s grace is killed and respawned without crash accounting. A High request finding no idle slot cancels one low build (newest claim first) instead of waiting out a whole TU.
- Module PCM builds inherit the requester's class: dependency preparation for a user request dispatches High, background indexing stays Low.
- Controller hygiene: the memory window no longer recovers upward while the foreground cap masks it (anti-windup), and the scaler neither counts a foreground- nor a zero-budget clamp as saturation.

Known gaps, deliberately deferred: a foreground requester joining mid-flight does not re-donate priority to already-linked deeper module dependencies, and a caller-supplied cancellation token cannot be composed with the scheduler's (today's only low-priority caller passes none); both are documented at the relevant sites.

## Tests

All four suites locally on RelWithDebInfo, plus a Debug (ASan + assertions) build and unit run: unit 1251, integration 351, smoke 3, snap 395, `npm run check` clean.

New coverage: unit tests for the round snapshot boundary, pause/resume mid-round, the foreground cap and its falling edge, cooperative-cancel victim selection (armed-source invariant, claim-order, skip-unarmed), and the cancel-grace kill; an integration regression that burns the whole pool's crash budget and asserts the round parks quietly (bounded requeue logging, responsive master) and finishes every file after revival.
