### PR TITLE
fix(navigation): repair lookup defects and pin behavior in snap corpus

### DIFF
--- a/src/index/shard.cpp
+++ b/src/index/shard.cpp
@@ -702,6 +702,12 @@ void Shard::lookup(std::uint32_t offset,
         }
     }
 
+    // A cursor between two tokens belongs to the one starting at it, so
+    // rows the offset only touches at their right edge yield after every
+    // row it is properly inside — `a+b` with the cursor before `b` must
+    // resolve to `b`, not `+`, while a cursor right after a lone token
+    // still hits that token.
+    llvm::SmallVector<std::uint32_t, 2> edge_rows;
     for(; lo < columns.size(); lo += 1) {
         auto row = static_cast<std::uint32_t>(lo);
         LocalSourceRange range{columns.begin_of(row), columns.end_of(row)};
@@ -711,9 +717,20 @@ void Shard::lookup(std::uint32_t offset,
         if(!row_live(true, row)) {
             continue;
         }
+        if(range.end == offset && range.begin != offset) {
+            edge_rows.push_back(row);
+            continue;
+        }
         Occurrence result{range, sym_hashes[occ_sym_id(root, row)]};
         if(!callback(result)) {
-            break;
+            return;
+        }
+    }
+    for(auto row: edge_rows) {
+        LocalSourceRange range{columns.begin_of(row), columns.end_of(row)};
+        Occurrence result{range, sym_hashes[occ_sym_id(root, row)]};
+        if(!callback(result)) {
+            return;
         }
     }
 }

--- a/src/index/tu_index.cpp
+++ b/src/index/tu_index.cpp
@@ -390,6 +390,22 @@ public:
             return;
         }
 
+        /// Constructions are call edges too, but only written ones — an
+        /// implicit copy or elided temporary has no paren/brace form and
+        /// would flood the constructor's callers.
+        if(auto* CCE = node.get<clang::CXXConstructExpr>()) {
+            if(!CCE->getParenOrBraceRange().isValid()) {
+                return;
+            }
+            const clang::NamedDecl* caller = enclosing_function(semantics, index);
+            const clang::NamedDecl* callee = CCE->getConstructor();
+            if(caller && callee) {
+                add_call_relation(caller, RelationKind::Callee, callee, CCE->getSourceRange());
+                add_call_relation(callee, RelationKind::Caller, caller, CCE->getSourceRange());
+            }
+            return;
+        }
+
         auto* D = node.get<clang::Decl>();
         if(!D) {
             return;

--- a/src/semantic/semantics.h
+++ b/src/semantic/semantics.h
@@ -212,7 +212,10 @@ private:
 bool should_ignore_token(const clang::syntax::Token& token);
 
 /// A name occurrence a node gives rise to: the decl the written name refers
-/// to, its role, and the name token's location.
+/// to, its role, and the name token's location. Multi-token names (`~Foo`,
+/// `operator int`) anchor at their first token: widening them to the full
+/// name overlaps the nested type reference, which the shard's
+/// disjoint-or-identical occurrence invariant cannot represent.
 struct NameOccurrence {
     const clang::NamedDecl* decl;
 

--- a/src/server/service/feature_router.cpp
+++ b/src/server/service/feature_router.cpp
@@ -478,10 +478,7 @@ FeatureRouter::RawResult FeatureRouter::implementation(std::shared_ptr<Session> 
         }
     }
 
-    co_return to_raw(index_query.query_symbol_targets(path,
-                                                      position,
-                                                      RelationKind::Implementation,
-                                                      session.get()));
+    co_return to_raw(index_query.query_implementation(path, position, session.get()));
 }
 
 FeatureRouter::RawResult FeatureRouter::call_hierarchy_prepare(std::shared_ptr<Session> session,
@@ -503,8 +500,15 @@ FeatureRouter::RawResult FeatureRouter::call_hierarchy_prepare(std::shared_ptr<S
     auto info = index_query.lookup_symbol(uri, path, position, session.get());
     if(!info)
         co_return serde_raw{"null"};
-    if(!(info->kind == SymbolKind::Function || info->kind == SymbolKind::Method))
+    if(!(info->kind == SymbolKind::Function || info->kind == SymbolKind::Method ||
+         info->kind == SymbolKind::Operator))
         co_return serde_raw{"null"};
+
+    // The item stands for the symbol, not the cursor: anchor it at the
+    // symbol's canonical site so expanding from a use renders the same
+    // root as expanding from the declaration.
+    if(auto canonical = index_query.resolve_symbol(info->hash))
+        info = canonical;
 
     std::vector<protocol::CallHierarchyItem> items;
     items.push_back(IndexQuery::build_call_hierarchy_item(*info));
@@ -569,6 +573,9 @@ FeatureRouter::RawResult FeatureRouter::type_hierarchy_prepare(std::shared_ptr<S
     if(!(info->kind == SymbolKind::Class || info->kind == SymbolKind::Struct ||
          info->kind == SymbolKind::Enum || info->kind == SymbolKind::Union))
         co_return serde_raw{"null"};
+
+    if(auto canonical = index_query.resolve_symbol(info->hash))
+        info = canonical;
 
     std::vector<protocol::TypeHierarchyItem> items;
     items.push_back(IndexQuery::build_type_hierarchy_item(*info));

--- a/src/server/service/query.cpp
+++ b/src/server/service/query.cpp
@@ -544,8 +544,8 @@ std::vector<protocol::Location> IndexQuery::query_implementation(llvm::StringRef
     if(!find_symbol_info(hit.hash, name, kind))
         return {};
 
-    bool type_like = kind == SymbolKind::Class || kind == SymbolKind::Struct ||
-                     kind == SymbolKind::Union;
+    bool type_like =
+        kind == SymbolKind::Class || kind == SymbolKind::Struct || kind == SymbolKind::Union;
     return resolve_target_locations(hit.hash,
                                     type_like ? RelationKind::Derived
                                               : RelationKind::Implementation);
@@ -624,20 +624,17 @@ std::optional<protocol::Location> IndexQuery::find_relation_location(index::Symb
         return overlay_result;
 
     visit_overlays([&](const index::TUIndex& state) {
-        overlay_lookup(state,
-                       hash,
-                       kind,
-                       [&](const OverlayFile& file, const index::Relation& r) {
-                           if(!should_serve_overlay_file(file.path))
-                               return true;
-                           auto uri = feature::to_uri(file.path);
-                           IndexedLineMap map(file.content, file.content_size, file.line_starts);
-                           if(auto range = map.to_range(r.range.begin, r.range.end)) {
-                               overlay_result = protocol::Location{uri, *range};
-                               return false;
-                           }
-                           return true;
-                       });
+        overlay_lookup(state, hash, kind, [&](const OverlayFile& file, const index::Relation& r) {
+            if(!should_serve_overlay_file(file.path))
+                return true;
+            auto uri = feature::to_uri(file.path);
+            IndexedLineMap map(file.content, file.content_size, file.line_starts);
+            if(auto range = map.to_range(r.range.begin, r.range.end)) {
+                overlay_result = protocol::Location{uri, *range};
+                return false;
+            }
+            return true;
+        });
         return !overlay_result.has_value();
     });
     if(overlay_result)

--- a/src/server/service/query.cpp
+++ b/src/server/service/query.cpp
@@ -529,8 +529,32 @@ std::vector<protocol::Location> IndexQuery::query_symbol_targets(llvm::StringRef
     if(hit.hash == 0)
         return {};
 
+    return resolve_target_locations(hit.hash, kind);
+}
+
+std::vector<protocol::Location> IndexQuery::query_implementation(llvm::StringRef path,
+                                                                 const protocol::Position& position,
+                                                                 Session* session) {
+    auto hit = resolve_cursor(path, position, session);
+    if(hit.hash == 0)
+        return {};
+
+    std::string name;
+    SymbolKind kind;
+    if(!find_symbol_info(hit.hash, name, kind))
+        return {};
+
+    bool type_like = kind == SymbolKind::Class || kind == SymbolKind::Struct ||
+                     kind == SymbolKind::Union;
+    return resolve_target_locations(hit.hash,
+                                    type_like ? RelationKind::Derived
+                                              : RelationKind::Implementation);
+}
+
+std::vector<protocol::Location> IndexQuery::resolve_target_locations(index::SymbolHash hash,
+                                                                     RelationKind kind) {
     llvm::SmallVector<index::SymbolHash> targets;
-    collect_unique_targets(hit.hash, kind, targets);
+    collect_unique_targets(hash, kind, targets);
 
     std::vector<protocol::Location> locations;
     for(auto target: targets) {
@@ -557,14 +581,15 @@ std::optional<SymbolInfo> IndexQuery::lookup_symbol(const std::string& uri,
     return SymbolInfo{hit.hash, std::move(name), sym_kind, uri, hit.range};
 }
 
-std::optional<protocol::Location> IndexQuery::find_definition_location(index::SymbolHash hash) {
+std::optional<protocol::Location> IndexQuery::find_relation_location(index::SymbolHash hash,
+                                                                     RelationKind kind) {
     std::optional<protocol::Location> session_result;
     visit_sessions([&](std::uint32_t id, const Session& session) -> bool {
         auto uri = lsp::URI::from_file_path(std::string(workspace.path_pool.resolve(id)));
         if(!uri)
             return true;
         auto map = session.line_map();
-        session.file_rows().lookup(hash, RelationKind::Definition, [&](const index::Relation& r) {
+        session.file_rows().lookup(hash, kind, [&](const index::Relation& r) {
             if(auto range = map.to_range(r.range.begin, r.range.end)) {
                 session_result = protocol::Location{uri->str(), *range};
                 return false;
@@ -586,7 +611,7 @@ std::optional<protocol::Location> IndexQuery::find_definition_location(index::Sy
         if(!uri)
             return true;
         auto map = session.line_map();
-        preamble_rows(state).lookup(hash, RelationKind::Definition, [&](const index::Relation& r) {
+        preamble_rows(state).lookup(hash, kind, [&](const index::Relation& r) {
             if(auto range = map.to_range(r.range.begin, r.range.end)) {
                 overlay_result = protocol::Location{uri->str(), *range};
                 return false;
@@ -601,7 +626,7 @@ std::optional<protocol::Location> IndexQuery::find_definition_location(index::Sy
     visit_overlays([&](const index::TUIndex& state) {
         overlay_lookup(state,
                        hash,
-                       RelationKind::Definition,
+                       kind,
                        [&](const OverlayFile& file, const index::Relation& r) {
                            if(!should_serve_overlay_file(file.path))
                                return true;
@@ -637,7 +662,7 @@ std::optional<protocol::Location> IndexQuery::find_definition_location(index::Sy
                            merged_index.content_size(),
                            merged_index.line_starts());
         std::optional<protocol::Location> result;
-        merged_index.lookup(hash, RelationKind::Definition, [&](const index::Relation& r) {
+        merged_index.lookup(hash, kind, [&](const index::Relation& r) {
             if(auto range = map.to_range(r.range.begin, r.range.end)) {
                 result = protocol::Location{uri->str(), *range};
                 return false;
@@ -649,6 +674,16 @@ std::optional<protocol::Location> IndexQuery::find_definition_location(index::Sy
     }
 
     return std::nullopt;
+}
+
+std::optional<protocol::Location> IndexQuery::find_definition_location(index::SymbolHash hash) {
+    return find_relation_location(hash, RelationKind::Definition);
+}
+
+std::optional<protocol::Location> IndexQuery::find_symbol_location(index::SymbolHash hash) {
+    if(auto location = find_relation_location(hash, RelationKind::Definition))
+        return location;
+    return find_relation_location(hash, RelationKind::Declaration);
 }
 
 std::optional<SymbolInfo>
@@ -790,10 +825,10 @@ std::optional<SymbolInfo> IndexQuery::resolve_symbol(index::SymbolHash hash) {
     SymbolKind kind;
     if(!find_symbol_info(hash, name, kind))
         return std::nullopt;
-    auto def_loc = find_definition_location(hash);
-    if(!def_loc)
+    auto location = find_symbol_location(hash);
+    if(!location)
         return std::nullopt;
-    return SymbolInfo{hash, std::move(name), kind, def_loc->uri, def_loc->range};
+    return SymbolInfo{hash, std::move(name), kind, location->uri, location->range};
 }
 
 /// The stored text of an indexed file, for preview slicing. Non-ASCII

--- a/src/server/service/query.h
+++ b/src/server/service/query.h
@@ -140,14 +140,21 @@ public:
                                                       const protocol::Position& position,
                                                       Session* session);
 
-    /// Query between-symbol relations (Implementation, TypeDefinition, ...)
-    /// for the symbol at cursor and resolve each target symbol to its
-    /// definition location — the two-hop query behind go-to-implementation
-    /// and go-to-type-definition.
+    /// Query between-symbol relations (TypeDefinition, ...) for the symbol
+    /// at cursor and resolve each target symbol to its canonical location —
+    /// the two-hop query behind go-to-type-definition.
     /// @param session  Active Session for this file, or nullptr.
     std::vector<protocol::Location> query_symbol_targets(llvm::StringRef path,
                                                          const protocol::Position& position,
                                                          RelationKind kind,
+                                                         Session* session);
+
+    /// Locations implementing the symbol at cursor: derived types for a
+    /// class-like symbol, Implementation relation targets (overrides)
+    /// otherwise.
+    /// @param session  Active Session for this file, or nullptr.
+    std::vector<protocol::Location> query_implementation(llvm::StringRef path,
+                                                         const protocol::Position& position,
                                                          Session* session);
 
     /// Look up symbol info (hash, name, kind, range) at a cursor position.
@@ -159,6 +166,13 @@ public:
 
     /// Find the definition location of a symbol by hash.
     std::optional<protocol::Location> find_definition_location(index::SymbolHash hash);
+
+    /// The symbol's canonical location: its definition, or its declaration
+    /// when nothing defines it (pure virtuals, externs, decl-only APIs).
+    std::optional<protocol::Location> find_symbol_location(index::SymbolHash hash);
+
+    /// Resolve a symbol hash into a SymbolInfo at its canonical location.
+    std::optional<SymbolInfo> resolve_symbol(index::SymbolHash hash);
 
     /// Find a symbol's name and kind by hash.
     bool find_symbol_info(index::SymbolHash hash, std::string& name, SymbolKind& kind) const;
@@ -302,8 +316,14 @@ private:
                                 RelationKind kind,
                                 llvm::SmallVectorImpl<index::SymbolHash>& targets);
 
-    /// Resolve a symbol hash into a SymbolInfo with definition location.
-    std::optional<SymbolInfo> resolve_symbol(index::SymbolHash hash);
+    /// One location per unique relation target, each resolved to its
+    /// canonical site.
+    std::vector<protocol::Location> resolve_target_locations(index::SymbolHash hash,
+                                                             RelationKind kind);
+
+    /// Find one location carrying the given relation kind for the symbol.
+    std::optional<protocol::Location> find_relation_location(index::SymbolHash hash,
+                                                             RelationKind kind);
 
     /// Check whether a path_id has an active Session.
     bool is_path_open(std::uint32_t path_id) const;

--- a/tests/snap/navigation/.clang-format
+++ b/tests/snap/navigation/.clang-format
@@ -1,0 +1,4 @@
+# These fixtures contain `§(name)` marker annotations that clang-format
+# would split apart, so formatting is disabled for this directory.
+DisableFormat: true
+SortIncludes: false

--- a/tests/snap/navigation/anonymous_namespace.cpp
+++ b/tests/snap/navigation/anonymous_namespace.cpp
@@ -1,0 +1,16 @@
+/// - verify: server
+
+namespace {
+
+int §(hidden_var)state = 1;
+
+int §(hidden_fn)next() {
+    state += 1;
+    return state;
+}
+
+}
+
+int read_hidden() {
+    return §(fn_use)next() + §(var_use)state;
+}

--- a/tests/snap/navigation/anonymous_namespace.snap.yml
+++ b/tests/snap/navigation/anonymous_namespace.snap.yml
@@ -11,7 +11,7 @@ fn_use:
     - { file: "${WS}/anonymous_namespace.cpp", range: "6:4-6:8" }
     - { file: "${WS}/anonymous_namespace.cpp", range: "14:11-14:15" }
   callHierarchy:
-    - { name: "next", kind: Function, file: "${WS}/anonymous_namespace.cpp", range: "14:11-14:15" }
+    - { name: "next", kind: Function, file: "${WS}/anonymous_namespace.cpp", range: "6:4-6:8" }
   incomingCalls:
     - { name: "read_hidden", kind: Function, file: "${WS}/anonymous_namespace.cpp", range: "13:4-13:15", fromRanges: ["14:11-14:17"] }
 

--- a/tests/snap/navigation/anonymous_namespace.snap.yml
+++ b/tests/snap/navigation/anonymous_namespace.snap.yml
@@ -1,0 +1,51 @@
+---
+created_at: 2026-08-22
+input_file: anonymous_namespace.cpp
+---
+fn_use:
+  definition:
+    - { file: "${WS}/anonymous_namespace.cpp", range: "6:4-6:8" }
+  declaration:
+    - { file: "${WS}/anonymous_namespace.cpp", range: "6:4-6:8" }
+  references:
+    - { file: "${WS}/anonymous_namespace.cpp", range: "6:4-6:8" }
+    - { file: "${WS}/anonymous_namespace.cpp", range: "14:11-14:15" }
+  callHierarchy:
+    - { name: "next", kind: Function, file: "${WS}/anonymous_namespace.cpp", range: "14:11-14:15" }
+  incomingCalls:
+    - { name: "read_hidden", kind: Function, file: "${WS}/anonymous_namespace.cpp", range: "13:4-13:15", fromRanges: ["14:11-14:17"] }
+
+hidden_fn:
+  definition:
+    - { file: "${WS}/anonymous_namespace.cpp", range: "6:4-6:8" }
+  declaration:
+    - { file: "${WS}/anonymous_namespace.cpp", range: "6:4-6:8" }
+  references:
+    - { file: "${WS}/anonymous_namespace.cpp", range: "6:4-6:8" }
+    - { file: "${WS}/anonymous_namespace.cpp", range: "14:11-14:15" }
+  callHierarchy:
+    - { name: "next", kind: Function, file: "${WS}/anonymous_namespace.cpp", range: "6:4-6:8" }
+  incomingCalls:
+    - { name: "read_hidden", kind: Function, file: "${WS}/anonymous_namespace.cpp", range: "13:4-13:15", fromRanges: ["14:11-14:17"] }
+
+hidden_var:
+  definition:
+    - { file: "${WS}/anonymous_namespace.cpp", range: "4:4-4:9" }
+  declaration:
+    - { file: "${WS}/anonymous_namespace.cpp", range: "4:4-4:9" }
+  references:
+    - { file: "${WS}/anonymous_namespace.cpp", range: "4:4-4:9" }
+    - { file: "${WS}/anonymous_namespace.cpp", range: "7:4-7:9" }
+    - { file: "${WS}/anonymous_namespace.cpp", range: "8:11-8:16" }
+    - { file: "${WS}/anonymous_namespace.cpp", range: "14:20-14:25" }
+
+var_use:
+  definition:
+    - { file: "${WS}/anonymous_namespace.cpp", range: "4:4-4:9" }
+  declaration:
+    - { file: "${WS}/anonymous_namespace.cpp", range: "4:4-4:9" }
+  references:
+    - { file: "${WS}/anonymous_namespace.cpp", range: "4:4-4:9" }
+    - { file: "${WS}/anonymous_namespace.cpp", range: "7:4-7:9" }
+    - { file: "${WS}/anonymous_namespace.cpp", range: "8:11-8:16" }
+    - { file: "${WS}/anonymous_namespace.cpp", range: "14:20-14:25" }

--- a/tests/snap/navigation/call_hierarchy.cpp
+++ b/tests/snap/navigation/call_hierarchy.cpp
@@ -1,0 +1,19 @@
+/// - verify: server
+
+int §(leaf)settle(int value) {
+    return value;
+}
+
+int §(mid)route(int value) {
+    return settle(value) + settle(value + 1);
+}
+
+int §(top)start(int value) {
+    return route(value);
+}
+
+int §(recursive)restart(int value) {
+    return route(value) + restart(value - 1);
+}
+
+int §(gate)cursor = 0;

--- a/tests/snap/navigation/call_hierarchy.snap.yml
+++ b/tests/snap/navigation/call_hierarchy.snap.yml
@@ -1,0 +1,70 @@
+---
+created_at: 2026-08-22
+input_file: call_hierarchy.cpp
+---
+gate:
+  definition:
+    - { file: "${WS}/call_hierarchy.cpp", range: "18:4-18:10" }
+  declaration:
+    - { file: "${WS}/call_hierarchy.cpp", range: "18:4-18:10" }
+  references:
+    - { file: "${WS}/call_hierarchy.cpp", range: "18:4-18:10" }
+
+leaf:
+  definition:
+    - { file: "${WS}/call_hierarchy.cpp", range: "2:4-2:10" }
+  declaration:
+    - { file: "${WS}/call_hierarchy.cpp", range: "2:4-2:10" }
+  references:
+    - { file: "${WS}/call_hierarchy.cpp", range: "2:4-2:10" }
+    - { file: "${WS}/call_hierarchy.cpp", range: "7:11-7:17" }
+    - { file: "${WS}/call_hierarchy.cpp", range: "7:27-7:33" }
+  callHierarchy:
+    - { name: "settle", kind: Function, file: "${WS}/call_hierarchy.cpp", range: "2:4-2:10" }
+  incomingCalls:
+    - { name: "route", kind: Function, file: "${WS}/call_hierarchy.cpp", range: "6:4-6:9", fromRanges: ["7:11-7:24", "7:27-7:44"] }
+
+mid:
+  definition:
+    - { file: "${WS}/call_hierarchy.cpp", range: "6:4-6:9" }
+  declaration:
+    - { file: "${WS}/call_hierarchy.cpp", range: "6:4-6:9" }
+  references:
+    - { file: "${WS}/call_hierarchy.cpp", range: "6:4-6:9" }
+    - { file: "${WS}/call_hierarchy.cpp", range: "11:11-11:16" }
+    - { file: "${WS}/call_hierarchy.cpp", range: "15:11-15:16" }
+  callHierarchy:
+    - { name: "route", kind: Function, file: "${WS}/call_hierarchy.cpp", range: "6:4-6:9" }
+  incomingCalls:
+    - { name: "start", kind: Function, file: "${WS}/call_hierarchy.cpp", range: "10:4-10:9", fromRanges: ["11:11-11:23"] }
+    - { name: "restart", kind: Function, file: "${WS}/call_hierarchy.cpp", range: "14:4-14:11", fromRanges: ["15:11-15:23"] }
+  outgoingCalls:
+    - { name: "settle", kind: Function, file: "${WS}/call_hierarchy.cpp", range: "2:4-2:10", fromRanges: ["7:11-7:24", "7:27-7:44"] }
+
+recursive:
+  definition:
+    - { file: "${WS}/call_hierarchy.cpp", range: "14:4-14:11" }
+  declaration:
+    - { file: "${WS}/call_hierarchy.cpp", range: "14:4-14:11" }
+  references:
+    - { file: "${WS}/call_hierarchy.cpp", range: "14:4-14:11" }
+    - { file: "${WS}/call_hierarchy.cpp", range: "15:26-15:33" }
+  callHierarchy:
+    - { name: "restart", kind: Function, file: "${WS}/call_hierarchy.cpp", range: "14:4-14:11" }
+  incomingCalls:
+    - { name: "restart", kind: Function, file: "${WS}/call_hierarchy.cpp", range: "14:4-14:11", fromRanges: ["15:26-15:44"] }
+  outgoingCalls:
+    - { name: "route", kind: Function, file: "${WS}/call_hierarchy.cpp", range: "6:4-6:9", fromRanges: ["15:11-15:23"] }
+    - { name: "restart", kind: Function, file: "${WS}/call_hierarchy.cpp", range: "14:4-14:11", fromRanges: ["15:26-15:44"] }
+
+top:
+  definition:
+    - { file: "${WS}/call_hierarchy.cpp", range: "10:4-10:9" }
+  declaration:
+    - { file: "${WS}/call_hierarchy.cpp", range: "10:4-10:9" }
+  references:
+    - { file: "${WS}/call_hierarchy.cpp", range: "10:4-10:9" }
+  callHierarchy:
+    - { name: "start", kind: Function, file: "${WS}/call_hierarchy.cpp", range: "10:4-10:9" }
+  outgoingCalls:
+    - { name: "route", kind: Function, file: "${WS}/call_hierarchy.cpp", range: "6:4-6:9", fromRanges: ["11:11-11:23"] }

--- a/tests/snap/navigation/concepts.cpp
+++ b/tests/snap/navigation/concepts.cpp
@@ -1,0 +1,21 @@
+/// - verify: server
+
+template <typename T>
+concept §(concept_def)Addable = requires(T value) {
+    value + value;
+};
+
+template <§(type_constraint)Addable T>
+T twice(T value) {
+    return value + value;
+}
+
+template <typename T>
+    requires §(requires_use)Addable<T>
+T combine(T left, T right) {
+    return left + right;
+}
+
+int use_concepts() {
+    return §(constrained_call)twice(2) + combine(3, 4);
+}

--- a/tests/snap/navigation/concepts.snap.yml
+++ b/tests/snap/navigation/concepts.snap.yml
@@ -1,0 +1,46 @@
+---
+created_at: 2026-08-22
+input_file: concepts.cpp
+---
+concept_def:
+  definition:
+    - { file: "${WS}/concepts.cpp", range: "3:8-3:15" }
+  declaration:
+    - { file: "${WS}/concepts.cpp", range: "3:8-3:15" }
+  references:
+    - { file: "${WS}/concepts.cpp", range: "3:8-3:15" }
+    - { file: "${WS}/concepts.cpp", range: "7:10-7:17" }
+    - { file: "${WS}/concepts.cpp", range: "13:13-13:20" }
+
+constrained_call:
+  definition:
+    - { file: "${WS}/concepts.cpp", range: "8:2-8:7" }
+  declaration:
+    - { file: "${WS}/concepts.cpp", range: "8:2-8:7" }
+  references:
+    - { file: "${WS}/concepts.cpp", range: "8:2-8:7" }
+    - { file: "${WS}/concepts.cpp", range: "19:11-19:16" }
+  callHierarchy:
+    - { name: "twice", kind: Function, file: "${WS}/concepts.cpp", range: "19:11-19:16" }
+  incomingCalls:
+    - { name: "use_concepts", kind: Function, file: "${WS}/concepts.cpp", range: "18:4-18:16", fromRanges: ["19:11-19:19"] }
+
+requires_use:
+  definition:
+    - { file: "${WS}/concepts.cpp", range: "3:8-3:15" }
+  declaration:
+    - { file: "${WS}/concepts.cpp", range: "3:8-3:15" }
+  references:
+    - { file: "${WS}/concepts.cpp", range: "3:8-3:15" }
+    - { file: "${WS}/concepts.cpp", range: "7:10-7:17" }
+    - { file: "${WS}/concepts.cpp", range: "13:13-13:20" }
+
+type_constraint:
+  definition:
+    - { file: "${WS}/concepts.cpp", range: "3:8-3:15" }
+  declaration:
+    - { file: "${WS}/concepts.cpp", range: "3:8-3:15" }
+  references:
+    - { file: "${WS}/concepts.cpp", range: "3:8-3:15" }
+    - { file: "${WS}/concepts.cpp", range: "7:10-7:17" }
+    - { file: "${WS}/concepts.cpp", range: "13:13-13:20" }

--- a/tests/snap/navigation/concepts.snap.yml
+++ b/tests/snap/navigation/concepts.snap.yml
@@ -21,7 +21,7 @@ constrained_call:
     - { file: "${WS}/concepts.cpp", range: "8:2-8:7" }
     - { file: "${WS}/concepts.cpp", range: "19:11-19:16" }
   callHierarchy:
-    - { name: "twice", kind: Function, file: "${WS}/concepts.cpp", range: "19:11-19:16" }
+    - { name: "twice", kind: Function, file: "${WS}/concepts.cpp", range: "8:2-8:7" }
   incomingCalls:
     - { name: "use_concepts", kind: Function, file: "${WS}/concepts.cpp", range: "18:4-18:16", fromRanges: ["19:11-19:19"] }
 

--- a/tests/snap/navigation/constructor_navigation.cpp
+++ b/tests/snap/navigation/constructor_navigation.cpp
@@ -5,8 +5,8 @@ struct Session {
     int id;
 };
 
-§(scope_use)Session::§(ctor_def)Session(int id): id(id) {}
+§(scope_use)Session::§(ctor_def)Session(int id) : id(id) {}
 
 Session open() {
-    return §(ctor_use)Session(7);
+    return §(ctor_use)Session§(ctor_invoke)(7);
 }

--- a/tests/snap/navigation/constructor_navigation.cpp
+++ b/tests/snap/navigation/constructor_navigation.cpp
@@ -1,0 +1,12 @@
+/// - verify: server
+
+struct Session {
+    §(ctor_decl)Session(int id);
+    int id;
+};
+
+§(scope_use)Session::§(ctor_def)Session(int id): id(id) {}
+
+Session open() {
+    return §(ctor_use)Session(7);
+}

--- a/tests/snap/navigation/constructor_navigation.snap.yml
+++ b/tests/snap/navigation/constructor_navigation.snap.yml
@@ -32,16 +32,18 @@ ctor_def:
 
 ctor_invoke:
   definition:
-    - { file: "${WS}/constructor_navigation.cpp", range: "2:7-2:14" }
+    - { file: "${WS}/constructor_navigation.cpp", range: "7:9-7:16" }
   declaration:
+    - { file: "${WS}/constructor_navigation.cpp", range: "3:4-3:11" }
+    - { file: "${WS}/constructor_navigation.cpp", range: "7:9-7:16" }
+  typeDefinition:
     - { file: "${WS}/constructor_navigation.cpp", range: "2:7-2:14" }
   references:
-    - { file: "${WS}/constructor_navigation.cpp", range: "2:7-2:14" }
-    - { file: "${WS}/constructor_navigation.cpp", range: "7:0-7:7" }
-    - { file: "${WS}/constructor_navigation.cpp", range: "9:0-9:7" }
-    - { file: "${WS}/constructor_navigation.cpp", range: "10:11-10:18" }
-  typeHierarchy:
-    - { name: "Session", kind: Struct, file: "${WS}/constructor_navigation.cpp", range: "2:7-2:14" }
+    - { file: "${WS}/constructor_navigation.cpp", range: "3:4-3:11" }
+    - { file: "${WS}/constructor_navigation.cpp", range: "7:9-7:16" }
+    - { file: "${WS}/constructor_navigation.cpp", range: "10:18-10:19" }
+  callHierarchy:
+    - { name: "Session", kind: Method, file: "${WS}/constructor_navigation.cpp", range: "7:9-7:16" }
 
 ctor_use:
   definition:

--- a/tests/snap/navigation/constructor_navigation.snap.yml
+++ b/tests/snap/navigation/constructor_navigation.snap.yml
@@ -14,7 +14,7 @@ ctor_decl:
     - { file: "${WS}/constructor_navigation.cpp", range: "7:9-7:16" }
     - { file: "${WS}/constructor_navigation.cpp", range: "10:18-10:19" }
   callHierarchy:
-    - { name: "Session", kind: Method, file: "${WS}/constructor_navigation.cpp", range: "3:4-3:11" }
+    - { name: "Session", kind: Method, file: "${WS}/constructor_navigation.cpp", range: "7:9-7:16" }
 
 ctor_def:
   definition:
@@ -41,7 +41,7 @@ ctor_use:
     - { file: "${WS}/constructor_navigation.cpp", range: "9:0-9:7" }
     - { file: "${WS}/constructor_navigation.cpp", range: "10:11-10:18" }
   typeHierarchy:
-    - { name: "Session", kind: Struct, file: "${WS}/constructor_navigation.cpp", range: "10:11-10:18" }
+    - { name: "Session", kind: Struct, file: "${WS}/constructor_navigation.cpp", range: "2:7-2:14" }
 
 scope_use:
   definition:
@@ -54,4 +54,4 @@ scope_use:
     - { file: "${WS}/constructor_navigation.cpp", range: "9:0-9:7" }
     - { file: "${WS}/constructor_navigation.cpp", range: "10:11-10:18" }
   typeHierarchy:
-    - { name: "Session", kind: Struct, file: "${WS}/constructor_navigation.cpp", range: "7:0-7:7" }
+    - { name: "Session", kind: Struct, file: "${WS}/constructor_navigation.cpp", range: "2:7-2:14" }

--- a/tests/snap/navigation/constructor_navigation.snap.yml
+++ b/tests/snap/navigation/constructor_navigation.snap.yml
@@ -15,6 +15,8 @@ ctor_decl:
     - { file: "${WS}/constructor_navigation.cpp", range: "10:18-10:19" }
   callHierarchy:
     - { name: "Session", kind: Method, file: "${WS}/constructor_navigation.cpp", range: "7:9-7:16" }
+  incomingCalls:
+    - { name: "open", kind: Function, file: "${WS}/constructor_navigation.cpp", range: "9:8-9:12", fromRanges: ["10:11-10:21"] }
 
 ctor_def:
   definition:
@@ -29,6 +31,8 @@ ctor_def:
     - { file: "${WS}/constructor_navigation.cpp", range: "10:18-10:19" }
   callHierarchy:
     - { name: "Session", kind: Method, file: "${WS}/constructor_navigation.cpp", range: "7:9-7:16" }
+  incomingCalls:
+    - { name: "open", kind: Function, file: "${WS}/constructor_navigation.cpp", range: "9:8-9:12", fromRanges: ["10:11-10:21"] }
 
 ctor_invoke:
   definition:
@@ -44,6 +48,8 @@ ctor_invoke:
     - { file: "${WS}/constructor_navigation.cpp", range: "10:18-10:19" }
   callHierarchy:
     - { name: "Session", kind: Method, file: "${WS}/constructor_navigation.cpp", range: "7:9-7:16" }
+  incomingCalls:
+    - { name: "open", kind: Function, file: "${WS}/constructor_navigation.cpp", range: "9:8-9:12", fromRanges: ["10:11-10:21"] }
 
 ctor_use:
   definition:

--- a/tests/snap/navigation/constructor_navigation.snap.yml
+++ b/tests/snap/navigation/constructor_navigation.snap.yml
@@ -1,0 +1,57 @@
+---
+created_at: 2026-08-22
+input_file: constructor_navigation.cpp
+---
+ctor_decl:
+  definition:
+    - { file: "${WS}/constructor_navigation.cpp", range: "7:9-7:16" }
+  declaration:
+    - { file: "${WS}/constructor_navigation.cpp", range: "7:9-7:16" }
+  typeDefinition:
+    - { file: "${WS}/constructor_navigation.cpp", range: "2:7-2:14" }
+  references:
+    - { file: "${WS}/constructor_navigation.cpp", range: "3:4-3:11" }
+    - { file: "${WS}/constructor_navigation.cpp", range: "7:9-7:16" }
+    - { file: "${WS}/constructor_navigation.cpp", range: "10:18-10:19" }
+  callHierarchy:
+    - { name: "Session", kind: Method, file: "${WS}/constructor_navigation.cpp", range: "3:4-3:11" }
+
+ctor_def:
+  definition:
+    - { file: "${WS}/constructor_navigation.cpp", range: "3:4-3:11" }
+  declaration:
+    - { file: "${WS}/constructor_navigation.cpp", range: "3:4-3:11" }
+  typeDefinition:
+    - { file: "${WS}/constructor_navigation.cpp", range: "2:7-2:14" }
+  references:
+    - { file: "${WS}/constructor_navigation.cpp", range: "3:4-3:11" }
+    - { file: "${WS}/constructor_navigation.cpp", range: "7:9-7:16" }
+    - { file: "${WS}/constructor_navigation.cpp", range: "10:18-10:19" }
+  callHierarchy:
+    - { name: "Session", kind: Method, file: "${WS}/constructor_navigation.cpp", range: "7:9-7:16" }
+
+ctor_use:
+  definition:
+    - { file: "${WS}/constructor_navigation.cpp", range: "2:7-2:14" }
+  declaration:
+    - { file: "${WS}/constructor_navigation.cpp", range: "2:7-2:14" }
+  references:
+    - { file: "${WS}/constructor_navigation.cpp", range: "2:7-2:14" }
+    - { file: "${WS}/constructor_navigation.cpp", range: "7:0-7:7" }
+    - { file: "${WS}/constructor_navigation.cpp", range: "9:0-9:7" }
+    - { file: "${WS}/constructor_navigation.cpp", range: "10:11-10:18" }
+  typeHierarchy:
+    - { name: "Session", kind: Struct, file: "${WS}/constructor_navigation.cpp", range: "10:11-10:18" }
+
+scope_use:
+  definition:
+    - { file: "${WS}/constructor_navigation.cpp", range: "2:7-2:14" }
+  declaration:
+    - { file: "${WS}/constructor_navigation.cpp", range: "2:7-2:14" }
+  references:
+    - { file: "${WS}/constructor_navigation.cpp", range: "2:7-2:14" }
+    - { file: "${WS}/constructor_navigation.cpp", range: "7:0-7:7" }
+    - { file: "${WS}/constructor_navigation.cpp", range: "9:0-9:7" }
+    - { file: "${WS}/constructor_navigation.cpp", range: "10:11-10:18" }
+  typeHierarchy:
+    - { name: "Session", kind: Struct, file: "${WS}/constructor_navigation.cpp", range: "7:0-7:7" }

--- a/tests/snap/navigation/constructor_navigation.snap.yml
+++ b/tests/snap/navigation/constructor_navigation.snap.yml
@@ -30,6 +30,19 @@ ctor_def:
   callHierarchy:
     - { name: "Session", kind: Method, file: "${WS}/constructor_navigation.cpp", range: "7:9-7:16" }
 
+ctor_invoke:
+  definition:
+    - { file: "${WS}/constructor_navigation.cpp", range: "2:7-2:14" }
+  declaration:
+    - { file: "${WS}/constructor_navigation.cpp", range: "2:7-2:14" }
+  references:
+    - { file: "${WS}/constructor_navigation.cpp", range: "2:7-2:14" }
+    - { file: "${WS}/constructor_navigation.cpp", range: "7:0-7:7" }
+    - { file: "${WS}/constructor_navigation.cpp", range: "9:0-9:7" }
+    - { file: "${WS}/constructor_navigation.cpp", range: "10:11-10:18" }
+  typeHierarchy:
+    - { name: "Session", kind: Struct, file: "${WS}/constructor_navigation.cpp", range: "2:7-2:14" }
+
 ctor_use:
   definition:
     - { file: "${WS}/constructor_navigation.cpp", range: "2:7-2:14" }

--- a/tests/snap/navigation/conversion_operator.cpp
+++ b/tests/snap/navigation/conversion_operator.cpp
@@ -1,0 +1,14 @@
+/// - verify: server
+
+struct Number {
+    int value;
+    §(conv_decl)operator int() const;
+};
+
+Number::§(conv_def)operator int() const {
+    return value;
+}
+
+int read_number(Number number) {
+    return number.§(conv_use)operator int();
+}

--- a/tests/snap/navigation/conversion_operator.snap.yml
+++ b/tests/snap/navigation/conversion_operator.snap.yml
@@ -12,7 +12,7 @@ conv_decl:
     - { file: "${WS}/conversion_operator.cpp", range: "7:8-7:16" }
     - { file: "${WS}/conversion_operator.cpp", range: "12:18-12:26" }
   callHierarchy:
-    - { name: "operator int", kind: Method, file: "${WS}/conversion_operator.cpp", range: "4:4-4:12" }
+    - { name: "operator int", kind: Method, file: "${WS}/conversion_operator.cpp", range: "7:8-7:16" }
   incomingCalls:
     - { name: "read_number", kind: Function, file: "${WS}/conversion_operator.cpp", range: "11:4-11:15", fromRanges: ["12:11-12:32"] }
 
@@ -41,6 +41,6 @@ conv_use:
     - { file: "${WS}/conversion_operator.cpp", range: "7:8-7:16" }
     - { file: "${WS}/conversion_operator.cpp", range: "12:18-12:26" }
   callHierarchy:
-    - { name: "operator int", kind: Method, file: "${WS}/conversion_operator.cpp", range: "12:18-12:26" }
+    - { name: "operator int", kind: Method, file: "${WS}/conversion_operator.cpp", range: "7:8-7:16" }
   incomingCalls:
     - { name: "read_number", kind: Function, file: "${WS}/conversion_operator.cpp", range: "11:4-11:15", fromRanges: ["12:11-12:32"] }

--- a/tests/snap/navigation/conversion_operator.snap.yml
+++ b/tests/snap/navigation/conversion_operator.snap.yml
@@ -1,0 +1,46 @@
+---
+created_at: 2026-08-22
+input_file: conversion_operator.cpp
+---
+conv_decl:
+  definition:
+    - { file: "${WS}/conversion_operator.cpp", range: "7:8-7:16" }
+  declaration:
+    - { file: "${WS}/conversion_operator.cpp", range: "7:8-7:16" }
+  references:
+    - { file: "${WS}/conversion_operator.cpp", range: "4:4-4:12" }
+    - { file: "${WS}/conversion_operator.cpp", range: "7:8-7:16" }
+    - { file: "${WS}/conversion_operator.cpp", range: "12:18-12:26" }
+  callHierarchy:
+    - { name: "operator int", kind: Method, file: "${WS}/conversion_operator.cpp", range: "4:4-4:12" }
+  incomingCalls:
+    - { name: "read_number", kind: Function, file: "${WS}/conversion_operator.cpp", range: "11:4-11:15", fromRanges: ["12:11-12:32"] }
+
+conv_def:
+  definition:
+    - { file: "${WS}/conversion_operator.cpp", range: "4:4-4:12" }
+  declaration:
+    - { file: "${WS}/conversion_operator.cpp", range: "4:4-4:12" }
+  references:
+    - { file: "${WS}/conversion_operator.cpp", range: "4:4-4:12" }
+    - { file: "${WS}/conversion_operator.cpp", range: "7:8-7:16" }
+    - { file: "${WS}/conversion_operator.cpp", range: "12:18-12:26" }
+  callHierarchy:
+    - { name: "operator int", kind: Method, file: "${WS}/conversion_operator.cpp", range: "7:8-7:16" }
+  incomingCalls:
+    - { name: "read_number", kind: Function, file: "${WS}/conversion_operator.cpp", range: "11:4-11:15", fromRanges: ["12:11-12:32"] }
+
+conv_use:
+  definition:
+    - { file: "${WS}/conversion_operator.cpp", range: "7:8-7:16" }
+  declaration:
+    - { file: "${WS}/conversion_operator.cpp", range: "4:4-4:12" }
+    - { file: "${WS}/conversion_operator.cpp", range: "7:8-7:16" }
+  references:
+    - { file: "${WS}/conversion_operator.cpp", range: "4:4-4:12" }
+    - { file: "${WS}/conversion_operator.cpp", range: "7:8-7:16" }
+    - { file: "${WS}/conversion_operator.cpp", range: "12:18-12:26" }
+  callHierarchy:
+    - { name: "operator int", kind: Method, file: "${WS}/conversion_operator.cpp", range: "12:18-12:26" }
+  incomingCalls:
+    - { name: "read_number", kind: Function, file: "${WS}/conversion_operator.cpp", range: "11:4-11:15", fromRanges: ["12:11-12:32"] }

--- a/tests/snap/navigation/corpus.json
+++ b/tests/snap/navigation/corpus.json
@@ -1,0 +1,4 @@
+{
+  "notes": "Freestanding, -undef and -nostdinc keep host stdlib symbols and platform macros out of the replies, so navigation targets stay identical across hosts. C++23 so the corpus covers current language constructs; module fixtures build their interface units from this same CDB.",
+  "flags": ["-std=c++23", "-ffreestanding", "-undef", "-nostdinc"]
+}

--- a/tests/snap/navigation/ctad_guide.cpp
+++ b/tests/snap/navigation/ctad_guide.cpp
@@ -2,7 +2,7 @@
 
 template <typename T>
 struct §(class_def)Box {
-    Box(T input): value(input) {}
+    Box(T input) : value(input) {}
     T value;
 };
 
@@ -10,6 +10,6 @@ template <typename T>
 §(guide_decl)Box(T) -> Box<T>;
 
 int read_box() {
-    §(ctad_use)Box box(7);
+    §(ctad_use)Box box§(ctad_invoke)(7);
     return box.value;
 }

--- a/tests/snap/navigation/ctad_guide.cpp
+++ b/tests/snap/navigation/ctad_guide.cpp
@@ -1,0 +1,15 @@
+/// - verify: server
+
+template <typename T>
+struct §(class_def)Box {
+    Box(T input): value(input) {}
+    T value;
+};
+
+template <typename T>
+§(guide_decl)Box(T) -> Box<T>;
+
+int read_box() {
+    §(ctad_use)Box box(7);
+    return box.value;
+}

--- a/tests/snap/navigation/ctad_guide.snap.yml
+++ b/tests/snap/navigation/ctad_guide.snap.yml
@@ -24,7 +24,7 @@ ctad_use:
     - { file: "${WS}/ctad_guide.cpp", range: "9:10-9:13" }
     - { file: "${WS}/ctad_guide.cpp", range: "12:4-12:7" }
   typeHierarchy:
-    - { name: "Box", kind: Struct, file: "${WS}/ctad_guide.cpp", range: "12:4-12:7" }
+    - { name: "Box", kind: Struct, file: "${WS}/ctad_guide.cpp", range: "3:7-3:10" }
 
 guide_decl:
   definition:

--- a/tests/snap/navigation/ctad_guide.snap.yml
+++ b/tests/snap/navigation/ctad_guide.snap.yml
@@ -16,14 +16,16 @@ class_def:
 
 ctad_invoke:
   definition:
-    - { file: "${WS}/ctad_guide.cpp", range: "12:8-12:11" }
+    - { file: "${WS}/ctad_guide.cpp", range: "4:4-4:7" }
   declaration:
-    - { file: "${WS}/ctad_guide.cpp", range: "12:8-12:11" }
+    - { file: "${WS}/ctad_guide.cpp", range: "4:4-4:7" }
   typeDefinition:
     - { file: "${WS}/ctad_guide.cpp", range: "3:7-3:10" }
   references:
-    - { file: "${WS}/ctad_guide.cpp", range: "12:8-12:11" }
-    - { file: "${WS}/ctad_guide.cpp", range: "13:11-13:14" }
+    - { file: "${WS}/ctad_guide.cpp", range: "4:4-4:7" }
+    - { file: "${WS}/ctad_guide.cpp", range: "12:11-12:12" }
+  callHierarchy:
+    - { name: "Box", kind: Method, file: "${WS}/ctad_guide.cpp", range: "4:4-4:7" }
 
 ctad_use:
   definition:

--- a/tests/snap/navigation/ctad_guide.snap.yml
+++ b/tests/snap/navigation/ctad_guide.snap.yml
@@ -26,6 +26,8 @@ ctad_invoke:
     - { file: "${WS}/ctad_guide.cpp", range: "12:11-12:12" }
   callHierarchy:
     - { name: "Box", kind: Method, file: "${WS}/ctad_guide.cpp", range: "4:4-4:7" }
+  incomingCalls:
+    - { name: "read_box", kind: Function, file: "${WS}/ctad_guide.cpp", range: "11:4-11:12", fromRanges: ["12:8-12:14"] }
 
 ctad_use:
   definition:

--- a/tests/snap/navigation/ctad_guide.snap.yml
+++ b/tests/snap/navigation/ctad_guide.snap.yml
@@ -1,0 +1,37 @@
+---
+created_at: 2026-08-22
+input_file: ctad_guide.cpp
+---
+class_def:
+  definition:
+    - { file: "${WS}/ctad_guide.cpp", range: "3:7-3:10" }
+  declaration:
+    - { file: "${WS}/ctad_guide.cpp", range: "3:7-3:10" }
+  references:
+    - { file: "${WS}/ctad_guide.cpp", range: "3:7-3:10" }
+    - { file: "${WS}/ctad_guide.cpp", range: "9:10-9:13" }
+    - { file: "${WS}/ctad_guide.cpp", range: "12:4-12:7" }
+  typeHierarchy:
+    - { name: "Box", kind: Struct, file: "${WS}/ctad_guide.cpp", range: "3:7-3:10" }
+
+ctad_use:
+  definition:
+    - { file: "${WS}/ctad_guide.cpp", range: "3:7-3:10" }
+  declaration:
+    - { file: "${WS}/ctad_guide.cpp", range: "3:7-3:10" }
+  references:
+    - { file: "${WS}/ctad_guide.cpp", range: "3:7-3:10" }
+    - { file: "${WS}/ctad_guide.cpp", range: "9:10-9:13" }
+    - { file: "${WS}/ctad_guide.cpp", range: "12:4-12:7" }
+  typeHierarchy:
+    - { name: "Box", kind: Struct, file: "${WS}/ctad_guide.cpp", range: "12:4-12:7" }
+
+guide_decl:
+  definition:
+    - { file: "${WS}/ctad_guide.cpp", range: "9:0-9:3" }
+  declaration:
+    - { file: "${WS}/ctad_guide.cpp", range: "9:0-9:3" }
+  references:
+    - { file: "${WS}/ctad_guide.cpp", range: "9:0-9:3" }
+  callHierarchy:
+    - { name: "<deduction guide for Box>", kind: Function, file: "${WS}/ctad_guide.cpp", range: "9:0-9:3" }

--- a/tests/snap/navigation/ctad_guide.snap.yml
+++ b/tests/snap/navigation/ctad_guide.snap.yml
@@ -14,6 +14,17 @@ class_def:
   typeHierarchy:
     - { name: "Box", kind: Struct, file: "${WS}/ctad_guide.cpp", range: "3:7-3:10" }
 
+ctad_invoke:
+  definition:
+    - { file: "${WS}/ctad_guide.cpp", range: "12:8-12:11" }
+  declaration:
+    - { file: "${WS}/ctad_guide.cpp", range: "12:8-12:11" }
+  typeDefinition:
+    - { file: "${WS}/ctad_guide.cpp", range: "3:7-3:10" }
+  references:
+    - { file: "${WS}/ctad_guide.cpp", range: "12:8-12:11" }
+    - { file: "${WS}/ctad_guide.cpp", range: "13:11-13:14" }
+
 ctad_use:
   definition:
     - { file: "${WS}/ctad_guide.cpp", range: "3:7-3:10" }

--- a/tests/snap/navigation/decl_def_alternate.cpp
+++ b/tests/snap/navigation/decl_def_alternate.cpp
@@ -1,0 +1,11 @@
+/// - verify: server
+
+int §(decl)scale(int value);
+
+int §(def)scale(int value) {
+    return value * 2;
+}
+
+int apply(int value) {
+    return §(use)scale(value);
+}

--- a/tests/snap/navigation/decl_def_alternate.snap.yml
+++ b/tests/snap/navigation/decl_def_alternate.snap.yml
@@ -12,7 +12,7 @@ decl:
     - { file: "${WS}/decl_def_alternate.cpp", range: "4:4-4:9" }
     - { file: "${WS}/decl_def_alternate.cpp", range: "9:11-9:16" }
   callHierarchy:
-    - { name: "scale", kind: Function, file: "${WS}/decl_def_alternate.cpp", range: "2:4-2:9" }
+    - { name: "scale", kind: Function, file: "${WS}/decl_def_alternate.cpp", range: "4:4-4:9" }
   incomingCalls:
     - { name: "apply", kind: Function, file: "${WS}/decl_def_alternate.cpp", range: "8:4-8:9", fromRanges: ["9:11-9:23"] }
 
@@ -41,6 +41,6 @@ use:
     - { file: "${WS}/decl_def_alternate.cpp", range: "4:4-4:9" }
     - { file: "${WS}/decl_def_alternate.cpp", range: "9:11-9:16" }
   callHierarchy:
-    - { name: "scale", kind: Function, file: "${WS}/decl_def_alternate.cpp", range: "9:11-9:16" }
+    - { name: "scale", kind: Function, file: "${WS}/decl_def_alternate.cpp", range: "4:4-4:9" }
   incomingCalls:
     - { name: "apply", kind: Function, file: "${WS}/decl_def_alternate.cpp", range: "8:4-8:9", fromRanges: ["9:11-9:23"] }

--- a/tests/snap/navigation/decl_def_alternate.snap.yml
+++ b/tests/snap/navigation/decl_def_alternate.snap.yml
@@ -1,0 +1,46 @@
+---
+created_at: 2026-08-22
+input_file: decl_def_alternate.cpp
+---
+decl:
+  definition:
+    - { file: "${WS}/decl_def_alternate.cpp", range: "4:4-4:9" }
+  declaration:
+    - { file: "${WS}/decl_def_alternate.cpp", range: "4:4-4:9" }
+  references:
+    - { file: "${WS}/decl_def_alternate.cpp", range: "2:4-2:9" }
+    - { file: "${WS}/decl_def_alternate.cpp", range: "4:4-4:9" }
+    - { file: "${WS}/decl_def_alternate.cpp", range: "9:11-9:16" }
+  callHierarchy:
+    - { name: "scale", kind: Function, file: "${WS}/decl_def_alternate.cpp", range: "2:4-2:9" }
+  incomingCalls:
+    - { name: "apply", kind: Function, file: "${WS}/decl_def_alternate.cpp", range: "8:4-8:9", fromRanges: ["9:11-9:23"] }
+
+def:
+  definition:
+    - { file: "${WS}/decl_def_alternate.cpp", range: "2:4-2:9" }
+  declaration:
+    - { file: "${WS}/decl_def_alternate.cpp", range: "2:4-2:9" }
+  references:
+    - { file: "${WS}/decl_def_alternate.cpp", range: "2:4-2:9" }
+    - { file: "${WS}/decl_def_alternate.cpp", range: "4:4-4:9" }
+    - { file: "${WS}/decl_def_alternate.cpp", range: "9:11-9:16" }
+  callHierarchy:
+    - { name: "scale", kind: Function, file: "${WS}/decl_def_alternate.cpp", range: "4:4-4:9" }
+  incomingCalls:
+    - { name: "apply", kind: Function, file: "${WS}/decl_def_alternate.cpp", range: "8:4-8:9", fromRanges: ["9:11-9:23"] }
+
+use:
+  definition:
+    - { file: "${WS}/decl_def_alternate.cpp", range: "4:4-4:9" }
+  declaration:
+    - { file: "${WS}/decl_def_alternate.cpp", range: "2:4-2:9" }
+    - { file: "${WS}/decl_def_alternate.cpp", range: "4:4-4:9" }
+  references:
+    - { file: "${WS}/decl_def_alternate.cpp", range: "2:4-2:9" }
+    - { file: "${WS}/decl_def_alternate.cpp", range: "4:4-4:9" }
+    - { file: "${WS}/decl_def_alternate.cpp", range: "9:11-9:16" }
+  callHierarchy:
+    - { name: "scale", kind: Function, file: "${WS}/decl_def_alternate.cpp", range: "9:11-9:16" }
+  incomingCalls:
+    - { name: "apply", kind: Function, file: "${WS}/decl_def_alternate.cpp", range: "8:4-8:9", fromRanges: ["9:11-9:23"] }

--- a/tests/snap/navigation/declaration_only.cpp
+++ b/tests/snap/navigation/declaration_only.cpp
@@ -7,6 +7,6 @@ extern int §(var_decl)threshold;
 
 int §(fn_decl)probe(int value);
 
-int watch(int value) {
+int §(caller)watch(int value) {
     return §(fn_use)probe(value) + §(var_use)threshold;
 }

--- a/tests/snap/navigation/declaration_only.cpp
+++ b/tests/snap/navigation/declaration_only.cpp
@@ -1,0 +1,12 @@
+/// - verify: server
+///
+/// Declaration-only symbols: definition falls back to the declarations
+/// instead of returning nothing.
+
+extern int §(var_decl)threshold;
+
+int §(fn_decl)probe(int value);
+
+int watch(int value) {
+    return §(fn_use)probe(value) + §(var_use)threshold;
+}

--- a/tests/snap/navigation/declaration_only.snap.yml
+++ b/tests/snap/navigation/declaration_only.snap.yml
@@ -1,0 +1,47 @@
+---
+created_at: 2026-08-22
+input_file: declaration_only.cpp
+---
+fn_decl:
+  definition:
+    - { file: "${WS}/declaration_only.cpp", range: "7:4-7:9" }
+  declaration:
+    - { file: "${WS}/declaration_only.cpp", range: "7:4-7:9" }
+  references:
+    - { file: "${WS}/declaration_only.cpp", range: "7:4-7:9" }
+    - { file: "${WS}/declaration_only.cpp", range: "10:11-10:16" }
+  callHierarchy:
+    - { name: "probe", kind: Function, file: "${WS}/declaration_only.cpp", range: "7:4-7:9" }
+  incomingCalls:
+    - { name: "watch", kind: Function, file: "${WS}/declaration_only.cpp", range: "9:4-9:9", fromRanges: ["10:11-10:23"] }
+
+fn_use:
+  definition:
+    - { file: "${WS}/declaration_only.cpp", range: "7:4-7:9" }
+  declaration:
+    - { file: "${WS}/declaration_only.cpp", range: "7:4-7:9" }
+  references:
+    - { file: "${WS}/declaration_only.cpp", range: "7:4-7:9" }
+    - { file: "${WS}/declaration_only.cpp", range: "10:11-10:16" }
+  callHierarchy:
+    - { name: "probe", kind: Function, file: "${WS}/declaration_only.cpp", range: "10:11-10:16" }
+  incomingCalls:
+    - { name: "watch", kind: Function, file: "${WS}/declaration_only.cpp", range: "9:4-9:9", fromRanges: ["10:11-10:23"] }
+
+var_decl:
+  definition:
+    - { file: "${WS}/declaration_only.cpp", range: "5:11-5:20" }
+  declaration:
+    - { file: "${WS}/declaration_only.cpp", range: "5:11-5:20" }
+  references:
+    - { file: "${WS}/declaration_only.cpp", range: "5:11-5:20" }
+    - { file: "${WS}/declaration_only.cpp", range: "10:26-10:35" }
+
+var_use:
+  definition:
+    - { file: "${WS}/declaration_only.cpp", range: "5:11-5:20" }
+  declaration:
+    - { file: "${WS}/declaration_only.cpp", range: "5:11-5:20" }
+  references:
+    - { file: "${WS}/declaration_only.cpp", range: "5:11-5:20" }
+    - { file: "${WS}/declaration_only.cpp", range: "10:26-10:35" }

--- a/tests/snap/navigation/declaration_only.snap.yml
+++ b/tests/snap/navigation/declaration_only.snap.yml
@@ -2,6 +2,18 @@
 created_at: 2026-08-22
 input_file: declaration_only.cpp
 ---
+caller:
+  definition:
+    - { file: "${WS}/declaration_only.cpp", range: "9:4-9:9" }
+  declaration:
+    - { file: "${WS}/declaration_only.cpp", range: "9:4-9:9" }
+  references:
+    - { file: "${WS}/declaration_only.cpp", range: "9:4-9:9" }
+  callHierarchy:
+    - { name: "watch", kind: Function, file: "${WS}/declaration_only.cpp", range: "9:4-9:9" }
+  outgoingCalls:
+    - { name: "probe", kind: Function, file: "${WS}/declaration_only.cpp", range: "7:4-7:9", fromRanges: ["10:11-10:23"] }
+
 fn_decl:
   definition:
     - { file: "${WS}/declaration_only.cpp", range: "7:4-7:9" }
@@ -24,7 +36,7 @@ fn_use:
     - { file: "${WS}/declaration_only.cpp", range: "7:4-7:9" }
     - { file: "${WS}/declaration_only.cpp", range: "10:11-10:16" }
   callHierarchy:
-    - { name: "probe", kind: Function, file: "${WS}/declaration_only.cpp", range: "10:11-10:16" }
+    - { name: "probe", kind: Function, file: "${WS}/declaration_only.cpp", range: "7:4-7:9" }
   incomingCalls:
     - { name: "watch", kind: Function, file: "${WS}/declaration_only.cpp", range: "9:4-9:9", fromRanges: ["10:11-10:23"] }
 

--- a/tests/snap/navigation/default_argument.cpp
+++ b/tests/snap/navigation/default_argument.cpp
@@ -1,0 +1,13 @@
+/// - verify: server
+
+int §(seed_def)seed = 4;
+
+int choose_default(int value = §(default_use)seed);
+
+int §(fn_def)choose_default(int value) {
+    return value;
+}
+
+int run_default() {
+    return §(call_use)choose_default();
+}

--- a/tests/snap/navigation/default_argument.snap.yml
+++ b/tests/snap/navigation/default_argument.snap.yml
@@ -13,7 +13,7 @@ call_use:
     - { file: "${WS}/default_argument.cpp", range: "6:4-6:18" }
     - { file: "${WS}/default_argument.cpp", range: "11:11-11:25" }
   callHierarchy:
-    - { name: "choose_default", kind: Function, file: "${WS}/default_argument.cpp", range: "11:11-11:25" }
+    - { name: "choose_default", kind: Function, file: "${WS}/default_argument.cpp", range: "6:4-6:18" }
   incomingCalls:
     - { name: "run_default", kind: Function, file: "${WS}/default_argument.cpp", range: "10:4-10:15", fromRanges: ["11:11-11:27"] }
 

--- a/tests/snap/navigation/default_argument.snap.yml
+++ b/tests/snap/navigation/default_argument.snap.yml
@@ -1,0 +1,50 @@
+---
+created_at: 2026-08-22
+input_file: default_argument.cpp
+---
+call_use:
+  definition:
+    - { file: "${WS}/default_argument.cpp", range: "6:4-6:18" }
+  declaration:
+    - { file: "${WS}/default_argument.cpp", range: "4:4-4:18" }
+    - { file: "${WS}/default_argument.cpp", range: "6:4-6:18" }
+  references:
+    - { file: "${WS}/default_argument.cpp", range: "4:4-4:18" }
+    - { file: "${WS}/default_argument.cpp", range: "6:4-6:18" }
+    - { file: "${WS}/default_argument.cpp", range: "11:11-11:25" }
+  callHierarchy:
+    - { name: "choose_default", kind: Function, file: "${WS}/default_argument.cpp", range: "11:11-11:25" }
+  incomingCalls:
+    - { name: "run_default", kind: Function, file: "${WS}/default_argument.cpp", range: "10:4-10:15", fromRanges: ["11:11-11:27"] }
+
+default_use:
+  definition:
+    - { file: "${WS}/default_argument.cpp", range: "2:4-2:8" }
+  declaration:
+    - { file: "${WS}/default_argument.cpp", range: "2:4-2:8" }
+  references:
+    - { file: "${WS}/default_argument.cpp", range: "2:4-2:8" }
+    - { file: "${WS}/default_argument.cpp", range: "4:31-4:35" }
+
+fn_def:
+  definition:
+    - { file: "${WS}/default_argument.cpp", range: "4:4-4:18" }
+  declaration:
+    - { file: "${WS}/default_argument.cpp", range: "4:4-4:18" }
+  references:
+    - { file: "${WS}/default_argument.cpp", range: "4:4-4:18" }
+    - { file: "${WS}/default_argument.cpp", range: "6:4-6:18" }
+    - { file: "${WS}/default_argument.cpp", range: "11:11-11:25" }
+  callHierarchy:
+    - { name: "choose_default", kind: Function, file: "${WS}/default_argument.cpp", range: "6:4-6:18" }
+  incomingCalls:
+    - { name: "run_default", kind: Function, file: "${WS}/default_argument.cpp", range: "10:4-10:15", fromRanges: ["11:11-11:27"] }
+
+seed_def:
+  definition:
+    - { file: "${WS}/default_argument.cpp", range: "2:4-2:8" }
+  declaration:
+    - { file: "${WS}/default_argument.cpp", range: "2:4-2:8" }
+  references:
+    - { file: "${WS}/default_argument.cpp", range: "2:4-2:8" }
+    - { file: "${WS}/default_argument.cpp", range: "4:31-4:35" }

--- a/tests/snap/navigation/dependent_names.cpp
+++ b/tests/snap/navigation/dependent_names.cpp
@@ -1,0 +1,7 @@
+/// - verify: server
+
+template <typename T>
+int inspect_dependent(T& value) {
+    typename T::§(dependent_type)result made = value.§(dependent_call)make();
+    return made + value.§(dependent_field)count;
+}

--- a/tests/snap/navigation/dependent_names.snap.yml
+++ b/tests/snap/navigation/dependent_names.snap.yml
@@ -1,0 +1,9 @@
+---
+created_at: 2026-08-22
+input_file: dependent_names.cpp
+---
+dependent_call: none
+
+dependent_field: none
+
+dependent_type: none

--- a/tests/snap/navigation/destructor_navigation.cpp
+++ b/tests/snap/navigation/destructor_navigation.cpp
@@ -1,0 +1,11 @@
+/// - verify: server
+
+struct Resource {
+    §(dtor_decl)~Resource();
+};
+
+Resource::§(dtor_def)~Resource() {}
+
+void release(Resource& resource) {
+    resource.§(dtor_use)~Resource();
+}

--- a/tests/snap/navigation/destructor_navigation.snap.yml
+++ b/tests/snap/navigation/destructor_navigation.snap.yml
@@ -1,0 +1,52 @@
+---
+created_at: 2026-08-22
+input_file: destructor_navigation.cpp
+---
+dtor_decl:
+  definition:
+    - { file: "${WS}/destructor_navigation.cpp", range: "6:10-6:11" }
+  declaration:
+    - { file: "${WS}/destructor_navigation.cpp", range: "6:10-6:11" }
+  typeDefinition:
+    - { file: "${WS}/destructor_navigation.cpp", range: "2:7-2:15" }
+  references:
+    - { file: "${WS}/destructor_navigation.cpp", range: "3:4-3:5" }
+    - { file: "${WS}/destructor_navigation.cpp", range: "6:10-6:11" }
+    - { file: "${WS}/destructor_navigation.cpp", range: "9:13-9:14" }
+  callHierarchy:
+    - { name: "~Resource", kind: Method, file: "${WS}/destructor_navigation.cpp", range: "3:4-3:5" }
+  incomingCalls:
+    - { name: "release", kind: Function, file: "${WS}/destructor_navigation.cpp", range: "8:5-8:12", fromRanges: ["9:4-9:24"] }
+
+dtor_def:
+  definition:
+    - { file: "${WS}/destructor_navigation.cpp", range: "3:4-3:5" }
+  declaration:
+    - { file: "${WS}/destructor_navigation.cpp", range: "3:4-3:5" }
+  typeDefinition:
+    - { file: "${WS}/destructor_navigation.cpp", range: "2:7-2:15" }
+  references:
+    - { file: "${WS}/destructor_navigation.cpp", range: "3:4-3:5" }
+    - { file: "${WS}/destructor_navigation.cpp", range: "6:10-6:11" }
+    - { file: "${WS}/destructor_navigation.cpp", range: "9:13-9:14" }
+  callHierarchy:
+    - { name: "~Resource", kind: Method, file: "${WS}/destructor_navigation.cpp", range: "6:10-6:11" }
+  incomingCalls:
+    - { name: "release", kind: Function, file: "${WS}/destructor_navigation.cpp", range: "8:5-8:12", fromRanges: ["9:4-9:24"] }
+
+dtor_use:
+  definition:
+    - { file: "${WS}/destructor_navigation.cpp", range: "6:10-6:11" }
+  declaration:
+    - { file: "${WS}/destructor_navigation.cpp", range: "3:4-3:5" }
+    - { file: "${WS}/destructor_navigation.cpp", range: "6:10-6:11" }
+  typeDefinition:
+    - { file: "${WS}/destructor_navigation.cpp", range: "2:7-2:15" }
+  references:
+    - { file: "${WS}/destructor_navigation.cpp", range: "3:4-3:5" }
+    - { file: "${WS}/destructor_navigation.cpp", range: "6:10-6:11" }
+    - { file: "${WS}/destructor_navigation.cpp", range: "9:13-9:14" }
+  callHierarchy:
+    - { name: "~Resource", kind: Method, file: "${WS}/destructor_navigation.cpp", range: "9:13-9:14" }
+  incomingCalls:
+    - { name: "release", kind: Function, file: "${WS}/destructor_navigation.cpp", range: "8:5-8:12", fromRanges: ["9:4-9:24"] }

--- a/tests/snap/navigation/destructor_navigation.snap.yml
+++ b/tests/snap/navigation/destructor_navigation.snap.yml
@@ -14,7 +14,7 @@ dtor_decl:
     - { file: "${WS}/destructor_navigation.cpp", range: "6:10-6:11" }
     - { file: "${WS}/destructor_navigation.cpp", range: "9:13-9:14" }
   callHierarchy:
-    - { name: "~Resource", kind: Method, file: "${WS}/destructor_navigation.cpp", range: "3:4-3:5" }
+    - { name: "~Resource", kind: Method, file: "${WS}/destructor_navigation.cpp", range: "6:10-6:11" }
   incomingCalls:
     - { name: "release", kind: Function, file: "${WS}/destructor_navigation.cpp", range: "8:5-8:12", fromRanges: ["9:4-9:24"] }
 
@@ -47,6 +47,6 @@ dtor_use:
     - { file: "${WS}/destructor_navigation.cpp", range: "6:10-6:11" }
     - { file: "${WS}/destructor_navigation.cpp", range: "9:13-9:14" }
   callHierarchy:
-    - { name: "~Resource", kind: Method, file: "${WS}/destructor_navigation.cpp", range: "9:13-9:14" }
+    - { name: "~Resource", kind: Method, file: "${WS}/destructor_navigation.cpp", range: "6:10-6:11" }
   incomingCalls:
     - { name: "release", kind: Function, file: "${WS}/destructor_navigation.cpp", range: "8:5-8:12", fromRanges: ["9:4-9:24"] }

--- a/tests/snap/navigation/enum_enumerator.cpp
+++ b/tests/snap/navigation/enum_enumerator.cpp
@@ -1,0 +1,16 @@
+/// - verify: server
+
+enum class State {
+    §(idle_def)Idle,
+    §(ready_def)Ready,
+};
+
+int state_code(State state) {
+    switch (state) {
+    case State::§(idle_case)Idle:
+        return 0;
+    case State::§(ready_case)Ready:
+        return 1;
+    }
+    return state == State::§(ready_use)Ready ? 2 : 3;
+}

--- a/tests/snap/navigation/enum_enumerator.snap.yml
+++ b/tests/snap/navigation/enum_enumerator.snap.yml
@@ -1,0 +1,61 @@
+---
+created_at: 2026-08-22
+input_file: enum_enumerator.cpp
+---
+idle_case:
+  definition:
+    - { file: "${WS}/enum_enumerator.cpp", range: "3:4-3:8" }
+  declaration:
+    - { file: "${WS}/enum_enumerator.cpp", range: "3:4-3:8" }
+  typeDefinition:
+    - { file: "${WS}/enum_enumerator.cpp", range: "2:11-2:16" }
+  references:
+    - { file: "${WS}/enum_enumerator.cpp", range: "3:4-3:8" }
+    - { file: "${WS}/enum_enumerator.cpp", range: "9:16-9:20" }
+
+idle_def:
+  definition:
+    - { file: "${WS}/enum_enumerator.cpp", range: "3:4-3:8" }
+  declaration:
+    - { file: "${WS}/enum_enumerator.cpp", range: "3:4-3:8" }
+  typeDefinition:
+    - { file: "${WS}/enum_enumerator.cpp", range: "2:11-2:16" }
+  references:
+    - { file: "${WS}/enum_enumerator.cpp", range: "3:4-3:8" }
+    - { file: "${WS}/enum_enumerator.cpp", range: "9:16-9:20" }
+
+ready_case:
+  definition:
+    - { file: "${WS}/enum_enumerator.cpp", range: "4:4-4:9" }
+  declaration:
+    - { file: "${WS}/enum_enumerator.cpp", range: "4:4-4:9" }
+  typeDefinition:
+    - { file: "${WS}/enum_enumerator.cpp", range: "2:11-2:16" }
+  references:
+    - { file: "${WS}/enum_enumerator.cpp", range: "4:4-4:9" }
+    - { file: "${WS}/enum_enumerator.cpp", range: "11:16-11:21" }
+    - { file: "${WS}/enum_enumerator.cpp", range: "14:27-14:32" }
+
+ready_def:
+  definition:
+    - { file: "${WS}/enum_enumerator.cpp", range: "4:4-4:9" }
+  declaration:
+    - { file: "${WS}/enum_enumerator.cpp", range: "4:4-4:9" }
+  typeDefinition:
+    - { file: "${WS}/enum_enumerator.cpp", range: "2:11-2:16" }
+  references:
+    - { file: "${WS}/enum_enumerator.cpp", range: "4:4-4:9" }
+    - { file: "${WS}/enum_enumerator.cpp", range: "11:16-11:21" }
+    - { file: "${WS}/enum_enumerator.cpp", range: "14:27-14:32" }
+
+ready_use:
+  definition:
+    - { file: "${WS}/enum_enumerator.cpp", range: "4:4-4:9" }
+  declaration:
+    - { file: "${WS}/enum_enumerator.cpp", range: "4:4-4:9" }
+  typeDefinition:
+    - { file: "${WS}/enum_enumerator.cpp", range: "2:11-2:16" }
+  references:
+    - { file: "${WS}/enum_enumerator.cpp", range: "4:4-4:9" }
+    - { file: "${WS}/enum_enumerator.cpp", range: "11:16-11:21" }
+    - { file: "${WS}/enum_enumerator.cpp", range: "14:27-14:32" }

--- a/tests/snap/navigation/friend_functions.cpp
+++ b/tests/snap/navigation/friend_functions.cpp
@@ -1,0 +1,19 @@
+/// - verify: server
+
+struct Vault {
+    int value;
+
+    friend int §(friend_decl)inspect(const Vault& vault);
+
+    friend int §(hidden_def)reveal(const Vault& vault) {
+        return vault.value;
+    }
+};
+
+int §(friend_def)inspect(const Vault& vault) {
+    return vault.value;
+}
+
+int inspect_vault(const Vault& vault) {
+    return §(friend_use)inspect(vault) + §(hidden_use)reveal(vault);
+}

--- a/tests/snap/navigation/friend_functions.snap.yml
+++ b/tests/snap/navigation/friend_functions.snap.yml
@@ -1,0 +1,72 @@
+---
+created_at: 2026-08-22
+input_file: friend_functions.cpp
+---
+friend_decl:
+  definition:
+    - { file: "${WS}/friend_functions.cpp", range: "12:4-12:11" }
+  declaration:
+    - { file: "${WS}/friend_functions.cpp", range: "12:4-12:11" }
+  references:
+    - { file: "${WS}/friend_functions.cpp", range: "5:15-5:22" }
+    - { file: "${WS}/friend_functions.cpp", range: "12:4-12:11" }
+    - { file: "${WS}/friend_functions.cpp", range: "17:11-17:18" }
+  callHierarchy:
+    - { name: "inspect", kind: Function, file: "${WS}/friend_functions.cpp", range: "5:15-5:22" }
+  incomingCalls:
+    - { name: "inspect_vault", kind: Function, file: "${WS}/friend_functions.cpp", range: "16:4-16:17", fromRanges: ["17:11-17:25"] }
+
+friend_def:
+  definition:
+    - { file: "${WS}/friend_functions.cpp", range: "5:15-5:22" }
+  declaration:
+    - { file: "${WS}/friend_functions.cpp", range: "5:15-5:22" }
+  references:
+    - { file: "${WS}/friend_functions.cpp", range: "5:15-5:22" }
+    - { file: "${WS}/friend_functions.cpp", range: "12:4-12:11" }
+    - { file: "${WS}/friend_functions.cpp", range: "17:11-17:18" }
+  callHierarchy:
+    - { name: "inspect", kind: Function, file: "${WS}/friend_functions.cpp", range: "12:4-12:11" }
+  incomingCalls:
+    - { name: "inspect_vault", kind: Function, file: "${WS}/friend_functions.cpp", range: "16:4-16:17", fromRanges: ["17:11-17:25"] }
+
+friend_use:
+  definition:
+    - { file: "${WS}/friend_functions.cpp", range: "12:4-12:11" }
+  declaration:
+    - { file: "${WS}/friend_functions.cpp", range: "5:15-5:22" }
+    - { file: "${WS}/friend_functions.cpp", range: "12:4-12:11" }
+  references:
+    - { file: "${WS}/friend_functions.cpp", range: "5:15-5:22" }
+    - { file: "${WS}/friend_functions.cpp", range: "12:4-12:11" }
+    - { file: "${WS}/friend_functions.cpp", range: "17:11-17:18" }
+  callHierarchy:
+    - { name: "inspect", kind: Function, file: "${WS}/friend_functions.cpp", range: "17:11-17:18" }
+  incomingCalls:
+    - { name: "inspect_vault", kind: Function, file: "${WS}/friend_functions.cpp", range: "16:4-16:17", fromRanges: ["17:11-17:25"] }
+
+hidden_def:
+  definition:
+    - { file: "${WS}/friend_functions.cpp", range: "7:15-7:21" }
+  declaration:
+    - { file: "${WS}/friend_functions.cpp", range: "7:15-7:21" }
+  references:
+    - { file: "${WS}/friend_functions.cpp", range: "7:15-7:21" }
+    - { file: "${WS}/friend_functions.cpp", range: "17:28-17:34" }
+  callHierarchy:
+    - { name: "reveal", kind: Function, file: "${WS}/friend_functions.cpp", range: "7:15-7:21" }
+  incomingCalls:
+    - { name: "inspect_vault", kind: Function, file: "${WS}/friend_functions.cpp", range: "16:4-16:17", fromRanges: ["17:28-17:41"] }
+
+hidden_use:
+  definition:
+    - { file: "${WS}/friend_functions.cpp", range: "7:15-7:21" }
+  declaration:
+    - { file: "${WS}/friend_functions.cpp", range: "7:15-7:21" }
+  references:
+    - { file: "${WS}/friend_functions.cpp", range: "7:15-7:21" }
+    - { file: "${WS}/friend_functions.cpp", range: "17:28-17:34" }
+  callHierarchy:
+    - { name: "reveal", kind: Function, file: "${WS}/friend_functions.cpp", range: "17:28-17:34" }
+  incomingCalls:
+    - { name: "inspect_vault", kind: Function, file: "${WS}/friend_functions.cpp", range: "16:4-16:17", fromRanges: ["17:28-17:41"] }

--- a/tests/snap/navigation/friend_functions.snap.yml
+++ b/tests/snap/navigation/friend_functions.snap.yml
@@ -12,7 +12,7 @@ friend_decl:
     - { file: "${WS}/friend_functions.cpp", range: "12:4-12:11" }
     - { file: "${WS}/friend_functions.cpp", range: "17:11-17:18" }
   callHierarchy:
-    - { name: "inspect", kind: Function, file: "${WS}/friend_functions.cpp", range: "5:15-5:22" }
+    - { name: "inspect", kind: Function, file: "${WS}/friend_functions.cpp", range: "12:4-12:11" }
   incomingCalls:
     - { name: "inspect_vault", kind: Function, file: "${WS}/friend_functions.cpp", range: "16:4-16:17", fromRanges: ["17:11-17:25"] }
 
@@ -41,7 +41,7 @@ friend_use:
     - { file: "${WS}/friend_functions.cpp", range: "12:4-12:11" }
     - { file: "${WS}/friend_functions.cpp", range: "17:11-17:18" }
   callHierarchy:
-    - { name: "inspect", kind: Function, file: "${WS}/friend_functions.cpp", range: "17:11-17:18" }
+    - { name: "inspect", kind: Function, file: "${WS}/friend_functions.cpp", range: "12:4-12:11" }
   incomingCalls:
     - { name: "inspect_vault", kind: Function, file: "${WS}/friend_functions.cpp", range: "16:4-16:17", fromRanges: ["17:11-17:25"] }
 
@@ -67,6 +67,6 @@ hidden_use:
     - { file: "${WS}/friend_functions.cpp", range: "7:15-7:21" }
     - { file: "${WS}/friend_functions.cpp", range: "17:28-17:34" }
   callHierarchy:
-    - { name: "reveal", kind: Function, file: "${WS}/friend_functions.cpp", range: "17:28-17:34" }
+    - { name: "reveal", kind: Function, file: "${WS}/friend_functions.cpp", range: "7:15-7:21" }
   incomingCalls:
     - { name: "inspect_vault", kind: Function, file: "${WS}/friend_functions.cpp", range: "16:4-16:17", fromRanges: ["17:28-17:41"] }

--- a/tests/snap/navigation/function_pointer.cpp
+++ b/tests/snap/navigation/function_pointer.cpp
@@ -1,0 +1,13 @@
+/// - verify: server
+
+int §(target_def)target(int value) {
+    return value + 1;
+}
+
+using Callback = int (*)(int);
+
+Callback §(pointer_def)callback = &§(address_use)target;
+
+int invoke_pointer() {
+    return §(pointer_call)callback(3);
+}

--- a/tests/snap/navigation/function_pointer.snap.yml
+++ b/tests/snap/navigation/function_pointer.snap.yml
@@ -11,7 +11,7 @@ address_use:
     - { file: "${WS}/function_pointer.cpp", range: "2:4-2:10" }
     - { file: "${WS}/function_pointer.cpp", range: "8:21-8:27" }
   callHierarchy:
-    - { name: "target", kind: Function, file: "${WS}/function_pointer.cpp", range: "8:21-8:27" }
+    - { name: "target", kind: Function, file: "${WS}/function_pointer.cpp", range: "2:4-2:10" }
 
 pointer_call:
   definition:

--- a/tests/snap/navigation/function_pointer.snap.yml
+++ b/tests/snap/navigation/function_pointer.snap.yml
@@ -1,0 +1,47 @@
+---
+created_at: 2026-08-22
+input_file: function_pointer.cpp
+---
+address_use:
+  definition:
+    - { file: "${WS}/function_pointer.cpp", range: "2:4-2:10" }
+  declaration:
+    - { file: "${WS}/function_pointer.cpp", range: "2:4-2:10" }
+  references:
+    - { file: "${WS}/function_pointer.cpp", range: "2:4-2:10" }
+    - { file: "${WS}/function_pointer.cpp", range: "8:21-8:27" }
+  callHierarchy:
+    - { name: "target", kind: Function, file: "${WS}/function_pointer.cpp", range: "8:21-8:27" }
+
+pointer_call:
+  definition:
+    - { file: "${WS}/function_pointer.cpp", range: "8:9-8:17" }
+  declaration:
+    - { file: "${WS}/function_pointer.cpp", range: "8:9-8:17" }
+  typeDefinition:
+    - { file: "${WS}/function_pointer.cpp", range: "6:6-6:14" }
+  references:
+    - { file: "${WS}/function_pointer.cpp", range: "8:9-8:17" }
+    - { file: "${WS}/function_pointer.cpp", range: "11:11-11:19" }
+
+pointer_def:
+  definition:
+    - { file: "${WS}/function_pointer.cpp", range: "8:9-8:17" }
+  declaration:
+    - { file: "${WS}/function_pointer.cpp", range: "8:9-8:17" }
+  typeDefinition:
+    - { file: "${WS}/function_pointer.cpp", range: "6:6-6:14" }
+  references:
+    - { file: "${WS}/function_pointer.cpp", range: "8:9-8:17" }
+    - { file: "${WS}/function_pointer.cpp", range: "11:11-11:19" }
+
+target_def:
+  definition:
+    - { file: "${WS}/function_pointer.cpp", range: "2:4-2:10" }
+  declaration:
+    - { file: "${WS}/function_pointer.cpp", range: "2:4-2:10" }
+  references:
+    - { file: "${WS}/function_pointer.cpp", range: "2:4-2:10" }
+    - { file: "${WS}/function_pointer.cpp", range: "8:21-8:27" }
+  callHierarchy:
+    - { name: "target", kind: Function, file: "${WS}/function_pointer.cpp", range: "2:4-2:10" }

--- a/tests/snap/navigation/header_source/lib.cpp
+++ b/tests/snap/navigation/header_source/lib.cpp
@@ -1,0 +1,5 @@
+#include "lib.h"
+
+int §(def)area(int width, int height) {
+    return width * height;
+}

--- a/tests/snap/navigation/header_source/lib.h
+++ b/tests/snap/navigation/header_source/lib.h
@@ -1,0 +1,7 @@
+#pragma once
+
+int §(decl)area(int width, int height);
+
+inline int §(inline_def)perimeter(int width, int height) {
+    return 2 * (width + height);
+}

--- a/tests/snap/navigation/header_source/main.cpp
+++ b/tests/snap/navigation/header_source/main.cpp
@@ -1,6 +1,6 @@
 /// - verify: server
 
-#include "lib.h"
+#include §(include_target)"lib.h"
 
 int floor_plan(int width, int height) {
     return §(use)area(width, height) + §(inline_use)perimeter(width, height);

--- a/tests/snap/navigation/header_source/main.cpp
+++ b/tests/snap/navigation/header_source/main.cpp
@@ -1,0 +1,7 @@
+/// - verify: server
+
+#include "lib.h"
+
+int floor_plan(int width, int height) {
+    return §(use)area(width, height) + §(inline_use)perimeter(width, height);
+}

--- a/tests/snap/navigation/header_source/main.snap.yml
+++ b/tests/snap/navigation/header_source/main.snap.yml
@@ -50,6 +50,10 @@ inline_def:
     - { name: "floor_plan", kind: Function, file: "${WS}/header_source/main.cpp", range: "4:4-4:14", fromRanges: ["5:33-5:57"] }
 
 --- main.cpp
+include_target:
+  definition:
+    - { file: "${WS}/header_source/lib.h", range: "0:0-0:0" }
+
 inline_use:
   definition:
     - { file: "${WS}/header_source/lib.h", range: "4:11-4:20" }

--- a/tests/snap/navigation/header_source/main.snap.yml
+++ b/tests/snap/navigation/header_source/main.snap.yml
@@ -1,0 +1,99 @@
+---
+created_at: 2026-08-22
+input_file: header_source/main.cpp
+---
+--- lib.cpp
+def:
+  definition:
+    - { file: "${WS}/header_source/lib.h", range: "2:4-2:8" }
+  declaration:
+    - { file: "${WS}/header_source/lib.h", range: "2:4-2:8" }
+  references:
+    - { file: "${WS}/header_source/lib.cpp", range: "2:4-2:8" }
+    - { file: "${WS}/header_source/lib.h", range: "2:4-2:8" }
+    - { file: "${WS}/header_source/main.cpp", range: "5:11-5:15" }
+    - { file: "${WS}/header_source/uses.cpp", range: "3:11-3:15" }
+  callHierarchy:
+    - { name: "area", kind: Function, file: "${WS}/header_source/lib.cpp", range: "2:4-2:8" }
+  incomingCalls:
+    - { name: "floor_plan", kind: Function, file: "${WS}/header_source/main.cpp", range: "4:4-4:14", fromRanges: ["5:11-5:30"] }
+    - { name: "wall_paint", kind: Function, file: "${WS}/header_source/uses.cpp", range: "2:4-2:14", fromRanges: ["3:11-3:30"] }
+
+--- lib.h
+decl:
+  definition:
+    - { file: "${WS}/header_source/lib.cpp", range: "2:4-2:8" }
+  declaration:
+    - { file: "${WS}/header_source/lib.cpp", range: "2:4-2:8" }
+  references:
+    - { file: "${WS}/header_source/lib.cpp", range: "2:4-2:8" }
+    - { file: "${WS}/header_source/lib.h", range: "2:4-2:8" }
+    - { file: "${WS}/header_source/main.cpp", range: "5:11-5:15" }
+    - { file: "${WS}/header_source/uses.cpp", range: "3:11-3:15" }
+  callHierarchy:
+    - { name: "area", kind: Function, file: "${WS}/header_source/lib.h", range: "2:4-2:8" }
+  incomingCalls:
+    - { name: "floor_plan", kind: Function, file: "${WS}/header_source/main.cpp", range: "4:4-4:14", fromRanges: ["5:11-5:30"] }
+    - { name: "wall_paint", kind: Function, file: "${WS}/header_source/uses.cpp", range: "2:4-2:14", fromRanges: ["3:11-3:30"] }
+
+inline_def:
+  definition:
+    - { file: "${WS}/header_source/lib.h", range: "4:11-4:20" }
+  declaration:
+    - { file: "${WS}/header_source/lib.h", range: "4:11-4:20" }
+  references:
+    - { file: "${WS}/header_source/lib.h", range: "4:11-4:20" }
+    - { file: "${WS}/header_source/main.cpp", range: "5:33-5:42" }
+  callHierarchy:
+    - { name: "perimeter", kind: Function, file: "${WS}/header_source/lib.h", range: "4:11-4:20" }
+  incomingCalls:
+    - { name: "floor_plan", kind: Function, file: "${WS}/header_source/main.cpp", range: "4:4-4:14", fromRanges: ["5:33-5:57"] }
+
+--- main.cpp
+inline_use:
+  definition:
+    - { file: "${WS}/header_source/lib.h", range: "4:11-4:20" }
+  declaration:
+    - { file: "${WS}/header_source/lib.h", range: "4:11-4:20" }
+  references:
+    - { file: "${WS}/header_source/lib.h", range: "4:11-4:20" }
+    - { file: "${WS}/header_source/main.cpp", range: "5:33-5:42" }
+  callHierarchy:
+    - { name: "perimeter", kind: Function, file: "${WS}/header_source/main.cpp", range: "5:33-5:42" }
+  incomingCalls:
+    - { name: "floor_plan", kind: Function, file: "${WS}/header_source/main.cpp", range: "4:4-4:14", fromRanges: ["5:33-5:57"] }
+
+use:
+  definition:
+    - { file: "${WS}/header_source/lib.cpp", range: "2:4-2:8" }
+  declaration:
+    - { file: "${WS}/header_source/lib.cpp", range: "2:4-2:8" }
+    - { file: "${WS}/header_source/lib.h", range: "2:4-2:8" }
+  references:
+    - { file: "${WS}/header_source/lib.cpp", range: "2:4-2:8" }
+    - { file: "${WS}/header_source/lib.h", range: "2:4-2:8" }
+    - { file: "${WS}/header_source/main.cpp", range: "5:11-5:15" }
+    - { file: "${WS}/header_source/uses.cpp", range: "3:11-3:15" }
+  callHierarchy:
+    - { name: "area", kind: Function, file: "${WS}/header_source/main.cpp", range: "5:11-5:15" }
+  incomingCalls:
+    - { name: "floor_plan", kind: Function, file: "${WS}/header_source/main.cpp", range: "4:4-4:14", fromRanges: ["5:11-5:30"] }
+    - { name: "wall_paint", kind: Function, file: "${WS}/header_source/uses.cpp", range: "2:4-2:14", fromRanges: ["3:11-3:30"] }
+
+--- uses.cpp
+second_use:
+  definition:
+    - { file: "${WS}/header_source/lib.cpp", range: "2:4-2:8" }
+  declaration:
+    - { file: "${WS}/header_source/lib.cpp", range: "2:4-2:8" }
+    - { file: "${WS}/header_source/lib.h", range: "2:4-2:8" }
+  references:
+    - { file: "${WS}/header_source/lib.cpp", range: "2:4-2:8" }
+    - { file: "${WS}/header_source/lib.h", range: "2:4-2:8" }
+    - { file: "${WS}/header_source/main.cpp", range: "5:11-5:15" }
+    - { file: "${WS}/header_source/uses.cpp", range: "3:11-3:15" }
+  callHierarchy:
+    - { name: "area", kind: Function, file: "${WS}/header_source/uses.cpp", range: "3:11-3:15" }
+  incomingCalls:
+    - { name: "floor_plan", kind: Function, file: "${WS}/header_source/main.cpp", range: "4:4-4:14", fromRanges: ["5:11-5:30"] }
+    - { name: "wall_paint", kind: Function, file: "${WS}/header_source/uses.cpp", range: "2:4-2:14", fromRanges: ["3:11-3:30"] }

--- a/tests/snap/navigation/header_source/main.snap.yml
+++ b/tests/snap/navigation/header_source/main.snap.yml
@@ -31,7 +31,7 @@ decl:
     - { file: "${WS}/header_source/main.cpp", range: "5:11-5:15" }
     - { file: "${WS}/header_source/uses.cpp", range: "3:11-3:15" }
   callHierarchy:
-    - { name: "area", kind: Function, file: "${WS}/header_source/lib.h", range: "2:4-2:8" }
+    - { name: "area", kind: Function, file: "${WS}/header_source/lib.cpp", range: "2:4-2:8" }
   incomingCalls:
     - { name: "floor_plan", kind: Function, file: "${WS}/header_source/main.cpp", range: "4:4-4:14", fromRanges: ["5:11-5:30"] }
     - { name: "wall_paint", kind: Function, file: "${WS}/header_source/uses.cpp", range: "2:4-2:14", fromRanges: ["3:11-3:30"] }
@@ -59,7 +59,7 @@ inline_use:
     - { file: "${WS}/header_source/lib.h", range: "4:11-4:20" }
     - { file: "${WS}/header_source/main.cpp", range: "5:33-5:42" }
   callHierarchy:
-    - { name: "perimeter", kind: Function, file: "${WS}/header_source/main.cpp", range: "5:33-5:42" }
+    - { name: "perimeter", kind: Function, file: "${WS}/header_source/lib.h", range: "4:11-4:20" }
   incomingCalls:
     - { name: "floor_plan", kind: Function, file: "${WS}/header_source/main.cpp", range: "4:4-4:14", fromRanges: ["5:33-5:57"] }
 
@@ -75,7 +75,7 @@ use:
     - { file: "${WS}/header_source/main.cpp", range: "5:11-5:15" }
     - { file: "${WS}/header_source/uses.cpp", range: "3:11-3:15" }
   callHierarchy:
-    - { name: "area", kind: Function, file: "${WS}/header_source/main.cpp", range: "5:11-5:15" }
+    - { name: "area", kind: Function, file: "${WS}/header_source/lib.cpp", range: "2:4-2:8" }
   incomingCalls:
     - { name: "floor_plan", kind: Function, file: "${WS}/header_source/main.cpp", range: "4:4-4:14", fromRanges: ["5:11-5:30"] }
     - { name: "wall_paint", kind: Function, file: "${WS}/header_source/uses.cpp", range: "2:4-2:14", fromRanges: ["3:11-3:30"] }
@@ -93,7 +93,7 @@ second_use:
     - { file: "${WS}/header_source/main.cpp", range: "5:11-5:15" }
     - { file: "${WS}/header_source/uses.cpp", range: "3:11-3:15" }
   callHierarchy:
-    - { name: "area", kind: Function, file: "${WS}/header_source/uses.cpp", range: "3:11-3:15" }
+    - { name: "area", kind: Function, file: "${WS}/header_source/lib.cpp", range: "2:4-2:8" }
   incomingCalls:
     - { name: "floor_plan", kind: Function, file: "${WS}/header_source/main.cpp", range: "4:4-4:14", fromRanges: ["5:11-5:30"] }
     - { name: "wall_paint", kind: Function, file: "${WS}/header_source/uses.cpp", range: "2:4-2:14", fromRanges: ["3:11-3:30"] }

--- a/tests/snap/navigation/header_source/uses.cpp
+++ b/tests/snap/navigation/header_source/uses.cpp
@@ -1,0 +1,5 @@
+#include "lib.h"
+
+int wall_paint(int width, int height) {
+    return §(second_use)area(width, height);
+}

--- a/tests/snap/navigation/implementation_virtual.cpp
+++ b/tests/snap/navigation/implementation_virtual.cpp
@@ -4,13 +4,13 @@ struct §(base)Shape {
     virtual int §(base_method)area() = 0;
 };
 
-struct Circle: Shape {
+struct Circle : Shape {
     int §(override_def)area() override {
         return 3;
     }
 };
 
-struct Square: Shape {
+struct Square : Shape {
     int area() override {
         return 4;
     }

--- a/tests/snap/navigation/implementation_virtual.cpp
+++ b/tests/snap/navigation/implementation_virtual.cpp
@@ -1,0 +1,21 @@
+/// - verify: server
+
+struct §(base)Shape {
+    virtual int §(base_method)area() = 0;
+};
+
+struct Circle: Shape {
+    int §(override_def)area() override {
+        return 3;
+    }
+};
+
+struct Square: Shape {
+    int area() override {
+        return 4;
+    }
+};
+
+int measure(Shape& shape) {
+    return shape.§(virtual_call)area();
+}

--- a/tests/snap/navigation/implementation_virtual.snap.yml
+++ b/tests/snap/navigation/implementation_virtual.snap.yml
@@ -12,8 +12,8 @@ base:
     - { file: "${WS}/implementation_virtual.cpp", range: "12:7-12:13" }
   references:
     - { file: "${WS}/implementation_virtual.cpp", range: "2:7-2:12" }
-    - { file: "${WS}/implementation_virtual.cpp", range: "6:15-6:20" }
-    - { file: "${WS}/implementation_virtual.cpp", range: "12:15-12:20" }
+    - { file: "${WS}/implementation_virtual.cpp", range: "6:16-6:21" }
+    - { file: "${WS}/implementation_virtual.cpp", range: "12:16-12:21" }
     - { file: "${WS}/implementation_virtual.cpp", range: "18:12-18:17" }
   typeHierarchy:
     - { name: "Shape", kind: Struct, file: "${WS}/implementation_virtual.cpp", range: "2:7-2:12" }

--- a/tests/snap/navigation/implementation_virtual.snap.yml
+++ b/tests/snap/navigation/implementation_virtual.snap.yml
@@ -7,6 +7,9 @@ base:
     - { file: "${WS}/implementation_virtual.cpp", range: "2:7-2:12" }
   declaration:
     - { file: "${WS}/implementation_virtual.cpp", range: "2:7-2:12" }
+  implementation:
+    - { file: "${WS}/implementation_virtual.cpp", range: "6:7-6:13" }
+    - { file: "${WS}/implementation_virtual.cpp", range: "12:7-12:13" }
   references:
     - { file: "${WS}/implementation_virtual.cpp", range: "2:7-2:12" }
     - { file: "${WS}/implementation_virtual.cpp", range: "6:15-6:20" }
@@ -56,6 +59,6 @@ virtual_call:
     - { file: "${WS}/implementation_virtual.cpp", range: "3:16-3:20" }
     - { file: "${WS}/implementation_virtual.cpp", range: "19:17-19:21" }
   callHierarchy:
-    - { name: "area", kind: Method, file: "${WS}/implementation_virtual.cpp", range: "19:17-19:21" }
+    - { name: "area", kind: Method, file: "${WS}/implementation_virtual.cpp", range: "3:16-3:20" }
   incomingCalls:
     - { name: "measure", kind: Function, file: "${WS}/implementation_virtual.cpp", range: "18:4-18:11", fromRanges: ["19:11-19:23"] }

--- a/tests/snap/navigation/implementation_virtual.snap.yml
+++ b/tests/snap/navigation/implementation_virtual.snap.yml
@@ -1,0 +1,61 @@
+---
+created_at: 2026-08-22
+input_file: implementation_virtual.cpp
+---
+base:
+  definition:
+    - { file: "${WS}/implementation_virtual.cpp", range: "2:7-2:12" }
+  declaration:
+    - { file: "${WS}/implementation_virtual.cpp", range: "2:7-2:12" }
+  references:
+    - { file: "${WS}/implementation_virtual.cpp", range: "2:7-2:12" }
+    - { file: "${WS}/implementation_virtual.cpp", range: "6:15-6:20" }
+    - { file: "${WS}/implementation_virtual.cpp", range: "12:15-12:20" }
+    - { file: "${WS}/implementation_virtual.cpp", range: "18:12-18:17" }
+  typeHierarchy:
+    - { name: "Shape", kind: Struct, file: "${WS}/implementation_virtual.cpp", range: "2:7-2:12" }
+  subtypes:
+    - { name: "Circle", kind: Struct, file: "${WS}/implementation_virtual.cpp", range: "6:7-6:13" }
+    - { name: "Square", kind: Struct, file: "${WS}/implementation_virtual.cpp", range: "12:7-12:13" }
+
+base_method:
+  definition:
+    - { file: "${WS}/implementation_virtual.cpp", range: "3:16-3:20" }
+  declaration:
+    - { file: "${WS}/implementation_virtual.cpp", range: "3:16-3:20" }
+  implementation:
+    - { file: "${WS}/implementation_virtual.cpp", range: "7:8-7:12" }
+    - { file: "${WS}/implementation_virtual.cpp", range: "13:8-13:12" }
+  references:
+    - { file: "${WS}/implementation_virtual.cpp", range: "3:16-3:20" }
+    - { file: "${WS}/implementation_virtual.cpp", range: "19:17-19:21" }
+  callHierarchy:
+    - { name: "area", kind: Method, file: "${WS}/implementation_virtual.cpp", range: "3:16-3:20" }
+  incomingCalls:
+    - { name: "measure", kind: Function, file: "${WS}/implementation_virtual.cpp", range: "18:4-18:11", fromRanges: ["19:11-19:23"] }
+
+override_def:
+  definition:
+    - { file: "${WS}/implementation_virtual.cpp", range: "7:8-7:12" }
+  declaration:
+    - { file: "${WS}/implementation_virtual.cpp", range: "7:8-7:12" }
+  references:
+    - { file: "${WS}/implementation_virtual.cpp", range: "7:8-7:12" }
+  callHierarchy:
+    - { name: "area", kind: Method, file: "${WS}/implementation_virtual.cpp", range: "7:8-7:12" }
+
+virtual_call:
+  definition:
+    - { file: "${WS}/implementation_virtual.cpp", range: "3:16-3:20" }
+  declaration:
+    - { file: "${WS}/implementation_virtual.cpp", range: "3:16-3:20" }
+  implementation:
+    - { file: "${WS}/implementation_virtual.cpp", range: "7:8-7:12" }
+    - { file: "${WS}/implementation_virtual.cpp", range: "13:8-13:12" }
+  references:
+    - { file: "${WS}/implementation_virtual.cpp", range: "3:16-3:20" }
+    - { file: "${WS}/implementation_virtual.cpp", range: "19:17-19:21" }
+  callHierarchy:
+    - { name: "area", kind: Method, file: "${WS}/implementation_virtual.cpp", range: "19:17-19:21" }
+  incomingCalls:
+    - { name: "measure", kind: Function, file: "${WS}/implementation_virtual.cpp", range: "18:4-18:11", fromRanges: ["19:11-19:23"] }

--- a/tests/snap/navigation/inherited_member_access.cpp
+++ b/tests/snap/navigation/inherited_member_access.cpp
@@ -6,7 +6,7 @@ struct §(base_def)Base {
     }
 };
 
-struct §(derived_def)Derived: Base {};
+struct §(derived_def)Derived : Base {};
 
 int measure_derived(const Derived& derived) {
     return derived.§(inherited_use)measure();

--- a/tests/snap/navigation/inherited_member_access.cpp
+++ b/tests/snap/navigation/inherited_member_access.cpp
@@ -1,0 +1,13 @@
+/// - verify: server
+
+struct §(base_def)Base {
+    int §(method_def)measure() const {
+        return 5;
+    }
+};
+
+struct §(derived_def)Derived: Base {};
+
+int measure_derived(const Derived& derived) {
+    return derived.§(inherited_use)measure();
+}

--- a/tests/snap/navigation/inherited_member_access.snap.yml
+++ b/tests/snap/navigation/inherited_member_access.snap.yml
@@ -7,6 +7,8 @@ base_def:
     - { file: "${WS}/inherited_member_access.cpp", range: "2:7-2:11" }
   declaration:
     - { file: "${WS}/inherited_member_access.cpp", range: "2:7-2:11" }
+  implementation:
+    - { file: "${WS}/inherited_member_access.cpp", range: "8:7-8:14" }
   references:
     - { file: "${WS}/inherited_member_access.cpp", range: "2:7-2:11" }
     - { file: "${WS}/inherited_member_access.cpp", range: "8:16-8:20" }
@@ -37,7 +39,7 @@ inherited_use:
     - { file: "${WS}/inherited_member_access.cpp", range: "3:8-3:15" }
     - { file: "${WS}/inherited_member_access.cpp", range: "11:19-11:26" }
   callHierarchy:
-    - { name: "measure", kind: Method, file: "${WS}/inherited_member_access.cpp", range: "11:19-11:26" }
+    - { name: "measure", kind: Method, file: "${WS}/inherited_member_access.cpp", range: "3:8-3:15" }
   incomingCalls:
     - { name: "measure_derived", kind: Function, file: "${WS}/inherited_member_access.cpp", range: "10:4-10:19", fromRanges: ["11:11-11:28"] }
 

--- a/tests/snap/navigation/inherited_member_access.snap.yml
+++ b/tests/snap/navigation/inherited_member_access.snap.yml
@@ -1,0 +1,55 @@
+---
+created_at: 2026-08-22
+input_file: inherited_member_access.cpp
+---
+base_def:
+  definition:
+    - { file: "${WS}/inherited_member_access.cpp", range: "2:7-2:11" }
+  declaration:
+    - { file: "${WS}/inherited_member_access.cpp", range: "2:7-2:11" }
+  references:
+    - { file: "${WS}/inherited_member_access.cpp", range: "2:7-2:11" }
+    - { file: "${WS}/inherited_member_access.cpp", range: "8:16-8:20" }
+  typeHierarchy:
+    - { name: "Base", kind: Struct, file: "${WS}/inherited_member_access.cpp", range: "2:7-2:11" }
+  subtypes:
+    - { name: "Derived", kind: Struct, file: "${WS}/inherited_member_access.cpp", range: "8:7-8:14" }
+
+derived_def:
+  definition:
+    - { file: "${WS}/inherited_member_access.cpp", range: "8:7-8:14" }
+  declaration:
+    - { file: "${WS}/inherited_member_access.cpp", range: "8:7-8:14" }
+  references:
+    - { file: "${WS}/inherited_member_access.cpp", range: "8:7-8:14" }
+    - { file: "${WS}/inherited_member_access.cpp", range: "10:26-10:33" }
+  typeHierarchy:
+    - { name: "Derived", kind: Struct, file: "${WS}/inherited_member_access.cpp", range: "8:7-8:14" }
+  supertypes:
+    - { name: "Base", kind: Struct, file: "${WS}/inherited_member_access.cpp", range: "2:7-2:11" }
+
+inherited_use:
+  definition:
+    - { file: "${WS}/inherited_member_access.cpp", range: "3:8-3:15" }
+  declaration:
+    - { file: "${WS}/inherited_member_access.cpp", range: "3:8-3:15" }
+  references:
+    - { file: "${WS}/inherited_member_access.cpp", range: "3:8-3:15" }
+    - { file: "${WS}/inherited_member_access.cpp", range: "11:19-11:26" }
+  callHierarchy:
+    - { name: "measure", kind: Method, file: "${WS}/inherited_member_access.cpp", range: "11:19-11:26" }
+  incomingCalls:
+    - { name: "measure_derived", kind: Function, file: "${WS}/inherited_member_access.cpp", range: "10:4-10:19", fromRanges: ["11:11-11:28"] }
+
+method_def:
+  definition:
+    - { file: "${WS}/inherited_member_access.cpp", range: "3:8-3:15" }
+  declaration:
+    - { file: "${WS}/inherited_member_access.cpp", range: "3:8-3:15" }
+  references:
+    - { file: "${WS}/inherited_member_access.cpp", range: "3:8-3:15" }
+    - { file: "${WS}/inherited_member_access.cpp", range: "11:19-11:26" }
+  callHierarchy:
+    - { name: "measure", kind: Method, file: "${WS}/inherited_member_access.cpp", range: "3:8-3:15" }
+  incomingCalls:
+    - { name: "measure_derived", kind: Function, file: "${WS}/inherited_member_access.cpp", range: "10:4-10:19", fromRanges: ["11:11-11:28"] }

--- a/tests/snap/navigation/inherited_member_access.snap.yml
+++ b/tests/snap/navigation/inherited_member_access.snap.yml
@@ -11,7 +11,7 @@ base_def:
     - { file: "${WS}/inherited_member_access.cpp", range: "8:7-8:14" }
   references:
     - { file: "${WS}/inherited_member_access.cpp", range: "2:7-2:11" }
-    - { file: "${WS}/inherited_member_access.cpp", range: "8:16-8:20" }
+    - { file: "${WS}/inherited_member_access.cpp", range: "8:17-8:21" }
   typeHierarchy:
     - { name: "Base", kind: Struct, file: "${WS}/inherited_member_access.cpp", range: "2:7-2:11" }
   subtypes:

--- a/tests/snap/navigation/inherited_using.cpp
+++ b/tests/snap/navigation/inherited_using.cpp
@@ -1,7 +1,7 @@
 /// - verify: server
 
 struct Base {
-    §(base_ctor)Base(int input): value(input) {}
+    §(base_ctor)Base(int input) : value(input) {}
 
     int §(base_member)read() const {
         return value;
@@ -10,7 +10,7 @@ struct Base {
     int value;
 };
 
-struct Derived: Base {
+struct Derived : Base {
     using Base::§(ctor_using)Base;
     using Base::§(member_using)read;
 };

--- a/tests/snap/navigation/inherited_using.cpp
+++ b/tests/snap/navigation/inherited_using.cpp
@@ -1,0 +1,21 @@
+/// - verify: server
+
+struct Base {
+    §(base_ctor)Base(int input): value(input) {}
+
+    int §(base_member)read() const {
+        return value;
+    }
+
+    int value;
+};
+
+struct Derived: Base {
+    using Base::§(ctor_using)Base;
+    using Base::§(member_using)read;
+};
+
+int read_derived() {
+    §(derived_use)Derived derived(3);
+    return derived.§(member_use)read();
+}

--- a/tests/snap/navigation/inherited_using.snap.yml
+++ b/tests/snap/navigation/inherited_using.snap.yml
@@ -1,0 +1,79 @@
+---
+created_at: 2026-08-22
+input_file: inherited_using.cpp
+---
+base_ctor:
+  definition:
+    - { file: "${WS}/inherited_using.cpp", range: "3:4-3:8" }
+  declaration:
+    - { file: "${WS}/inherited_using.cpp", range: "3:4-3:8" }
+  typeDefinition:
+    - { file: "${WS}/inherited_using.cpp", range: "2:7-2:11" }
+  references:
+    - { file: "${WS}/inherited_using.cpp", range: "3:4-3:8" }
+  callHierarchy:
+    - { name: "Base", kind: Method, file: "${WS}/inherited_using.cpp", range: "3:4-3:8" }
+
+base_member:
+  definition:
+    - { file: "${WS}/inherited_using.cpp", range: "5:8-5:12" }
+  declaration:
+    - { file: "${WS}/inherited_using.cpp", range: "5:8-5:12" }
+  references:
+    - { file: "${WS}/inherited_using.cpp", range: "5:8-5:12" }
+    - { file: "${WS}/inherited_using.cpp", range: "19:19-19:23" }
+  callHierarchy:
+    - { name: "read", kind: Method, file: "${WS}/inherited_using.cpp", range: "5:8-5:12" }
+  incomingCalls:
+    - { name: "read_derived", kind: Function, file: "${WS}/inherited_using.cpp", range: "17:4-17:16", fromRanges: ["19:11-19:25"] }
+
+ctor_using:
+  definition:
+    - { file: "${WS}/inherited_using.cpp", range: "3:4-3:8" }
+  declaration:
+    - { file: "${WS}/inherited_using.cpp", range: "3:4-3:8" }
+  typeDefinition:
+    - { file: "${WS}/inherited_using.cpp", range: "2:7-2:11" }
+  references:
+    - { file: "${WS}/inherited_using.cpp", range: "3:4-3:8" }
+  callHierarchy:
+    - { name: "Base", kind: Method, file: "${WS}/inherited_using.cpp", range: "13:16-13:20" }
+
+derived_use:
+  definition:
+    - { file: "${WS}/inherited_using.cpp", range: "12:7-12:14" }
+  declaration:
+    - { file: "${WS}/inherited_using.cpp", range: "12:7-12:14" }
+  references:
+    - { file: "${WS}/inherited_using.cpp", range: "12:7-12:14" }
+    - { file: "${WS}/inherited_using.cpp", range: "18:4-18:11" }
+  typeHierarchy:
+    - { name: "Derived", kind: Struct, file: "${WS}/inherited_using.cpp", range: "18:4-18:11" }
+  supertypes:
+    - { name: "Base", kind: Struct, file: "${WS}/inherited_using.cpp", range: "2:7-2:11" }
+
+member_use:
+  definition:
+    - { file: "${WS}/inherited_using.cpp", range: "5:8-5:12" }
+  declaration:
+    - { file: "${WS}/inherited_using.cpp", range: "5:8-5:12" }
+  references:
+    - { file: "${WS}/inherited_using.cpp", range: "5:8-5:12" }
+    - { file: "${WS}/inherited_using.cpp", range: "19:19-19:23" }
+  callHierarchy:
+    - { name: "read", kind: Method, file: "${WS}/inherited_using.cpp", range: "19:19-19:23" }
+  incomingCalls:
+    - { name: "read_derived", kind: Function, file: "${WS}/inherited_using.cpp", range: "17:4-17:16", fromRanges: ["19:11-19:25"] }
+
+member_using:
+  definition:
+    - { file: "${WS}/inherited_using.cpp", range: "5:8-5:12" }
+  declaration:
+    - { file: "${WS}/inherited_using.cpp", range: "5:8-5:12" }
+  references:
+    - { file: "${WS}/inherited_using.cpp", range: "5:8-5:12" }
+    - { file: "${WS}/inherited_using.cpp", range: "19:19-19:23" }
+  callHierarchy:
+    - { name: "read", kind: Method, file: "${WS}/inherited_using.cpp", range: "14:16-14:20" }
+  incomingCalls:
+    - { name: "read_derived", kind: Function, file: "${WS}/inherited_using.cpp", range: "17:4-17:16", fromRanges: ["19:11-19:25"] }

--- a/tests/snap/navigation/inherited_using.snap.yml
+++ b/tests/snap/navigation/inherited_using.snap.yml
@@ -37,7 +37,7 @@ ctor_using:
   references:
     - { file: "${WS}/inherited_using.cpp", range: "3:4-3:8" }
   callHierarchy:
-    - { name: "Base", kind: Method, file: "${WS}/inherited_using.cpp", range: "13:16-13:20" }
+    - { name: "Base", kind: Method, file: "${WS}/inherited_using.cpp", range: "3:4-3:8" }
 
 derived_use:
   definition:
@@ -48,7 +48,7 @@ derived_use:
     - { file: "${WS}/inherited_using.cpp", range: "12:7-12:14" }
     - { file: "${WS}/inherited_using.cpp", range: "18:4-18:11" }
   typeHierarchy:
-    - { name: "Derived", kind: Struct, file: "${WS}/inherited_using.cpp", range: "18:4-18:11" }
+    - { name: "Derived", kind: Struct, file: "${WS}/inherited_using.cpp", range: "12:7-12:14" }
   supertypes:
     - { name: "Base", kind: Struct, file: "${WS}/inherited_using.cpp", range: "2:7-2:11" }
 
@@ -61,7 +61,7 @@ member_use:
     - { file: "${WS}/inherited_using.cpp", range: "5:8-5:12" }
     - { file: "${WS}/inherited_using.cpp", range: "19:19-19:23" }
   callHierarchy:
-    - { name: "read", kind: Method, file: "${WS}/inherited_using.cpp", range: "19:19-19:23" }
+    - { name: "read", kind: Method, file: "${WS}/inherited_using.cpp", range: "5:8-5:12" }
   incomingCalls:
     - { name: "read_derived", kind: Function, file: "${WS}/inherited_using.cpp", range: "17:4-17:16", fromRanges: ["19:11-19:25"] }
 
@@ -74,6 +74,6 @@ member_using:
     - { file: "${WS}/inherited_using.cpp", range: "5:8-5:12" }
     - { file: "${WS}/inherited_using.cpp", range: "19:19-19:23" }
   callHierarchy:
-    - { name: "read", kind: Method, file: "${WS}/inherited_using.cpp", range: "14:16-14:20" }
+    - { name: "read", kind: Method, file: "${WS}/inherited_using.cpp", range: "5:8-5:12" }
   incomingCalls:
     - { name: "read_derived", kind: Function, file: "${WS}/inherited_using.cpp", range: "17:4-17:16", fromRanges: ["19:11-19:25"] }

--- a/tests/snap/navigation/inline_definition.cpp
+++ b/tests/snap/navigation/inline_definition.cpp
@@ -1,0 +1,9 @@
+/// - verify: server
+
+int §(def)twice(int value) {
+    return value + value;
+}
+
+int caller() {
+    return §(use)twice(21);
+}

--- a/tests/snap/navigation/inline_definition.snap.yml
+++ b/tests/snap/navigation/inline_definition.snap.yml
@@ -24,6 +24,6 @@ use:
     - { file: "${WS}/inline_definition.cpp", range: "2:4-2:9" }
     - { file: "${WS}/inline_definition.cpp", range: "7:11-7:16" }
   callHierarchy:
-    - { name: "twice", kind: Function, file: "${WS}/inline_definition.cpp", range: "7:11-7:16" }
+    - { name: "twice", kind: Function, file: "${WS}/inline_definition.cpp", range: "2:4-2:9" }
   incomingCalls:
     - { name: "caller", kind: Function, file: "${WS}/inline_definition.cpp", range: "6:4-6:10", fromRanges: ["7:11-7:20"] }

--- a/tests/snap/navigation/inline_definition.snap.yml
+++ b/tests/snap/navigation/inline_definition.snap.yml
@@ -1,0 +1,29 @@
+---
+created_at: 2026-08-22
+input_file: inline_definition.cpp
+---
+def:
+  definition:
+    - { file: "${WS}/inline_definition.cpp", range: "2:4-2:9" }
+  declaration:
+    - { file: "${WS}/inline_definition.cpp", range: "2:4-2:9" }
+  references:
+    - { file: "${WS}/inline_definition.cpp", range: "2:4-2:9" }
+    - { file: "${WS}/inline_definition.cpp", range: "7:11-7:16" }
+  callHierarchy:
+    - { name: "twice", kind: Function, file: "${WS}/inline_definition.cpp", range: "2:4-2:9" }
+  incomingCalls:
+    - { name: "caller", kind: Function, file: "${WS}/inline_definition.cpp", range: "6:4-6:10", fromRanges: ["7:11-7:20"] }
+
+use:
+  definition:
+    - { file: "${WS}/inline_definition.cpp", range: "2:4-2:9" }
+  declaration:
+    - { file: "${WS}/inline_definition.cpp", range: "2:4-2:9" }
+  references:
+    - { file: "${WS}/inline_definition.cpp", range: "2:4-2:9" }
+    - { file: "${WS}/inline_definition.cpp", range: "7:11-7:16" }
+  callHierarchy:
+    - { name: "twice", kind: Function, file: "${WS}/inline_definition.cpp", range: "7:11-7:16" }
+  incomingCalls:
+    - { name: "caller", kind: Function, file: "${WS}/inline_definition.cpp", range: "6:4-6:10", fromRanges: ["7:11-7:20"] }

--- a/tests/snap/navigation/lambda_variable.cpp
+++ b/tests/snap/navigation/lambda_variable.cpp
@@ -1,0 +1,9 @@
+/// - verify: server
+
+int apply_lambda(int seed) {
+    int §(captured_def)base = seed;
+    auto §(lambda_def)add = [§(capture_use)base](int value) {
+        return base + value;
+    };
+    return §(lambda_call)add(1);
+}

--- a/tests/snap/navigation/lambda_variable.snap.yml
+++ b/tests/snap/navigation/lambda_variable.snap.yml
@@ -1,0 +1,41 @@
+---
+created_at: 2026-08-22
+input_file: lambda_variable.cpp
+---
+capture_use:
+  definition:
+    - { file: "${WS}/lambda_variable.cpp", range: "3:8-3:12" }
+  declaration:
+    - { file: "${WS}/lambda_variable.cpp", range: "3:8-3:12" }
+  references:
+    - { file: "${WS}/lambda_variable.cpp", range: "3:8-3:12" }
+    - { file: "${WS}/lambda_variable.cpp", range: "4:16-4:20" }
+    - { file: "${WS}/lambda_variable.cpp", range: "5:15-5:19" }
+
+captured_def:
+  definition:
+    - { file: "${WS}/lambda_variable.cpp", range: "3:8-3:12" }
+  declaration:
+    - { file: "${WS}/lambda_variable.cpp", range: "3:8-3:12" }
+  references:
+    - { file: "${WS}/lambda_variable.cpp", range: "3:8-3:12" }
+    - { file: "${WS}/lambda_variable.cpp", range: "4:16-4:20" }
+    - { file: "${WS}/lambda_variable.cpp", range: "5:15-5:19" }
+
+lambda_call:
+  definition:
+    - { file: "${WS}/lambda_variable.cpp", range: "4:9-4:12" }
+  declaration:
+    - { file: "${WS}/lambda_variable.cpp", range: "4:9-4:12" }
+  references:
+    - { file: "${WS}/lambda_variable.cpp", range: "4:9-4:12" }
+    - { file: "${WS}/lambda_variable.cpp", range: "7:11-7:14" }
+
+lambda_def:
+  definition:
+    - { file: "${WS}/lambda_variable.cpp", range: "4:9-4:12" }
+  declaration:
+    - { file: "${WS}/lambda_variable.cpp", range: "4:9-4:12" }
+  references:
+    - { file: "${WS}/lambda_variable.cpp", range: "4:9-4:12" }
+    - { file: "${WS}/lambda_variable.cpp", range: "7:11-7:14" }

--- a/tests/snap/navigation/macro_sites.cpp
+++ b/tests/snap/navigation/macro_sites.cpp
@@ -1,0 +1,17 @@
+/// - verify: server
+///
+/// Macro-driven occurrences record spelling positions while relations
+/// record expansion positions, so cursor-site detection (and with it
+/// def/decl alternation) deliberately stays inert at these sites.
+
+#define §(macro_def_site)DECLARE_HOOK(name) int name(int value)
+
+§(macro_name_use)DECLARE_HOOK(§(macro_decl)notify);
+
+DECLARE_HOOK(§(macro_def)notify) {
+    return value + 1;
+}
+
+int trigger(int value) {
+    return §(plain_use)notify(value);
+}

--- a/tests/snap/navigation/macro_sites.snap.yml
+++ b/tests/snap/navigation/macro_sites.snap.yml
@@ -13,9 +13,7 @@ macro_decl:
     - { file: "${WS}/macro_sites.cpp", range: "10:0-10:12" }
     - { file: "${WS}/macro_sites.cpp", range: "15:11-15:17" }
   callHierarchy:
-    - { name: "notify", kind: Function, file: "${WS}/macro_sites.cpp", range: "8:13-8:19" }
-  incomingCalls:
-    - { name: "trigger", kind: Function, file: "${WS}/macro_sites.cpp", range: "14:4-14:11", fromRanges: ["15:11-15:24"] }
+    - { name: "notify", kind: Function, file: "${WS}/macro_sites.cpp", range: "10:0-10:12" }
 
 macro_def:
   definition:
@@ -28,9 +26,7 @@ macro_def:
     - { file: "${WS}/macro_sites.cpp", range: "10:0-10:12" }
     - { file: "${WS}/macro_sites.cpp", range: "15:11-15:17" }
   callHierarchy:
-    - { name: "notify", kind: Function, file: "${WS}/macro_sites.cpp", range: "10:13-10:19" }
-  incomingCalls:
-    - { name: "trigger", kind: Function, file: "${WS}/macro_sites.cpp", range: "14:4-14:11", fromRanges: ["15:11-15:24"] }
+    - { name: "notify", kind: Function, file: "${WS}/macro_sites.cpp", range: "10:0-10:12" }
 
 macro_def_site:
   definition:
@@ -63,6 +59,4 @@ plain_use:
     - { file: "${WS}/macro_sites.cpp", range: "10:0-10:12" }
     - { file: "${WS}/macro_sites.cpp", range: "15:11-15:17" }
   callHierarchy:
-    - { name: "notify", kind: Function, file: "${WS}/macro_sites.cpp", range: "15:11-15:17" }
-  incomingCalls:
-    - { name: "trigger", kind: Function, file: "${WS}/macro_sites.cpp", range: "14:4-14:11", fromRanges: ["15:11-15:24"] }
+    - { name: "notify", kind: Function, file: "${WS}/macro_sites.cpp", range: "10:0-10:12" }

--- a/tests/snap/navigation/macro_sites.snap.yml
+++ b/tests/snap/navigation/macro_sites.snap.yml
@@ -1,0 +1,68 @@
+---
+created_at: 2026-08-22
+input_file: macro_sites.cpp
+---
+macro_decl:
+  definition:
+    - { file: "${WS}/macro_sites.cpp", range: "10:0-10:12" }
+  declaration:
+    - { file: "${WS}/macro_sites.cpp", range: "8:0-8:12" }
+    - { file: "${WS}/macro_sites.cpp", range: "10:0-10:12" }
+  references:
+    - { file: "${WS}/macro_sites.cpp", range: "8:0-8:12" }
+    - { file: "${WS}/macro_sites.cpp", range: "10:0-10:12" }
+    - { file: "${WS}/macro_sites.cpp", range: "15:11-15:17" }
+  callHierarchy:
+    - { name: "notify", kind: Function, file: "${WS}/macro_sites.cpp", range: "8:13-8:19" }
+  incomingCalls:
+    - { name: "trigger", kind: Function, file: "${WS}/macro_sites.cpp", range: "14:4-14:11", fromRanges: ["15:11-15:24"] }
+
+macro_def:
+  definition:
+    - { file: "${WS}/macro_sites.cpp", range: "10:0-10:12" }
+  declaration:
+    - { file: "${WS}/macro_sites.cpp", range: "8:0-8:12" }
+    - { file: "${WS}/macro_sites.cpp", range: "10:0-10:12" }
+  references:
+    - { file: "${WS}/macro_sites.cpp", range: "8:0-8:12" }
+    - { file: "${WS}/macro_sites.cpp", range: "10:0-10:12" }
+    - { file: "${WS}/macro_sites.cpp", range: "15:11-15:17" }
+  callHierarchy:
+    - { name: "notify", kind: Function, file: "${WS}/macro_sites.cpp", range: "10:13-10:19" }
+  incomingCalls:
+    - { name: "trigger", kind: Function, file: "${WS}/macro_sites.cpp", range: "14:4-14:11", fromRanges: ["15:11-15:24"] }
+
+macro_def_site:
+  definition:
+    - { file: "${WS}/macro_sites.cpp", range: "6:8-6:20" }
+  declaration:
+    - { file: "${WS}/macro_sites.cpp", range: "6:8-6:20" }
+  references:
+    - { file: "${WS}/macro_sites.cpp", range: "6:8-6:20" }
+    - { file: "${WS}/macro_sites.cpp", range: "8:0-8:12" }
+    - { file: "${WS}/macro_sites.cpp", range: "10:0-10:12" }
+
+macro_name_use:
+  definition:
+    - { file: "${WS}/macro_sites.cpp", range: "6:8-6:20" }
+  declaration:
+    - { file: "${WS}/macro_sites.cpp", range: "6:8-6:20" }
+  references:
+    - { file: "${WS}/macro_sites.cpp", range: "6:8-6:20" }
+    - { file: "${WS}/macro_sites.cpp", range: "8:0-8:12" }
+    - { file: "${WS}/macro_sites.cpp", range: "10:0-10:12" }
+
+plain_use:
+  definition:
+    - { file: "${WS}/macro_sites.cpp", range: "10:0-10:12" }
+  declaration:
+    - { file: "${WS}/macro_sites.cpp", range: "8:0-8:12" }
+    - { file: "${WS}/macro_sites.cpp", range: "10:0-10:12" }
+  references:
+    - { file: "${WS}/macro_sites.cpp", range: "8:0-8:12" }
+    - { file: "${WS}/macro_sites.cpp", range: "10:0-10:12" }
+    - { file: "${WS}/macro_sites.cpp", range: "15:11-15:17" }
+  callHierarchy:
+    - { name: "notify", kind: Function, file: "${WS}/macro_sites.cpp", range: "15:11-15:17" }
+  incomingCalls:
+    - { name: "trigger", kind: Function, file: "${WS}/macro_sites.cpp", range: "14:4-14:11", fromRanges: ["15:11-15:24"] }

--- a/tests/snap/navigation/module_basic/main.cpp
+++ b/tests/snap/navigation/module_basic/main.cpp
@@ -1,0 +1,7 @@
+/// - verify: server
+
+import §(import_name)math;
+
+int total(int left, int right) {
+    return §(imported_use)add(left, right);
+}

--- a/tests/snap/navigation/module_basic/main.snap.yml
+++ b/tests/snap/navigation/module_basic/main.snap.yml
@@ -1,0 +1,50 @@
+---
+created_at: 2026-08-22
+input_file: module_basic/main.cpp
+---
+--- main.cpp
+import_name:
+  definition:
+    - { file: "${WS}/module_basic/math.cppm", range: "0:14-0:18" }
+  declaration:
+    - { file: "${WS}/module_basic/math.cppm", range: "0:14-0:18" }
+  references:
+    - { file: "${WS}/module_basic/main.cpp", range: "2:7-2:11" }
+    - { file: "${WS}/module_basic/math.cppm", range: "0:14-0:18" }
+
+imported_use:
+  definition:
+    - { file: "${WS}/module_basic/math.cppm", range: "2:11-2:14" }
+  declaration:
+    - { file: "${WS}/module_basic/math.cppm", range: "2:11-2:14" }
+  references:
+    - { file: "${WS}/module_basic/main.cpp", range: "5:11-5:14" }
+    - { file: "${WS}/module_basic/math.cppm", range: "2:11-2:14" }
+  callHierarchy:
+    - { name: "add", kind: Function, file: "${WS}/module_basic/main.cpp", range: "5:11-5:14" }
+  incomingCalls:
+    - { name: "total", kind: Function, file: "${WS}/module_basic/main.cpp", range: "4:4-4:9", fromRanges: ["5:11-5:27"] }
+
+--- math.cppm
+exported_def:
+  definition:
+    - { file: "${WS}/module_basic/math.cppm", range: "2:11-2:14" }
+  declaration:
+    - { file: "${WS}/module_basic/math.cppm", range: "2:11-2:14" }
+  references:
+    - { file: "${WS}/module_basic/main.cpp", range: "5:11-5:14" }
+    - { file: "${WS}/module_basic/math.cppm", range: "2:11-2:14" }
+  callHierarchy:
+    - { name: "add", kind: Function, file: "${WS}/module_basic/math.cppm", range: "2:11-2:14" }
+  incomingCalls:
+    - { name: "total", kind: Function, file: "${WS}/module_basic/main.cpp", range: "4:4-4:9", fromRanges: ["5:11-5:27"] }
+
+internal_def:
+  definition:
+    - { file: "${WS}/module_basic/math.cppm", range: "6:4-6:9" }
+  declaration:
+    - { file: "${WS}/module_basic/math.cppm", range: "6:4-6:9" }
+  references:
+    - { file: "${WS}/module_basic/math.cppm", range: "6:4-6:9" }
+  callHierarchy:
+    - { name: "carry", kind: Function, file: "${WS}/module_basic/math.cppm", range: "6:4-6:9" }

--- a/tests/snap/navigation/module_basic/main.snap.yml
+++ b/tests/snap/navigation/module_basic/main.snap.yml
@@ -21,7 +21,7 @@ imported_use:
     - { file: "${WS}/module_basic/main.cpp", range: "5:11-5:14" }
     - { file: "${WS}/module_basic/math.cppm", range: "2:11-2:14" }
   callHierarchy:
-    - { name: "add", kind: Function, file: "${WS}/module_basic/main.cpp", range: "5:11-5:14" }
+    - { name: "add", kind: Function, file: "${WS}/module_basic/math.cppm", range: "2:11-2:14" }
   incomingCalls:
     - { name: "total", kind: Function, file: "${WS}/module_basic/main.cpp", range: "4:4-4:9", fromRanges: ["5:11-5:27"] }
 

--- a/tests/snap/navigation/module_basic/math.cppm
+++ b/tests/snap/navigation/module_basic/math.cppm
@@ -1,0 +1,9 @@
+export module math;
+
+export int §(exported_def)add(int left, int right) {
+    return left + right;
+}
+
+int §(internal_def)carry(int value) {
+    return value;
+}

--- a/tests/snap/navigation/module_impl_unit/iface.cppm
+++ b/tests/snap/navigation/module_impl_unit/iface.cppm
@@ -1,0 +1,3 @@
+export module §(iface_module_name)store;
+
+export int §(iface_decl)fetch(int key);

--- a/tests/snap/navigation/module_impl_unit/impl.cpp
+++ b/tests/snap/navigation/module_impl_unit/impl.cpp
@@ -1,0 +1,5 @@
+module §(impl_module_name)store;
+
+int §(impl_def)fetch(int key) {
+    return key * 2;
+}

--- a/tests/snap/navigation/module_impl_unit/main.cpp
+++ b/tests/snap/navigation/module_impl_unit/main.cpp
@@ -1,0 +1,7 @@
+/// - verify: server
+
+import store;
+
+int lookup(int key) {
+    return §(use)fetch(key);
+}

--- a/tests/snap/navigation/module_impl_unit/main.snap.yml
+++ b/tests/snap/navigation/module_impl_unit/main.snap.yml
@@ -1,0 +1,69 @@
+---
+created_at: 2026-08-22
+input_file: module_impl_unit/main.cpp
+---
+--- iface.cppm
+iface_decl:
+  definition:
+    - { file: "${WS}/module_impl_unit/impl.cpp", range: "2:4-2:9" }
+  declaration:
+    - { file: "${WS}/module_impl_unit/impl.cpp", range: "2:4-2:9" }
+  references:
+    - { file: "${WS}/module_impl_unit/iface.cppm", range: "2:11-2:16" }
+    - { file: "${WS}/module_impl_unit/impl.cpp", range: "2:4-2:9" }
+    - { file: "${WS}/module_impl_unit/main.cpp", range: "5:11-5:16" }
+  callHierarchy:
+    - { name: "fetch", kind: Function, file: "${WS}/module_impl_unit/iface.cppm", range: "2:11-2:16" }
+  incomingCalls:
+    - { name: "lookup", kind: Function, file: "${WS}/module_impl_unit/main.cpp", range: "4:4-4:10", fromRanges: ["5:11-5:21"] }
+
+iface_module_name:
+  definition:
+    - { file: "${WS}/module_impl_unit/iface.cppm", range: "0:14-0:19" }
+  declaration:
+    - { file: "${WS}/module_impl_unit/iface.cppm", range: "0:14-0:19" }
+  references:
+    - { file: "${WS}/module_impl_unit/iface.cppm", range: "0:14-0:19" }
+    - { file: "${WS}/module_impl_unit/impl.cpp", range: "0:7-0:12" }
+    - { file: "${WS}/module_impl_unit/main.cpp", range: "2:7-2:12" }
+
+--- impl.cpp
+impl_def:
+  definition:
+    - { file: "${WS}/module_impl_unit/iface.cppm", range: "2:11-2:16" }
+  declaration:
+    - { file: "${WS}/module_impl_unit/iface.cppm", range: "2:11-2:16" }
+  references:
+    - { file: "${WS}/module_impl_unit/iface.cppm", range: "2:11-2:16" }
+    - { file: "${WS}/module_impl_unit/impl.cpp", range: "2:4-2:9" }
+    - { file: "${WS}/module_impl_unit/main.cpp", range: "5:11-5:16" }
+  callHierarchy:
+    - { name: "fetch", kind: Function, file: "${WS}/module_impl_unit/impl.cpp", range: "2:4-2:9" }
+  incomingCalls:
+    - { name: "lookup", kind: Function, file: "${WS}/module_impl_unit/main.cpp", range: "4:4-4:10", fromRanges: ["5:11-5:21"] }
+
+impl_module_name:
+  definition:
+    - { file: "${WS}/module_impl_unit/iface.cppm", range: "0:14-0:19" }
+  declaration:
+    - { file: "${WS}/module_impl_unit/iface.cppm", range: "0:14-0:19" }
+  references:
+    - { file: "${WS}/module_impl_unit/iface.cppm", range: "0:14-0:19" }
+    - { file: "${WS}/module_impl_unit/impl.cpp", range: "0:7-0:12" }
+    - { file: "${WS}/module_impl_unit/main.cpp", range: "2:7-2:12" }
+
+--- main.cpp
+use:
+  definition:
+    - { file: "${WS}/module_impl_unit/impl.cpp", range: "2:4-2:9" }
+  declaration:
+    - { file: "${WS}/module_impl_unit/iface.cppm", range: "2:11-2:16" }
+    - { file: "${WS}/module_impl_unit/impl.cpp", range: "2:4-2:9" }
+  references:
+    - { file: "${WS}/module_impl_unit/iface.cppm", range: "2:11-2:16" }
+    - { file: "${WS}/module_impl_unit/impl.cpp", range: "2:4-2:9" }
+    - { file: "${WS}/module_impl_unit/main.cpp", range: "5:11-5:16" }
+  callHierarchy:
+    - { name: "fetch", kind: Function, file: "${WS}/module_impl_unit/main.cpp", range: "5:11-5:16" }
+  incomingCalls:
+    - { name: "lookup", kind: Function, file: "${WS}/module_impl_unit/main.cpp", range: "4:4-4:10", fromRanges: ["5:11-5:21"] }

--- a/tests/snap/navigation/module_impl_unit/main.snap.yml
+++ b/tests/snap/navigation/module_impl_unit/main.snap.yml
@@ -13,7 +13,7 @@ iface_decl:
     - { file: "${WS}/module_impl_unit/impl.cpp", range: "2:4-2:9" }
     - { file: "${WS}/module_impl_unit/main.cpp", range: "5:11-5:16" }
   callHierarchy:
-    - { name: "fetch", kind: Function, file: "${WS}/module_impl_unit/iface.cppm", range: "2:11-2:16" }
+    - { name: "fetch", kind: Function, file: "${WS}/module_impl_unit/impl.cpp", range: "2:4-2:9" }
   incomingCalls:
     - { name: "lookup", kind: Function, file: "${WS}/module_impl_unit/main.cpp", range: "4:4-4:10", fromRanges: ["5:11-5:21"] }
 
@@ -64,6 +64,6 @@ use:
     - { file: "${WS}/module_impl_unit/impl.cpp", range: "2:4-2:9" }
     - { file: "${WS}/module_impl_unit/main.cpp", range: "5:11-5:16" }
   callHierarchy:
-    - { name: "fetch", kind: Function, file: "${WS}/module_impl_unit/main.cpp", range: "5:11-5:16" }
+    - { name: "fetch", kind: Function, file: "${WS}/module_impl_unit/impl.cpp", range: "2:4-2:9" }
   incomingCalls:
     - { name: "lookup", kind: Function, file: "${WS}/module_impl_unit/main.cpp", range: "4:4-4:10", fromRanges: ["5:11-5:21"] }

--- a/tests/snap/navigation/module_partition/geo.cppm
+++ b/tests/snap/navigation/module_partition/geo.cppm
@@ -1,0 +1,7 @@
+export module geo;
+
+export import :§(partition_ref)shapes;
+
+export int §(primary_fn)area(int width, int height) {
+    return width * height;
+}

--- a/tests/snap/navigation/module_partition/geo_shapes.cppm
+++ b/tests/snap/navigation/module_partition/geo_shapes.cppm
@@ -1,0 +1,5 @@
+export module geo:§(partition_name)shapes;
+
+export int §(partition_fn)corners() {
+    return 4;
+}

--- a/tests/snap/navigation/module_partition/main.cpp
+++ b/tests/snap/navigation/module_partition/main.cpp
@@ -1,0 +1,7 @@
+/// - verify: server
+
+import geo;
+
+int build() {
+    return §(use_primary)area(2, 3) + §(use_partition)corners();
+}

--- a/tests/snap/navigation/module_partition/main.snap.yml
+++ b/tests/snap/navigation/module_partition/main.snap.yml
@@ -1,0 +1,76 @@
+---
+created_at: 2026-08-22
+input_file: module_partition/main.cpp
+---
+--- geo.cppm
+partition_ref:
+  definition:
+    - { file: "${WS}/module_partition/geo_shapes.cppm", range: "0:14-0:24" }
+  declaration:
+    - { file: "${WS}/module_partition/geo_shapes.cppm", range: "0:14-0:24" }
+  references:
+    - { file: "${WS}/module_partition/geo.cppm", range: "2:14-2:15" }
+    - { file: "${WS}/module_partition/geo_shapes.cppm", range: "0:14-0:24" }
+
+primary_fn:
+  definition:
+    - { file: "${WS}/module_partition/geo.cppm", range: "4:11-4:15" }
+  declaration:
+    - { file: "${WS}/module_partition/geo.cppm", range: "4:11-4:15" }
+  references:
+    - { file: "${WS}/module_partition/geo.cppm", range: "4:11-4:15" }
+    - { file: "${WS}/module_partition/main.cpp", range: "5:11-5:15" }
+  callHierarchy:
+    - { name: "area", kind: Function, file: "${WS}/module_partition/geo.cppm", range: "4:11-4:15" }
+  incomingCalls:
+    - { name: "build", kind: Function, file: "${WS}/module_partition/main.cpp", range: "4:4-4:9", fromRanges: ["5:11-5:21"] }
+
+--- geo_shapes.cppm
+partition_fn:
+  definition:
+    - { file: "${WS}/module_partition/geo_shapes.cppm", range: "2:11-2:18" }
+  declaration:
+    - { file: "${WS}/module_partition/geo_shapes.cppm", range: "2:11-2:18" }
+  references:
+    - { file: "${WS}/module_partition/geo_shapes.cppm", range: "2:11-2:18" }
+    - { file: "${WS}/module_partition/main.cpp", range: "5:24-5:31" }
+  callHierarchy:
+    - { name: "corners", kind: Function, file: "${WS}/module_partition/geo_shapes.cppm", range: "2:11-2:18" }
+  incomingCalls:
+    - { name: "build", kind: Function, file: "${WS}/module_partition/main.cpp", range: "4:4-4:9", fromRanges: ["5:24-5:33"] }
+
+partition_name:
+  definition:
+    - { file: "${WS}/module_partition/geo_shapes.cppm", range: "0:14-0:24" }
+  declaration:
+    - { file: "${WS}/module_partition/geo_shapes.cppm", range: "0:14-0:24" }
+  references:
+    - { file: "${WS}/module_partition/geo.cppm", range: "2:14-2:15" }
+    - { file: "${WS}/module_partition/geo_shapes.cppm", range: "0:14-0:24" }
+
+--- main.cpp
+use_partition:
+  definition:
+    - { file: "${WS}/module_partition/geo_shapes.cppm", range: "2:11-2:18" }
+  declaration:
+    - { file: "${WS}/module_partition/geo_shapes.cppm", range: "2:11-2:18" }
+  references:
+    - { file: "${WS}/module_partition/geo_shapes.cppm", range: "2:11-2:18" }
+    - { file: "${WS}/module_partition/main.cpp", range: "5:24-5:31" }
+  callHierarchy:
+    - { name: "corners", kind: Function, file: "${WS}/module_partition/main.cpp", range: "5:24-5:31" }
+  incomingCalls:
+    - { name: "build", kind: Function, file: "${WS}/module_partition/main.cpp", range: "4:4-4:9", fromRanges: ["5:24-5:33"] }
+
+use_primary:
+  definition:
+    - { file: "${WS}/module_partition/geo.cppm", range: "4:11-4:15" }
+  declaration:
+    - { file: "${WS}/module_partition/geo.cppm", range: "4:11-4:15" }
+  references:
+    - { file: "${WS}/module_partition/geo.cppm", range: "4:11-4:15" }
+    - { file: "${WS}/module_partition/main.cpp", range: "5:11-5:15" }
+  callHierarchy:
+    - { name: "area", kind: Function, file: "${WS}/module_partition/main.cpp", range: "5:11-5:15" }
+  incomingCalls:
+    - { name: "build", kind: Function, file: "${WS}/module_partition/main.cpp", range: "4:4-4:9", fromRanges: ["5:11-5:21"] }

--- a/tests/snap/navigation/module_partition/main.snap.yml
+++ b/tests/snap/navigation/module_partition/main.snap.yml
@@ -58,7 +58,7 @@ use_partition:
     - { file: "${WS}/module_partition/geo_shapes.cppm", range: "2:11-2:18" }
     - { file: "${WS}/module_partition/main.cpp", range: "5:24-5:31" }
   callHierarchy:
-    - { name: "corners", kind: Function, file: "${WS}/module_partition/main.cpp", range: "5:24-5:31" }
+    - { name: "corners", kind: Function, file: "${WS}/module_partition/geo_shapes.cppm", range: "2:11-2:18" }
   incomingCalls:
     - { name: "build", kind: Function, file: "${WS}/module_partition/main.cpp", range: "4:4-4:9", fromRanges: ["5:24-5:33"] }
 
@@ -71,6 +71,6 @@ use_primary:
     - { file: "${WS}/module_partition/geo.cppm", range: "4:11-4:15" }
     - { file: "${WS}/module_partition/main.cpp", range: "5:11-5:15" }
   callHierarchy:
-    - { name: "area", kind: Function, file: "${WS}/module_partition/main.cpp", range: "5:11-5:15" }
+    - { name: "area", kind: Function, file: "${WS}/module_partition/geo.cppm", range: "4:11-4:15" }
   incomingCalls:
     - { name: "build", kind: Function, file: "${WS}/module_partition/main.cpp", range: "4:4-4:9", fromRanges: ["5:11-5:21"] }

--- a/tests/snap/navigation/multi_declaration.cpp
+++ b/tests/snap/navigation/multi_declaration.cpp
@@ -1,0 +1,12 @@
+/// - verify: server
+
+int §(first_decl)clamp(int value);
+int §(second_decl)clamp(int value);
+
+int §(def)clamp(int value) {
+    return value < 0 ? 0 : value;
+}
+
+int hold(int value) {
+    return §(use)clamp(value);
+}

--- a/tests/snap/navigation/multi_declaration.snap.yml
+++ b/tests/snap/navigation/multi_declaration.snap.yml
@@ -1,0 +1,69 @@
+---
+created_at: 2026-08-22
+input_file: multi_declaration.cpp
+---
+def:
+  definition:
+    - { file: "${WS}/multi_declaration.cpp", range: "2:4-2:9" }
+    - { file: "${WS}/multi_declaration.cpp", range: "3:4-3:9" }
+  declaration:
+    - { file: "${WS}/multi_declaration.cpp", range: "2:4-2:9" }
+    - { file: "${WS}/multi_declaration.cpp", range: "3:4-3:9" }
+  references:
+    - { file: "${WS}/multi_declaration.cpp", range: "2:4-2:9" }
+    - { file: "${WS}/multi_declaration.cpp", range: "3:4-3:9" }
+    - { file: "${WS}/multi_declaration.cpp", range: "5:4-5:9" }
+    - { file: "${WS}/multi_declaration.cpp", range: "10:11-10:16" }
+  callHierarchy:
+    - { name: "clamp", kind: Function, file: "${WS}/multi_declaration.cpp", range: "5:4-5:9" }
+  incomingCalls:
+    - { name: "hold", kind: Function, file: "${WS}/multi_declaration.cpp", range: "9:4-9:8", fromRanges: ["10:11-10:23"] }
+
+first_decl:
+  definition:
+    - { file: "${WS}/multi_declaration.cpp", range: "5:4-5:9" }
+  declaration:
+    - { file: "${WS}/multi_declaration.cpp", range: "3:4-3:9" }
+    - { file: "${WS}/multi_declaration.cpp", range: "5:4-5:9" }
+  references:
+    - { file: "${WS}/multi_declaration.cpp", range: "2:4-2:9" }
+    - { file: "${WS}/multi_declaration.cpp", range: "3:4-3:9" }
+    - { file: "${WS}/multi_declaration.cpp", range: "5:4-5:9" }
+    - { file: "${WS}/multi_declaration.cpp", range: "10:11-10:16" }
+  callHierarchy:
+    - { name: "clamp", kind: Function, file: "${WS}/multi_declaration.cpp", range: "2:4-2:9" }
+  incomingCalls:
+    - { name: "hold", kind: Function, file: "${WS}/multi_declaration.cpp", range: "9:4-9:8", fromRanges: ["10:11-10:23"] }
+
+second_decl:
+  definition:
+    - { file: "${WS}/multi_declaration.cpp", range: "5:4-5:9" }
+  declaration:
+    - { file: "${WS}/multi_declaration.cpp", range: "2:4-2:9" }
+    - { file: "${WS}/multi_declaration.cpp", range: "5:4-5:9" }
+  references:
+    - { file: "${WS}/multi_declaration.cpp", range: "2:4-2:9" }
+    - { file: "${WS}/multi_declaration.cpp", range: "3:4-3:9" }
+    - { file: "${WS}/multi_declaration.cpp", range: "5:4-5:9" }
+    - { file: "${WS}/multi_declaration.cpp", range: "10:11-10:16" }
+  callHierarchy:
+    - { name: "clamp", kind: Function, file: "${WS}/multi_declaration.cpp", range: "3:4-3:9" }
+  incomingCalls:
+    - { name: "hold", kind: Function, file: "${WS}/multi_declaration.cpp", range: "9:4-9:8", fromRanges: ["10:11-10:23"] }
+
+use:
+  definition:
+    - { file: "${WS}/multi_declaration.cpp", range: "5:4-5:9" }
+  declaration:
+    - { file: "${WS}/multi_declaration.cpp", range: "2:4-2:9" }
+    - { file: "${WS}/multi_declaration.cpp", range: "3:4-3:9" }
+    - { file: "${WS}/multi_declaration.cpp", range: "5:4-5:9" }
+  references:
+    - { file: "${WS}/multi_declaration.cpp", range: "2:4-2:9" }
+    - { file: "${WS}/multi_declaration.cpp", range: "3:4-3:9" }
+    - { file: "${WS}/multi_declaration.cpp", range: "5:4-5:9" }
+    - { file: "${WS}/multi_declaration.cpp", range: "10:11-10:16" }
+  callHierarchy:
+    - { name: "clamp", kind: Function, file: "${WS}/multi_declaration.cpp", range: "10:11-10:16" }
+  incomingCalls:
+    - { name: "hold", kind: Function, file: "${WS}/multi_declaration.cpp", range: "9:4-9:8", fromRanges: ["10:11-10:23"] }

--- a/tests/snap/navigation/multi_declaration.snap.yml
+++ b/tests/snap/navigation/multi_declaration.snap.yml
@@ -31,7 +31,7 @@ first_decl:
     - { file: "${WS}/multi_declaration.cpp", range: "5:4-5:9" }
     - { file: "${WS}/multi_declaration.cpp", range: "10:11-10:16" }
   callHierarchy:
-    - { name: "clamp", kind: Function, file: "${WS}/multi_declaration.cpp", range: "2:4-2:9" }
+    - { name: "clamp", kind: Function, file: "${WS}/multi_declaration.cpp", range: "5:4-5:9" }
   incomingCalls:
     - { name: "hold", kind: Function, file: "${WS}/multi_declaration.cpp", range: "9:4-9:8", fromRanges: ["10:11-10:23"] }
 
@@ -47,7 +47,7 @@ second_decl:
     - { file: "${WS}/multi_declaration.cpp", range: "5:4-5:9" }
     - { file: "${WS}/multi_declaration.cpp", range: "10:11-10:16" }
   callHierarchy:
-    - { name: "clamp", kind: Function, file: "${WS}/multi_declaration.cpp", range: "3:4-3:9" }
+    - { name: "clamp", kind: Function, file: "${WS}/multi_declaration.cpp", range: "5:4-5:9" }
   incomingCalls:
     - { name: "hold", kind: Function, file: "${WS}/multi_declaration.cpp", range: "9:4-9:8", fromRanges: ["10:11-10:23"] }
 
@@ -64,6 +64,6 @@ use:
     - { file: "${WS}/multi_declaration.cpp", range: "5:4-5:9" }
     - { file: "${WS}/multi_declaration.cpp", range: "10:11-10:16" }
   callHierarchy:
-    - { name: "clamp", kind: Function, file: "${WS}/multi_declaration.cpp", range: "10:11-10:16" }
+    - { name: "clamp", kind: Function, file: "${WS}/multi_declaration.cpp", range: "5:4-5:9" }
   incomingCalls:
     - { name: "hold", kind: Function, file: "${WS}/multi_declaration.cpp", range: "9:4-9:8", fromRanges: ["10:11-10:23"] }

--- a/tests/snap/navigation/negative_controls.cpp
+++ b/tests/snap/navigation/negative_controls.cpp
@@ -1,0 +1,7 @@
+/// - verify: server
+
+int choose_literal(bool condition) {
+    §(keyword_if)if (condition)
+        §(keyword_return)return §(literal_value)42;
+    return 0;
+}

--- a/tests/snap/navigation/negative_controls.snap.yml
+++ b/tests/snap/navigation/negative_controls.snap.yml
@@ -1,0 +1,9 @@
+---
+created_at: 2026-08-22
+input_file: negative_controls.cpp
+---
+keyword_if: none
+
+keyword_return: none
+
+literal_value: none

--- a/tests/snap/navigation/nested_class.cpp
+++ b/tests/snap/navigation/nested_class.cpp
@@ -1,0 +1,15 @@
+/// - verify: server
+
+struct Outer {
+    struct §(inner_def)Inner {
+        int §(member_decl)read() const;
+    };
+};
+
+int Outer::§(inner_scope)Inner::§(member_def)read() const {
+    return 1;
+}
+
+int read_inner(const Outer::Inner& inner) {
+    return inner.§(member_use)read();
+}

--- a/tests/snap/navigation/nested_class.snap.yml
+++ b/tests/snap/navigation/nested_class.snap.yml
@@ -1,0 +1,70 @@
+---
+created_at: 2026-08-22
+input_file: nested_class.cpp
+---
+inner_def:
+  definition:
+    - { file: "${WS}/nested_class.cpp", range: "3:11-3:16" }
+  declaration:
+    - { file: "${WS}/nested_class.cpp", range: "3:11-3:16" }
+  references:
+    - { file: "${WS}/nested_class.cpp", range: "3:11-3:16" }
+    - { file: "${WS}/nested_class.cpp", range: "8:11-8:16" }
+    - { file: "${WS}/nested_class.cpp", range: "12:28-12:33" }
+  typeHierarchy:
+    - { name: "Inner", kind: Struct, file: "${WS}/nested_class.cpp", range: "3:11-3:16" }
+
+inner_scope:
+  definition:
+    - { file: "${WS}/nested_class.cpp", range: "3:11-3:16" }
+  declaration:
+    - { file: "${WS}/nested_class.cpp", range: "3:11-3:16" }
+  references:
+    - { file: "${WS}/nested_class.cpp", range: "3:11-3:16" }
+    - { file: "${WS}/nested_class.cpp", range: "8:11-8:16" }
+    - { file: "${WS}/nested_class.cpp", range: "12:28-12:33" }
+  typeHierarchy:
+    - { name: "Inner", kind: Struct, file: "${WS}/nested_class.cpp", range: "8:11-8:16" }
+
+member_decl:
+  definition:
+    - { file: "${WS}/nested_class.cpp", range: "8:18-8:22" }
+  declaration:
+    - { file: "${WS}/nested_class.cpp", range: "8:18-8:22" }
+  references:
+    - { file: "${WS}/nested_class.cpp", range: "4:12-4:16" }
+    - { file: "${WS}/nested_class.cpp", range: "8:18-8:22" }
+    - { file: "${WS}/nested_class.cpp", range: "13:17-13:21" }
+  callHierarchy:
+    - { name: "read", kind: Method, file: "${WS}/nested_class.cpp", range: "4:12-4:16" }
+  incomingCalls:
+    - { name: "read_inner", kind: Function, file: "${WS}/nested_class.cpp", range: "12:4-12:14", fromRanges: ["13:11-13:23"] }
+
+member_def:
+  definition:
+    - { file: "${WS}/nested_class.cpp", range: "4:12-4:16" }
+  declaration:
+    - { file: "${WS}/nested_class.cpp", range: "4:12-4:16" }
+  references:
+    - { file: "${WS}/nested_class.cpp", range: "4:12-4:16" }
+    - { file: "${WS}/nested_class.cpp", range: "8:18-8:22" }
+    - { file: "${WS}/nested_class.cpp", range: "13:17-13:21" }
+  callHierarchy:
+    - { name: "read", kind: Method, file: "${WS}/nested_class.cpp", range: "8:18-8:22" }
+  incomingCalls:
+    - { name: "read_inner", kind: Function, file: "${WS}/nested_class.cpp", range: "12:4-12:14", fromRanges: ["13:11-13:23"] }
+
+member_use:
+  definition:
+    - { file: "${WS}/nested_class.cpp", range: "8:18-8:22" }
+  declaration:
+    - { file: "${WS}/nested_class.cpp", range: "4:12-4:16" }
+    - { file: "${WS}/nested_class.cpp", range: "8:18-8:22" }
+  references:
+    - { file: "${WS}/nested_class.cpp", range: "4:12-4:16" }
+    - { file: "${WS}/nested_class.cpp", range: "8:18-8:22" }
+    - { file: "${WS}/nested_class.cpp", range: "13:17-13:21" }
+  callHierarchy:
+    - { name: "read", kind: Method, file: "${WS}/nested_class.cpp", range: "13:17-13:21" }
+  incomingCalls:
+    - { name: "read_inner", kind: Function, file: "${WS}/nested_class.cpp", range: "12:4-12:14", fromRanges: ["13:11-13:23"] }

--- a/tests/snap/navigation/nested_class.snap.yml
+++ b/tests/snap/navigation/nested_class.snap.yml
@@ -24,7 +24,7 @@ inner_scope:
     - { file: "${WS}/nested_class.cpp", range: "8:11-8:16" }
     - { file: "${WS}/nested_class.cpp", range: "12:28-12:33" }
   typeHierarchy:
-    - { name: "Inner", kind: Struct, file: "${WS}/nested_class.cpp", range: "8:11-8:16" }
+    - { name: "Inner", kind: Struct, file: "${WS}/nested_class.cpp", range: "3:11-3:16" }
 
 member_decl:
   definition:
@@ -36,7 +36,7 @@ member_decl:
     - { file: "${WS}/nested_class.cpp", range: "8:18-8:22" }
     - { file: "${WS}/nested_class.cpp", range: "13:17-13:21" }
   callHierarchy:
-    - { name: "read", kind: Method, file: "${WS}/nested_class.cpp", range: "4:12-4:16" }
+    - { name: "read", kind: Method, file: "${WS}/nested_class.cpp", range: "8:18-8:22" }
   incomingCalls:
     - { name: "read_inner", kind: Function, file: "${WS}/nested_class.cpp", range: "12:4-12:14", fromRanges: ["13:11-13:23"] }
 
@@ -65,6 +65,6 @@ member_use:
     - { file: "${WS}/nested_class.cpp", range: "8:18-8:22" }
     - { file: "${WS}/nested_class.cpp", range: "13:17-13:21" }
   callHierarchy:
-    - { name: "read", kind: Method, file: "${WS}/nested_class.cpp", range: "13:17-13:21" }
+    - { name: "read", kind: Method, file: "${WS}/nested_class.cpp", range: "8:18-8:22" }
   incomingCalls:
     - { name: "read_inner", kind: Function, file: "${WS}/nested_class.cpp", range: "12:4-12:14", fromRanges: ["13:11-13:23"] }

--- a/tests/snap/navigation/operator_overload.cpp
+++ b/tests/snap/navigation/operator_overload.cpp
@@ -1,0 +1,15 @@
+/// - verify: server
+
+struct Vec {
+    int x;
+};
+
+Vec operator+(Vec left, Vec right);
+
+Vec §(op_def)operator+(Vec left, Vec right) {
+    return Vec{left.x + right.x};
+}
+
+Vec combine(Vec left, Vec right) {
+    return left §(op_use)+ right;
+}

--- a/tests/snap/navigation/operator_overload.snap.yml
+++ b/tests/snap/navigation/operator_overload.snap.yml
@@ -11,6 +11,10 @@ op_def:
     - { file: "${WS}/operator_overload.cpp", range: "6:4-6:12" }
     - { file: "${WS}/operator_overload.cpp", range: "8:4-8:12" }
     - { file: "${WS}/operator_overload.cpp", range: "13:16-13:17" }
+  callHierarchy:
+    - { name: "operator+", kind: Operator, file: "${WS}/operator_overload.cpp", range: "8:4-8:12" }
+  incomingCalls:
+    - { name: "combine", kind: Function, file: "${WS}/operator_overload.cpp", range: "12:4-12:11", fromRanges: ["13:11-13:23"] }
 
 op_use:
   definition:
@@ -22,3 +26,7 @@ op_use:
     - { file: "${WS}/operator_overload.cpp", range: "6:4-6:12" }
     - { file: "${WS}/operator_overload.cpp", range: "8:4-8:12" }
     - { file: "${WS}/operator_overload.cpp", range: "13:16-13:17" }
+  callHierarchy:
+    - { name: "operator+", kind: Operator, file: "${WS}/operator_overload.cpp", range: "8:4-8:12" }
+  incomingCalls:
+    - { name: "combine", kind: Function, file: "${WS}/operator_overload.cpp", range: "12:4-12:11", fromRanges: ["13:11-13:23"] }

--- a/tests/snap/navigation/operator_overload.snap.yml
+++ b/tests/snap/navigation/operator_overload.snap.yml
@@ -1,0 +1,24 @@
+---
+created_at: 2026-08-22
+input_file: operator_overload.cpp
+---
+op_def:
+  definition:
+    - { file: "${WS}/operator_overload.cpp", range: "6:4-6:12" }
+  declaration:
+    - { file: "${WS}/operator_overload.cpp", range: "6:4-6:12" }
+  references:
+    - { file: "${WS}/operator_overload.cpp", range: "6:4-6:12" }
+    - { file: "${WS}/operator_overload.cpp", range: "8:4-8:12" }
+    - { file: "${WS}/operator_overload.cpp", range: "13:16-13:17" }
+
+op_use:
+  definition:
+    - { file: "${WS}/operator_overload.cpp", range: "8:4-8:12" }
+  declaration:
+    - { file: "${WS}/operator_overload.cpp", range: "6:4-6:12" }
+    - { file: "${WS}/operator_overload.cpp", range: "8:4-8:12" }
+  references:
+    - { file: "${WS}/operator_overload.cpp", range: "6:4-6:12" }
+    - { file: "${WS}/operator_overload.cpp", range: "8:4-8:12" }
+    - { file: "${WS}/operator_overload.cpp", range: "13:16-13:17" }

--- a/tests/snap/navigation/overload_references.cpp
+++ b/tests/snap/navigation/overload_references.cpp
@@ -1,0 +1,13 @@
+/// - verify: server
+
+int §(int_def)select(int value) {
+    return value;
+}
+
+double §(double_def)select(double value) {
+    return value;
+}
+
+int choose() {
+    return §(int_use)select(1) + static_cast<int>(§(double_use)select(2.0));
+}

--- a/tests/snap/navigation/overload_references.snap.yml
+++ b/tests/snap/navigation/overload_references.snap.yml
@@ -1,0 +1,55 @@
+---
+created_at: 2026-08-22
+input_file: overload_references.cpp
+---
+double_def:
+  definition:
+    - { file: "${WS}/overload_references.cpp", range: "6:7-6:13" }
+  declaration:
+    - { file: "${WS}/overload_references.cpp", range: "6:7-6:13" }
+  references:
+    - { file: "${WS}/overload_references.cpp", range: "6:7-6:13" }
+    - { file: "${WS}/overload_references.cpp", range: "11:40-11:46" }
+  callHierarchy:
+    - { name: "select", kind: Function, file: "${WS}/overload_references.cpp", range: "6:7-6:13" }
+  incomingCalls:
+    - { name: "choose", kind: Function, file: "${WS}/overload_references.cpp", range: "10:4-10:10", fromRanges: ["11:40-11:51"] }
+
+double_use:
+  definition:
+    - { file: "${WS}/overload_references.cpp", range: "6:7-6:13" }
+  declaration:
+    - { file: "${WS}/overload_references.cpp", range: "6:7-6:13" }
+  references:
+    - { file: "${WS}/overload_references.cpp", range: "6:7-6:13" }
+    - { file: "${WS}/overload_references.cpp", range: "11:40-11:46" }
+  callHierarchy:
+    - { name: "select", kind: Function, file: "${WS}/overload_references.cpp", range: "11:40-11:46" }
+  incomingCalls:
+    - { name: "choose", kind: Function, file: "${WS}/overload_references.cpp", range: "10:4-10:10", fromRanges: ["11:40-11:51"] }
+
+int_def:
+  definition:
+    - { file: "${WS}/overload_references.cpp", range: "2:4-2:10" }
+  declaration:
+    - { file: "${WS}/overload_references.cpp", range: "2:4-2:10" }
+  references:
+    - { file: "${WS}/overload_references.cpp", range: "2:4-2:10" }
+    - { file: "${WS}/overload_references.cpp", range: "11:11-11:17" }
+  callHierarchy:
+    - { name: "select", kind: Function, file: "${WS}/overload_references.cpp", range: "2:4-2:10" }
+  incomingCalls:
+    - { name: "choose", kind: Function, file: "${WS}/overload_references.cpp", range: "10:4-10:10", fromRanges: ["11:11-11:20"] }
+
+int_use:
+  definition:
+    - { file: "${WS}/overload_references.cpp", range: "2:4-2:10" }
+  declaration:
+    - { file: "${WS}/overload_references.cpp", range: "2:4-2:10" }
+  references:
+    - { file: "${WS}/overload_references.cpp", range: "2:4-2:10" }
+    - { file: "${WS}/overload_references.cpp", range: "11:11-11:17" }
+  callHierarchy:
+    - { name: "select", kind: Function, file: "${WS}/overload_references.cpp", range: "11:11-11:17" }
+  incomingCalls:
+    - { name: "choose", kind: Function, file: "${WS}/overload_references.cpp", range: "10:4-10:10", fromRanges: ["11:11-11:20"] }

--- a/tests/snap/navigation/overload_references.snap.yml
+++ b/tests/snap/navigation/overload_references.snap.yml
@@ -24,7 +24,7 @@ double_use:
     - { file: "${WS}/overload_references.cpp", range: "6:7-6:13" }
     - { file: "${WS}/overload_references.cpp", range: "11:40-11:46" }
   callHierarchy:
-    - { name: "select", kind: Function, file: "${WS}/overload_references.cpp", range: "11:40-11:46" }
+    - { name: "select", kind: Function, file: "${WS}/overload_references.cpp", range: "6:7-6:13" }
   incomingCalls:
     - { name: "choose", kind: Function, file: "${WS}/overload_references.cpp", range: "10:4-10:10", fromRanges: ["11:40-11:51"] }
 
@@ -50,6 +50,6 @@ int_use:
     - { file: "${WS}/overload_references.cpp", range: "2:4-2:10" }
     - { file: "${WS}/overload_references.cpp", range: "11:11-11:17" }
   callHierarchy:
-    - { name: "select", kind: Function, file: "${WS}/overload_references.cpp", range: "11:11-11:17" }
+    - { name: "select", kind: Function, file: "${WS}/overload_references.cpp", range: "2:4-2:10" }
   incomingCalls:
     - { name: "choose", kind: Function, file: "${WS}/overload_references.cpp", range: "10:4-10:10", fromRanges: ["11:11-11:20"] }

--- a/tests/snap/navigation/shadowed_names.cpp
+++ b/tests/snap/navigation/shadowed_names.cpp
@@ -1,0 +1,12 @@
+/// - verify: server
+
+int §(global_def)value = 1;
+
+int read_shadowed(int §(param_def)value) {
+    int sum = §(param_use)value;
+    {
+        int §(local_def)value = 3;
+        sum += §(local_use)value;
+    }
+    return sum + ::§(global_use)value;
+}

--- a/tests/snap/navigation/shadowed_names.snap.yml
+++ b/tests/snap/navigation/shadowed_names.snap.yml
@@ -1,0 +1,57 @@
+---
+created_at: 2026-08-22
+input_file: shadowed_names.cpp
+---
+global_def:
+  definition:
+    - { file: "${WS}/shadowed_names.cpp", range: "2:4-2:9" }
+  declaration:
+    - { file: "${WS}/shadowed_names.cpp", range: "2:4-2:9" }
+  references:
+    - { file: "${WS}/shadowed_names.cpp", range: "2:4-2:9" }
+    - { file: "${WS}/shadowed_names.cpp", range: "10:19-10:24" }
+
+global_use:
+  definition:
+    - { file: "${WS}/shadowed_names.cpp", range: "2:4-2:9" }
+  declaration:
+    - { file: "${WS}/shadowed_names.cpp", range: "2:4-2:9" }
+  references:
+    - { file: "${WS}/shadowed_names.cpp", range: "2:4-2:9" }
+    - { file: "${WS}/shadowed_names.cpp", range: "10:19-10:24" }
+
+local_def:
+  definition:
+    - { file: "${WS}/shadowed_names.cpp", range: "7:12-7:17" }
+  declaration:
+    - { file: "${WS}/shadowed_names.cpp", range: "7:12-7:17" }
+  references:
+    - { file: "${WS}/shadowed_names.cpp", range: "7:12-7:17" }
+    - { file: "${WS}/shadowed_names.cpp", range: "8:15-8:20" }
+
+local_use:
+  definition:
+    - { file: "${WS}/shadowed_names.cpp", range: "7:12-7:17" }
+  declaration:
+    - { file: "${WS}/shadowed_names.cpp", range: "7:12-7:17" }
+  references:
+    - { file: "${WS}/shadowed_names.cpp", range: "7:12-7:17" }
+    - { file: "${WS}/shadowed_names.cpp", range: "8:15-8:20" }
+
+param_def:
+  definition:
+    - { file: "${WS}/shadowed_names.cpp", range: "4:22-4:27" }
+  declaration:
+    - { file: "${WS}/shadowed_names.cpp", range: "4:22-4:27" }
+  references:
+    - { file: "${WS}/shadowed_names.cpp", range: "4:22-4:27" }
+    - { file: "${WS}/shadowed_names.cpp", range: "5:14-5:19" }
+
+param_use:
+  definition:
+    - { file: "${WS}/shadowed_names.cpp", range: "4:22-4:27" }
+  declaration:
+    - { file: "${WS}/shadowed_names.cpp", range: "4:22-4:27" }
+  references:
+    - { file: "${WS}/shadowed_names.cpp", range: "4:22-4:27" }
+    - { file: "${WS}/shadowed_names.cpp", range: "5:14-5:19" }

--- a/tests/snap/navigation/static_data_member.cpp
+++ b/tests/snap/navigation/static_data_member.cpp
@@ -1,0 +1,11 @@
+/// - verify: server
+
+struct Counter {
+    static int §(member_decl)value;
+};
+
+int Counter::§(member_def)value = 1;
+
+int read_counter() {
+    return Counter::§(member_use)value;
+}

--- a/tests/snap/navigation/static_data_member.snap.yml
+++ b/tests/snap/navigation/static_data_member.snap.yml
@@ -1,0 +1,34 @@
+---
+created_at: 2026-08-22
+input_file: static_data_member.cpp
+---
+member_decl:
+  definition:
+    - { file: "${WS}/static_data_member.cpp", range: "6:13-6:18" }
+  declaration:
+    - { file: "${WS}/static_data_member.cpp", range: "6:13-6:18" }
+  references:
+    - { file: "${WS}/static_data_member.cpp", range: "3:15-3:20" }
+    - { file: "${WS}/static_data_member.cpp", range: "6:13-6:18" }
+    - { file: "${WS}/static_data_member.cpp", range: "9:20-9:25" }
+
+member_def:
+  definition:
+    - { file: "${WS}/static_data_member.cpp", range: "3:15-3:20" }
+  declaration:
+    - { file: "${WS}/static_data_member.cpp", range: "3:15-3:20" }
+  references:
+    - { file: "${WS}/static_data_member.cpp", range: "3:15-3:20" }
+    - { file: "${WS}/static_data_member.cpp", range: "6:13-6:18" }
+    - { file: "${WS}/static_data_member.cpp", range: "9:20-9:25" }
+
+member_use:
+  definition:
+    - { file: "${WS}/static_data_member.cpp", range: "6:13-6:18" }
+  declaration:
+    - { file: "${WS}/static_data_member.cpp", range: "3:15-3:20" }
+    - { file: "${WS}/static_data_member.cpp", range: "6:13-6:18" }
+  references:
+    - { file: "${WS}/static_data_member.cpp", range: "3:15-3:20" }
+    - { file: "${WS}/static_data_member.cpp", range: "6:13-6:18" }
+    - { file: "${WS}/static_data_member.cpp", range: "9:20-9:25" }

--- a/tests/snap/navigation/structured_binding.cpp
+++ b/tests/snap/navigation/structured_binding.cpp
@@ -1,0 +1,15 @@
+/// - verify: server
+
+struct Pair {
+    int first;
+    int second;
+};
+
+Pair make_pair() {
+    return {1, 2};
+}
+
+int sum_pair() {
+    auto [§(left_def)left, §(right_def)right] = make_pair();
+    return §(left_use)left + §(right_use)right;
+}

--- a/tests/snap/navigation/structured_binding.snap.yml
+++ b/tests/snap/navigation/structured_binding.snap.yml
@@ -1,0 +1,38 @@
+---
+created_at: 2026-08-22
+input_file: structured_binding.cpp
+---
+left_def:
+  definition:
+    - { file: "${WS}/structured_binding.cpp", range: "12:9-12:10" }
+  declaration:
+    - { file: "${WS}/structured_binding.cpp", range: "12:9-12:10" }
+  references:
+    - { file: "${WS}/structured_binding.cpp", range: "12:9-12:10" }
+
+left_use:
+  definition:
+    - { file: "${WS}/structured_binding.cpp", range: "12:10-12:14" }
+  declaration:
+    - { file: "${WS}/structured_binding.cpp", range: "12:10-12:14" }
+  references:
+    - { file: "${WS}/structured_binding.cpp", range: "12:10-12:14" }
+    - { file: "${WS}/structured_binding.cpp", range: "13:11-13:15" }
+
+right_def:
+  definition:
+    - { file: "${WS}/structured_binding.cpp", range: "12:16-12:21" }
+  declaration:
+    - { file: "${WS}/structured_binding.cpp", range: "12:16-12:21" }
+  references:
+    - { file: "${WS}/structured_binding.cpp", range: "12:16-12:21" }
+    - { file: "${WS}/structured_binding.cpp", range: "13:18-13:23" }
+
+right_use:
+  definition:
+    - { file: "${WS}/structured_binding.cpp", range: "12:16-12:21" }
+  declaration:
+    - { file: "${WS}/structured_binding.cpp", range: "12:16-12:21" }
+  references:
+    - { file: "${WS}/structured_binding.cpp", range: "12:16-12:21" }
+    - { file: "${WS}/structured_binding.cpp", range: "13:18-13:23" }

--- a/tests/snap/navigation/structured_binding.snap.yml
+++ b/tests/snap/navigation/structured_binding.snap.yml
@@ -4,11 +4,12 @@ input_file: structured_binding.cpp
 ---
 left_def:
   definition:
-    - { file: "${WS}/structured_binding.cpp", range: "12:9-12:10" }
+    - { file: "${WS}/structured_binding.cpp", range: "12:10-12:14" }
   declaration:
-    - { file: "${WS}/structured_binding.cpp", range: "12:9-12:10" }
+    - { file: "${WS}/structured_binding.cpp", range: "12:10-12:14" }
   references:
-    - { file: "${WS}/structured_binding.cpp", range: "12:9-12:10" }
+    - { file: "${WS}/structured_binding.cpp", range: "12:10-12:14" }
+    - { file: "${WS}/structured_binding.cpp", range: "13:11-13:15" }
 
 left_use:
   definition:

--- a/tests/snap/navigation/template_navigation.cpp
+++ b/tests/snap/navigation/template_navigation.cpp
@@ -1,0 +1,29 @@
+/// - verify: server
+
+template <typename T>
+T §(primary)identity(T value) {
+    return value;
+}
+
+template <>
+int §(spec)identity<int>(int value) {
+    return value + 1;
+}
+
+template <typename T>
+struct §(class_primary)Box {
+    T §(member_decl)get();
+    T value;
+};
+
+template <typename T>
+T Box<T>::§(member_def)get() {
+    return value;
+}
+
+int drive() {
+    §(class_use)Box<int> box;
+    box.value = 1;
+    return §(use_spec)identity(2) + static_cast<int>(§(use_primary)identity(2.5)) +
+           box.§(member_use)get();
+}

--- a/tests/snap/navigation/template_navigation.snap.yml
+++ b/tests/snap/navigation/template_navigation.snap.yml
@@ -24,7 +24,7 @@ class_use:
     - { file: "${WS}/template_navigation.cpp", range: "19:2-19:5" }
     - { file: "${WS}/template_navigation.cpp", range: "24:4-24:7" }
   typeHierarchy:
-    - { name: "Box", kind: Struct, file: "${WS}/template_navigation.cpp", range: "24:4-24:7" }
+    - { name: "Box", kind: Struct, file: "${WS}/template_navigation.cpp", range: "13:7-13:10" }
 
 member_decl:
   definition:
@@ -36,7 +36,7 @@ member_decl:
     - { file: "${WS}/template_navigation.cpp", range: "19:10-19:13" }
     - { file: "${WS}/template_navigation.cpp", range: "27:15-27:18" }
   callHierarchy:
-    - { name: "get", kind: Method, file: "${WS}/template_navigation.cpp", range: "14:6-14:9" }
+    - { name: "get", kind: Method, file: "${WS}/template_navigation.cpp", range: "19:10-19:13" }
   incomingCalls:
     - { name: "drive", kind: Function, file: "${WS}/template_navigation.cpp", range: "23:4-23:9", fromRanges: ["27:11-27:20"] }
 
@@ -65,7 +65,7 @@ member_use:
     - { file: "${WS}/template_navigation.cpp", range: "19:10-19:13" }
     - { file: "${WS}/template_navigation.cpp", range: "27:15-27:18" }
   callHierarchy:
-    - { name: "get", kind: Method, file: "${WS}/template_navigation.cpp", range: "27:15-27:18" }
+    - { name: "get", kind: Method, file: "${WS}/template_navigation.cpp", range: "19:10-19:13" }
   incomingCalls:
     - { name: "drive", kind: Function, file: "${WS}/template_navigation.cpp", range: "23:4-23:9", fromRanges: ["27:11-27:20"] }
 
@@ -104,7 +104,7 @@ use_primary:
     - { file: "${WS}/template_navigation.cpp", range: "3:2-3:10" }
     - { file: "${WS}/template_navigation.cpp", range: "26:42-26:50" }
   callHierarchy:
-    - { name: "identity", kind: Function, file: "${WS}/template_navigation.cpp", range: "26:42-26:50" }
+    - { name: "identity", kind: Function, file: "${WS}/template_navigation.cpp", range: "3:2-3:10" }
   incomingCalls:
     - { name: "drive", kind: Function, file: "${WS}/template_navigation.cpp", range: "23:4-23:9", fromRanges: ["26:42-26:55"] }
 
@@ -117,6 +117,6 @@ use_spec:
     - { file: "${WS}/template_navigation.cpp", range: "8:4-8:12" }
     - { file: "${WS}/template_navigation.cpp", range: "26:11-26:19" }
   callHierarchy:
-    - { name: "identity", kind: Function, file: "${WS}/template_navigation.cpp", range: "26:11-26:19" }
+    - { name: "identity", kind: Function, file: "${WS}/template_navigation.cpp", range: "8:4-8:12" }
   incomingCalls:
     - { name: "drive", kind: Function, file: "${WS}/template_navigation.cpp", range: "23:4-23:9", fromRanges: ["26:11-26:22"] }

--- a/tests/snap/navigation/template_navigation.snap.yml
+++ b/tests/snap/navigation/template_navigation.snap.yml
@@ -1,0 +1,122 @@
+---
+created_at: 2026-08-22
+input_file: template_navigation.cpp
+---
+class_primary:
+  definition:
+    - { file: "${WS}/template_navigation.cpp", range: "13:7-13:10" }
+  declaration:
+    - { file: "${WS}/template_navigation.cpp", range: "13:7-13:10" }
+  references:
+    - { file: "${WS}/template_navigation.cpp", range: "13:7-13:10" }
+    - { file: "${WS}/template_navigation.cpp", range: "19:2-19:5" }
+    - { file: "${WS}/template_navigation.cpp", range: "24:4-24:7" }
+  typeHierarchy:
+    - { name: "Box", kind: Struct, file: "${WS}/template_navigation.cpp", range: "13:7-13:10" }
+
+class_use:
+  definition:
+    - { file: "${WS}/template_navigation.cpp", range: "13:7-13:10" }
+  declaration:
+    - { file: "${WS}/template_navigation.cpp", range: "13:7-13:10" }
+  references:
+    - { file: "${WS}/template_navigation.cpp", range: "13:7-13:10" }
+    - { file: "${WS}/template_navigation.cpp", range: "19:2-19:5" }
+    - { file: "${WS}/template_navigation.cpp", range: "24:4-24:7" }
+  typeHierarchy:
+    - { name: "Box", kind: Struct, file: "${WS}/template_navigation.cpp", range: "24:4-24:7" }
+
+member_decl:
+  definition:
+    - { file: "${WS}/template_navigation.cpp", range: "19:10-19:13" }
+  declaration:
+    - { file: "${WS}/template_navigation.cpp", range: "19:10-19:13" }
+  references:
+    - { file: "${WS}/template_navigation.cpp", range: "14:6-14:9" }
+    - { file: "${WS}/template_navigation.cpp", range: "19:10-19:13" }
+    - { file: "${WS}/template_navigation.cpp", range: "27:15-27:18" }
+  callHierarchy:
+    - { name: "get", kind: Method, file: "${WS}/template_navigation.cpp", range: "14:6-14:9" }
+  incomingCalls:
+    - { name: "drive", kind: Function, file: "${WS}/template_navigation.cpp", range: "23:4-23:9", fromRanges: ["27:11-27:20"] }
+
+member_def:
+  definition:
+    - { file: "${WS}/template_navigation.cpp", range: "14:6-14:9" }
+  declaration:
+    - { file: "${WS}/template_navigation.cpp", range: "14:6-14:9" }
+  references:
+    - { file: "${WS}/template_navigation.cpp", range: "14:6-14:9" }
+    - { file: "${WS}/template_navigation.cpp", range: "19:10-19:13" }
+    - { file: "${WS}/template_navigation.cpp", range: "27:15-27:18" }
+  callHierarchy:
+    - { name: "get", kind: Method, file: "${WS}/template_navigation.cpp", range: "19:10-19:13" }
+  incomingCalls:
+    - { name: "drive", kind: Function, file: "${WS}/template_navigation.cpp", range: "23:4-23:9", fromRanges: ["27:11-27:20"] }
+
+member_use:
+  definition:
+    - { file: "${WS}/template_navigation.cpp", range: "19:10-19:13" }
+  declaration:
+    - { file: "${WS}/template_navigation.cpp", range: "14:6-14:9" }
+    - { file: "${WS}/template_navigation.cpp", range: "19:10-19:13" }
+  references:
+    - { file: "${WS}/template_navigation.cpp", range: "14:6-14:9" }
+    - { file: "${WS}/template_navigation.cpp", range: "19:10-19:13" }
+    - { file: "${WS}/template_navigation.cpp", range: "27:15-27:18" }
+  callHierarchy:
+    - { name: "get", kind: Method, file: "${WS}/template_navigation.cpp", range: "27:15-27:18" }
+  incomingCalls:
+    - { name: "drive", kind: Function, file: "${WS}/template_navigation.cpp", range: "23:4-23:9", fromRanges: ["27:11-27:20"] }
+
+primary:
+  definition:
+    - { file: "${WS}/template_navigation.cpp", range: "3:2-3:10" }
+  declaration:
+    - { file: "${WS}/template_navigation.cpp", range: "3:2-3:10" }
+  references:
+    - { file: "${WS}/template_navigation.cpp", range: "3:2-3:10" }
+    - { file: "${WS}/template_navigation.cpp", range: "26:42-26:50" }
+  callHierarchy:
+    - { name: "identity", kind: Function, file: "${WS}/template_navigation.cpp", range: "3:2-3:10" }
+  incomingCalls:
+    - { name: "drive", kind: Function, file: "${WS}/template_navigation.cpp", range: "23:4-23:9", fromRanges: ["26:42-26:55"] }
+
+spec:
+  definition:
+    - { file: "${WS}/template_navigation.cpp", range: "8:4-8:12" }
+  declaration:
+    - { file: "${WS}/template_navigation.cpp", range: "8:4-8:12" }
+  references:
+    - { file: "${WS}/template_navigation.cpp", range: "8:4-8:12" }
+    - { file: "${WS}/template_navigation.cpp", range: "26:11-26:19" }
+  callHierarchy:
+    - { name: "identity", kind: Function, file: "${WS}/template_navigation.cpp", range: "8:4-8:12" }
+  incomingCalls:
+    - { name: "drive", kind: Function, file: "${WS}/template_navigation.cpp", range: "23:4-23:9", fromRanges: ["26:11-26:22"] }
+
+use_primary:
+  definition:
+    - { file: "${WS}/template_navigation.cpp", range: "3:2-3:10" }
+  declaration:
+    - { file: "${WS}/template_navigation.cpp", range: "3:2-3:10" }
+  references:
+    - { file: "${WS}/template_navigation.cpp", range: "3:2-3:10" }
+    - { file: "${WS}/template_navigation.cpp", range: "26:42-26:50" }
+  callHierarchy:
+    - { name: "identity", kind: Function, file: "${WS}/template_navigation.cpp", range: "26:42-26:50" }
+  incomingCalls:
+    - { name: "drive", kind: Function, file: "${WS}/template_navigation.cpp", range: "23:4-23:9", fromRanges: ["26:42-26:55"] }
+
+use_spec:
+  definition:
+    - { file: "${WS}/template_navigation.cpp", range: "8:4-8:12" }
+  declaration:
+    - { file: "${WS}/template_navigation.cpp", range: "8:4-8:12" }
+  references:
+    - { file: "${WS}/template_navigation.cpp", range: "8:4-8:12" }
+    - { file: "${WS}/template_navigation.cpp", range: "26:11-26:19" }
+  callHierarchy:
+    - { name: "identity", kind: Function, file: "${WS}/template_navigation.cpp", range: "26:11-26:19" }
+  incomingCalls:
+    - { name: "drive", kind: Function, file: "${WS}/template_navigation.cpp", range: "23:4-23:9", fromRanges: ["26:11-26:22"] }

--- a/tests/snap/navigation/type_definition.cpp
+++ b/tests/snap/navigation/type_definition.cpp
@@ -1,0 +1,16 @@
+/// - verify: server
+
+struct §(type)Point {
+    int x;
+    int y;
+};
+
+using §(alias)Alias = Point;
+
+Point §(var)origin;
+Alias §(alias_var)corner;
+
+int probe() {
+    §(auto_var)auto copy = origin;
+    return copy.x;
+}

--- a/tests/snap/navigation/type_definition.snap.yml
+++ b/tests/snap/navigation/type_definition.snap.yml
@@ -1,0 +1,49 @@
+---
+created_at: 2026-08-22
+input_file: type_definition.cpp
+---
+alias:
+  definition:
+    - { file: "${WS}/type_definition.cpp", range: "7:6-7:11" }
+  declaration:
+    - { file: "${WS}/type_definition.cpp", range: "7:6-7:11" }
+  typeDefinition:
+    - { file: "${WS}/type_definition.cpp", range: "2:7-2:12" }
+  references:
+    - { file: "${WS}/type_definition.cpp", range: "7:6-7:11" }
+    - { file: "${WS}/type_definition.cpp", range: "10:0-10:5" }
+
+alias_var:
+  definition:
+    - { file: "${WS}/type_definition.cpp", range: "10:6-10:12" }
+  declaration:
+    - { file: "${WS}/type_definition.cpp", range: "10:6-10:12" }
+  typeDefinition:
+    - { file: "${WS}/type_definition.cpp", range: "7:6-7:11" }
+  references:
+    - { file: "${WS}/type_definition.cpp", range: "10:6-10:12" }
+
+auto_var: none
+
+type:
+  definition:
+    - { file: "${WS}/type_definition.cpp", range: "2:7-2:12" }
+  declaration:
+    - { file: "${WS}/type_definition.cpp", range: "2:7-2:12" }
+  references:
+    - { file: "${WS}/type_definition.cpp", range: "2:7-2:12" }
+    - { file: "${WS}/type_definition.cpp", range: "7:14-7:19" }
+    - { file: "${WS}/type_definition.cpp", range: "9:0-9:5" }
+  typeHierarchy:
+    - { name: "Point", kind: Struct, file: "${WS}/type_definition.cpp", range: "2:7-2:12" }
+
+var:
+  definition:
+    - { file: "${WS}/type_definition.cpp", range: "9:6-9:12" }
+  declaration:
+    - { file: "${WS}/type_definition.cpp", range: "9:6-9:12" }
+  typeDefinition:
+    - { file: "${WS}/type_definition.cpp", range: "2:7-2:12" }
+  references:
+    - { file: "${WS}/type_definition.cpp", range: "9:6-9:12" }
+    - { file: "${WS}/type_definition.cpp", range: "13:16-13:22" }

--- a/tests/snap/navigation/type_hierarchy.cpp
+++ b/tests/snap/navigation/type_hierarchy.cpp
@@ -2,11 +2,20 @@
 
 struct §(root)Widget {};
 
-struct §(mid)Control: Widget {};
+struct §(mid)Control : Widget {};
 
-struct Button: Control {};
+struct Button : Control {};
 
-struct Label: Control {};
+struct Label : Control {};
+
+struct Extra {};
+
+struct §(multi)Panel : Control, Extra {};
+
+union §(union_def)Packet {
+    int raw;
+    unsigned bits;
+};
 
 enum class §(leaf_enum)Mode : int {};
 

--- a/tests/snap/navigation/type_hierarchy.cpp
+++ b/tests/snap/navigation/type_hierarchy.cpp
@@ -1,0 +1,15 @@
+/// - verify: server
+
+struct §(root)Widget {};
+
+struct §(mid)Control: Widget {};
+
+struct Button: Control {};
+
+struct Label: Control {};
+
+enum class §(leaf_enum)Mode : int {};
+
+int §(gate_fn)helper() {
+    return 0;
+}

--- a/tests/snap/navigation/type_hierarchy.snap.yml
+++ b/tests/snap/navigation/type_hierarchy.snap.yml
@@ -27,6 +27,9 @@ mid:
     - { file: "${WS}/type_hierarchy.cpp", range: "4:7-4:14" }
   declaration:
     - { file: "${WS}/type_hierarchy.cpp", range: "4:7-4:14" }
+  implementation:
+    - { file: "${WS}/type_hierarchy.cpp", range: "6:7-6:13" }
+    - { file: "${WS}/type_hierarchy.cpp", range: "8:7-8:12" }
   references:
     - { file: "${WS}/type_hierarchy.cpp", range: "4:7-4:14" }
     - { file: "${WS}/type_hierarchy.cpp", range: "6:15-6:22" }
@@ -44,6 +47,8 @@ root:
     - { file: "${WS}/type_hierarchy.cpp", range: "2:7-2:13" }
   declaration:
     - { file: "${WS}/type_hierarchy.cpp", range: "2:7-2:13" }
+  implementation:
+    - { file: "${WS}/type_hierarchy.cpp", range: "4:7-4:14" }
   references:
     - { file: "${WS}/type_hierarchy.cpp", range: "2:7-2:13" }
     - { file: "${WS}/type_hierarchy.cpp", range: "4:16-4:22" }

--- a/tests/snap/navigation/type_hierarchy.snap.yml
+++ b/tests/snap/navigation/type_hierarchy.snap.yml
@@ -1,0 +1,53 @@
+---
+created_at: 2026-08-22
+input_file: type_hierarchy.cpp
+---
+gate_fn:
+  definition:
+    - { file: "${WS}/type_hierarchy.cpp", range: "12:4-12:10" }
+  declaration:
+    - { file: "${WS}/type_hierarchy.cpp", range: "12:4-12:10" }
+  references:
+    - { file: "${WS}/type_hierarchy.cpp", range: "12:4-12:10" }
+  callHierarchy:
+    - { name: "helper", kind: Function, file: "${WS}/type_hierarchy.cpp", range: "12:4-12:10" }
+
+leaf_enum:
+  definition:
+    - { file: "${WS}/type_hierarchy.cpp", range: "10:11-10:15" }
+  declaration:
+    - { file: "${WS}/type_hierarchy.cpp", range: "10:11-10:15" }
+  references:
+    - { file: "${WS}/type_hierarchy.cpp", range: "10:11-10:15" }
+  typeHierarchy:
+    - { name: "Mode", kind: Enum, file: "${WS}/type_hierarchy.cpp", range: "10:11-10:15" }
+
+mid:
+  definition:
+    - { file: "${WS}/type_hierarchy.cpp", range: "4:7-4:14" }
+  declaration:
+    - { file: "${WS}/type_hierarchy.cpp", range: "4:7-4:14" }
+  references:
+    - { file: "${WS}/type_hierarchy.cpp", range: "4:7-4:14" }
+    - { file: "${WS}/type_hierarchy.cpp", range: "6:15-6:22" }
+    - { file: "${WS}/type_hierarchy.cpp", range: "8:14-8:21" }
+  typeHierarchy:
+    - { name: "Control", kind: Struct, file: "${WS}/type_hierarchy.cpp", range: "4:7-4:14" }
+  supertypes:
+    - { name: "Widget", kind: Struct, file: "${WS}/type_hierarchy.cpp", range: "2:7-2:13" }
+  subtypes:
+    - { name: "Button", kind: Struct, file: "${WS}/type_hierarchy.cpp", range: "6:7-6:13" }
+    - { name: "Label", kind: Struct, file: "${WS}/type_hierarchy.cpp", range: "8:7-8:12" }
+
+root:
+  definition:
+    - { file: "${WS}/type_hierarchy.cpp", range: "2:7-2:13" }
+  declaration:
+    - { file: "${WS}/type_hierarchy.cpp", range: "2:7-2:13" }
+  references:
+    - { file: "${WS}/type_hierarchy.cpp", range: "2:7-2:13" }
+    - { file: "${WS}/type_hierarchy.cpp", range: "4:16-4:22" }
+  typeHierarchy:
+    - { name: "Widget", kind: Struct, file: "${WS}/type_hierarchy.cpp", range: "2:7-2:13" }
+  subtypes:
+    - { name: "Control", kind: Struct, file: "${WS}/type_hierarchy.cpp", range: "4:7-4:14" }

--- a/tests/snap/navigation/type_hierarchy.snap.yml
+++ b/tests/snap/navigation/type_hierarchy.snap.yml
@@ -4,23 +4,23 @@ input_file: type_hierarchy.cpp
 ---
 gate_fn:
   definition:
-    - { file: "${WS}/type_hierarchy.cpp", range: "12:4-12:10" }
+    - { file: "${WS}/type_hierarchy.cpp", range: "21:4-21:10" }
   declaration:
-    - { file: "${WS}/type_hierarchy.cpp", range: "12:4-12:10" }
+    - { file: "${WS}/type_hierarchy.cpp", range: "21:4-21:10" }
   references:
-    - { file: "${WS}/type_hierarchy.cpp", range: "12:4-12:10" }
+    - { file: "${WS}/type_hierarchy.cpp", range: "21:4-21:10" }
   callHierarchy:
-    - { name: "helper", kind: Function, file: "${WS}/type_hierarchy.cpp", range: "12:4-12:10" }
+    - { name: "helper", kind: Function, file: "${WS}/type_hierarchy.cpp", range: "21:4-21:10" }
 
 leaf_enum:
   definition:
-    - { file: "${WS}/type_hierarchy.cpp", range: "10:11-10:15" }
+    - { file: "${WS}/type_hierarchy.cpp", range: "19:11-19:15" }
   declaration:
-    - { file: "${WS}/type_hierarchy.cpp", range: "10:11-10:15" }
+    - { file: "${WS}/type_hierarchy.cpp", range: "19:11-19:15" }
   references:
-    - { file: "${WS}/type_hierarchy.cpp", range: "10:11-10:15" }
+    - { file: "${WS}/type_hierarchy.cpp", range: "19:11-19:15" }
   typeHierarchy:
-    - { name: "Mode", kind: Enum, file: "${WS}/type_hierarchy.cpp", range: "10:11-10:15" }
+    - { name: "Mode", kind: Enum, file: "${WS}/type_hierarchy.cpp", range: "19:11-19:15" }
 
 mid:
   definition:
@@ -30,10 +30,12 @@ mid:
   implementation:
     - { file: "${WS}/type_hierarchy.cpp", range: "6:7-6:13" }
     - { file: "${WS}/type_hierarchy.cpp", range: "8:7-8:12" }
+    - { file: "${WS}/type_hierarchy.cpp", range: "12:7-12:12" }
   references:
     - { file: "${WS}/type_hierarchy.cpp", range: "4:7-4:14" }
-    - { file: "${WS}/type_hierarchy.cpp", range: "6:15-6:22" }
-    - { file: "${WS}/type_hierarchy.cpp", range: "8:14-8:21" }
+    - { file: "${WS}/type_hierarchy.cpp", range: "6:16-6:23" }
+    - { file: "${WS}/type_hierarchy.cpp", range: "8:15-8:22" }
+    - { file: "${WS}/type_hierarchy.cpp", range: "12:15-12:22" }
   typeHierarchy:
     - { name: "Control", kind: Struct, file: "${WS}/type_hierarchy.cpp", range: "4:7-4:14" }
   supertypes:
@@ -41,6 +43,20 @@ mid:
   subtypes:
     - { name: "Button", kind: Struct, file: "${WS}/type_hierarchy.cpp", range: "6:7-6:13" }
     - { name: "Label", kind: Struct, file: "${WS}/type_hierarchy.cpp", range: "8:7-8:12" }
+    - { name: "Panel", kind: Struct, file: "${WS}/type_hierarchy.cpp", range: "12:7-12:12" }
+
+multi:
+  definition:
+    - { file: "${WS}/type_hierarchy.cpp", range: "12:7-12:12" }
+  declaration:
+    - { file: "${WS}/type_hierarchy.cpp", range: "12:7-12:12" }
+  references:
+    - { file: "${WS}/type_hierarchy.cpp", range: "12:7-12:12" }
+  typeHierarchy:
+    - { name: "Panel", kind: Struct, file: "${WS}/type_hierarchy.cpp", range: "12:7-12:12" }
+  supertypes:
+    - { name: "Control", kind: Struct, file: "${WS}/type_hierarchy.cpp", range: "4:7-4:14" }
+    - { name: "Extra", kind: Struct, file: "${WS}/type_hierarchy.cpp", range: "10:7-10:12" }
 
 root:
   definition:
@@ -51,8 +67,18 @@ root:
     - { file: "${WS}/type_hierarchy.cpp", range: "4:7-4:14" }
   references:
     - { file: "${WS}/type_hierarchy.cpp", range: "2:7-2:13" }
-    - { file: "${WS}/type_hierarchy.cpp", range: "4:16-4:22" }
+    - { file: "${WS}/type_hierarchy.cpp", range: "4:17-4:23" }
   typeHierarchy:
     - { name: "Widget", kind: Struct, file: "${WS}/type_hierarchy.cpp", range: "2:7-2:13" }
   subtypes:
     - { name: "Control", kind: Struct, file: "${WS}/type_hierarchy.cpp", range: "4:7-4:14" }
+
+union_def:
+  definition:
+    - { file: "${WS}/type_hierarchy.cpp", range: "14:6-14:12" }
+  declaration:
+    - { file: "${WS}/type_hierarchy.cpp", range: "14:6-14:12" }
+  references:
+    - { file: "${WS}/type_hierarchy.cpp", range: "14:6-14:12" }
+  typeHierarchy:
+    - { name: "Packet", kind: Class, file: "${WS}/type_hierarchy.cpp", range: "14:6-14:12" }

--- a/tests/snap/navigation/unicode_columns.cpp
+++ b/tests/snap/navigation/unicode_columns.cpp
@@ -1,0 +1,9 @@
+/// - verify: server
+///
+/// Positions are UTF-16 code units: the string mixes a CJK char, a
+/// 2-byte char, and a surrogate-pair char, so the columns after it pin
+/// the byte/UTF-16 conversion on both the cursor and the reply side.
+
+int §(def)width = 3;
+
+const char* text = "宽¢€𝄞"; int §(after_unicode)area = §(use)width + 1;

--- a/tests/snap/navigation/unicode_columns.snap.yml
+++ b/tests/snap/navigation/unicode_columns.snap.yml
@@ -1,0 +1,29 @@
+---
+created_at: 2026-08-22
+input_file: unicode_columns.cpp
+---
+after_unicode:
+  definition:
+    - { file: "${WS}/unicode_columns.cpp", range: "8:32-8:36" }
+  declaration:
+    - { file: "${WS}/unicode_columns.cpp", range: "8:32-8:36" }
+  references:
+    - { file: "${WS}/unicode_columns.cpp", range: "8:32-8:36" }
+
+def:
+  definition:
+    - { file: "${WS}/unicode_columns.cpp", range: "6:4-6:9" }
+  declaration:
+    - { file: "${WS}/unicode_columns.cpp", range: "6:4-6:9" }
+  references:
+    - { file: "${WS}/unicode_columns.cpp", range: "6:4-6:9" }
+    - { file: "${WS}/unicode_columns.cpp", range: "8:39-8:44" }
+
+use:
+  definition:
+    - { file: "${WS}/unicode_columns.cpp", range: "6:4-6:9" }
+  declaration:
+    - { file: "${WS}/unicode_columns.cpp", range: "6:4-6:9" }
+  references:
+    - { file: "${WS}/unicode_columns.cpp", range: "6:4-6:9" }
+    - { file: "${WS}/unicode_columns.cpp", range: "8:39-8:44" }

--- a/tests/snap/navigation/using_alias.cpp
+++ b/tests/snap/navigation/using_alias.cpp
@@ -1,0 +1,17 @@
+/// - verify: server
+
+namespace core {
+
+int §(target_def)compute(int value) {
+    return value;
+}
+
+}
+
+namespace §(ns_alias)api = §(ns_alias_target)core;
+
+using core::§(using_decl)compute;
+
+int run(int value) {
+    return §(direct_use)compute(value) + api::§(qualified_use)compute(value);
+}

--- a/tests/snap/navigation/using_alias.snap.yml
+++ b/tests/snap/navigation/using_alias.snap.yml
@@ -12,7 +12,7 @@ direct_use:
     - { file: "${WS}/using_alias.cpp", range: "15:11-15:18" }
     - { file: "${WS}/using_alias.cpp", range: "15:33-15:40" }
   callHierarchy:
-    - { name: "compute", kind: Function, file: "${WS}/using_alias.cpp", range: "15:11-15:18" }
+    - { name: "compute", kind: Function, file: "${WS}/using_alias.cpp", range: "4:4-4:11" }
   incomingCalls:
     - { name: "run", kind: Function, file: "${WS}/using_alias.cpp", range: "14:4-14:7", fromRanges: ["15:11-15:25", "15:28-15:47"] }
 
@@ -45,7 +45,7 @@ qualified_use:
     - { file: "${WS}/using_alias.cpp", range: "15:11-15:18" }
     - { file: "${WS}/using_alias.cpp", range: "15:33-15:40" }
   callHierarchy:
-    - { name: "compute", kind: Function, file: "${WS}/using_alias.cpp", range: "15:33-15:40" }
+    - { name: "compute", kind: Function, file: "${WS}/using_alias.cpp", range: "4:4-4:11" }
   incomingCalls:
     - { name: "run", kind: Function, file: "${WS}/using_alias.cpp", range: "14:4-14:7", fromRanges: ["15:11-15:25", "15:28-15:47"] }
 
@@ -73,6 +73,6 @@ using_decl:
     - { file: "${WS}/using_alias.cpp", range: "15:11-15:18" }
     - { file: "${WS}/using_alias.cpp", range: "15:33-15:40" }
   callHierarchy:
-    - { name: "compute", kind: Function, file: "${WS}/using_alias.cpp", range: "12:12-12:19" }
+    - { name: "compute", kind: Function, file: "${WS}/using_alias.cpp", range: "4:4-4:11" }
   incomingCalls:
     - { name: "run", kind: Function, file: "${WS}/using_alias.cpp", range: "14:4-14:7", fromRanges: ["15:11-15:25", "15:28-15:47"] }

--- a/tests/snap/navigation/using_alias.snap.yml
+++ b/tests/snap/navigation/using_alias.snap.yml
@@ -1,0 +1,78 @@
+---
+created_at: 2026-08-22
+input_file: using_alias.cpp
+---
+direct_use:
+  definition:
+    - { file: "${WS}/using_alias.cpp", range: "4:4-4:11" }
+  declaration:
+    - { file: "${WS}/using_alias.cpp", range: "4:4-4:11" }
+  references:
+    - { file: "${WS}/using_alias.cpp", range: "4:4-4:11" }
+    - { file: "${WS}/using_alias.cpp", range: "15:11-15:18" }
+    - { file: "${WS}/using_alias.cpp", range: "15:33-15:40" }
+  callHierarchy:
+    - { name: "compute", kind: Function, file: "${WS}/using_alias.cpp", range: "15:11-15:18" }
+  incomingCalls:
+    - { name: "run", kind: Function, file: "${WS}/using_alias.cpp", range: "14:4-14:7", fromRanges: ["15:11-15:25", "15:28-15:47"] }
+
+ns_alias:
+  definition:
+    - { file: "${WS}/using_alias.cpp", range: "10:10-10:13" }
+  declaration:
+    - { file: "${WS}/using_alias.cpp", range: "10:10-10:13" }
+  references:
+    - { file: "${WS}/using_alias.cpp", range: "10:10-10:13" }
+    - { file: "${WS}/using_alias.cpp", range: "15:28-15:31" }
+
+ns_alias_target:
+  definition:
+    - { file: "${WS}/using_alias.cpp", range: "2:10-2:14" }
+  declaration:
+    - { file: "${WS}/using_alias.cpp", range: "2:10-2:14" }
+  references:
+    - { file: "${WS}/using_alias.cpp", range: "2:10-2:14" }
+    - { file: "${WS}/using_alias.cpp", range: "10:16-10:20" }
+    - { file: "${WS}/using_alias.cpp", range: "12:6-12:10" }
+
+qualified_use:
+  definition:
+    - { file: "${WS}/using_alias.cpp", range: "4:4-4:11" }
+  declaration:
+    - { file: "${WS}/using_alias.cpp", range: "4:4-4:11" }
+  references:
+    - { file: "${WS}/using_alias.cpp", range: "4:4-4:11" }
+    - { file: "${WS}/using_alias.cpp", range: "15:11-15:18" }
+    - { file: "${WS}/using_alias.cpp", range: "15:33-15:40" }
+  callHierarchy:
+    - { name: "compute", kind: Function, file: "${WS}/using_alias.cpp", range: "15:33-15:40" }
+  incomingCalls:
+    - { name: "run", kind: Function, file: "${WS}/using_alias.cpp", range: "14:4-14:7", fromRanges: ["15:11-15:25", "15:28-15:47"] }
+
+target_def:
+  definition:
+    - { file: "${WS}/using_alias.cpp", range: "4:4-4:11" }
+  declaration:
+    - { file: "${WS}/using_alias.cpp", range: "4:4-4:11" }
+  references:
+    - { file: "${WS}/using_alias.cpp", range: "4:4-4:11" }
+    - { file: "${WS}/using_alias.cpp", range: "15:11-15:18" }
+    - { file: "${WS}/using_alias.cpp", range: "15:33-15:40" }
+  callHierarchy:
+    - { name: "compute", kind: Function, file: "${WS}/using_alias.cpp", range: "4:4-4:11" }
+  incomingCalls:
+    - { name: "run", kind: Function, file: "${WS}/using_alias.cpp", range: "14:4-14:7", fromRanges: ["15:11-15:25", "15:28-15:47"] }
+
+using_decl:
+  definition:
+    - { file: "${WS}/using_alias.cpp", range: "4:4-4:11" }
+  declaration:
+    - { file: "${WS}/using_alias.cpp", range: "4:4-4:11" }
+  references:
+    - { file: "${WS}/using_alias.cpp", range: "4:4-4:11" }
+    - { file: "${WS}/using_alias.cpp", range: "15:11-15:18" }
+    - { file: "${WS}/using_alias.cpp", range: "15:33-15:40" }
+  callHierarchy:
+    - { name: "compute", kind: Function, file: "${WS}/using_alias.cpp", range: "12:12-12:19" }
+  incomingCalls:
+    - { name: "run", kind: Function, file: "${WS}/using_alias.cpp", range: "14:4-14:7", fromRanges: ["15:11-15:25", "15:28-15:47"] }

--- a/tests/snap/navigation/variable_template.cpp
+++ b/tests/snap/navigation/variable_template.cpp
@@ -1,0 +1,11 @@
+/// - verify: server
+
+template <typename T>
+T §(primary)zero = T{};
+
+template <>
+int §(specialization)zero<int> = 7;
+
+int read_zero() {
+    return §(spec_use)zero<int> + static_cast<int>(§(primary_use)zero<double>);
+}

--- a/tests/snap/navigation/variable_template.snap.yml
+++ b/tests/snap/navigation/variable_template.snap.yml
@@ -1,0 +1,43 @@
+---
+created_at: 2026-08-22
+input_file: variable_template.cpp
+---
+primary:
+  definition:
+    - { file: "${WS}/variable_template.cpp", range: "3:2-3:6" }
+  declaration:
+    - { file: "${WS}/variable_template.cpp", range: "3:2-3:6" }
+  typeDefinition:
+    - { file: "${WS}/variable_template.cpp", range: "2:19-2:20" }
+  references:
+    - { file: "${WS}/variable_template.cpp", range: "3:2-3:6" }
+    - { file: "${WS}/variable_template.cpp", range: "9:40-9:44" }
+
+primary_use:
+  definition:
+    - { file: "${WS}/variable_template.cpp", range: "3:2-3:6" }
+  declaration:
+    - { file: "${WS}/variable_template.cpp", range: "3:2-3:6" }
+  typeDefinition:
+    - { file: "${WS}/variable_template.cpp", range: "2:19-2:20" }
+  references:
+    - { file: "${WS}/variable_template.cpp", range: "3:2-3:6" }
+    - { file: "${WS}/variable_template.cpp", range: "9:40-9:44" }
+
+spec_use:
+  definition:
+    - { file: "${WS}/variable_template.cpp", range: "6:4-6:8" }
+  declaration:
+    - { file: "${WS}/variable_template.cpp", range: "6:4-6:8" }
+  references:
+    - { file: "${WS}/variable_template.cpp", range: "6:4-6:8" }
+    - { file: "${WS}/variable_template.cpp", range: "9:11-9:15" }
+
+specialization:
+  definition:
+    - { file: "${WS}/variable_template.cpp", range: "6:4-6:8" }
+  declaration:
+    - { file: "${WS}/variable_template.cpp", range: "6:4-6:8" }
+  references:
+    - { file: "${WS}/variable_template.cpp", range: "6:4-6:8" }
+    - { file: "${WS}/variable_template.cpp", range: "9:11-9:15" }

--- a/tools/snap/features/navigation.ts
+++ b/tools/snap/features/navigation.ts
@@ -68,11 +68,20 @@ function locationLines(locations: proto.Location[], root: string): string[] {
 
 type HierarchyItem = proto.CallHierarchyItem | proto.TypeHierarchyItem;
 
+/// `selection` and `detail` render only when they carry information beyond
+/// `range` — today clice always sets selectionRange == range and no detail,
+/// so their appearance in a snapshot IS the regression signal.
 function itemFields(item: HierarchyItem, root: string): { file: string; body: string } {
     const file = normalizeFileUri(item.uri, root);
-    const body =
+    let body =
         `name: ${yamlStr(item.name)}, kind: ${enumName(proto.SymbolKind, item.kind)}, ` +
         `file: ${yamlStr(file)}, range: "${fmtRange(item.range)}"`;
+    if (byRange(item.range, item.selectionRange) !== 0) {
+        body += `, selection: "${fmtRange(item.selectionRange)}"`;
+    }
+    if (item.detail !== undefined) {
+        body += `, detail: ${yamlStr(item.detail)}`;
+    }
     return { file, body };
 }
 
@@ -82,6 +91,14 @@ function itemLines(items: HierarchyItem[], root: string): string[] {
             const { file, body } = itemFields(item, root);
             return { file, range: item.range, entry: `- { ${body} }` };
         }),
+    );
+}
+
+/// Prepare replies expand into per-item sections, so their order must be
+/// pinned before iteration, not only at render time.
+function sortItems<T extends HierarchyItem>(items: T[]): T[] {
+    return [...items].sort(
+        (a, b) => (a.uri < b.uri ? -1 : a.uri > b.uri ? 1 : 0) || byRange(a.range, b.range),
     );
 }
 
@@ -128,7 +145,7 @@ export const navigation: Feature = {
             const references = (await client.referencesAt(uri, line, character)) ?? [];
             sections.push(["references", locationLines(references, ctx.root)]);
 
-            const callItems = (await client.prepareCallHierarchy(uri, line, character)) ?? [];
+            const callItems = sortItems((await client.prepareCallHierarchy(uri, line, character)) ?? []);
             sections.push(["callHierarchy", itemLines(callItems, ctx.root)]);
             for (const item of callItems) {
                 const incoming = (await client.callHierarchyIncoming(item)) ?? [];
@@ -149,7 +166,7 @@ export const navigation: Feature = {
                 ]);
             }
 
-            const typeItems = (await client.prepareTypeHierarchy(uri, line, character)) ?? [];
+            const typeItems = sortItems((await client.prepareTypeHierarchy(uri, line, character)) ?? []);
             sections.push(["typeHierarchy", itemLines(typeItems, ctx.root)]);
             for (const item of typeItems) {
                 const supertypes = (await client.typeHierarchySupertypes(item)) ?? [];

--- a/tools/snap/features/navigation.ts
+++ b/tools/snap/features/navigation.ts
@@ -145,7 +145,9 @@ export const navigation: Feature = {
             const references = (await client.referencesAt(uri, line, character)) ?? [];
             sections.push(["references", locationLines(references, ctx.root)]);
 
-            const callItems = sortItems((await client.prepareCallHierarchy(uri, line, character)) ?? []);
+            const callItems = sortItems(
+                (await client.prepareCallHierarchy(uri, line, character)) ?? [],
+            );
             sections.push(["callHierarchy", itemLines(callItems, ctx.root)]);
             for (const item of callItems) {
                 const incoming = (await client.callHierarchyIncoming(item)) ?? [];
@@ -166,7 +168,9 @@ export const navigation: Feature = {
                 ]);
             }
 
-            const typeItems = sortItems((await client.prepareTypeHierarchy(uri, line, character)) ?? []);
+            const typeItems = sortItems(
+                (await client.prepareTypeHierarchy(uri, line, character)) ?? [],
+            );
             sections.push(["typeHierarchy", itemLines(typeItems, ctx.root)]);
             for (const item of typeItems) {
                 const supertypes = (await client.typeHierarchySupertypes(item)) ?? [];

--- a/tools/snap/features/navigation.ts
+++ b/tools/snap/features/navigation.ts
@@ -1,0 +1,177 @@
+import * as proto from "vscode-languageserver-protocol";
+import { markerPoints } from "../annotation.ts";
+import { enumName, fmtRange, OffsetConverter, type Feature } from "../render.ts";
+import { normalizeFileUri, yamlStr } from "../snapshot.ts";
+
+/// The full symbol-lookup profile at each `§`-marker: definition,
+/// declaration, typeDefinition, implementation, references, and one level
+/// of call/type hierarchy, rendered as one block per marker with empty
+/// sections dropped. Replies aggregate open sessions with index state, so
+/// only the server path exists; a read-only index provider (the
+/// `clice query` direction) is the precondition for an inspect twin.
+///
+/// Every list is sorted before rendering — reply order leaks container
+/// iteration order (grouped relations come out of a DenseMap) and must
+/// not be pinned.
+
+interface Located {
+    file: string;
+    range: proto.Range;
+    entry: string;
+}
+
+function byRange(a: proto.Range, b: proto.Range): number {
+    return (
+        a.start.line - b.start.line ||
+        a.start.character - b.start.character ||
+        a.end.line - b.end.line ||
+        a.end.character - b.end.character
+    );
+}
+
+function rendered(entries: Located[]): string[] {
+    entries.sort(
+        (a, b) =>
+            (a.file < b.file ? -1 : a.file > b.file ? 1 : 0) ||
+            byRange(a.range, b.range) ||
+            (a.entry < b.entry ? -1 : a.entry > b.entry ? 1 : 0),
+    );
+    return entries.map(({ entry }) => entry);
+}
+
+function asLocations(
+    reply: proto.Location | (proto.Location | proto.LocationLink)[] | null,
+): proto.Location[] {
+    if (reply === null) {
+        return [];
+    }
+    return (Array.isArray(reply) ? reply : [reply]).map((entry) => {
+        if (!("uri" in entry)) {
+            throw new Error("clice replies plain Location arrays, not LocationLink");
+        }
+        return entry;
+    });
+}
+
+function locationLines(locations: proto.Location[], root: string): string[] {
+    return rendered(
+        locations.map((location) => {
+            const file = normalizeFileUri(location.uri, root);
+            return {
+                file,
+                range: location.range,
+                entry: `- { file: ${yamlStr(file)}, range: "${fmtRange(location.range)}" }`,
+            };
+        }),
+    );
+}
+
+type HierarchyItem = proto.CallHierarchyItem | proto.TypeHierarchyItem;
+
+function itemFields(item: HierarchyItem, root: string): { file: string; body: string } {
+    const file = normalizeFileUri(item.uri, root);
+    const body =
+        `name: ${yamlStr(item.name)}, kind: ${enumName(proto.SymbolKind, item.kind)}, ` +
+        `file: ${yamlStr(file)}, range: "${fmtRange(item.range)}"`;
+    return { file, body };
+}
+
+function itemLines(items: HierarchyItem[], root: string): string[] {
+    return rendered(
+        items.map((item) => {
+            const { file, body } = itemFields(item, root);
+            return { file, range: item.range, entry: `- { ${body} }` };
+        }),
+    );
+}
+
+function callLines(
+    calls: { item: proto.CallHierarchyItem; fromRanges: proto.Range[] }[],
+    root: string,
+): string[] {
+    return rendered(
+        calls.map(({ item, fromRanges }) => {
+            const { file, body } = itemFields(item, root);
+            const ranges = [...fromRanges]
+                .sort(byRange)
+                .map((range) => `"${fmtRange(range)}"`)
+                .join(", ");
+            return {
+                file,
+                range: item.range,
+                entry: `- { ${body}, fromRanges: [${ranges}] }`,
+            };
+        }),
+    );
+}
+
+export const navigation: Feature = {
+    shape: "point",
+    fromInspect() {
+        throw new Error("navigation has no inspect path; use verify: server");
+    },
+    async fromServer(client, uri, ctx) {
+        const map = new OffsetConverter(ctx.stripped);
+        const out: string[] = [];
+        for (const [name, offset] of markerPoints(ctx.source)) {
+            const { line, character } = map.position(offset);
+            const sections: [string, string[]][] = [];
+
+            const definition = asLocations(await client.definitionAt(uri, line, character));
+            sections.push(["definition", locationLines(definition, ctx.root)]);
+            const declaration = asLocations(await client.declarationAt(uri, line, character));
+            sections.push(["declaration", locationLines(declaration, ctx.root)]);
+            const typeDefinition = asLocations(await client.typeDefinitionAt(uri, line, character));
+            sections.push(["typeDefinition", locationLines(typeDefinition, ctx.root)]);
+            const implementation = asLocations(await client.implementationAt(uri, line, character));
+            sections.push(["implementation", locationLines(implementation, ctx.root)]);
+            const references = (await client.referencesAt(uri, line, character)) ?? [];
+            sections.push(["references", locationLines(references, ctx.root)]);
+
+            const callItems = (await client.prepareCallHierarchy(uri, line, character)) ?? [];
+            sections.push(["callHierarchy", itemLines(callItems, ctx.root)]);
+            for (const item of callItems) {
+                const incoming = (await client.callHierarchyIncoming(item)) ?? [];
+                sections.push([
+                    "incomingCalls",
+                    callLines(
+                        incoming.map((call) => ({ item: call.from, fromRanges: call.fromRanges })),
+                        ctx.root,
+                    ),
+                ]);
+                const outgoing = (await client.callHierarchyOutgoing(item)) ?? [];
+                sections.push([
+                    "outgoingCalls",
+                    callLines(
+                        outgoing.map((call) => ({ item: call.to, fromRanges: call.fromRanges })),
+                        ctx.root,
+                    ),
+                ]);
+            }
+
+            const typeItems = (await client.prepareTypeHierarchy(uri, line, character)) ?? [];
+            sections.push(["typeHierarchy", itemLines(typeItems, ctx.root)]);
+            for (const item of typeItems) {
+                const supertypes = (await client.typeHierarchySupertypes(item)) ?? [];
+                sections.push(["supertypes", itemLines(supertypes, ctx.root)]);
+                const subtypes = (await client.typeHierarchySubtypes(item)) ?? [];
+                sections.push(["subtypes", itemLines(subtypes, ctx.root)]);
+            }
+
+            if (out.length > 0) {
+                out.push("");
+            }
+            const present = sections.filter(([, lines]) => lines.length > 0);
+            if (present.length === 0) {
+                out.push(`${name}: none`);
+                continue;
+            }
+            out.push(`${name}:`);
+            for (const [label, lines] of present) {
+                out.push(`  ${label}:`);
+                out.push(...lines.map((entryLine) => `    ${entryLine}`));
+            }
+        }
+        return out;
+    },
+};

--- a/tools/snap/registry.ts
+++ b/tools/snap/registry.ts
@@ -9,6 +9,7 @@ import { documentSymbol } from "./features/document_symbol.ts";
 import { foldingRange } from "./features/folding_range.ts";
 import { hover } from "./features/hover.ts";
 import { inlayHint } from "./features/inlay_hint.ts";
+import { navigation } from "./features/navigation.ts";
 import { semanticTokens } from "./features/semantic_tokens.ts";
 import { signatureHelp } from "./features/signature_help.ts";
 import { tuIndex } from "./features/tu_index.ts";
@@ -21,6 +22,7 @@ const FEATURES: Record<string, Feature> = {
     folding_range: foldingRange,
     hover,
     inlay_hint: inlayHint,
+    navigation,
     semantic_tokens: semanticTokens,
     signature_help: signatureHelp,
     tu_index: tuIndex,


### PR DESCRIPTION
## What changed

Two things land together: a navigation snap corpus that pins the full symbol-lookup surface, and fixes for the defects the corpus exposed.

**Snap corpus** (`tests/snap/navigation/`, 38 fixtures, `verify: server`): every `§`-marker renders a profile of definition / declaration / typeDefinition / implementation / references plus one level of call and type hierarchy, with empty sections dropped and all lists sorted before rendering. Coverage spans the #626 def↔decl alternation scenarios (header/source bounce, inline definitions, declaration-only symbols, multi-redeclarations), modules (import → interface unit, interface ↔ implementation unit, partitions, module-name navigation), templates (primary vs explicit specialization resolution, out-of-line members), macro sites (spelling/expansion behavior pinned as-is), hierarchies (multiple inheritance, recursion, kind gates), and a long tail of edge scenarios: destructors, operators, friends, overload sets, structured bindings, concepts, CTAD, inherited constructors, anonymous namespaces, UTF-16 columns past non-ASCII text, and negative controls on keywords and literals.

**Fixes** the corpus caught:

- Call/type-hierarchy prepare items anchor at the symbol's canonical location instead of the cursor occurrence, so expanding from a use renders the same root as expanding from the declaration. `resolve_symbol` now falls back to the declaration when nothing defines the symbol — which also stops declaration-only callees from silently vanishing out of hierarchy expansions.
- `SymbolKind::Operator` passes the call-hierarchy gate, so overloaded operators get call graphs.
- `textDocument/implementation` on a class-like symbol serves its derived types, mirroring method overrides.
- At a boundary between two occurrences, the token starting at the cursor wins over the one merely touched at its right edge: the first name of a structured binding no longer resolves to `[`, the `(` of `T(args)` navigates to the constructor, and `a+b` with the cursor before `b` resolves to `b`.
- Written constructions record call edges, so constructors have incoming calls. The gate is the spelled paren/brace form: `T(args)` and `T{args}` produce edges, while implicit copies, elided temporaries, and delimiter-less forms (`T x;`, `T y = 1;`) stay out of the graph.

Behaviors deliberately pinned rather than changed stay visible in the snapshots (sugar-preserving typeDefinition, weak references excluded from find-references, deduction guides unlinked from CTAD sites). Hierarchy expansion still resolves targets through the project index, so internal-linkage targets in closed files stay invisible there — a pre-existing property shared by subtypes and incoming calls, not specific to the new implementation path. Destructor and operator name ranges still cover only their first token: widening them makes the name range overlap the nested type reference, which the shard's disjoint-or-identical occurrence invariant cannot represent — that needs index-format-level support for nested ranges first.

## Tests

- New: `tests/snap/navigation/` — 38 fixtures / 39 snap tests, all `verify: server`, plus a new marker in the corpus pinning declaration-only callees in outgoing calls.
- All four suites pass locally on RelWithDebInfo: unit (1286), integration (355), smoke (3/3), snap (436). `npm run check` clean.
