### PR TITLE
fix(glob): bounds-check pattern reads for '[' at end of pattern

### DIFF
--- a/src/support/glob_pattern.cpp
+++ b/src/support/glob_pattern.cpp
@@ -88,7 +88,7 @@ static std::expected<llvm::SmallVector<std::string, 1>, std::string>
             }
             while(i != e && s[i] != ']') {
                 if(s[i] == '\\') {
-                    if(i == e) {
+                    if(i + 1 == e) {
                         return std::unexpected{
                             "Invalid glob pattern, unmatched '[', with stray "
                             "'\\' inside"};

--- a/src/support/glob_pattern.cpp
+++ b/src/support/glob_pattern.cpp
@@ -33,7 +33,7 @@ static std::expected<GlobCharSet, std::string> expand(llvm::StringRef s, llvm::S
                 ++i;
                 if(c_end == '\\') {
                     ++i;
-                    if(s[i] == e) {
+                    if(i == e) {
                         return std::unexpected{"Invalid expansions: stary `\\`"};
                     }
                     c_end = s[i];
@@ -83,7 +83,7 @@ static std::expected<llvm::SmallVector<std::string, 1>, std::string>
     for(size_t i = 0, e = s.size(); i != e; ++i) {
         if(s[i] == '[') {
             ++i;
-            if(s[i] == ']') {
+            if(i != e && s[i] == ']') {
                 ++i;
             }
             while(i != e && s[i] != ']') {
@@ -215,7 +215,7 @@ std::expected<GlobPattern::SubGlobPattern, std::string>
         if(s[i] == '[') {
             ++i;
             size_t j = i;
-            if(s[j] == ']') {
+            if(j != e && s[j] == ']') {
                 // ']' is allowed as the first character of a character class. '[]'
                 // is invalid. So, just skip the first character.
                 ++j;

--- a/tests/unit/support/glob_pattern_tests.cpp
+++ b/tests/unit/support/glob_pattern_tests.cpp
@@ -27,6 +27,14 @@ TEST_CASE(PatternSema) {
 
     auto Pat3 = clice::GlobPattern::create("/foo/bar/baz/**////*.{c,cc}", 100);
     ASSERT_FALSE(Pat3.has_value());
+
+    // An unmatched '[' at the end of the pattern must be reported as an error
+    // instead of reading past the end of the pattern string.
+    auto Pat4 = clice::GlobPattern::create("foo[", 100);
+    ASSERT_FALSE(Pat4.has_value());
+
+    auto Pat5 = clice::GlobPattern::create("{a,b}[", 100);
+    ASSERT_FALSE(Pat5.has_value());
 }
 
 TEST_CASE(SingleSlashPrefix) {

--- a/tests/unit/support/glob_pattern_tests.cpp
+++ b/tests/unit/support/glob_pattern_tests.cpp
@@ -35,6 +35,10 @@ TEST_CASE(PatternSema) {
 
     auto Pat5 = clice::GlobPattern::create("{a,b}[", 100);
     ASSERT_FALSE(Pat5.has_value());
+
+    // Same for an unmatched '[' whose last char is an escaping backslash.
+    auto Pat6 = clice::GlobPattern::create("{a,b}[\\", 100);
+    ASSERT_FALSE(Pat6.has_value());
 }
 
 TEST_CASE(SingleSlashPrefix) {


### PR DESCRIPTION
## Problem

Two out-of-bounds reads in `GlobPattern` when a pattern ends with an unmatched `[`:

**1. `parseBraceExpansions`** — after `++i` on `[`, `s[i]` is read without checking `i != e`:

```cpp
if(s[i] == '[') {
    ++i;
    if(s[i] == ']') {   // s[i] read at i == e
```

Trigger: `GlobPattern::create("{a,b}[")` (the brace forces entry into `parseBraceExpansions`).

**2. `SubGlobPattern::create`** — same shape, `s[j]` read at `j == e`:

```cpp
if(s[i] == '[') {
    ++i;
    size_t j = i;
    if(s[j] == ']') {   // s[j] read at j == e
```

Trigger: `GlobPattern::create("foo[")`.

Impact: in Debug builds (assertions enabled) `llvm::StringRef::operator[]` aborts the process; in release builds these are heap overreads (UB). Since patterns come from user config rules, a trailing `[` in a rule pattern crashes / overreads instead of being reported as `unmatched '['`.

## Fix

Add the missing `i != e` / `j != e` guards. Both inputs now fall through to the existing `unmatched '['` error path and `create()` returns the intended error.

Also fix a latent typo in `expand()`: `if(s[i] == e)` compares a character against the size — should be `if(i == e)` (matches the upstream LLVM `GlobPattern` this code derives from). The branch is unreachable today (a trailing `\` in the char class would escape the closing `]`), but the check is wrong as written.

## Testing

Reproduced with an ASan harness (patterns >15 chars so the `std::string` lives on the heap; verified the llvm `StringRef` debug assertion fires on `main` for both inputs):

```
== CASE 2 (foo[) ==   assertion `Index < size()' failed   (before)
== CASE 3 ({a,b}[) == assertion `Index < size()' failed   (before)
```

After the fix both return `Invalid glob pattern, unmatched '['`, and the full pre-existing suite (9 cases incl. the `SingleSlashPrefix` test from #616) passes.

Add regression tests in `PatternSema` for trailing `[` with and without braces.