### PR TITLE
test(command): cover build-system compilation databases

### DIFF
--- a/tests/data/compilation_database/bazel.json
+++ b/tests/data/compilation_database/bazel.json
@@ -1,0 +1,17 @@
+[
+  {
+    "directory": "project",
+    "arguments": [
+      "clang++",
+      "-DBAZEL_BUILD",
+      "-iquote",
+      ".",
+      "-c",
+      "src/main.cpp",
+      "-o",
+      "bazel-out/app/main.o"
+    ],
+    "file": "src/main.cpp",
+    "output": "bazel-out/app/main.o"
+  }
+]

--- a/tests/data/compilation_database/cmake.json
+++ b/tests/data/compilation_database/cmake.json
@@ -1,0 +1,8 @@
+[
+  {
+    "directory": "project",
+    "command": "clang++ -DCMAKE_BUILD -Iinclude -o CMakeFiles/app.dir/src/main.cpp.o -c src/main.cpp",
+    "file": "src/main.cpp",
+    "output": "CMakeFiles/app.dir/src/main.cpp.o"
+  }
+]

--- a/tests/data/compilation_database/make.json
+++ b/tests/data/compilation_database/make.json
@@ -1,0 +1,16 @@
+[
+  {
+    "arguments": [
+      "clang++",
+      "-DMAKE_BUILD",
+      "-Iinclude",
+      "-c",
+      "src/main.cpp",
+      "-o",
+      "build/main.o"
+    ],
+    "directory": "project",
+    "file": "src/main.cpp",
+    "output": "build/main.o"
+  }
+]

--- a/tests/data/compilation_database/xmake.json
+++ b/tests/data/compilation_database/xmake.json
@@ -1,0 +1,15 @@
+[
+  {
+    "directory": "project",
+    "file": "src/main.cpp",
+    "arguments": [
+      "clang++",
+      "-DXMAKE_BUILD",
+      "-Iinclude",
+      "-c",
+      "src/main.cpp",
+      "-o",
+      "build/.objs/app/src/main.cpp.o"
+    ]
+  }
+]

--- a/tests/unit/command/command_tests.cpp
+++ b/tests/unit/command/command_tests.cpp
@@ -490,6 +490,37 @@ TEST_CASE(LoadMixedFormats) {
     EXPECT_CONTAINS(print_argv(b.front().to_argv()), "-std=c++23");
 };
 
+TEST_CASE(LoadBuildSystemFixtures) {
+    struct Fixture {
+        llvm::StringLiteral name;
+        llvm::StringLiteral definition;
+    };
+
+    constexpr std::array fixtures = {
+        Fixture{"cmake.json", "CMAKE_BUILD"},
+        Fixture{"bazel.json", "BAZEL_BUILD"},
+        Fixture{"make.json",  "MAKE_BUILD" },
+        Fixture{"xmake.json", "XMAKE_BUILD"},
+    };
+
+    for(auto fixture: fixtures) {
+        CompilationDatabase database;
+        auto fixture_path = path::join(test_dir, "compilation_database", fixture.name);
+        auto count = database.load(fixture_path);
+        ASSERT_TRUE(count.has_value());
+        ASSERT_EQ(*count, 1U);
+
+        auto source = path::join("project", "src/main.cpp");
+        auto commands = database.lookup(source, quiet_options());
+        ASSERT_EQ(commands.size(), 1U);
+
+        auto argv = print_argv(commands.front().to_argv());
+        EXPECT_CONTAINS(argv, fixture.definition);
+        EXPECT_NOT_CONTAINS(argv, " -c ");
+        EXPECT_NOT_CONTAINS(argv, " -o ");
+    }
+};
+
 TEST_CASE(LoadErrorRecovery) {
     /// Bad entries should be skipped; good entries still load.
     CompilationDatabase database;


### PR DESCRIPTION
## Summary

- add representative compilation-database fixtures for CMake, Bazel, Make/Bear, and XMake
- cover both standard CDB encodings: `command` strings and `arguments` arrays
- load every fixture through `CompilationDatabase::load`
- verify semantic defines survive while compile-only `-c` and output `-o` flags are removed

The paths proposed in #218 no longer exist after the test and CI redesign, so this targets the remaining build-system compatibility coverage in the current command test suite.

## Testing

- project build succeeds with the locked LLVM 22.1.8 toolchain
- `Command.LoadBuildSystemFixtures` passes
- all 26 `Command.*` unit tests pass

Refs #218