### PR TITLE
chore: add codex delegation skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8,6 +8,7 @@ Detailed knowledge lives in skills — load them at the moments their descriptio
 - **write-tests** — before writing or modifying anything under `tests/` (fixture forms, snapshot workflow and rules, pitfalls).
 - **pr** — before committing, opening a PR, or checking on an open one (pre-push checks, self-review, CI/review watching).
 - **resolve-comments** — each watch round of an open PR: pulls unresolved review threads, fixes and resolves them, returns a summary.
+- **codex** — before delegating work to the codex CLI: adversarial plan review, code review, debugging, test writing, scoped implementation.
 - **build / test / format** — build the project, run suites, format sources.
 - **release / upgrade-llvm** — release operations and LLVM upgrades.
 

--- a/.claude/skills/codex/SKILL.md
+++ b/.claude/skills/codex/SKILL.md
@@ -39,14 +39,22 @@ codex exec -m gpt-5.6-sol -c model_reasoning_effort=xhigh \
   (review, test writing, implementation) must be told in the prompt which
   rule files to read first, e.g. `.claude/CLAUDE.md` and the cpp-style skill.
 
-Code review has a purpose-built mode that collects the diff itself:
+The canonical code-review invocation is the standard form with a prompt that
+loads the repo rules and reviews the branch diff:
 
 ```bash
-codex exec review --base origin/main \
-  -m gpt-5.6-sol -c model_reasoning_effort=xhigh -o /tmp/codex-review.md
+codex exec -m gpt-5.6-sol -c model_reasoning_effort=xhigh \
+  --dangerously-bypass-approvals-and-sandbox -o /tmp/codex-review.md \
+  "Read .claude/CLAUDE.md and .claude/skills/cpp-style/SKILL.md and apply
+their rules. Review the changes in 'git diff origin/main...HEAD' for
+correctness, style, and test coverage. Report ranked findings, each with
+file:line and a concrete failure scenario."
 ```
 
-Also `--uncommitted` (staged + unstaged + untracked) and `--commit <sha>`.
+The built-in `codex exec review --base origin/main` collects the diff itself,
+but `--base` is mutually exclusive with the prompt argument, so it can never
+see the repo rules — use it only as a quick rules-blind supplementary pass
+(also `--uncommitted`, `--commit <sha>`).
 
 ## Multi-round sessions
 
@@ -76,6 +84,8 @@ into independent continuations.
   its diff as you would a PR — you own what gets committed. Verification
   (build + suites) happens in the main session, and the hard rules (never
   weaken tests, never push unverified) apply unchanged to codex-authored code.
+  Any run that may modify files gets its own git worktree — the main checkout
+  is for analysis-only runs, or edits will race with this session's.
 - **Never let codex run the integration or snap suites while this session
   might also run them** — concurrent runs in one checkout clobber each other's
   workspace `.clice`. Either codex runs them and you don't, or codex analyzes
@@ -86,7 +96,7 @@ into independent continuations.
 - **Plan review**: point it at the doc path; ask for attacks ranked by
   severity, each with a minimal counterexample. Fold confirmed findings back
   into the doc.
-- **Code review**: `codex exec review --base origin/main` — the primary
+- **Code review**: the canonical review command above — the primary
   self-review pass of the pr skill.
 - **Debug**: give the failing test, the repro command, and the suspect area;
   ask for a root-cause hypothesis plus the experiment that would confirm it.
@@ -103,4 +113,6 @@ into independent continuations.
 
 If a run dies before writing `-o`, the transcript is at
 `~/.codex/sessions/YYYY/MM/DD/*.jsonl`; the final reply is the last record
-with payload `type == "message"` and `role == "assistant"`.
+with payload `type == "message"` and `role == "assistant"`. These transcripts
+persist indefinitely and record full prompts, file contents, and command
+output — treat `~/.codex/sessions/` as sensitive local data.

--- a/.claude/skills/codex/SKILL.md
+++ b/.claude/skills/codex/SKILL.md
@@ -44,7 +44,7 @@ loads the repo rules and reviews the branch diff:
 
 ```bash
 codex exec -m gpt-5.6-sol -c model_reasoning_effort=xhigh \
-  --dangerously-bypass-approvals-and-sandbox -o /tmp/codex-review.md \
+  --dangerously-bypass-approvals-and-sandbox -o /tmp/codex-review-<topic>.md \
   "Read .claude/CLAUDE.md and .claude/skills/cpp-style/SKILL.md and apply
 their rules. Review the changes in 'git diff origin/main...HEAD' for
 correctness, style, and test coverage. Report ranked findings, each with
@@ -62,10 +62,10 @@ see the repo rules — use it only as a quick rules-blind supplementary pass
 (`--last` picks the newest session). Use it for successive adversarial rounds,
 "now fix what you found", or clarifying questions — never restate context in a
 fresh session. Execution-scoped flags are NOT inherited from the resumed
-session: repeat `-c model_reasoning_effort=xhigh`,
+session: repeat `-m gpt-5.6-sol`, `-c model_reasoning_effort=xhigh`,
 `--dangerously-bypass-approvals-and-sandbox`, and a fresh `-o` path on every
-resume, or the follow-up silently runs at default effort, sandboxed, and
-without an output file. `codex exec fork <session-id>` branches one history
+resume, or the follow-up silently runs on the default model at default
+effort, sandboxed, and without an output file. `codex exec fork <session-id>` branches one history
 into independent continuations.
 
 ## Discipline

--- a/.claude/skills/codex/SKILL.md
+++ b/.claude/skills/codex/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: codex
+description: Drive the codex CLI (GPT-5.6-sol) as a delegate — adversarial plan review, code review, debugging, test writing, scoped implementation. Read BEFORE invoking codex.
+---
+
+# Codex Delegation
+
+`codex` is an installed CLI agent backed by GPT-5.6-sol — cheap, strong, and
+independent of this session's blind spots. Prefer it for: adversarial review of
+a design or plan, pre-PR code review, root-causing a bug, adding tests to probe
+behavior, and implementing well-scoped tasks. The independence is the value: it
+was not part of writing the thing it reviews.
+
+## Invocation
+
+```bash
+codex exec -m gpt-5.6-sol -c model_reasoning_effort=xhigh \
+  --dangerously-bypass-approvals-and-sandbox \
+  -o /tmp/codex-<topic>.md \
+  "<prompt>"
+```
+
+- Always pass `-o` — it writes the final reply to a file; stdout mixes it into
+  the transcript and truncates easily.
+- The full bypass is deliberate: the sandbox breaks builds and tooling. Codex
+  therefore runs with your permissions — scope the prompt accordingly.
+- xhigh runs take minutes to tens of minutes: run in the background and keep
+  working, no sleep polling.
+- The startup header prints `session id: <uuid>` — capture it whenever a
+  follow-up round is plausible.
+- If `gpt-5.6-sol` is rejected (plan/auth), drop `-m` to use the account
+  default, and say so when reporting results.
+- Prompt shape: the task, the exact files/commands in scope, and the answer
+  format you want (e.g. "numbered findings, each with a minimal
+  counterexample"). Codex reads files itself — point at paths instead of
+  pasting content.
+- Codex does not auto-load `.claude/` docs — it discovers only `AGENTS.md`,
+  which this repo does not have. Any run that should follow project rules
+  (review, test writing, implementation) must be told in the prompt which
+  rule files to read first, e.g. `.claude/CLAUDE.md` and the cpp-style skill.
+
+Code review has a purpose-built mode that collects the diff itself:
+
+```bash
+codex exec review --base origin/main \
+  -m gpt-5.6-sol -c model_reasoning_effort=xhigh -o /tmp/codex-review.md
+```
+
+Also `--uncommitted` (staged + unstaged + untracked) and `--commit <sha>`.
+
+## Multi-round sessions
+
+`codex exec resume <session-id> "<follow-up>"` continues with full context
+(`--last` picks the newest session). Use it for successive adversarial rounds,
+"now fix what you found", or clarifying questions — never restate context in a
+fresh session. Execution-scoped flags are NOT inherited from the resumed
+session: repeat `-c model_reasoning_effort=xhigh`,
+`--dangerously-bypass-approvals-and-sandbox`, and a fresh `-o` path on every
+resume, or the follow-up silently runs at default effort, sandboxed, and
+without an output file. `codex exec fork <session-id>` branches one history
+into independent continuations.
+
+## Discipline
+
+- **Codex output is hypothesis, not verdict.** Every concrete claim ("this
+  input breaks it") gets an empirical probe before you act on it; "looks fine"
+  carries no weight. Experience runs both ways — codex has correctly refuted
+  arguments this side was sure of, and confidently asserted things a probe then
+  disproved. The probe decides, never authority.
+- **Adversarial loop** (plans/designs): write the doc → codex attacks it
+  (demand concrete counterexamples, not general commentary) → probe each
+  counterexample → revise the doc, recording adopted and refuted findings →
+  `resume` the session for the next round. Stop when a round yields no new
+  confirmed finding.
+- **When codex edits code** (implementation, debug fixes, new tests): review
+  its diff as you would a PR — you own what gets committed. Verification
+  (build + suites) happens in the main session, and the hard rules (never
+  weaken tests, never push unverified) apply unchanged to codex-authored code.
+- **Never let codex run the integration or snap suites while this session
+  might also run them** — concurrent runs in one checkout clobber each other's
+  workspace `.clice`. Either codex runs them and you don't, or codex analyzes
+  and you verify.
+
+## Recipes
+
+- **Plan review**: point it at the doc path; ask for attacks ranked by
+  severity, each with a minimal counterexample. Fold confirmed findings back
+  into the doc.
+- **Code review**: `codex exec review --base origin/main` — the primary
+  self-review pass of the pr skill.
+- **Debug**: give the failing test, the repro command, and the suspect area;
+  ask for a root-cause hypothesis plus the experiment that would confirm it.
+  Let it run the repro itself.
+- **Test writing**: point it at the write-tests skill and 2-3 neighboring
+  fixtures as the template; ask it to add cases probing a specific behavior
+  and report which outputs look wrong versus expected. Suspicious snapshot
+  diffs are findings — never `UPDATE_SNAPSHOTS` over them.
+- **Implementation**: a well-scoped task with acceptance criteria and pointers
+  to the 2-3 existing features whose structure it should copy. Then review and
+  verify as above.
+
+## Recovery
+
+If a run dies before writing `-o`, the transcript is at
+`~/.codex/sessions/YYYY/MM/DD/*.jsonl`; the final reply is the last record
+with payload `type == "message"` and `role == "assistant"`.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -23,7 +23,7 @@ Never push anything unverified — "it compiles" is not verified, and CI is not 
 
 Review the full diff (`git diff origin/main...HEAD` — never the local `main`, which goes stale) and fix everything confirmed before opening:
 
-1. **Primary: codex review** (the codex skill) — `codex exec review --base origin/main` with gpt-5.6-sol at xhigh, with a prompt telling it to first read `.claude/CLAUDE.md` and the cpp-style skill and apply their rules (codex does not auto-load `.claude/` docs). Treat findings as hypotheses: verify each concrete claim before fixing it.
+1. **Primary: codex review** (the codex skill) — the canonical rules-aware review command: plain `codex exec` with gpt-5.6-sol at xhigh and a prompt that reads `.claude/CLAUDE.md` plus the cpp-style skill and reviews `git diff origin/main...HEAD` (the built-in `codex exec review --base` cannot take a prompt, so it never sees the repo rules). Treat findings as hypotheses: verify each concrete claim before fixing it.
 2. **Supplement** — when codex is unavailable, or as an extra pass on high-risk diffs: 3 parallel subagents reviewing independently — correctness (logic errors, edge cases, undefined behavior), style (naming, cpp-style skill rules), tests (new functionality covered, no existing tests broken or weakened).
 
 ## Opening

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -21,7 +21,7 @@ Never push anything unverified — "it compiles" is not verified, and CI is not 
 
 ## Self-review (before opening)
 
-Review the full diff (`git diff origin/main...HEAD` — never the local `main`, which goes stale) and fix everything confirmed before opening:
+Commit all work first — the review diff only sees commits, so a dirty worktree means the reviewer inspects an incomplete patch (`git status` must be clean). Then review the full diff (`git diff origin/main...HEAD` — never the local `main`, which goes stale) and fix everything confirmed before opening:
 
 1. **Primary: codex review** (the codex skill) — the canonical rules-aware review command: plain `codex exec` with gpt-5.6-sol at xhigh and a prompt that reads `.claude/CLAUDE.md` plus the cpp-style skill and reviews `git diff origin/main...HEAD` (the built-in `codex exec review --base` cannot take a prompt, so it never sees the repo rules). Treat findings as hypotheses: verify each concrete claim before fixing it.
 2. **Supplement** — when codex is unavailable, or as an extra pass on high-risk diffs: 3 parallel subagents reviewing independently — correctness (logic errors, edge cases, undefined behavior), style (naming, cpp-style skill rules), tests (new functionality covered, no existing tests broken or weakened).

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -21,11 +21,10 @@ Never push anything unverified — "it compiles" is not verified, and CI is not 
 
 ## Self-review (before opening)
 
-Launch **3 parallel subagents** to review the full diff (`git diff origin/main...HEAD` — never the local `main`, which goes stale) independently, and fix everything they report before opening:
+Review the full diff (`git diff origin/main...HEAD` — never the local `main`, which goes stale) and fix everything confirmed before opening:
 
-1. **Correctness reviewer**: logic errors, edge cases, undefined behavior, off-by-one mistakes.
-2. **Style reviewer**: naming conventions, coding style, cpp-style skill rules.
-3. **Test reviewer**: new functionality has tests, edge cases are covered, no existing tests were broken or weakened.
+1. **Primary: codex review** (the codex skill) — `codex exec review --base origin/main` with gpt-5.6-sol at xhigh, with a prompt telling it to first read `.claude/CLAUDE.md` and the cpp-style skill and apply their rules (codex does not auto-load `.claude/` docs). Treat findings as hypotheses: verify each concrete claim before fixing it.
+2. **Supplement** — when codex is unavailable, or as an extra pass on high-risk diffs: 3 parallel subagents reviewing independently — correctness (logic errors, edge cases, undefined behavior), style (naming, cpp-style skill rules), tests (new functionality covered, no existing tests broken or weakened).
 
 ## Opening
 


### PR DESCRIPTION
## What changed

Adds a `codex` skill to `.claude/skills/` documenting how to delegate work to the codex CLI: invocation defaults (gpt-5.6-sol at xhigh reasoning, full sandbox bypass, `-o` output file, background runs), multi-round sessions via `resume`/`fork` (execution-scoped flags must be repeated), the verification discipline (codex output is hypothesis until probed; adversarial review loop for plans), and recipes for plan review, code review, debugging, test writing, and scoped implementation.

The pr skill's self-review section now uses codex review (`codex exec review --base origin/main`) as the primary pass, with the previous 3-subagent review as supplement. CLAUDE.md gains an index line for the new skill.

Since codex only auto-discovers `AGENTS.md` (absent here), both skills instruct passing the repo rule files explicitly in the prompt.

## Tests

Docs-only change under `.claude/` — no code paths affected. The documented commands (`exec` with `-o`, `resume` context retention, `exec review`) were each verified against codex 0.148 before writing them down.