### PR TITLE
fix(glob): only reject consecutive slashes, not single slashes or short segments

### DIFF
--- a/src/support/glob_pattern.cpp
+++ b/src/support/glob_pattern.cpp
@@ -166,17 +166,11 @@ std::expected<GlobPattern, std::string> GlobPattern::create(llvm::StringRef s,
     // Store the prefix that does not contain any metacharacter.
     GlobPattern pat;
     size_t prefix_size = s.find_first_of("?*[{\\");
+    if(s.substr(0, prefix_size).contains("//")) {
+        return std::unexpected{"Multiple `/` is not allowed"};
+    }
     if(prefix_size == std::string::npos) {
-        pat.prefix = s.substr(0, prefix_size).str();
-        // check if there is multiple `/` in prefix
-        size_t last_slash = 0;
-        size_t size = pat.prefix.size();
-        for(size_t i = 0; i < size; ++i) {
-            if(s[i] == '/' && i - last_slash == 1) {
-                return std::unexpected{"Multiple `/` is not allowed"};
-            }
-            last_slash = i;
-        }
+        pat.prefix = s.str();
         return pat;
     }
     if(prefix_size != 0 && s[prefix_size - 1] == '/') {
@@ -184,15 +178,6 @@ std::expected<GlobPattern, std::string> GlobPattern::create(llvm::StringRef s,
         --prefix_size;
     }
     pat.prefix = s.substr(0, prefix_size).str();
-    // check if there is multiple `/` in prefix
-    size_t last_slash = 0;
-    size_t size = pat.prefix.size();
-    for(size_t i = 0; i < size; ++i) {
-        if(s[i] == '/' && i - last_slash == 1) {
-            return std::unexpected{"Multiple `/` is not allowed"};
-        }
-        last_slash = i;
-    }
     s = s.substr(pat.prefix_at_seg_end ? prefix_size + 1 : prefix_size);
 
     llvm::SmallVector<std::string, 1> sub_pats;
@@ -268,7 +253,7 @@ std::expected<GlobPattern::SubGlobPattern, std::string>
                 return std::unexpected{"Invalid glob pattern, stray '\\'"};
             }
         } else if(s[i] == '/') {
-            if(i - current_gs->start == 1) {
+            if(i != 0 && i == current_gs->start) {
                 return std::unexpected{"Multiple `/` is not allowed"};
             }
             current_gs->end = i;

--- a/tests/unit/support/glob_pattern_tests.cpp
+++ b/tests/unit/support/glob_pattern_tests.cpp
@@ -29,6 +29,50 @@ TEST_CASE(PatternSema) {
     ASSERT_FALSE(Pat3.has_value());
 }
 
+TEST_CASE(SingleSlashPrefix) {
+    // A single `/` inside the literal prefix (e.g. `src/foo` of `src/foo*.c`)
+    // is not a "multiple `/`" and must be accepted.
+    PATDEF(Pat1, "a/b")
+    ASSERT_TRUE(Pat1.match("a/b"));
+    ASSERT_FALSE(Pat1.match("ab"));
+    ASSERT_FALSE(Pat1.match("a/c"));
+
+    PATDEF(Pat2, "src/foo*.c")
+    ASSERT_TRUE(Pat2.match("src/foo.c"));
+    ASSERT_TRUE(Pat2.match("src/foo1.c"));
+    ASSERT_FALSE(Pat2.match("src/foo.cpp"));
+    ASSERT_FALSE(Pat2.match("src/bar1.c"));
+
+    PATDEF(Pat3, "/foo/bar/baz/*.c")
+    ASSERT_TRUE(Pat3.match("/foo/bar/baz/x.c"));
+    ASSERT_FALSE(Pat3.match("/foo/bar/baz/x/y.c"));
+
+    // A one-character segment (e.g. `*`) followed by `/` is also valid.
+    PATDEF(Pat4, "foo*/bar")
+    ASSERT_TRUE(Pat4.match("foo/bar"));
+    ASSERT_TRUE(Pat4.match("fooX/bar"));
+    ASSERT_TRUE(Pat4.match("fooXY/bar"));
+    ASSERT_FALSE(Pat4.match("fooX/baz"));
+
+    PATDEF(Pat5, "*/foo")
+    ASSERT_TRUE(Pat5.match("x/foo"));
+    ASSERT_FALSE(Pat5.match("x/y/foo"));
+
+    PATDEF(Pat6, "src/*/test.c")
+    ASSERT_TRUE(Pat6.match("src/x/test.c"));
+    ASSERT_FALSE(Pat6.match("src/x/y/test.c"));
+
+    // Real consecutive `/` must still be rejected.
+    auto Pat7 = clice::GlobPattern::create("a//b", 100);
+    ASSERT_FALSE(Pat7.has_value());
+
+    auto Pat8 = clice::GlobPattern::create("src//foo*.c", 100);
+    ASSERT_FALSE(Pat8.has_value());
+
+    auto Pat9 = clice::GlobPattern::create("a/*//b", 100);
+    ASSERT_FALSE(Pat9.has_value());
+}
+
 TEST_CASE(MaxSubGlob) {
     auto Pat1 = clice::GlobPattern::create("{AAA,BBB,AB*}");
     ASSERT_TRUE(Pat1.has_value());


### PR DESCRIPTION
## Problem

Both "Multiple `/` is not allowed" checks in `GlobPattern` are off-by-one and reject many valid patterns at compile time:

**1. Prefix check in `GlobPattern::create`** ([src/support/glob_pattern.cpp](https://github.com/clice-io/clice/blob/main/src/support/glob_pattern.cpp))

```cpp
size_t last_slash = 0;
for(size_t i = 0; i < size; ++i) {
    if(s[i] == '/' && i - last_slash == 1) { ... }
    last_slash = i;   // updated every iteration
}
```

`last_slash = i` runs unconditionally, so `i - last_slash == 1` holds at every position — the loop degenerates into "reject any `/` in the prefix (except position 0)". Valid patterns like `a/b` or `src/foo*.c` fail to compile with `Multiple `/` is not allowed`.

**2. Segment check in `SubGlobPattern::create`**

```cpp
if(i - current_gs->start == 1) { return std::unexpected{"Multiple `/` is not allowed"}; }
```

This intends to catch empty segments (`//`) but instead rejects every length-1 segment. Patterns with a single-character glob segment — `foo*/bar`, `src/*/test.c`, `*/foo` — all fail to compile.

Since these patterns are rejected at construction, any user rule in `.clice/config` matching these shapes is silently dropped (with only a `LOG_WARN`) in `Config::load`, so the fix also restores rule-matching behavior for such patterns.

## Fix

- Prefix: check `s.substr(0, prefix_size).contains("//")` — equivalent to the original intent, and it also covers the full prefix before the `prefix_at_seg_end` adjustment.
- Segment: check `i != 0 && i == current_gs->start` — only a genuinely empty segment triggers the error, while a leading `/` is still accepted.

## Testing

Verified with a standalone harness (clang 22 + LLVMSupport, extracted verbatim logic — the repo's pixi toolchain could not run in this environment):

- 16 of 31 assertions fail on `main` (every legal pattern above is wrongly rejected); all 31 pass with this fix.
- The pre-existing 8 test cases in `tests/unit/support/glob_pattern_tests.cpp` still pass; genuine `//` patterns (`a//b`, `/foo/bar/baz////aaa.{c,cc}`, `a/*//b`) are still rejected.
- Added a `SingleSlashPrefix` regression test covering slash-bearing prefixes, single-character segments, and real `//` rejection.