### PR TITLE
feat(command): support nvcc toolchain

### DIFF
--- a/.github/workflows/native-test.yml
+++ b/.github/workflows/native-test.yml
@@ -85,16 +85,6 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-      # The NVCC toolchain tests need a real nvcc plus the toolkit headers
-      # clang's CUDA wrapper includes unconditionally (cudart, curand). No
-      # GPU is required — compilation and the --dryrun probe are pure CPU.
-      - name: Install CUDA toolchain
-        if: runner.os == 'Linux'
-        run: |
-          pixi global install "cuda-nvcc=12.9.*" --with "cuda-cudart-dev=12.9.*" --with libcurand-dev
-          pixi global expose add --environment cuda-nvcc nvcc
-          echo "$HOME/.pixi/bin" >> "$GITHUB_PATH"
-
       - name: Unit tests
         timeout-minutes: 5
         run: pixi run -e test-run unit-test ${{ matrix.build_type }}

--- a/.github/workflows/native-test.yml
+++ b/.github/workflows/native-test.yml
@@ -85,6 +85,16 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      # The NVCC toolchain tests need a real nvcc plus the toolkit headers
+      # clang's CUDA wrapper includes unconditionally (cudart, curand). No
+      # GPU is required — compilation and the --dryrun probe are pure CPU.
+      - name: Install CUDA toolchain
+        if: runner.os == 'Linux'
+        run: |
+          pixi global install "cuda-nvcc=12.9.*" --with "cuda-cudart-dev=12.9.*" --with libcurand-dev
+          pixi global expose add --environment cuda-nvcc nvcc
+          echo "$HOME/.pixi/bin" >> "$GITHUB_PATH"
+
       - name: Unit tests
         timeout-minutes: 5
         run: pixi run -e test-run unit-test ${{ matrix.build_type }}

--- a/docs/en/design/command-resolve.md
+++ b/docs/en/design/command-resolve.md
@@ -63,7 +63,7 @@ Both `CanonicalCommand` and `CompilationInfo` are deduplicated via `ObjectSet` -
 
 On lookup, `CompilationDatabase` assembles a `CompilationInfo` into a `CompileCommand` -- the final output of the command processing pipeline, containing the complete compilation flags and source file path, ready to be submitted to toolchain probing or the Clang frontend.
 
-For files without a CDB entry (e.g., a file the user opens that is not part of the project), `CompilationDatabase` synthesizes a default command -- selecting `clang` or `clang++ -std=c++20` based on the file extension.
+For files without a CDB entry (e.g., a file the user opens that is not part of the project), `CompilationDatabase` synthesizes a default command -- selecting `clang` or `clang++ -std=c++20` based on the file extension. CUDA files (`.cu`/`.cuh`) additionally force `-x cuda`: `.cuh` is not an extension clang recognizes, so without it the driver would treat the file as linker input.
 
 `CompilationDatabase` also provides the ability to group by configuration: `ConfigGroup` aggregates files that share the same `CompilationInfo`. This is the right granularity for extracting search path configurations during dependency scanning -- different `-I` paths produce different groups. For toolchain probing, the granularity is coarser (user-content options don't affect probing results), so `Toolchain` further deduplicates on top of `ConfigGroup`.
 
@@ -162,7 +162,7 @@ After the four tiers are concatenated, deduplication begins from the Angled tier
 
 ## Known Limitations
 
-- **Incomplete support for some compiler families.** NVCC and Intel compilers (`icc`, `icx`, `dpcpp`) are recognized but currently fall through to the generic Clang driver path without dedicated probing logic. This means these compilers' special system paths may not be correctly discovered.
+- **Incomplete support for some compiler families.** Intel compilers (`icc`, `icx`, `dpcpp`) are recognized but currently fall through to the generic Clang driver path without dedicated probing logic, so their special system paths may not be correctly discovered. NVCC has dedicated probing (parsing `nvcc --dryrun` output into a clang CUDA invocation), but only with a GCC or Clang host compiler -- nvcc driving MSVC `cl` is not supported yet, and multi-architecture commands parse the newest architecture only.
 
 - **SearchConfig does not support all search path options.** `-cxx-isystem` (system directories effective only in C++ mode), `-iwithsysroot` (prepends sysroot to path), and HeaderMap support are not yet implemented. These options are uncommon in practice but may appear in specific Apple or cross-compilation toolchains.
 

--- a/docs/zh/design/command-resolve.md
+++ b/docs/zh/design/command-resolve.md
@@ -63,7 +63,7 @@ clice 将整个命令处理流程自动化：从 CDB 中读取命令后，自动
 
 查找时，`CompilationDatabase` 将 `CompilationInfo` 组装为 `CompileCommand`——这是命令处理流水线的最终输出，包含完整的编译选项和源文件路径，可直接提交给工具链探测或 Clang 前端。
 
-对于没有 CDB 条目的文件（例如用户打开了一个不在项目中的文件），`CompilationDatabase` 会合成一个默认命令——根据文件扩展名选择 `clang` 或 `clang++ -std=c++20`。
+对于没有 CDB 条目的文件（例如用户打开了一个不在项目中的文件），`CompilationDatabase` 会合成一个默认命令——根据文件扩展名选择 `clang` 或 `clang++ -std=c++20`。CUDA 文件（`.cu`/`.cuh`）会额外强制 `-x cuda`：`.cuh` 不是 clang 认识的扩展名，不加语言标记时驱动器会把它当作链接器输入。
 
 `CompilationDatabase` 还提供了按配置分组的能力：`ConfigGroup` 将共享相同 `CompilationInfo` 的文件聚合在一起。这是依赖扫描中提取搜索路径配置的正确粒度——不同的 `-I` 路径产生不同的分组。对于工具链探测，粒度更粗（用户内容选项不影响探测结果），因此 `Toolchain` 会在 `ConfigGroup` 的基础上进一步去重。
 
@@ -162,7 +162,7 @@ CDB 加载使用 simdjson 流式解析 JSON，逐条处理：
 
 ## 已知局限
 
-- **部分编译器家族支持不完整。** NVCC 和 Intel 编译器（`icc`、`icx`、`dpcpp`）虽然被识别，但目前回退到通用的 Clang 驱动路径，没有专门的探测逻辑。这意味着这些编译器的特殊系统路径可能无法被正确发现。
+- **部分编译器家族支持不完整。** Intel 编译器（`icc`、`icx`、`dpcpp`）虽然被识别，但目前回退到通用的 Clang 驱动路径，没有专门的探测逻辑，其特殊系统路径可能无法被正确发现。NVCC 已有专门探测（解析 `nvcc --dryrun` 输出并合成 clang 的 CUDA 调用），但仅支持 GCC/Clang 宿主编译器——nvcc 驱动 MSVC `cl` 的形态尚不支持，多架构命令也只按最新架构解析。
 
 - **SearchConfig 不支持部分搜索路径选项。** `-cxx-isystem`（仅 C++ 模式生效的系统目录）、`-iwithsysroot`（拼接 sysroot 前缀）和 HeaderMap 支持尚未实现。这些选项在实际项目中不常见，但可能在特定的 Apple 或交叉编译工具链中出现。
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1943,19 +1943,34 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-15.2.0-h53410ce_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-13.3.73-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-13.3.29-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-dev-13.3.29-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-static-13.3.29-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-13.3.73-hcdd1206_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-impl-13.3.73-h85509e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-tools-13.3.73-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc_linux-64-13.3.73-hb2fc203_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-impl-13.3.73-h4bc722e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-13.3.73-h4bc722e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.2.0-hc6a0c74_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-h8ddf172_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_28.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-15.2.0-h834e499_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-he8f701c_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.2.0-h71fc77c_28.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260526.0-cxx17_h7b12aa8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-10.4.3.29-h676940d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-dev-10.4.3.29-h676940d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
@@ -1967,6 +1982,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvptxcompiler-dev-13.3.73-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h984fb3e_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
@@ -1985,8 +2001,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-13.3.3.4.1-ha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-13.3.73-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-64-13.3.29-h376f20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-64-13.3.29-h376f20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-13.3.29-h376f20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-64-13.3.29-h376f20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-64-13.3.73-he91c749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-64-13.3.73-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-13.3-hcbadf70_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_120.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-64-13.3.73-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_120.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
@@ -2285,6 +2311,16 @@ packages:
   run_exports: {}
   size: 3562702
   timestamp: 1784214485346
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
+  sha256: 08d7238663fc408ba2ab60b02fa3d06a7ca9d872962e03e90c7e0fdecb7ed1d0
+  md5: 32fd07abe84eb14f17c7f5cc6fa8df82
+  depends:
+  - binutils_impl_linux-64 2.46.1 default_hfdba357_102
+  license: GPL-3.0-only
+  license_family: GPL
+  run_exports: {}
+  size: 36337
+  timestamp: 1784214551894
 - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-aarch64-2.46.1-default_h7726a90_102.conda
   sha256: 93d44efadc8dc60003ae50956c94f437d94e6f1c63a53fdb3ed9df5a474386c8
   md5: 12a97546d52047d2587a258d8020f429
@@ -2675,6 +2711,141 @@ packages:
   run_exports: {}
   size: 32354
   timestamp: 1784923998243
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-13.3.73-ha770c72_0.conda
+  sha256: c15de6531b48744560311f3db12a2503e57d5ed737f4613e9f5ec56e96ae1967
+  md5: 0250c452d2fbe477d4ea1a4c43e8c2b5
+  depends:
+  - cuda-version >=13.3,<13.4.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports: {}
+  size: 30173
+  timestamp: 1782782850002
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-13.3.29-hecca717_0.conda
+  sha256: 3d74819f261d77a410e8f8ddbd973446c312ec76605d60619d9b85113eca9632
+  md5: 3fc21c99786b908fd7f32ea279fc9780
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-cudart_linux-64 13.3.29 h376f20c_0
+  - cuda-version >=13.3,<13.4.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports: {}
+  size: 24659
+  timestamp: 1779898425780
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-dev-13.3.29-hecca717_0.conda
+  sha256: 050ac942737f501b5dee21c0bbfa77f4617c52269f188ab66a5e2b8b7acd0f22
+  md5: e21171cc900f202b2af82f1afddbdfcf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-cudart 13.3.29 hecca717_0
+  - cuda-cudart-dev_linux-64 13.3.29 h376f20c_0
+  - cuda-cudart-static 13.3.29 hecca717_0
+  - cuda-version >=13.3,<13.4.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports:
+    weak:
+    - cuda-cudart >=13.3.29,<14.0a0
+  size: 25129
+  timestamp: 1779898446163
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-static-13.3.29-hecca717_0.conda
+  sha256: e2596138baef66e9b7fa08329e944d3ef8cca7c3d2da28d32bc37ff7e4801d1a
+  md5: 3a99ba2e09c508fd8b8b0eaf6d37a376
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-cudart-static_linux-64 13.3.29 h376f20c_0
+  - cuda-version >=13.3,<13.4.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports: {}
+  size: 24626
+  timestamp: 1779898435744
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-13.3.73-hcdd1206_0.conda
+  sha256: 01d5cc80942839a30044e5eb5367ddd34a81e19039ac80e4e9d1307198bed357
+  md5: 2666999cfd09d7e494b56711407a23c0
+  depends:
+  - cuda-nvcc_linux-64 13.3.73.*
+  - gcc_linux-64
+  - gxx_linux-64
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports: {}
+  size: 24719
+  timestamp: 1782788494465
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-impl-13.3.73-h85509e4_0.conda
+  sha256: 045ccc13794e218fab32bd4d5638d64937e7816439b259c7ec692850d8b45f40
+  md5: 9f21e3ffc7e997ae5eafd099cda0eaa7
+  depends:
+  - cuda-cudart >=13.3.29,<14.0a0
+  - cuda-cudart-dev
+  - cuda-nvcc-dev_linux-64 13.3.73 he91c749_0
+  - cuda-nvcc-tools 13.3.73 he02047a_0
+  - cuda-nvvm-impl 13.3.73 h4bc722e_0
+  - cuda-version >=13.3,<13.4.0a0
+  - libnvptxcompiler-dev 13.3.73 ha770c72_0
+  constrains:
+  - gcc_impl_linux-64 >=6,<16.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports: {}
+  size: 28083
+  timestamp: 1782783017264
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-tools-13.3.73-he02047a_0.conda
+  sha256: 2367b8c3b2b950ae6c3ec2e5353e343ab81d652786f9f4a894d8aec87d8220ec
+  md5: 5425950025883aab32919f2a42e1274b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-crt-tools 13.3.73 ha770c72_0
+  - cuda-nvvm-tools 13.3.73 h4bc722e_0
+  - cuda-version >=13.3,<13.4.0a0
+  - libgcc >=12
+  - libstdcxx >=12
+  constrains:
+  - gcc_impl_linux-64 >=6,<16.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports: {}
+  size: 34673506
+  timestamp: 1782782957431
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc_linux-64-13.3.73-hb2fc203_0.conda
+  sha256: 65de0c6c5027756dcb972b2a1a6729047631b18d16158e6d0efc3cca6faeb637
+  md5: 56f481b40c83319e4fa672cde344762a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-cudart-dev_linux-64 13.3.*
+  - cuda-driver-dev_linux-64 13.3.*
+  - cuda-nvcc-dev_linux-64 13.3.73.*
+  - cuda-nvcc-impl 13.3.73.*
+  - cuda-nvcc-tools 13.3.73.*
+  - sysroot_linux-64 >=2.17,<3.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports:
+    strong:
+    - cuda-version >=13.3,<14
+  size: 26975
+  timestamp: 1782788493954
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-impl-13.3.73-h4bc722e_0.conda
+  sha256: 41f356d6c38af4d2be789b13697469eb2eb61fc7aaf2765ae8dc5845587a36f7
+  md5: e9fa0c38f175daa97354d21e74603588
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=13.3,<13.4.0a0
+  - libgcc >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports: {}
+  size: 22429305
+  timestamp: 1782782861319
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-13.3.73-h4bc722e_0.conda
+  sha256: f853f097a67a197608fafc193ab877393c7735b1da2364572172cc9eff262775
+  md5: d5c9cf56873f461074420e70970604a9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=13.3,<13.4.0a0
+  - libgcc >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports: {}
+  size: 29734373
+  timestamp: 1782782895477
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fd-find-10.3.0-hdab8a38_0.conda
   sha256: 55d3011ca72e1d97acc651b2af5d4d4d785988a8cfa9026205e9cf11f2d4ee67
   md5: 1b8aaa7bb23496abb0e23369db7fb5b7
@@ -2727,6 +2898,20 @@ packages:
   run_exports: {}
   size: 85916233
   timestamp: 1784923109666
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_28.conda
+  sha256: 57e7204cf78133f34b20c3e8aabf360db22a0a25b190823ce74cce25c4fefc88
+  md5: 1947dad907c82aef51f4e102ed42fbdd
+  depends:
+  - gcc_impl_linux-64 15.2.0.*
+  - binutils_linux-64
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    strong:
+    - libgcc >=15
+  size: 29394
+  timestamp: 1785174991052
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-aarch64-15.2.0-hf143b70_27.conda
   sha256: abab9571b8b7e6bdea801ab9f98625084ac9efe902e4f797e8dc0101827e7d1f
   md5: 9037db896880a369fc9e47045109eabc
@@ -2780,6 +2965,22 @@ packages:
   run_exports: {}
   size: 15952476
   timestamp: 1784923278899
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.2.0-h71fc77c_28.conda
+  sha256: 2090221d24cc477d73d2a0e667fb395520e5a2222af1371d157fc70a96e385ec
+  md5: e110dfbcd087ae679df62975fcde1abc
+  depends:
+  - gxx_impl_linux-64 15.2.0.*
+  - gcc_linux-64 ==15.2.0 h7be306e_28
+  - binutils_linux-64
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    strong:
+    - libstdcxx >=15
+    - libgcc >=15
+  size: 27880
+  timestamp: 1785174991052
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-aarch64-15.2.0-ha206bb4_27.conda
   sha256: 746fd1d7ec3d22db5fb8a5d04322b7b0ded0e7a4a3d4c2f1d1535bddaf70a7d6
   md5: 0201e09a96ca558c50a7b2938aed38e0
@@ -3066,6 +3267,35 @@ packages:
     - libcompiler-rt >=22.1.8
   size: 10100897
   timestamp: 1781741177454
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-10.4.3.29-h676940d_0.conda
+  sha256: 9a1615a44f0d01fcc23b4f1be4c8f86b2e19e3974481e826180dd261b67dcad6
+  md5: 6172124b5a746cc1f3f9fc7fac9f6740
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cuda-version >=13.3,<13.4.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports: {}
+  size: 43805393
+  timestamp: 1779897559895
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-dev-10.4.3.29-h676940d_0.conda
+  sha256: 5f1ad7adcb482f246d207409b1db36d5a6d5a91844e8cb74c76393358ab5ce18
+  md5: ea57e481652c4663c42be59a6857faf1
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cuda-version >=13.3,<13.4.0a0
+  - libcurand 10.4.3.29 h676940d_0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - libcurand-static >=10.4.3.29
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports:
+    weak:
+    - libcurand >=10.4.3.29,<11.0a0
+  size: 254305
+  timestamp: 1779897620210
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.17.0-h4e3cde8_1.conda
   sha256: 2d7be2fe0f58a0945692abee7bb909f8b19284b518d958747e5ff51d0655c303
   md5: 117499f93e892ea1e57fdca16c2e8351
@@ -3480,6 +3710,16 @@ packages:
     - libnghttp2 >=1.68.1,<2.0a0
   size: 663344
   timestamp: 1773854035739
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvptxcompiler-dev-13.3.73-ha770c72_0.conda
+  sha256: 4c0cd2ab8f6f457460073d8e8ae29102ec78c1ccbb924a29a493168520b87715
+  md5: b9f4e0cdb17f457324bc4255ccb923f7
+  depends:
+  - cuda-version >=13.3,<13.4.0a0
+  - libnvptxcompiler-dev_linux-64 13.3.73 ha770c72_0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports: {}
+  size: 27824
+  timestamp: 1782783006640
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-h49b2146_1.conda
   sha256: 71118885feab91c61bea4e9532ec46e0653b24f02e563681f822915aee8435bb
   md5: af5ddfb52ad25d833c70c7511478d4eb
@@ -6141,6 +6381,99 @@ packages:
   run_exports: {}
   size: 16698
   timestamp: 1781741176960
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-13.3.3.4.1-ha770c72_1.conda
+  sha256: fa44586fc308d0089fb5f014d5b53cbea19a2e83cd7bbd1e19c79140293be9a3
+  md5: 199a317645eac1a18745d05dc551ab6e
+  depends:
+  - cuda-version >=13.3,<13.4.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports: {}
+  size: 1486700
+  timestamp: 1785874560026
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-13.3.73-ha770c72_0.conda
+  sha256: 94894c81f0257fc8a7daee9e18f885ce5e26adf1494e05b57ffb0660d59096cd
+  md5: 05b21494055e653903a447c506e091c8
+  depends:
+  - cuda-version >=13.3,<13.4.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports: {}
+  size: 116550
+  timestamp: 1782782846502
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-64-13.3.29-h376f20c_0.conda
+  sha256: d95f1b404119e3f72edb7ac5dbd4443e2d7d040f7d68c3905c0dd7ad78f11311
+  md5: 4165013e8d24dd61774458e6f2e36c32
+  depends:
+  - cuda-cccl_linux-64
+  - cuda-cudart-static_linux-64
+  - cuda-cudart_linux-64
+  - cuda-version >=13.3,<13.4.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports:
+    weak:
+    - cuda-cudart >=13.3.29,<14.0a0
+  size: 405020
+  timestamp: 1779898430134
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-64-13.3.29-h376f20c_0.conda
+  sha256: fa920f2c2154ea2ace2d55457e43af8e7bfc2c94fa5ec7276792ad411d1011d1
+  md5: 7d4fe2a79d971522b3ad68b772c197eb
+  depends:
+  - cuda-version >=13.3,<13.4.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports: {}
+  size: 1126340
+  timestamp: 1779898412056
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-13.3.29-h376f20c_0.conda
+  sha256: a86028f94acf37b17ca2280734ae9dcc407cdf68a9c400102d323a3b15e52f0b
+  md5: 10949c6dfe9157fedb19170bd6e0b835
+  depends:
+  - cuda-version >=13.3,<13.4.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports: {}
+  size: 206064
+  timestamp: 1779898416941
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-64-13.3.29-h376f20c_0.conda
+  sha256: 40e9c9f18311719c249bd8b81e73f1c3f56ef5b31db97ec393a5ab5373264d5e
+  md5: 50da0977db20840628e946e4bd3b2ecb
+  depends:
+  - cuda-version >=13.3,<13.4.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports: {}
+  size: 39968
+  timestamp: 1779898421393
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-64-13.3.73-he91c749_0.conda
+  sha256: 7ae22c090ec77f76361360b87b9b7ec05a79f5847093eef3ddabd9c3011ce814
+  md5: c8e6ae26cd927c2024989e3dc384e7e4
+  depends:
+  - cuda-crt-dev_linux-64 13.3.73 ha770c72_0
+  - cuda-nvvm-dev_linux-64 13.3.73 ha770c72_0
+  - cuda-version >=13.3,<13.4.0a0
+  - libgcc >=6
+  - libnvptxcompiler-dev_linux-64 13.3.73 ha770c72_0
+  constrains:
+  - gcc_impl_linux-64 >=6,<16.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports: {}
+  size: 29208
+  timestamp: 1782783012737
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-64-13.3.73-ha770c72_0.conda
+  sha256: 64859da589e9d4512b564d813273407b30a4213238f787ef958b84a7960cf469
+  md5: ad71cad219a0ba0234e5592a279e8b3f
+  depends:
+  - cuda-version >=13.3,<13.4.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports: {}
+  size: 27969
+  timestamp: 1782782853086
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-13.3-hcbadf70_3.conda
+  sha256: bd8ee668f416bdd0f6548b2413550ae83d3834665a5be869a2daf99233ec526e
+  md5: 0fd72afdcc74560b80eb74b78767c454
+  constrains:
+  - __cuda >=13
+  - cudatoolkit 13.3|13.3.*
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports: {}
+  size: 22083
+  timestamp: 1779891651771
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-3.10.0-he073ed8_18.conda
   sha256: a922841ad80bd7b222502e65c07ecb67e4176c4fa5b03678a005f39fcc98be4b
   md5: ad8527bf134a90e1c9ed35fa0b64318c
@@ -6250,6 +6583,15 @@ packages:
   run_exports: {}
   size: 2344703
   timestamp: 1784923037742
+- conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-64-13.3.73-ha770c72_0.conda
+  sha256: ce0bfe25aa8a37bc3952a6e03c2011ccac21fae04ec8708b1dcbcdaa25855a44
+  md5: 97fc0cd4e5271c7f3c6266eaa2190079
+  depends:
+  - cuda-version >=13.3,<13.4.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  run_exports: {}
+  size: 10915505
+  timestamp: 1782782934448
 - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_120.conda
   sha256: 3cabbd98a31d584517c9d8588f5a5b32b49d9898bcce379f41f6138d5af6d6be
   md5: 05a8304d2ab5aa21c7144a114596f669

--- a/pixi.toml
+++ b/pixi.toml
@@ -23,7 +23,7 @@ cross-linux-arm64 = ["build", "package", "cross-linux-arm64"]
 cross-windows-arm64 = ["build", "package", "cross-windows-arm64"]
 node = ["node"]
 format = ["format"]
-test-run = ["test"]
+test-run = ["test", "cuda"]
 editor = ["editor", "node"]
 
 # ============================================================================== #
@@ -97,6 +97,16 @@ gxx = "==15.2.0"
 # The symbolization round-trip test replays the release strip/GSYM flow
 # (linux-only, like the crash tests it builds on).
 llvm-tools = "==22.1.8"
+
+# The NVCC toolchain tests drive a real nvcc; cudart is the runtime the
+# probe compiles against and curand is included unconditionally by clang's
+# CUDA wrapper header. Linux-only: there are no osx packages and the
+# Windows host compiler (cl) is not supported by the query yet. No GPU is
+# needed — compilation and the --dryrun probe are pure CPU.
+[feature.cuda.target.linux-64.dependencies]
+cuda-nvcc = "13.*"
+cuda-cudart-dev = "13.*"
+libcurand-dev = "*"
 
 # The linux-aarch64 cross-test job runs the integration suite on a native
 # arm64 runner, so the symbolization test needs the same tools there.

--- a/src/command/argument_parser.cpp
+++ b/src/command/argument_parser.cpp
@@ -387,6 +387,11 @@ bool is_c_family_file(llvm::StringRef filename) {
     if(ext.empty()) {
         return false;
     }
+    /// CUDA's header convention is missing from clang's extension table
+    /// (classifying one needs -x cuda), but it is C-family.
+    if(ext == ".cuh") {
+        return true;
+    }
     /// Drop the leading dot: ".cpp" -> "cpp".
     auto type = types::lookupTypeForExtension(ext.drop_front());
     return type != types::TY_INVALID && types::isAcceptedByClang(type);

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -455,14 +455,18 @@ CompileCommand CompilationDatabase::build_command(std::uint32_t path_id,
         flags.insert(flags.end(), args.begin(), args.end());
     };
 
+    bool is_nvcc =
+        Toolchain::driver_family(info->canonical->arguments.front()) == CompilerFamily::NVCC;
+
     /// Rule flags for an NVCC entry arrive in the same nvcc spellings as
-    /// the command they edit — rewrite them like the command itself, so
-    /// removes match the translated canonical and appends reach clang in
-    /// spellings it parses.
-    auto translate_rule_flags = [&](llvm::ArrayRef<std::string> rule_flags) {
+    /// the command they edit — rewrite them like the command itself. Removes
+    /// translate standalone so they reproduce exactly the flags the base
+    /// translation emitted; appends translate as edits so an appended
+    /// default state (`-rdc=false` over an rdc base) cancels the base's
+    /// translated state instead of vanishing.
+    auto translate_rule_flags = [&](llvm::ArrayRef<std::string> rule_flags, bool edit) {
         std::vector<std::string> result(rule_flags.begin(), rule_flags.end());
-        if(result.empty() ||
-           Toolchain::driver_family(info->canonical->arguments.front()) != CompilerFamily::NVCC) {
+        if(result.empty() || !is_nvcc) {
             return result;
         }
         std::vector<const char*> argv;
@@ -471,7 +475,7 @@ CompileCommand CompilationDatabase::build_command(std::uint32_t path_id,
         for(auto& arg: result) {
             argv.push_back(arg.c_str());
         }
-        auto translated = translate_nvcc_command(argv, directory);
+        auto translated = translate_nvcc_command(argv, directory, edit);
         result.assign(std::make_move_iterator(translated.begin() + 1),
                       std::make_move_iterator(translated.end()));
         return result;
@@ -488,7 +492,31 @@ CompileCommand CompilationDatabase::build_command(std::uint32_t path_id,
     }
 
     // Apply remove filter.
-    auto remove_flags = translate_rule_flags(options.remove);
+    std::vector<std::string> remove_source(options.remove.begin(), options.remove.end());
+    if(is_nvcc) {
+        /// A wildcard arch removal (`-arch=*`, `--generate-code=*`) names no
+        /// concrete architecture, so translating it emits nothing and the
+        /// rule silently misses — rewrite it to the wildcard form of the
+        /// arch option the translated base actually carries.
+        for(std::size_t i = 0; i < remove_source.size(); i += 1) {
+            llvm::StringRef flag = remove_source[i];
+            for(llvm::StringRef spelling:
+                {"-arch", "--gpu-architecture", "-gencode", "--generate-code"}) {
+                bool joined = flag.starts_with(spelling) && flag.substr(spelling.size()) == "=*";
+                bool separate =
+                    flag == spelling && i + 1 < remove_source.size() && remove_source[i + 1] == "*";
+                if(!joined && !separate) {
+                    continue;
+                }
+                if(separate) {
+                    remove_source.erase(remove_source.begin() + i + 1);
+                }
+                remove_source[i] = "--cuda-gpu-arch=*";
+                break;
+            }
+        }
+    }
+    auto remove_flags = translate_rule_flags(remove_source, /*edit=*/false);
     if(!remove_flags.empty()) {
         std::vector<kota::option::ParsedArg> remove_args;
         for(auto& result: option::table().parse(remove_flags)) {
@@ -539,7 +567,7 @@ CompileCommand CompilationDatabase::build_command(std::uint32_t path_id,
         }
     }
 
-    for(auto& arg: translate_rule_flags(options.append)) {
+    for(auto& arg: translate_rule_flags(options.append, /*edit=*/true)) {
         append_arg(arg);
     }
 

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -494,10 +494,10 @@ CompileCommand CompilationDatabase::build_command(std::uint32_t path_id,
     // Apply remove filter.
     std::vector<std::string> remove_source(options.remove.begin(), options.remove.end());
     if(is_nvcc) {
-        /// A wildcard arch removal (`-arch=*`, `--generate-code=*`) names no
-        /// concrete architecture, so translating it emits nothing and the
-        /// rule silently misses — rewrite it to the wildcard form of the
-        /// arch option the translated base actually carries.
+        /// A wildcard arch removal (`-arch=*`, `--generate-code=*`) must
+        /// clear whichever form the translated base carries: numeric archs
+        /// become `--cuda-gpu-arch=`, non-numeric selections persist as
+        /// `-arch=` probe tokens — rewrite to both wildcards.
         for(std::size_t i = 0; i < remove_source.size(); i += 1) {
             llvm::StringRef flag = remove_source[i];
             for(llvm::StringRef spelling:
@@ -512,6 +512,8 @@ CompileCommand CompilationDatabase::build_command(std::uint32_t path_id,
                     remove_source.erase(remove_source.begin() + i + 1);
                 }
                 remove_source[i] = "--cuda-gpu-arch=*";
+                remove_source.insert(remove_source.begin() + i + 1, "-arch=*");
+                i += 1;
                 break;
             }
         }
@@ -544,9 +546,14 @@ CompileCommand CompilationDatabase::build_command(std::uint32_t path_id,
             bool removed = false;
             for(auto& remove: range) {
                 /// All unknown options share one id; their identity is the
-                /// spelling (NVCC probe flags persist as unknown tokens).
+                /// spelling (NVCC probe flags persist as unknown tokens). A
+                /// trailing `=*` wildcards the value part, mirroring the
+                /// known-option value wildcard below.
                 if(id == option::OPT_UNKNOWN) {
-                    if(arg.spelling == remove.spelling) {
+                    llvm::StringRef pattern = remove.spelling;
+                    bool wildcard = pattern.consume_back("*") && pattern.ends_with("=");
+                    if(wildcard ? llvm::StringRef(arg.spelling).starts_with(pattern)
+                                : arg.spelling == remove.spelling) {
                         removed = true;
                         break;
                     }

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -543,7 +543,11 @@ llvm::SmallVector<CompileCommand> CompilationDatabase::lookup(llvm::StringRef fi
         } else if(file.ends_with(".cu") || file.ends_with(".cuh")) {
             /// .cuh is not a clang-known extension: without -x the driver
             /// classifies it as linker input and builds no compile job.
-            flags = {"clang++", "-std=c++20", "-x", "cuda"};
+            /// Device-only pins the same device-side view NVCC-backed
+            /// commands default to, instead of whichever job the toolchain
+            /// query happens to pick from a two-sided compilation; a config
+            /// rule appending --cuda-host-only still wins as the later flag.
+            flags = {"clang++", "-std=c++20", "-x", "cuda", "--cuda-device-only"};
         } else {
             flags = {"clang"};
         }

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -459,11 +459,10 @@ CompileCommand CompilationDatabase::build_command(std::uint32_t path_id,
         Toolchain::driver_family(info->canonical->arguments.front()) == CompilerFamily::NVCC;
 
     /// Rule flags for an NVCC entry arrive in the same nvcc spellings as
-    /// the command they edit — rewrite them like the command itself. Removes
-    /// translate standalone so they reproduce exactly the flags the base
-    /// translation emitted; appends translate as edits so an appended
-    /// default state (`-rdc=false` over an rdc base) cancels the base's
-    /// translated state instead of vanishing.
+    /// the command they edit — rewrite them like the command itself.
+    /// Appends translate as one command edit, so an appended default state
+    /// (`-rdc=false` over an rdc base) cancels the base's translated state
+    /// instead of vanishing.
     auto translate_rule_flags = [&](llvm::ArrayRef<std::string> rule_flags, bool edit) {
         std::vector<std::string> result(rule_flags.begin(), rule_flags.end());
         if(result.empty() || !is_nvcc) {
@@ -518,7 +517,29 @@ CompileCommand CompilationDatabase::build_command(std::uint32_t path_id,
             }
         }
     }
-    auto remove_flags = translate_rule_flags(remove_source, /*edit=*/false);
+    /// Remove patterns are an independent list, not one command: translated
+    /// whole, nvcc's last-wins would swallow every alternative value of a
+    /// stateful option but the last. Each pattern translates alone —
+    /// standalone, so it reproduces exactly the flags the base translation
+    /// emitted — pairing a separate value token (never dash-led) with its
+    /// spelling.
+    std::vector<std::string> remove_flags;
+    if(is_nvcc) {
+        for(std::size_t i = 0; i < remove_source.size(); i += 1) {
+            std::size_t count = 1;
+            if(llvm::StringRef(remove_source[i]).starts_with("-") && i + 1 < remove_source.size() &&
+               !llvm::StringRef(remove_source[i + 1]).starts_with("-"))
+                count = 2;
+            auto pattern = translate_rule_flags(llvm::ArrayRef(remove_source).slice(i, count),
+                                                /*edit=*/false);
+            remove_flags.insert(remove_flags.end(),
+                                std::make_move_iterator(pattern.begin()),
+                                std::make_move_iterator(pattern.end()));
+            i += count - 1;
+        }
+    } else {
+        remove_flags = std::move(remove_source);
+    }
     if(!remove_flags.empty()) {
         std::vector<kota::option::ParsedArg> remove_args;
         for(auto& result: option::table().parse(remove_flags)) {

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -578,6 +578,12 @@ CompileCommand CompilationDatabase::build_command(std::uint32_t path_id,
         append_arg(arg);
     }
 
+    /// An appended -gencode adds its architecture next to the base's, the
+    /// way nvcc itself accumulates them — resolve them to the newest.
+    if(is_nvcc) {
+        collapse_gpu_arch_flags(flags);
+    }
+
     return CompileCommand{
         ResolvedFlags{directory, std::move(flags), false},
         paths.resolve(path_id).data()

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -455,6 +455,28 @@ CompileCommand CompilationDatabase::build_command(std::uint32_t path_id,
         flags.insert(flags.end(), args.begin(), args.end());
     };
 
+    /// Rule flags for an NVCC entry arrive in the same nvcc spellings as
+    /// the command they edit — rewrite them like the command itself, so
+    /// removes match the translated canonical and appends reach clang in
+    /// spellings it parses.
+    auto translate_rule_flags = [&](llvm::ArrayRef<std::string> rule_flags) {
+        std::vector<std::string> result(rule_flags.begin(), rule_flags.end());
+        if(result.empty() ||
+           Toolchain::driver_family(info->canonical->arguments.front()) != CompilerFamily::NVCC) {
+            return result;
+        }
+        std::vector<const char*> argv;
+        argv.reserve(result.size() + 1);
+        argv.push_back(info->canonical->arguments.front());
+        for(auto& arg: result) {
+            argv.push_back(arg.c_str());
+        }
+        auto translated = translate_nvcc_command(argv, directory);
+        result.assign(std::make_move_iterator(translated.begin() + 1),
+                      std::make_move_iterator(translated.end()));
+        return result;
+    };
+
     append_args(info->canonical->arguments);
     append_args(info->patch);
 
@@ -466,13 +488,10 @@ CompileCommand CompilationDatabase::build_command(std::uint32_t path_id,
     }
 
     // Apply remove filter.
-    if(!options.remove.empty()) {
-        std::vector<std::string> remove_strs;
-        for(auto& s: options.remove) {
-            remove_strs.push_back(s);
-        }
+    auto remove_flags = translate_rule_flags(options.remove);
+    if(!remove_flags.empty()) {
         std::vector<kota::option::ParsedArg> remove_args;
-        for(auto& result: option::table().parse(remove_strs)) {
+        for(auto& result: option::table().parse(remove_flags)) {
             if(result.has_value()) {
                 remove_args.push_back(*result);
             }
@@ -496,6 +515,15 @@ CompileCommand CompilationDatabase::build_command(std::uint32_t path_id,
             auto range = ranges::equal_range(remove_args, id, {}, get_id);
             bool removed = false;
             for(auto& remove: range) {
+                /// All unknown options share one id; their identity is the
+                /// spelling (NVCC probe flags persist as unknown tokens).
+                if(id == option::OPT_UNKNOWN) {
+                    if(arg.spelling == remove.spelling) {
+                        removed = true;
+                        break;
+                    }
+                    continue;
+                }
                 if(remove.values.size() == 1 && remove.values[0] == "*") {
                     removed = true;
                     break;
@@ -511,7 +539,7 @@ CompileCommand CompilationDatabase::build_command(std::uint32_t path_id,
         }
     }
 
-    for(auto& arg: options.append) {
+    for(auto& arg: translate_rule_flags(options.append)) {
         append_arg(arg);
     }
 

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -8,6 +8,8 @@
 #include <string_view>
 
 #include "simdjson.h"
+#include "command/nvcc.h"
+#include "command/toolchain.h"
 #include "support/filesystem.h"
 #include "support/logging.h"
 
@@ -84,6 +86,18 @@ object_ptr<CompilationInfo>
                                                llvm::StringRef directory,
                                                llvm::ArrayRef<const char*> arguments) {
     assert(!arguments.empty() && "arguments must contain at least the driver");
+
+    /// clang's option table cannot parse nvcc's own spellings, and the loop
+    /// below discards what it cannot parse — rewrite them first so the
+    /// regular classification applies.
+    std::vector<std::string> nvcc_translated;
+    llvm::SmallVector<const char*, 32> nvcc_arguments;
+    if(Toolchain::driver_family(arguments[0]) == CompilerFamily::NVCC) {
+        nvcc_translated = translate_nvcc_command(arguments).arguments;
+        for(auto& arg: nvcc_translated)
+            nvcc_arguments.push_back(arg.c_str());
+        arguments = nvcc_arguments;
+    }
 
     auto render_arg = [&](auto& out, const kota::option::ParsedArg& arg) {
         auto cb = [&](std::string_view s) {
@@ -166,6 +180,16 @@ object_ptr<CompilationInfo>
 
         /// Everything else goes into canonical.
         render_arg(canonical_args, arg);
+    }
+
+    /// The `-ccbin=` token the translation appended is unknown to the table
+    /// and was dropped above — the NVCC toolchain query needs it in canonical.
+    if(!nvcc_translated.empty()) {
+        for(llvm::StringRef arg: arguments) {
+            if(arg.starts_with(nvcc_ccbin_prefix)) {
+                canonical_args.push_back(strings.save(arg).data());
+            }
+        }
     }
 
     /// Dedup canonical command.
@@ -515,6 +539,10 @@ llvm::SmallVector<CompileCommand> CompilationDatabase::lookup(llvm::StringRef fi
         std::vector<const char*> flags;
         if(file.ends_with(".cpp") || file.ends_with(".hpp") || file.ends_with(".cc")) {
             flags = {"clang++", "-std=c++20"};
+        } else if(file.ends_with(".cu") || file.ends_with(".cuh")) {
+            /// .cuh is not a clang-known extension: without -x the driver
+            /// classifies it as linker input and builds no compile job.
+            flags = {"clang++", "-std=c++20", "-x", "cuda"};
         } else {
             flags = {"clang"};
         }

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -93,7 +93,7 @@ object_ptr<CompilationInfo>
     std::vector<std::string> nvcc_translated;
     llvm::SmallVector<const char*, 32> nvcc_arguments;
     if(Toolchain::driver_family(arguments[0]) == CompilerFamily::NVCC) {
-        nvcc_translated = translate_nvcc_command(arguments).arguments;
+        nvcc_translated = translate_nvcc_command(arguments, directory);
         for(auto& arg: nvcc_translated)
             nvcc_arguments.push_back(arg.c_str());
         arguments = nvcc_arguments;
@@ -182,11 +182,12 @@ object_ptr<CompilationInfo>
         render_arg(canonical_args, arg);
     }
 
-    /// The `-ccbin=` token the translation appended is unknown to the table
-    /// and was dropped above — the NVCC toolchain query needs it in canonical.
+    /// The probe-flag tokens the translation appended are unknown to the
+    /// table and were dropped above — the NVCC toolchain query needs them
+    /// in canonical.
     if(!nvcc_translated.empty()) {
         for(llvm::StringRef arg: arguments) {
-            if(arg.starts_with(nvcc_ccbin_prefix)) {
+            if(is_nvcc_probe_flag(arg)) {
                 canonical_args.push_back(strings.save(arg).data());
             }
         }

--- a/src/command/nvcc.cpp
+++ b/src/command/nvcc.cpp
@@ -4,12 +4,14 @@
 #include <format>
 
 #include "support/filesystem.h"
+#include "support/logging.h"
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Program.h"
 #include "llvm/Support/StringSaver.h"
 
@@ -17,7 +19,11 @@ namespace clice {
 
 namespace {
 
-/// One GPU architecture named inside an -arch/-code/-gencode value.
+constexpr llvm::StringLiteral ccbin_prefix = "-ccbin=";
+constexpr llvm::StringLiteral target_directory_prefix = "--target-directory=";
+constexpr llvm::StringLiteral allow_unsupported_flag = "--allow-unsupported-compiler";
+
+/// One GPU architecture named inside an -arch/-gencode value.
 struct ArchToken {
     unsigned number = 0;
 
@@ -25,8 +31,8 @@ struct ArchToken {
     char suffix = 0;
 };
 
-/// Scan a spec like "arch=compute_90a,code=[compute_90a,sm_90a]" for
-/// sm_NN / compute_NN tokens. `lto_NN` entries name LTO intermediates, not
+/// Scan a spec like "compute_90a" or "arch=compute_90a" for sm_NN /
+/// compute_NN tokens. `lto_NN` entries name LTO intermediates, not
 /// architectures, and are ignored.
 void collect_archs(llvm::StringRef spec, llvm::SmallVectorImpl<ArchToken>& out) {
     for(llvm::StringRef prefix: {"sm_", "compute_"}) {
@@ -53,6 +59,20 @@ void collect_archs(llvm::StringRef spec, llvm::SmallVectorImpl<ArchToken>& out) 
     }
 }
 
+/// Only the `arch=` clause of a -gencode value names the virtual
+/// architecture the device front end compiles for; `code=` entries are
+/// ptxas targets (`-gencode arch=compute_80,code=sm_90` preprocesses with
+/// `__CUDA_ARCH__` == 800).
+void collect_gencode_archs(llvm::StringRef spec, llvm::SmallVectorImpl<ArchToken>& out) {
+    llvm::SmallVector<llvm::StringRef> pieces;
+    spec.split(pieces, ',', -1, false);
+    for(llvm::StringRef piece: pieces) {
+        piece = piece.trim();
+        if(piece.consume_front("arch="))
+            collect_archs(piece, out);
+    }
+}
+
 /// The newest architecture wins; at equal number the fuller feature set does
 /// ('a' unlocks the arch-specific instructions the family 'f' and plain
 /// forms hide, e.g. sm_90a for Hopper GMMA/TMA).
@@ -69,16 +89,91 @@ std::string select_gpu_arch(llvm::ArrayRef<ArchToken> archs) {
     return result;
 }
 
+/// nvcc resolves relative paths against its working directory — the compile
+/// directory — not against ours.
+std::string absolutize(llvm::StringRef value, llvm::StringRef directory) {
+    if(value.empty() || directory.empty() || path::is_absolute(value))
+        return value.str();
+    return path::join(directory, value);
+}
+
+/// `--options-file` pulls additional nvcc arguments from a response file —
+/// CMake routes long CUDA include lists through one — so dropping it would
+/// lose every -I inside. Each pass splices all response files in place;
+/// repeated passes resolve nested files, with a small cap as a cycle guard.
+std::vector<std::string> expand_options_files(llvm::ArrayRef<const char*> arguments,
+                                              llvm::StringRef directory) {
+    std::vector<std::string> args(arguments.begin(), arguments.end());
+
+    for(int depth = 0; depth < 4; depth += 1) {
+        bool expanded = false;
+        std::vector<std::string> next;
+        next.reserve(args.size());
+
+        for(std::size_t i = 0; i < args.size(); i += 1) {
+            llvm::StringRef arg = args[i];
+            llvm::StringRef value;
+
+            if(arg == "-optf" || arg == "--options-file") {
+                if(i + 1 < args.size()) {
+                    i += 1;
+                    value = args[i];
+                }
+            } else if(arg.consume_front("-optf=") || arg.consume_front("--options-file=")) {
+                value = arg;
+            } else {
+                next.emplace_back(std::move(args[i]));
+                continue;
+            }
+
+            expanded = true;
+            llvm::SmallVector<llvm::StringRef> files;
+            value.split(files, ',', -1, false);
+            for(llvm::StringRef file: files) {
+                auto file_path = absolutize(file, directory);
+                auto buffer = llvm::MemoryBuffer::getFile(file_path);
+                if(!buffer) {
+                    LOG_WARN("Cannot read nvcc options file {}: {}",
+                             file_path,
+                             buffer.getError().message());
+                    continue;
+                }
+
+                llvm::BumpPtrAllocator alloc;
+                llvm::StringSaver saver(alloc);
+                llvm::SmallVector<const char*> tokens;
+                llvm::cl::TokenizeGNUCommandLine((*buffer)->getBuffer(), saver, tokens);
+                for(llvm::StringRef token: tokens)
+                    next.emplace_back(token);
+            }
+        }
+
+        args = std::move(next);
+        if(!expanded)
+            break;
+    }
+
+    return args;
+}
+
 }  // namespace
 
-NVCCCommand translate_nvcc_command(llvm::ArrayRef<const char*> arguments) {
-    NVCCCommand result;
-    result.arguments.emplace_back(arguments[0]);
+bool is_nvcc_probe_flag(llvm::StringRef arg) {
+    return arg.starts_with(ccbin_prefix) || arg == allow_unsupported_flag ||
+           arg.starts_with(target_directory_prefix);
+}
+
+std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> arguments,
+                                                llvm::StringRef directory) {
+    std::vector<std::string> result;
+    result.emplace_back(arguments[0]);
 
     llvm::SmallVector<ArchToken> archs;
     std::string host_compiler;
+    std::string target_directory;
+    bool allow_unsupported = false;
 
-    auto args = arguments.drop_front();
+    auto args = expand_options_files(arguments.drop_front(), directory);
 
     /// Match `-opt value` / `-opt=value` for any of the spellings, advancing
     /// past a separate value. A spelling at the end of the command matches
@@ -104,24 +199,45 @@ NVCCCommand translate_nvcc_command(llvm::ArrayRef<const char*> arguments) {
         return false;
     };
 
+    /// nvcc treats every preprocessor value as a comma-separated list,
+    /// short spellings included: `-Ia,b` names two directories.
+    auto emit_list = [&](llvm::StringRef flag, llvm::StringRef value) {
+        llvm::SmallVector<llvm::StringRef> pieces;
+        value.split(pieces, ',', -1, false);
+        for(auto piece: pieces) {
+            result.emplace_back(flag);
+            result.emplace_back(piece);
+        }
+    };
+
     for(std::size_t i = 0; i < args.size(); i += 1) {
         llvm::StringRef arg = args[i];
         llvm::StringRef value;
 
-        if(value_of(i,
-                    {"-gencode",
-                     "--generate-code",
-                     "-arch",
-                     "--gpu-architecture",
-                     "-code",
-                     "--gpu-code"},
-                    value)) {
+        if(value_of(i, {"-gencode", "--generate-code"}, value)) {
+            collect_gencode_archs(value, archs);
+            continue;
+        }
+        if(value_of(i, {"-arch", "--gpu-architecture"}, value)) {
             collect_archs(value, archs);
+            continue;
+        }
+        /// ptxas targets only — consumed so the value cannot leak, never
+        /// harvested.
+        if(value_of(i, {"-code", "--gpu-code"}, value)) {
             continue;
         }
 
         if(value_of(i, {"-ccbin", "--compiler-bindir"}, value)) {
-            host_compiler = value;
+            host_compiler = absolutize(value, directory);
+            continue;
+        }
+        if(arg == "--allow-unsupported-compiler" || arg == "-allow-unsupported-compiler") {
+            allow_unsupported = true;
+            continue;
+        }
+        if(value_of(i, {"-target-dir", "--target-directory"}, value)) {
+            target_directory = value;
             continue;
         }
 
@@ -130,72 +246,90 @@ NVCCCommand translate_nvcc_command(llvm::ArrayRef<const char*> arguments) {
             llvm::SmallVector<llvm::StringRef> pieces;
             value.split(pieces, ',', -1, false);
             for(auto piece: pieces)
-                result.arguments.emplace_back(piece);
+                result.emplace_back(piece);
             continue;
         }
 
         if(value_of(i, {"-std", "--std"}, value)) {
-            result.arguments.emplace_back(("-std=" + value).str());
+            result.emplace_back(("-std=" + value).str());
             continue;
         }
 
         if(value_of(i, {"-x", "--x"}, value)) {
-            result.arguments.emplace_back("-x");
-            result.arguments.emplace_back(value == "cu" ? "cuda" : value.str());
+            result.emplace_back("-x");
+            result.emplace_back(value == "cu" ? "cuda" : value.str());
             continue;
         }
 
         if(value_of(i, {"-rdc", "--relocatable-device-code"}, value)) {
             if(value == "true") {
-                result.arguments.emplace_back("-fgpu-rdc");
+                result.emplace_back("-fgpu-rdc");
                 /// nvcc defines it; clang's -fgpu-rdc does not.
-                result.arguments.emplace_back("-D__CUDACC_RDC__");
+                result.emplace_back("-D__CUDACC_RDC__");
             }
+            continue;
+        }
+        /// Separate compilation implies -rdc=true.
+        if(arg == "-dc" || arg == "--device-c") {
+            result.emplace_back("-fgpu-rdc");
+            result.emplace_back("-D__CUDACC_RDC__");
+            continue;
+        }
+        if(arg == "-ewp" || arg == "--extensible-whole-program") {
+            result.emplace_back("-D__CUDACC_EWP__");
             continue;
         }
 
         if(value_of(i, {"-default-stream", "--default-stream"}, value)) {
             if(value == "per-thread")
-                result.arguments.emplace_back("-DCUDA_API_PER_THREAD_DEFAULT_STREAM=1");
+                result.emplace_back("-DCUDA_API_PER_THREAD_DEFAULT_STREAM=1");
             continue;
         }
 
         /// Feature toggles whose only parse-visible effect is a macro.
         if(arg == "--expt-relaxed-constexpr" || arg == "-expt-relaxed-constexpr") {
-            result.arguments.emplace_back("-D__CUDACC_RELAXED_CONSTEXPR__");
+            result.emplace_back("-D__CUDACC_RELAXED_CONSTEXPR__");
             continue;
         }
         if(arg == "--expt-extended-lambda" || arg == "-expt-extended-lambda" ||
            arg == "--extended-lambda" || arg == "-extended-lambda") {
-            result.arguments.emplace_back("-D__CUDACC_EXTENDED_LAMBDA__");
+            result.emplace_back("-D__CUDACC_EXTENDED_LAMBDA__");
             continue;
         }
 
-        /// Long-form preprocessor aliases, rewritten to the short spellings
-        /// the CDB classification knows.
-        if(value_of(i, {"--define-macro"}, value)) {
-            result.arguments.emplace_back("-D");
-            result.arguments.emplace_back(value);
+        /// Preprocessor list options, rewritten to the short spellings the
+        /// CDB classification knows. The exact-spelling matches must come
+        /// before the direct-join ones: `-include` also starts with "-I".
+        if(value_of(i, {"-isystem", "--system-include"}, value)) {
+            emit_list("-isystem", value);
             continue;
         }
-        if(value_of(i, {"--undefine-macro"}, value)) {
-            result.arguments.emplace_back("-U");
-            result.arguments.emplace_back(value);
+        if(value_of(i, {"-include", "--pre-include"}, value)) {
+            emit_list("-include", value);
             continue;
         }
-        if(value_of(i, {"--include-path"}, value)) {
-            result.arguments.emplace_back("-I");
-            result.arguments.emplace_back(value);
+        if(arg.size() > 2 && arg.starts_with("-I") && arg[2] != '=') {
+            emit_list("-I", arg.substr(2));
             continue;
         }
-        if(value_of(i, {"--system-include", "-isystem"}, value)) {
-            result.arguments.emplace_back("-isystem");
-            result.arguments.emplace_back(value);
+        if(value_of(i, {"-I", "--include-path"}, value)) {
+            emit_list("-I", value);
             continue;
         }
-        if(value_of(i, {"--pre-include"}, value)) {
-            result.arguments.emplace_back("-include");
-            result.arguments.emplace_back(value);
+        if(arg.size() > 2 && arg.starts_with("-D") && arg[2] != '=') {
+            emit_list("-D", arg.substr(2));
+            continue;
+        }
+        if(value_of(i, {"-D", "--define-macro"}, value)) {
+            emit_list("-D", value);
+            continue;
+        }
+        if(arg.size() > 2 && arg.starts_with("-U") && arg[2] != '=') {
+            emit_list("-U", arg.substr(2));
+            continue;
+        }
+        if(value_of(i, {"-U", "--undefine-macro"}, value)) {
+            emit_list("-U", value);
             continue;
         }
 
@@ -214,22 +348,24 @@ NVCCCommand translate_nvcc_command(llvm::ArrayRef<const char*> arguments) {
                      "-Xlinker",
                      "--linker-options",
                      "-Xcudafe",
-                     "--options-file",
-                     "-optf",
                      "--threads",
                      "-t"},
                     value)) {
             continue;
         }
 
-        result.arguments.emplace_back(arg);
+        result.emplace_back(arg);
     }
 
     if(!archs.empty())
-        result.arguments.emplace_back("--cuda-gpu-arch=" + select_gpu_arch(archs));
+        result.emplace_back("--cuda-gpu-arch=" + select_gpu_arch(archs));
 
     if(!host_compiler.empty())
-        result.arguments.emplace_back((llvm::Twine(nvcc_ccbin_prefix) + host_compiler).str());
+        result.emplace_back((llvm::Twine(ccbin_prefix) + host_compiler).str());
+    if(allow_unsupported)
+        result.emplace_back(allow_unsupported_flag.str());
+    if(!target_directory.empty())
+        result.emplace_back((llvm::Twine(target_directory_prefix) + target_directory).str());
 
     return result;
 }

--- a/src/command/nvcc.cpp
+++ b/src/command/nvcc.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <format>
+#include <optional>
 
 #include "support/filesystem.h"
 #include "support/logging.h"
@@ -193,7 +194,8 @@ bool is_nvcc_probe_flag(llvm::StringRef arg) {
 }
 
 std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> arguments,
-                                                llvm::StringRef directory) {
+                                                llvm::StringRef directory,
+                                                bool edit) {
     std::vector<std::string> result;
     result.emplace_back(arguments[0]);
 
@@ -206,7 +208,7 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
     std::string target_directory;
     llvm::StringRef default_stream;
     bool allow_unsupported = false;
-    bool rdc = false;
+    std::optional<bool> rdc;
     bool ewp = false;
     bool relaxed_constexpr = false;
     bool extended_lambda = false;
@@ -416,10 +418,13 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
     /// later `-U` can undo them (`-dc -U__CUDACC_RDC__` parses without the
     /// RDC macro) — the synthetic ones render first.
     std::vector<std::string> prelude;
-    if(rdc) {
+    if(rdc == true) {
         prelude.emplace_back("-fgpu-rdc");
         /// nvcc defines it; clang's -fgpu-rdc does not.
         prelude.emplace_back("-D__CUDACC_RDC__");
+    } else if(edit && rdc == false) {
+        prelude.emplace_back("-fno-gpu-rdc");
+        prelude.emplace_back("-U__CUDACC_RDC__");
     }
     if(relaxed_constexpr)
         prelude.emplace_back("-D__CUDACC_RELAXED_CONSTEXPR__");
@@ -437,12 +442,17 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
     /// preprocessor flags.
     if(default_stream == "per-thread")
         result.emplace_back("-DCUDA_API_PER_THREAD_DEFAULT_STREAM=1");
+    else if(edit && !default_stream.empty())
+        result.emplace_back("-UCUDA_API_PER_THREAD_DEFAULT_STREAM");
 
     /// nvcc rejects mixing -gencode with -arch, so at most one list is
     /// populated.
     auto& archs = gencode_archs.empty() ? arch_archs : gencode_archs;
-    if(!archs.empty())
+    if(!archs.empty()) {
+        if(edit)
+            result.emplace_back("--no-offload-arch=all");
         result.emplace_back("--cuda-gpu-arch=" + select_gpu_arch(archs));
+    }
 
     if(!host_compiler.empty())
         result.emplace_back((llvm::Twine(ccbin_prefix) + host_compiler).str());

--- a/src/command/nvcc.cpp
+++ b/src/command/nvcc.cpp
@@ -32,6 +32,8 @@ struct ArchToken {
 
     /// 'a' (arch-specific) or 'f' (family) variant, 0 for the plain form.
     char suffix = 0;
+
+    bool operator==(const ArchToken&) const = default;
 };
 
 /// Scan a spec like "compute_90a" or "arch=compute_90a" for sm_NN /
@@ -211,6 +213,8 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
     std::string host_compiler;
     std::string target_directory;
     llvm::StringRef default_stream;
+    llvm::StringRef machine;
+    llvm::StringRef optimize;
     bool allow_unsupported = false;
     std::optional<bool> rdc;
     bool ewp = false;
@@ -317,17 +321,23 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
             continue;
         }
 
-        /// The joined short forms -m32/-m64 are already clang's spellings
-        /// and fall through below; a value nvcc rejects pins nothing.
+        /// The joined short forms -m32/-m64 are nvcc-fatal and fall through
+        /// below as clang's own spellings; a value nvcc rejects pins
+        /// nothing.
         if(value_of(i, {"-m", "--machine"}, value)) {
             if(value == "32" || value == "64")
-                result.emplace_back(("-m" + value).str());
+                machine = value;
             continue;
         }
 
-        /// Joined -O3 is already clang's spelling and falls through below.
         if(value_of(i, {"-O", "--optimize"}, value)) {
-            result.emplace_back(("-O" + value).str());
+            optimize = value;
+            continue;
+        }
+        /// nvcc reads joined -O3 as its own option, not host passthrough.
+        if(arg.size() > 2 && arg.starts_with("-O") &&
+           std::ranges::all_of(arg.drop_front(2), llvm::isDigit)) {
+            optimize = arg.drop_front(2);
             continue;
         }
 
@@ -462,22 +472,39 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
         prelude.emplace_back("-D__CUDACC_DEBUG__");
     if(use_fast_math)
         prelude.emplace_back("-fgpu-approx-transcendentals");
+    /// The stream cancellation also renders ahead of the segment's own
+    /// flags: the base's injected macro sits before the seam either way,
+    /// and an explicit -D of the macro inside this edit must survive the
+    /// -U, like it survives nvcc's absent injection.
+    if(edit && !default_stream.empty() && default_stream != "per-thread")
+        prelude.emplace_back("-UCUDA_API_PER_THREAD_DEFAULT_STREAM");
     result.insert(result.begin() + 1, prelude.begin(), prelude.end());
 
     /// The stream macro is nvcc's one exception: it lands after the user's
     /// preprocessor flags.
     if(default_stream == "per-thread")
         result.emplace_back("-DCUDA_API_PER_THREAD_DEFAULT_STREAM=1");
-    else if(edit && !default_stream.empty())
-        result.emplace_back("-UCUDA_API_PER_THREAD_DEFAULT_STREAM");
 
-    /// nvcc rejects mixing -gencode with -arch, so at most one list is
-    /// populated.
-    auto& archs = gencode_archs.empty() ? arch_archs : gencode_archs;
+    /// nvcc's own -O/-m always land after the -Xcompiler payloads on the
+    /// host line, beating them regardless of input order.
+    if(!machine.empty())
+        result.emplace_back(("-m" + machine).str());
+    if(!optimize.empty())
+        result.emplace_back(("-O" + optimize).str());
+
+    /// nvcc compiles the union of the -gencode entries and the (last-wins)
+    /// -arch choice, one device pass each — the newest of the union is the
+    /// view. A non-numeric -arch next to -gencode entries joins nvcc's
+    /// union too, but resolving it needs the dryrun; the numeric side
+    /// approximates the pick.
+    llvm::SmallVector<ArchToken> archs = gencode_archs;
+    archs.append(arch_archs.begin(), arch_archs.end());
     if(!archs.empty()) {
-        /// An -arch edit replaces the base's architectures like nvcc's own
-        /// last-wins; -gencode entries accumulate onto them instead, so an
-        /// appended one must not erase the base's choice.
+        /// A pure -arch edit replaces the base's architectures: nvcc itself
+        /// would union it with the base's -gencode entries, but an appended
+        /// -arch reads as the user picking the view outright. -gencode
+        /// edits accumulate like nvcc's own, emitted bare for
+        /// collapse_gpu_arch_flags to resolve against the base's.
         if(edit && gencode_archs.empty())
             result.emplace_back("--no-offload-arch=all");
         result.emplace_back("--cuda-gpu-arch=" + select_gpu_arch(archs));
@@ -503,16 +530,39 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
 void collapse_gpu_arch_flags(std::vector<const char*>& flags) {
     struct ActiveArch {
         std::size_t index;
+        llvm::SmallVector<ArchToken, 1> tokens;
         std::pair<unsigned, int> rank;
     };
 
     /// The arch flags still alive under clang's accumulate semantics:
-    /// --no-offload-arch=all erases everything before it.
+    /// --no-offload-arch=all erases everything before it, a specific
+    /// --no-offload-arch=sm_NN only its matches.
     llvm::SmallVector<ActiveArch> active;
     for(std::size_t i = 0; i < flags.size(); i += 1) {
         llvm::StringRef arg = flags[i];
         if(arg == "--no-offload-arch=all") {
             active.clear();
+            continue;
+        }
+        if(arg.starts_with("--no-offload-arch=")) {
+            llvm::SmallVector<ArchToken> removed;
+            collect_archs(arg.substr(arg.find('=') + 1), removed);
+            if(removed.empty())
+                return;
+            auto matched = [&](const ArchToken& token) {
+                return std::ranges::contains(removed, token);
+            };
+            for(std::size_t j = active.size(); j > 0;) {
+                j -= 1;
+                auto& entry = active[j];
+                if(std::ranges::none_of(entry.tokens, matched))
+                    continue;
+                /// A flag naming both erased and surviving architectures
+                /// cannot drop at flag granularity — bail like below.
+                if(!std::ranges::all_of(entry.tokens, matched))
+                    return;
+                active.erase(active.begin() + j);
+            }
             continue;
         }
         if(!arg.starts_with("--cuda-gpu-arch=") && !arg.starts_with("--offload-arch="))
@@ -526,7 +576,7 @@ void collapse_gpu_arch_flags(std::vector<const char*>& flags) {
         if(tokens.empty())
             return;
         auto rank = arch_rank(*std::ranges::max_element(tokens, {}, arch_rank));
-        active.push_back({.index = i, .rank = rank});
+        active.push_back({.index = i, .tokens = std::move(tokens), .rank = rank});
     }
     if(active.size() < 2)
         return;

--- a/src/command/nvcc.cpp
+++ b/src/command/nvcc.cpp
@@ -210,6 +210,7 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
     bool ewp = false;
     bool relaxed_constexpr = false;
     bool extended_lambda = false;
+    bool device_debug = false;
 
     auto args = expand_options_files(arguments.drop_front(), directory);
 
@@ -335,6 +336,12 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
             extended_lambda = true;
             continue;
         }
+        /// Consumed rather than passed through: clang reads a bare -G as
+        /// its small-data-threshold option.
+        if(arg == "-G" || arg == "--device-debug") {
+            device_debug = true;
+            continue;
+        }
 
         /// Preprocessor list options, rewritten to the short spellings the
         /// CDB classification knows. The exact-spelling matches must come
@@ -411,6 +418,8 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
         prelude.emplace_back("-D__CUDACC_EXTENDED_LAMBDA__");
     if(ewp)
         prelude.emplace_back("-D__CUDACC_EWP__");
+    if(device_debug)
+        prelude.emplace_back("-D__CUDACC_DEBUG__");
     result.insert(result.begin() + 1, prelude.begin(), prelude.end());
 
     /// The stream macro is nvcc's one exception: it lands after the user's

--- a/src/command/nvcc.cpp
+++ b/src/command/nvcc.cpp
@@ -153,23 +153,28 @@ std::vector<std::string> expand_options_files(llvm::ArrayRef<const char*> argume
             }
 
             expanded = true;
-            /// The value is one file path, taken verbatim: comma-splitting
-            /// it would shred native Windows paths.
-            auto file_path = absolutize(value, directory);
-            auto buffer = llvm::MemoryBuffer::getFile(file_path);
-            if(!buffer) {
-                LOG_WARN("Cannot read nvcc options file {}: {}",
-                         file_path,
-                         buffer.getError().message());
-                continue;
-            }
+            /// The value is a comma-separated file list (`-optf a.rsp,b.rsp`
+            /// reads both); a literal comma in a path arrives escaped as
+            /// `\,`, so the split leaves native Windows paths intact.
+            llvm::SmallVector<std::string> files;
+            split_list(value, files);
+            for(llvm::StringRef file: files) {
+                auto file_path = absolutize(file, directory);
+                auto buffer = llvm::MemoryBuffer::getFile(file_path);
+                if(!buffer) {
+                    LOG_WARN("Cannot read nvcc options file {}: {}",
+                             file_path,
+                             buffer.getError().message());
+                    continue;
+                }
 
-            llvm::BumpPtrAllocator alloc;
-            llvm::StringSaver saver(alloc);
-            llvm::SmallVector<const char*> tokens;
-            llvm::cl::TokenizeGNUCommandLine((*buffer)->getBuffer(), saver, tokens);
-            for(llvm::StringRef token: tokens)
-                next.emplace_back(token);
+                llvm::BumpPtrAllocator alloc;
+                llvm::StringSaver saver(alloc);
+                llvm::SmallVector<const char*> tokens;
+                llvm::cl::TokenizeGNUCommandLine((*buffer)->getBuffer(), saver, tokens);
+                for(llvm::StringRef token: tokens)
+                    next.emplace_back(token);
+            }
         }
 
         args = std::move(next);
@@ -279,12 +284,14 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
             continue;
         }
 
-        /// nvcc packs several host flags into one comma-separated value.
+        /// nvcc packs several host flags into one comma-separated value,
+        /// under the same `\,` escape as every other list option
+        /// (`-Xcompiler=-Wl\,-z\,defs` reaches the host as one flag).
         if(value_of(i, {"-Xcompiler", "--compiler-options"}, value)) {
-            llvm::SmallVector<llvm::StringRef> pieces;
-            value.split(pieces, ',', -1, false);
-            for(auto piece: pieces)
-                result.emplace_back(piece);
+            llvm::SmallVector<std::string> pieces;
+            split_list(value, pieces);
+            for(auto& piece: pieces)
+                result.emplace_back(std::move(piece));
             continue;
         }
 
@@ -429,6 +436,7 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
 
 std::expected<NVCCDryrunInfo, std::string> parse_nvcc_dryrun(llvm::StringRef output) {
     NVCCDryrunInfo info;
+    llvm::StringRef nvvm_dir;
 
     auto harvest_defines = [](llvm::ArrayRef<const char*> tokens, std::vector<std::string>& out) {
         for(llvm::StringRef token: tokens) {
@@ -454,6 +462,11 @@ std::expected<NVCCDryrunInfo, std::string> parse_nvcc_dryrun(llvm::StringRef out
 
         if(line.consume_front("TOP=")) {
             info.cuda_path = line.trim();
+            continue;
+        }
+
+        if(line.consume_front("NVVMIR_LIBRARY_DIR=")) {
+            nvvm_dir = line.trim();
             continue;
         }
 
@@ -516,8 +529,11 @@ std::expected<NVCCDryrunInfo, std::string> parse_nvcc_dryrun(llvm::StringRef out
         harvest_defines(tail, is_device ? info.device_defines : info.host_defines);
     }
 
-    if(info.cuda_path.empty())
-        return std::unexpected("nvcc dryrun output has no TOP= line naming the toolkit root");
+    /// A dryrun without `TOP=` still names the toolkit root indirectly:
+    /// `NVVMIR_LIBRARY_DIR=` is `<root>/nvvm/libdevice`.
+    if(info.cuda_path.empty() && !nvvm_dir.empty())
+        info.cuda_path = path::parent_path(path::parent_path(nvvm_dir));
+
     if(info.host_compiler.empty())
         return std::unexpected("nvcc dryrun output has no host preprocess command");
 

--- a/src/command/nvcc.cpp
+++ b/src/command/nvcc.cpp
@@ -398,8 +398,6 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
         /// nvcc defines it; clang's -fgpu-rdc does not.
         prelude.emplace_back("-D__CUDACC_RDC__");
     }
-    if(default_stream == "per-thread")
-        prelude.emplace_back("-DCUDA_API_PER_THREAD_DEFAULT_STREAM=1");
     if(relaxed_constexpr)
         prelude.emplace_back("-D__CUDACC_RELAXED_CONSTEXPR__");
     if(extended_lambda)
@@ -407,6 +405,11 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
     if(ewp)
         prelude.emplace_back("-D__CUDACC_EWP__");
     result.insert(result.begin() + 1, prelude.begin(), prelude.end());
+
+    /// The stream macro is nvcc's one exception: it lands after the user's
+    /// preprocessor flags.
+    if(default_stream == "per-thread")
+        result.emplace_back("-DCUDA_API_PER_THREAD_DEFAULT_STREAM=1");
 
     /// nvcc rejects mixing -gencode with -arch, so at most one list is
     /// populated.

--- a/src/command/nvcc.cpp
+++ b/src/command/nvcc.cpp
@@ -211,6 +211,7 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
     bool relaxed_constexpr = false;
     bool extended_lambda = false;
     bool device_debug = false;
+    bool use_fast_math = false;
 
     auto args = expand_options_files(arguments.drop_front(), directory);
 
@@ -342,6 +343,14 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
             device_debug = true;
             continue;
         }
+        /// Device fast math has no preprocess-visible effect in nvcc (cicc
+        /// swaps the transcendentals itself); clang's flag selects the same
+        /// fast variants in its math wrapper via
+        /// __CLANG_GPU_APPROX_TRANSCENDENTALS__.
+        if(arg == "--use_fast_math" || arg == "-use_fast_math") {
+            use_fast_math = true;
+            continue;
+        }
 
         /// Preprocessor list options, rewritten to the short spellings the
         /// CDB classification knows. The exact-spelling matches must come
@@ -420,6 +429,8 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
         prelude.emplace_back("-D__CUDACC_EWP__");
     if(device_debug)
         prelude.emplace_back("-D__CUDACC_DEBUG__");
+    if(use_fast_math)
+        prelude.emplace_back("-fgpu-approx-transcendentals");
     result.insert(result.begin() + 1, prelude.begin(), prelude.end());
 
     /// The stream macro is nvcc's one exception: it lands after the user's
@@ -446,6 +457,7 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
 std::expected<NVCCDryrunInfo, std::string> parse_nvcc_dryrun(llvm::StringRef output) {
     NVCCDryrunInfo info;
     llvm::StringRef nvvm_dir;
+    llvm::SmallVector<const char*, 64> first_command;
 
     auto harvest_defines = [](llvm::ArrayRef<const char*> tokens, std::vector<std::string>& out) {
         for(llvm::StringRef token: tokens) {
@@ -524,6 +536,10 @@ std::expected<NVCCDryrunInfo, std::string> parse_nvcc_dryrun(llvm::StringRef out
         }
 
         auto tail = llvm::ArrayRef(tokens).drop_front();
+
+        if(first_command.empty())
+            first_command.assign(tokens.begin(), tokens.end());
+
         bool is_preprocess = std::ranges::contains(tail, llvm::StringRef("-E"));
         if(!is_preprocess)
             continue;
@@ -543,8 +559,21 @@ std::expected<NVCCDryrunInfo, std::string> parse_nvcc_dryrun(llvm::StringRef out
     if(info.cuda_path.empty() && !nvvm_dir.empty())
         info.cuda_path = path::parent_path(path::parent_path(nvvm_dir));
 
+    /// A host-language input (`nvcc -c foo.cpp`) compiles in a single host
+    /// step with no preprocess stage: the first pipeline command is the
+    /// host compile line. Its defines are kept unfiltered — outside CUDA
+    /// mode clang derives none of them (nvcc injects even
+    /// __CUDA_ARCH_LIST__ there).
+    if(info.host_compiler.empty() && !first_command.empty()) {
+        info.host_compiler = first_command[0];
+        for(llvm::StringRef token: llvm::ArrayRef(first_command).drop_front()) {
+            if(token.consume_front("-D"))
+                info.host_defines.emplace_back(token);
+        }
+    }
+
     if(info.host_compiler.empty())
-        return std::unexpected("nvcc dryrun output has no host preprocess command");
+        return std::unexpected("nvcc dryrun output has no host compile command");
 
     return info;
 }

--- a/src/command/nvcc.cpp
+++ b/src/command/nvcc.cpp
@@ -90,22 +90,24 @@ std::string select_gpu_arch(llvm::ArrayRef<ArchToken> archs) {
 }
 
 /// nvcc resolves relative paths against its working directory — the compile
-/// directory — not against ours.
+/// directory — not against ours. A leading slash is absolute on POSIX and
+/// root-relative on Windows: never compile-directory-relative.
 std::string absolutize(llvm::StringRef value, llvm::StringRef directory) {
-    if(value.empty() || directory.empty() || path::is_absolute(value))
+    if(value.empty() || directory.empty() || path::is_absolute(value) || value.front() == '/')
         return value.str();
     return path::join(directory, value);
 }
 
-/// Split on unescaped commas. nvcc's backslash escapes the next character
-/// unconditionally (`a\,b` is one value with a comma, `a\\,b` is `a\` and
-/// `b`, `a\x` is `ax`).
+/// Split on unescaped commas, `\,` reading as a literal comma. Other
+/// backslashes stay verbatim: they are path separators on Windows, and
+/// nvcc's fuller Linux-side escape processing (a backslash escapes any next
+/// character) would destroy every native path.
 void split_list(llvm::StringRef value, llvm::SmallVectorImpl<std::string>& out) {
     std::string piece;
     for(std::size_t i = 0; i < value.size(); i += 1) {
         char c = value[i];
-        if(c == '\\' && i + 1 < value.size()) {
-            piece += value[i + 1];
+        if(c == '\\' && i + 1 < value.size() && value[i + 1] == ',') {
+            piece += ',';
             i += 1;
             continue;
         }
@@ -151,25 +153,23 @@ std::vector<std::string> expand_options_files(llvm::ArrayRef<const char*> argume
             }
 
             expanded = true;
-            llvm::SmallVector<std::string> files;
-            split_list(value, files);
-            for(llvm::StringRef file: files) {
-                auto file_path = absolutize(file, directory);
-                auto buffer = llvm::MemoryBuffer::getFile(file_path);
-                if(!buffer) {
-                    LOG_WARN("Cannot read nvcc options file {}: {}",
-                             file_path,
-                             buffer.getError().message());
-                    continue;
-                }
-
-                llvm::BumpPtrAllocator alloc;
-                llvm::StringSaver saver(alloc);
-                llvm::SmallVector<const char*> tokens;
-                llvm::cl::TokenizeGNUCommandLine((*buffer)->getBuffer(), saver, tokens);
-                for(llvm::StringRef token: tokens)
-                    next.emplace_back(token);
+            /// The value is one file path, taken verbatim: comma-splitting
+            /// it would shred native Windows paths.
+            auto file_path = absolutize(value, directory);
+            auto buffer = llvm::MemoryBuffer::getFile(file_path);
+            if(!buffer) {
+                LOG_WARN("Cannot read nvcc options file {}: {}",
+                         file_path,
+                         buffer.getError().message());
+                continue;
             }
+
+            llvm::BumpPtrAllocator alloc;
+            llvm::StringSaver saver(alloc);
+            llvm::SmallVector<const char*> tokens;
+            llvm::cl::TokenizeGNUCommandLine((*buffer)->getBuffer(), saver, tokens);
+            for(llvm::StringRef token: tokens)
+                next.emplace_back(token);
         }
 
         args = std::move(next);

--- a/src/command/nvcc.cpp
+++ b/src/command/nvcc.cpp
@@ -1,0 +1,334 @@
+#include "command/nvcc.h"
+
+#include <algorithm>
+#include <format>
+
+#include "support/filesystem.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Support/Allocator.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Program.h"
+#include "llvm/Support/StringSaver.h"
+
+namespace clice {
+
+namespace {
+
+/// One GPU architecture named inside an -arch/-code/-gencode value.
+struct ArchToken {
+    unsigned number = 0;
+
+    /// 'a' (arch-specific) or 'f' (family) variant, 0 for the plain form.
+    char suffix = 0;
+};
+
+/// Scan a spec like "arch=compute_90a,code=[compute_90a,sm_90a]" for
+/// sm_NN / compute_NN tokens. `lto_NN` entries name LTO intermediates, not
+/// architectures, and are ignored.
+void collect_archs(llvm::StringRef spec, llvm::SmallVectorImpl<ArchToken>& out) {
+    for(llvm::StringRef prefix: {"sm_", "compute_"}) {
+        std::size_t pos = 0;
+        while((pos = spec.find(prefix, pos)) != llvm::StringRef::npos) {
+            pos += prefix.size();
+            auto rest = spec.substr(pos);
+
+            unsigned number = 0;
+            std::size_t len = 0;
+            while(len < rest.size() && llvm::isDigit(rest[len])) {
+                number = number * 10 + (rest[len] - '0');
+                len += 1;
+            }
+            if(len == 0)
+                continue;
+
+            char suffix = 0;
+            if(len < rest.size() && llvm::isAlpha(rest[len]))
+                suffix = rest[len];
+
+            out.push_back({number, suffix});
+        }
+    }
+}
+
+/// The newest architecture wins; at equal number the fuller feature set does
+/// ('a' unlocks the arch-specific instructions the family 'f' and plain
+/// forms hide, e.g. sm_90a for Hopper GMMA/TMA).
+std::string select_gpu_arch(llvm::ArrayRef<ArchToken> archs) {
+    auto rank = [](const ArchToken& arch) {
+        auto suffix_rank = arch.suffix == 'a' ? 2 : arch.suffix == 'f' ? 1 : 0;
+        return std::pair(arch.number, suffix_rank);
+    };
+    auto best = *std::ranges::max_element(archs, {}, rank);
+
+    auto result = std::format("sm_{}", best.number);
+    if(best.suffix != 0)
+        result += best.suffix;
+    return result;
+}
+
+}  // namespace
+
+NVCCCommand translate_nvcc_command(llvm::ArrayRef<const char*> arguments) {
+    NVCCCommand result;
+    result.arguments.emplace_back(arguments[0]);
+
+    llvm::SmallVector<ArchToken> archs;
+    std::string host_compiler;
+
+    auto args = arguments.drop_front();
+
+    /// Match `-opt value` / `-opt=value` for any of the spellings, advancing
+    /// past a separate value. A spelling at the end of the command matches
+    /// with an empty value.
+    auto value_of = [&](std::size_t& i,
+                        std::initializer_list<llvm::StringRef> spellings,
+                        llvm::StringRef& value) {
+        llvm::StringRef arg = args[i];
+        for(auto spelling: spellings) {
+            if(arg == spelling) {
+                value = {};
+                if(i + 1 < args.size()) {
+                    i += 1;
+                    value = args[i];
+                }
+                return true;
+            }
+            if(arg.starts_with(spelling) && arg[spelling.size()] == '=') {
+                value = arg.substr(spelling.size() + 1);
+                return true;
+            }
+        }
+        return false;
+    };
+
+    for(std::size_t i = 0; i < args.size(); i += 1) {
+        llvm::StringRef arg = args[i];
+        llvm::StringRef value;
+
+        if(value_of(i,
+                    {"-gencode",
+                     "--generate-code",
+                     "-arch",
+                     "--gpu-architecture",
+                     "-code",
+                     "--gpu-code"},
+                    value)) {
+            collect_archs(value, archs);
+            continue;
+        }
+
+        if(value_of(i, {"-ccbin", "--compiler-bindir"}, value)) {
+            host_compiler = value;
+            continue;
+        }
+
+        /// nvcc packs several host flags into one comma-separated value.
+        if(value_of(i, {"-Xcompiler", "--compiler-options"}, value)) {
+            llvm::SmallVector<llvm::StringRef> pieces;
+            value.split(pieces, ',', -1, false);
+            for(auto piece: pieces)
+                result.arguments.emplace_back(piece);
+            continue;
+        }
+
+        if(value_of(i, {"-std", "--std"}, value)) {
+            result.arguments.emplace_back(("-std=" + value).str());
+            continue;
+        }
+
+        if(value_of(i, {"-x", "--x"}, value)) {
+            result.arguments.emplace_back("-x");
+            result.arguments.emplace_back(value == "cu" ? "cuda" : value.str());
+            continue;
+        }
+
+        if(value_of(i, {"-rdc", "--relocatable-device-code"}, value)) {
+            if(value == "true") {
+                result.arguments.emplace_back("-fgpu-rdc");
+                /// nvcc defines it; clang's -fgpu-rdc does not.
+                result.arguments.emplace_back("-D__CUDACC_RDC__");
+            }
+            continue;
+        }
+
+        if(value_of(i, {"-default-stream", "--default-stream"}, value)) {
+            if(value == "per-thread")
+                result.arguments.emplace_back("-DCUDA_API_PER_THREAD_DEFAULT_STREAM=1");
+            continue;
+        }
+
+        /// Feature toggles whose only parse-visible effect is a macro.
+        if(arg == "--expt-relaxed-constexpr" || arg == "-expt-relaxed-constexpr") {
+            result.arguments.emplace_back("-D__CUDACC_RELAXED_CONSTEXPR__");
+            continue;
+        }
+        if(arg == "--expt-extended-lambda" || arg == "-expt-extended-lambda" ||
+           arg == "--extended-lambda" || arg == "-extended-lambda") {
+            result.arguments.emplace_back("-D__CUDACC_EXTENDED_LAMBDA__");
+            continue;
+        }
+
+        /// Long-form preprocessor aliases, rewritten to the short spellings
+        /// the CDB classification knows.
+        if(value_of(i, {"--define-macro"}, value)) {
+            result.arguments.emplace_back("-D");
+            result.arguments.emplace_back(value);
+            continue;
+        }
+        if(value_of(i, {"--undefine-macro"}, value)) {
+            result.arguments.emplace_back("-U");
+            result.arguments.emplace_back(value);
+            continue;
+        }
+        if(value_of(i, {"--include-path"}, value)) {
+            result.arguments.emplace_back("-I");
+            result.arguments.emplace_back(value);
+            continue;
+        }
+        if(value_of(i, {"--system-include", "-isystem"}, value)) {
+            result.arguments.emplace_back("-isystem");
+            result.arguments.emplace_back(value);
+            continue;
+        }
+        if(value_of(i, {"--pre-include"}, value)) {
+            result.arguments.emplace_back("-include");
+            result.arguments.emplace_back(value);
+            continue;
+        }
+
+        /// Pass-through wrappers for other tools: dropped together with the
+        /// value, which could otherwise be mistaken for a host flag
+        /// (`-Xptxas -O3` sets the ptxas level, not the host one).
+        if(value_of(i,
+                    {"-Xptxas",
+                     "--ptxas-options",
+                     "-Xnvlink",
+                     "--nvlink-options",
+                     "-Xfatbin",
+                     "--fatbin-options",
+                     "-Xarchive",
+                     "--archive-options",
+                     "-Xlinker",
+                     "--linker-options",
+                     "-Xcudafe",
+                     "--options-file",
+                     "-optf",
+                     "--threads",
+                     "-t"},
+                    value)) {
+            continue;
+        }
+
+        result.arguments.emplace_back(arg);
+    }
+
+    if(!archs.empty())
+        result.arguments.emplace_back("--cuda-gpu-arch=" + select_gpu_arch(archs));
+
+    if(!host_compiler.empty())
+        result.arguments.emplace_back((llvm::Twine(nvcc_ccbin_prefix) + host_compiler).str());
+
+    return result;
+}
+
+std::expected<NVCCDryrunInfo, std::string> parse_nvcc_dryrun(llvm::StringRef output) {
+    NVCCDryrunInfo info;
+
+    auto harvest_defines = [](llvm::ArrayRef<const char*> tokens, std::vector<std::string>& out) {
+        for(llvm::StringRef token: tokens) {
+            if(!token.consume_front("-D"))
+                continue;
+            auto name = token.substr(0, token.find('='));
+            if(name == "__CUDACC__" || name == "__CUDA_ARCH__" || name == "__CUDA_ARCH_LIST__")
+                continue;
+            out.emplace_back(token);
+        }
+    };
+
+    llvm::BumpPtrAllocator alloc;
+    llvm::StringSaver saver(alloc);
+
+    llvm::SmallVector<llvm::StringRef> lines;
+    output.split(lines, '\n', -1, false);
+
+    for(llvm::StringRef line: lines) {
+        line = line.trim();
+        if(!line.consume_front("#$ "))
+            continue;
+
+        if(line.consume_front("TOP=")) {
+            info.cuda_path = line.trim();
+            continue;
+        }
+
+        if(line.consume_front("PATH=")) {
+            llvm::SmallVector<llvm::StringRef> dirs;
+            line.split(dirs, llvm::sys::EnvPathSeparator, -1, false);
+            for(auto dir: dirs)
+                info.search_path.emplace_back(dir);
+            continue;
+        }
+
+        /// Remaining lines are either environment assignments (INCLUDES=...,
+        /// CICC_PATH=..., no space before '=') or pipeline commands.
+        auto head = line.take_until([](char c) { return c == ' '; });
+        if(head.contains('='))
+            continue;
+
+        llvm::SmallVector<const char*, 64> tokens;
+        llvm::cl::TokenizeGNUCommandLine(line, saver, tokens);
+        if(tokens.empty())
+            continue;
+
+        llvm::StringRef argv0 = tokens[0];
+        auto program = path::filename(argv0);
+
+        if(program == "cudafe++") {
+            for(llvm::StringRef token: tokens) {
+                if(token.starts_with("--c++")) {
+                    info.cpp_dialect = token.substr(2);
+                    break;
+                }
+            }
+            continue;
+        }
+
+        if(program == "cicc") {
+            for(std::size_t i = 0; i + 1 < tokens.size(); i += 1) {
+                llvm::StringRef token = tokens[i];
+                llvm::StringRef arch = tokens[i + 1];
+                if(token == "-arch" && arch.consume_front("compute_")) {
+                    info.default_arch = ("sm_" + arch).str();
+                    break;
+                }
+            }
+            continue;
+        }
+
+        auto tail = llvm::ArrayRef(tokens).drop_front();
+        bool is_preprocess = std::ranges::contains(tail, llvm::StringRef("-E"));
+        if(!is_preprocess)
+            continue;
+
+        bool is_device = std::ranges::any_of(tail, [](llvm::StringRef token) {
+            return token.starts_with("-D__CUDA_ARCH__");
+        });
+
+        if(info.host_compiler.empty())
+            info.host_compiler = argv0;
+
+        harvest_defines(tail, is_device ? info.device_defines : info.host_defines);
+    }
+
+    if(info.cuda_path.empty())
+        return std::unexpected("nvcc dryrun output has no TOP= line naming the toolkit root");
+    if(info.host_compiler.empty())
+        return std::unexpected("nvcc dryrun output has no host preprocess command");
+
+    return info;
+}
+
+}  // namespace clice

--- a/src/command/nvcc.cpp
+++ b/src/command/nvcc.cpp
@@ -97,6 +97,29 @@ std::string absolutize(llvm::StringRef value, llvm::StringRef directory) {
     return path::join(directory, value);
 }
 
+/// Split on unescaped commas: nvcc reads `\,` as a literal comma inside a
+/// value (`-DFOO=a\,b` defines FOO=a,b).
+void split_list(llvm::StringRef value, llvm::SmallVectorImpl<std::string>& out) {
+    std::string piece;
+    for(std::size_t i = 0; i < value.size(); i += 1) {
+        char c = value[i];
+        if(c == '\\' && i + 1 < value.size() && value[i + 1] == ',') {
+            piece += ',';
+            i += 1;
+            continue;
+        }
+        if(c == ',') {
+            if(!piece.empty())
+                out.push_back(std::move(piece));
+            piece.clear();
+            continue;
+        }
+        piece += c;
+    }
+    if(!piece.empty())
+        out.push_back(std::move(piece));
+}
+
 /// `--options-file` pulls additional nvcc arguments from a response file —
 /// CMake routes long CUDA include lists through one — so dropping it would
 /// lose every -I inside. Each pass splices all response files in place;
@@ -127,8 +150,8 @@ std::vector<std::string> expand_options_files(llvm::ArrayRef<const char*> argume
             }
 
             expanded = true;
-            llvm::SmallVector<llvm::StringRef> files;
-            value.split(files, ',', -1, false);
+            llvm::SmallVector<std::string> files;
+            split_list(value, files);
             for(llvm::StringRef file: files) {
                 auto file_path = absolutize(file, directory);
                 auto buffer = llvm::MemoryBuffer::getFile(file_path);
@@ -168,10 +191,16 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
     std::vector<std::string> result;
     result.emplace_back(arguments[0]);
 
-    llvm::SmallVector<ArchToken> archs;
+    /// Stateful nvcc options are last-wins (`-rdc=true -rdc=false` compiles
+    /// without relocatable device code), so they collect here and render
+    /// once at the end. -gencode is the exception: entries accumulate.
+    llvm::SmallVector<ArchToken> gencode_archs;
+    llvm::SmallVector<ArchToken> arch_archs;
     std::string host_compiler;
     std::string target_directory;
+    llvm::StringRef default_stream;
     bool allow_unsupported = false;
+    bool rdc = false;
 
     auto args = expand_options_files(arguments.drop_front(), directory);
 
@@ -202,11 +231,11 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
     /// nvcc treats every preprocessor value as a comma-separated list,
     /// short spellings included: `-Ia,b` names two directories.
     auto emit_list = [&](llvm::StringRef flag, llvm::StringRef value) {
-        llvm::SmallVector<llvm::StringRef> pieces;
-        value.split(pieces, ',', -1, false);
-        for(auto piece: pieces) {
+        llvm::SmallVector<std::string> pieces;
+        split_list(value, pieces);
+        for(auto& piece: pieces) {
             result.emplace_back(flag);
-            result.emplace_back(piece);
+            result.emplace_back(std::move(piece));
         }
     };
 
@@ -215,11 +244,12 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
         llvm::StringRef value;
 
         if(value_of(i, {"-gencode", "--generate-code"}, value)) {
-            collect_gencode_archs(value, archs);
+            collect_gencode_archs(value, gencode_archs);
             continue;
         }
         if(value_of(i, {"-arch", "--gpu-architecture"}, value)) {
-            collect_archs(value, archs);
+            arch_archs.clear();
+            collect_archs(value, arch_archs);
             continue;
         }
         /// ptxas targets only — consumed so the value cannot leak, never
@@ -229,7 +259,10 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
         }
 
         if(value_of(i, {"-ccbin", "--compiler-bindir"}, value)) {
-            host_compiler = absolutize(value, directory);
+            /// A bare program name resolves on PATH like nvcc would; only
+            /// path-shaped values anchor to the compile directory.
+            bool path_shaped = value.contains('/') || value.contains('\\');
+            host_compiler = path_shaped ? absolutize(value, directory) : value.str();
             continue;
         }
         if(arg == "--allow-unsupported-compiler" || arg == "-allow-unsupported-compiler") {
@@ -262,17 +295,12 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
         }
 
         if(value_of(i, {"-rdc", "--relocatable-device-code"}, value)) {
-            if(value == "true") {
-                result.emplace_back("-fgpu-rdc");
-                /// nvcc defines it; clang's -fgpu-rdc does not.
-                result.emplace_back("-D__CUDACC_RDC__");
-            }
+            rdc = value == "true";
             continue;
         }
         /// Separate compilation implies -rdc=true.
         if(arg == "-dc" || arg == "--device-c") {
-            result.emplace_back("-fgpu-rdc");
-            result.emplace_back("-D__CUDACC_RDC__");
+            rdc = true;
             continue;
         }
         if(arg == "-ewp" || arg == "--extensible-whole-program") {
@@ -281,8 +309,7 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
         }
 
         if(value_of(i, {"-default-stream", "--default-stream"}, value)) {
-            if(value == "per-thread")
-                result.emplace_back("-DCUDA_API_PER_THREAD_DEFAULT_STREAM=1");
+            default_stream = value;
             continue;
         }
 
@@ -357,8 +384,19 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
         result.emplace_back(arg);
     }
 
+    /// nvcc rejects mixing -gencode with -arch, so at most one list is
+    /// populated.
+    auto& archs = gencode_archs.empty() ? arch_archs : gencode_archs;
     if(!archs.empty())
         result.emplace_back("--cuda-gpu-arch=" + select_gpu_arch(archs));
+
+    if(rdc) {
+        result.emplace_back("-fgpu-rdc");
+        /// nvcc defines it; clang's -fgpu-rdc does not.
+        result.emplace_back("-D__CUDACC_RDC__");
+    }
+    if(default_stream == "per-thread")
+        result.emplace_back("-DCUDA_API_PER_THREAD_DEFAULT_STREAM=1");
 
     if(!host_compiler.empty())
         result.emplace_back((llvm::Twine(ccbin_prefix) + host_compiler).str());

--- a/src/command/nvcc.cpp
+++ b/src/command/nvcc.cpp
@@ -23,6 +23,7 @@ namespace {
 constexpr llvm::StringLiteral ccbin_prefix = "-ccbin=";
 constexpr llvm::StringLiteral target_directory_prefix = "--target-directory=";
 constexpr llvm::StringLiteral allow_unsupported_flag = "--allow-unsupported-compiler";
+constexpr llvm::StringLiteral gpu_arch_prefix = "-arch=";
 
 /// One GPU architecture named inside an -arch/-gencode value.
 struct ArchToken {
@@ -190,7 +191,7 @@ std::vector<std::string> expand_options_files(llvm::ArrayRef<const char*> argume
 
 bool is_nvcc_probe_flag(llvm::StringRef arg) {
     return arg.starts_with(ccbin_prefix) || arg == allow_unsupported_flag ||
-           arg.starts_with(target_directory_prefix);
+           arg.starts_with(target_directory_prefix) || arg.starts_with(gpu_arch_prefix);
 }
 
 std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> arguments,
@@ -204,6 +205,7 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
     /// once at the end. -gencode is the exception: entries accumulate.
     llvm::SmallVector<ArchToken> gencode_archs;
     llvm::SmallVector<ArchToken> arch_archs;
+    llvm::StringRef arch_special;
     std::string host_compiler;
     std::string target_directory;
     llvm::StringRef default_stream;
@@ -262,7 +264,10 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
         }
         if(value_of(i, {"-arch", "--gpu-architecture"}, value)) {
             arch_archs.clear();
+            arch_special = {};
             collect_archs(value, arch_archs);
+            if(arch_archs.empty())
+                arch_special = value;
             continue;
         }
         /// ptxas targets only — consumed so the value cannot leak, never
@@ -307,6 +312,25 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
         if(value_of(i, {"-x", "--x"}, value)) {
             result.emplace_back("-x");
             result.emplace_back(value == "cu" ? "cuda" : value.str());
+            continue;
+        }
+
+        /// The joined short forms -m32/-m64 are already clang's spellings
+        /// and fall through below; a value nvcc rejects pins nothing.
+        if(value_of(i, {"-m", "--machine"}, value)) {
+            if(value == "32" || value == "64")
+                result.emplace_back(("-m" + value).str());
+            continue;
+        }
+
+        /// Joined -O3 is already clang's spelling and falls through below.
+        if(value_of(i, {"-O", "--optimize"}, value)) {
+            result.emplace_back(("-O" + value).str());
+            continue;
+        }
+
+        if(arg == "--disable-warnings" || arg == "-disable-warnings") {
+            result.emplace_back("-w");
             continue;
         }
 
@@ -452,6 +476,13 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
         if(edit)
             result.emplace_back("--no-offload-arch=all");
         result.emplace_back("--cuda-gpu-arch=" + select_gpu_arch(archs));
+    } else if(!arch_special.empty()) {
+        /// A non-numeric selection (native, all, all-major) only nvcc can
+        /// resolve: it persists as a probe token, the dryrun runs with it,
+        /// and its cicc line then names the concrete architecture.
+        if(edit)
+            result.emplace_back("--no-offload-arch=all");
+        result.emplace_back((llvm::Twine(gpu_arch_prefix) + arch_special).str());
     }
 
     if(!host_compiler.empty())
@@ -467,6 +498,7 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
 std::expected<NVCCDryrunInfo, std::string> parse_nvcc_dryrun(llvm::StringRef output) {
     NVCCDryrunInfo info;
     llvm::StringRef nvvm_dir;
+    llvm::SmallVector<ArchToken> cicc_archs;
     llvm::SmallVector<const char*, 64> first_command;
 
     auto harvest_defines = [](llvm::ArrayRef<const char*> tokens, std::vector<std::string>& out) {
@@ -533,14 +565,13 @@ std::expected<NVCCDryrunInfo, std::string> parse_nvcc_dryrun(llvm::StringRef out
             continue;
         }
 
+        /// A probe carrying `-arch=all` runs one cicc per architecture:
+        /// collect them all and pick by the same newest-wins policy as the
+        /// translation.
         if(program == "cicc") {
             for(std::size_t i = 0; i + 1 < tokens.size(); i += 1) {
-                llvm::StringRef token = tokens[i];
-                llvm::StringRef arch = tokens[i + 1];
-                if(token == "-arch" && arch.consume_front("compute_")) {
-                    info.default_arch = ("sm_" + arch).str();
-                    break;
-                }
+                if(llvm::StringRef(tokens[i]) == "-arch")
+                    collect_archs(tokens[i + 1], cicc_archs);
             }
             continue;
         }
@@ -568,6 +599,9 @@ std::expected<NVCCDryrunInfo, std::string> parse_nvcc_dryrun(llvm::StringRef out
     /// `NVVMIR_LIBRARY_DIR=` is `<root>/nvvm/libdevice`.
     if(info.cuda_path.empty() && !nvvm_dir.empty())
         info.cuda_path = path::parent_path(path::parent_path(nvvm_dir));
+
+    if(!cicc_archs.empty())
+        info.default_arch = select_gpu_arch(cicc_archs);
 
     /// A host-language input (`nvcc -c foo.cpp`) compiles in a single host
     /// step with no preprocess stage: the first pipeline command is the

--- a/src/command/nvcc.cpp
+++ b/src/command/nvcc.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <format>
 #include <optional>
+#include <ranges>
 
 #include "support/filesystem.h"
 #include "support/logging.h"
@@ -78,12 +79,13 @@ void collect_gencode_archs(llvm::StringRef spec, llvm::SmallVectorImpl<ArchToken
 /// The newest architecture wins; at equal number the fuller feature set does
 /// ('a' unlocks the arch-specific instructions the family 'f' and plain
 /// forms hide, e.g. sm_90a for Hopper GMMA/TMA).
+std::pair<unsigned, int> arch_rank(const ArchToken& arch) {
+    int suffix_rank = arch.suffix == 'a' ? 2 : arch.suffix == 'f' ? 1 : 0;
+    return {arch.number, suffix_rank};
+}
+
 std::string select_gpu_arch(llvm::ArrayRef<ArchToken> archs) {
-    auto rank = [](const ArchToken& arch) {
-        auto suffix_rank = arch.suffix == 'a' ? 2 : arch.suffix == 'f' ? 1 : 0;
-        return std::pair(arch.number, suffix_rank);
-    };
-    auto best = *std::ranges::max_element(archs, {}, rank);
+    auto best = *std::ranges::max_element(archs, {}, arch_rank);
 
     auto result = std::format("sm_{}", best.number);
     if(best.suffix != 0)
@@ -473,7 +475,10 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
     /// populated.
     auto& archs = gencode_archs.empty() ? arch_archs : gencode_archs;
     if(!archs.empty()) {
-        if(edit)
+        /// An -arch edit replaces the base's architectures like nvcc's own
+        /// last-wins; -gencode entries accumulate onto them instead, so an
+        /// appended one must not erase the base's choice.
+        if(edit && gencode_archs.empty())
             result.emplace_back("--no-offload-arch=all");
         result.emplace_back("--cuda-gpu-arch=" + select_gpu_arch(archs));
     } else if(!arch_special.empty()) {
@@ -493,6 +498,44 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
         result.emplace_back((llvm::Twine(target_directory_prefix) + target_directory).str());
 
     return result;
+}
+
+void collapse_gpu_arch_flags(std::vector<const char*>& flags) {
+    struct ActiveArch {
+        std::size_t index;
+        std::pair<unsigned, int> rank;
+    };
+
+    /// The arch flags still alive under clang's accumulate semantics:
+    /// --no-offload-arch=all erases everything before it.
+    llvm::SmallVector<ActiveArch> active;
+    for(std::size_t i = 0; i < flags.size(); i += 1) {
+        llvm::StringRef arg = flags[i];
+        if(arg == "--no-offload-arch=all") {
+            active.clear();
+            continue;
+        }
+        if(!arg.starts_with("--cuda-gpu-arch=") && !arg.starts_with("--offload-arch="))
+            continue;
+
+        llvm::SmallVector<ArchToken> tokens;
+        collect_archs(arg.substr(arg.find('=') + 1), tokens);
+        /// A value without an sm_NN/compute_NN token (a raw clang spelling
+        /// like --offload-arch=native in a config append) is outside the
+        /// ranking — leave the whole command to clang's own semantics.
+        if(tokens.empty())
+            return;
+        auto rank = arch_rank(*std::ranges::max_element(tokens, {}, arch_rank));
+        active.push_back({.index = i, .rank = rank});
+    }
+    if(active.size() < 2)
+        return;
+
+    auto best = std::ranges::max(active, {}, &ActiveArch::rank).rank;
+    for(auto& arch: active | std::views::reverse) {
+        if(arch.rank < best)
+            flags.erase(flags.begin() + arch.index);
+    }
 }
 
 std::expected<NVCCDryrunInfo, std::string> parse_nvcc_dryrun(llvm::StringRef output) {

--- a/src/command/nvcc.cpp
+++ b/src/command/nvcc.cpp
@@ -97,14 +97,15 @@ std::string absolutize(llvm::StringRef value, llvm::StringRef directory) {
     return path::join(directory, value);
 }
 
-/// Split on unescaped commas: nvcc reads `\,` as a literal comma inside a
-/// value (`-DFOO=a\,b` defines FOO=a,b).
+/// Split on unescaped commas. nvcc's backslash escapes the next character
+/// unconditionally (`a\,b` is one value with a comma, `a\\,b` is `a\` and
+/// `b`, `a\x` is `ax`).
 void split_list(llvm::StringRef value, llvm::SmallVectorImpl<std::string>& out) {
     std::string piece;
     for(std::size_t i = 0; i < value.size(); i += 1) {
         char c = value[i];
-        if(c == '\\' && i + 1 < value.size() && value[i + 1] == ',') {
-            piece += ',';
+        if(c == '\\' && i + 1 < value.size()) {
+            piece += value[i + 1];
             i += 1;
             continue;
         }
@@ -201,6 +202,9 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
     llvm::StringRef default_stream;
     bool allow_unsupported = false;
     bool rdc = false;
+    bool ewp = false;
+    bool relaxed_constexpr = false;
+    bool extended_lambda = false;
 
     auto args = expand_options_files(arguments.drop_front(), directory);
 
@@ -261,7 +265,8 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
         if(value_of(i, {"-ccbin", "--compiler-bindir"}, value)) {
             /// A bare program name resolves on PATH like nvcc would; only
             /// path-shaped values anchor to the compile directory.
-            bool path_shaped = value.contains('/') || value.contains('\\');
+            bool path_shaped =
+                value.contains('/') || value.contains('\\') || value == "." || value == "..";
             host_compiler = path_shaped ? absolutize(value, directory) : value.str();
             continue;
         }
@@ -304,7 +309,7 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
             continue;
         }
         if(arg == "-ewp" || arg == "--extensible-whole-program") {
-            result.emplace_back("-D__CUDACC_EWP__");
+            ewp = true;
             continue;
         }
 
@@ -315,12 +320,12 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
 
         /// Feature toggles whose only parse-visible effect is a macro.
         if(arg == "--expt-relaxed-constexpr" || arg == "-expt-relaxed-constexpr") {
-            result.emplace_back("-D__CUDACC_RELAXED_CONSTEXPR__");
+            relaxed_constexpr = true;
             continue;
         }
         if(arg == "--expt-extended-lambda" || arg == "-expt-extended-lambda" ||
            arg == "--extended-lambda" || arg == "-extended-lambda") {
-            result.emplace_back("-D__CUDACC_EXTENDED_LAMBDA__");
+            extended_lambda = true;
             continue;
         }
 
@@ -384,19 +389,30 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
         result.emplace_back(arg);
     }
 
+    /// nvcc injects its macros ahead of the user's preprocessor flags, so a
+    /// later `-U` can undo them (`-dc -U__CUDACC_RDC__` parses without the
+    /// RDC macro) — the synthetic ones render first.
+    std::vector<std::string> prelude;
+    if(rdc) {
+        prelude.emplace_back("-fgpu-rdc");
+        /// nvcc defines it; clang's -fgpu-rdc does not.
+        prelude.emplace_back("-D__CUDACC_RDC__");
+    }
+    if(default_stream == "per-thread")
+        prelude.emplace_back("-DCUDA_API_PER_THREAD_DEFAULT_STREAM=1");
+    if(relaxed_constexpr)
+        prelude.emplace_back("-D__CUDACC_RELAXED_CONSTEXPR__");
+    if(extended_lambda)
+        prelude.emplace_back("-D__CUDACC_EXTENDED_LAMBDA__");
+    if(ewp)
+        prelude.emplace_back("-D__CUDACC_EWP__");
+    result.insert(result.begin() + 1, prelude.begin(), prelude.end());
+
     /// nvcc rejects mixing -gencode with -arch, so at most one list is
     /// populated.
     auto& archs = gencode_archs.empty() ? arch_archs : gencode_archs;
     if(!archs.empty())
         result.emplace_back("--cuda-gpu-arch=" + select_gpu_arch(archs));
-
-    if(rdc) {
-        result.emplace_back("-fgpu-rdc");
-        /// nvcc defines it; clang's -fgpu-rdc does not.
-        result.emplace_back("-D__CUDACC_RDC__");
-    }
-    if(default_stream == "per-thread")
-        result.emplace_back("-DCUDA_API_PER_THREAD_DEFAULT_STREAM=1");
 
     if(!host_compiler.empty())
         result.emplace_back((llvm::Twine(ccbin_prefix) + host_compiler).str());

--- a/src/command/nvcc.h
+++ b/src/command/nvcc.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <expected>
+#include <string>
+#include <vector>
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace clice {
+
+/// clang's option table has no spelling for nvcc's `-ccbin`, so the host
+/// compiler travels through the canonical command as this verbatim token
+/// (`-ccbin=<path>`), written by the CDB translation below and consumed by
+/// the NVCC toolchain query.
+constexpr inline llvm::StringLiteral nvcc_ccbin_prefix = "-ccbin=";
+
+/// An nvcc driver command rewritten into spellings clang's option table
+/// parses, so the regular CDB classification (canonical / user-content /
+/// discarded) applies unchanged.
+struct NVCCCommand {
+    /// The driver followed by translated flags: `-gencode`/`-arch`/`-code`
+    /// become the single best `--cuda-gpu-arch=`, `-x cu` becomes `-x cuda`,
+    /// `-Xcompiler` values are unwrapped into plain host flags, long-form
+    /// preprocessor aliases become their short spellings, and macro-defining
+    /// toggles (`--expt-extended-lambda`, ...) become their `-D` effect.
+    /// nvcc options that cannot affect parsing are dropped, together with
+    /// their values when those could be mistaken for flags (`-Xptxas -O3`).
+    /// A `-ccbin=<path>` token is appended when a host compiler was named.
+    std::vector<std::string> arguments;
+};
+
+NVCCCommand translate_nvcc_command(llvm::ArrayRef<const char*> arguments);
+
+/// What one `nvcc --dryrun` run reveals about the toolchain. The dryrun
+/// prints the whole compilation pipeline (host preprocess, cudafe++, device
+/// preprocess, cicc, ...) without executing it — CMake detects CUDA
+/// toolchains from the same output.
+struct NVCCDryrunInfo {
+    /// The toolkit root (`TOP=` line), valid for clang's `--cuda-path`.
+    /// Deriving it from the nvcc binary's location instead is wrong for
+    /// split layouts (conda puts it under `targets/<triple>`).
+    std::string cuda_path;
+
+    /// argv[0] of the host preprocess line — the compiler nvcc actually
+    /// drives, resolved from `-ccbin`, environment, or its defaults. Often
+    /// a bare program name that only exists on `search_path`.
+    std::string host_compiler;
+
+    /// The PATH nvcc augments for its sub-commands (`PATH=` line) — where a
+    /// bare `host_compiler` resolves. Layouts that activate an environment
+    /// around nvcc (conda) keep the host toolchain here, not on our PATH.
+    std::vector<std::string> search_path;
+
+    /// nvcc's default C++ dialect (`cudafe++ --c++17` → "c++17"), applied
+    /// when the user command names none.
+    std::string cpp_dialect;
+
+    /// nvcc's default GPU architecture (`cicc -arch compute_52` → "sm_52"),
+    /// applied when the user command names none.
+    std::string default_arch;
+
+    /// Macros nvcc injects into the host and device preprocess (without the
+    /// `-D`), minus the ones clang derives itself: `__CUDACC__`,
+    /// `__CUDA_ARCH__` and `__CUDA_ARCH_LIST__` come from the language mode
+    /// and `--cuda-gpu-arch`, and redefining them would conflict. The rest
+    /// (`__CUDACC_VER_MAJOR__`, ...) clang never defines, yet headers gate
+    /// on them — CUTLASS keeps every SM90 path invisible without them.
+    std::vector<std::string> host_defines;
+    std::vector<std::string> device_defines;
+};
+
+std::expected<NVCCDryrunInfo, std::string> parse_nvcc_dryrun(llvm::StringRef output);
+
+}  // namespace clice

--- a/src/command/nvcc.h
+++ b/src/command/nvcc.h
@@ -9,28 +9,38 @@
 
 namespace clice {
 
-/// clang's option table has no spelling for nvcc's `-ccbin`, so the host
-/// compiler travels through the canonical command as this verbatim token
-/// (`-ccbin=<path>`), written by the CDB translation below and consumed by
-/// the NVCC toolchain query.
-constexpr inline llvm::StringLiteral nvcc_ccbin_prefix = "-ccbin=";
+/// nvcc options that select the toolchain itself (`-ccbin=<path>`,
+/// `--allow-unsupported-compiler`, `--target-directory=<name>`): clang's
+/// option table has no spelling for them, so the translation re-emits them
+/// as normalized verbatim tokens. They survive CDB classification into the
+/// canonical command — keying the toolchain cache — and the NVCC query
+/// forwards them to its `nvcc --dryrun` probe so the probe runs against the
+/// build's real toolchain.
+bool is_nvcc_probe_flag(llvm::StringRef arg);
 
-/// An nvcc driver command rewritten into spellings clang's option table
-/// parses, so the regular CDB classification (canonical / user-content /
-/// discarded) applies unchanged.
-struct NVCCCommand {
-    /// The driver followed by translated flags: `-gencode`/`-arch`/`-code`
-    /// become the single best `--cuda-gpu-arch=`, `-x cu` becomes `-x cuda`,
-    /// `-Xcompiler` values are unwrapped into plain host flags, long-form
-    /// preprocessor aliases become their short spellings, and macro-defining
-    /// toggles (`--expt-extended-lambda`, ...) become their `-D` effect.
-    /// nvcc options that cannot affect parsing are dropped, together with
-    /// their values when those could be mistaken for flags (`-Xptxas -O3`).
-    /// A `-ccbin=<path>` token is appended when a host compiler was named.
-    std::vector<std::string> arguments;
-};
-
-NVCCCommand translate_nvcc_command(llvm::ArrayRef<const char*> arguments);
+/// Rewrite an nvcc driver command into flags clang's option table parses,
+/// so the regular CDB classification (canonical / user-content / discarded)
+/// applies unchanged:
+///
+/// - `-gencode`/`-arch` collapse to the single best `--cuda-gpu-arch=`.
+///   Only `arch=` clauses count — they name the virtual architecture the
+///   device front end compiles for, while `code=` entries are ptxas targets
+///   that never set `__CUDA_ARCH__`. The newest wins; at equal number
+///   'a' > 'f' > plain ('a' unlocks e.g. Hopper GMMA/TMA).
+/// - Preprocessor options split their comma-separated values, short
+///   spellings included: `-Ia,b` names two directories, `-DA=1,B=2` two
+///   macros.
+/// - `-Xcompiler` values unwrap into plain host flags, `-x cu` becomes
+///   `-x cuda`, and macro-defining toggles (`--extended-lambda`,
+///   `-rdc=true`, `-dc`, `-ewp`, `--default-stream per-thread`, ...) become
+///   their exact macro effect.
+/// - `--options-file` response files are expanded in place, resolved
+///   against `directory` like a relative `-ccbin` — nvcc resolves both
+///   against its working directory.
+/// - Remaining nvcc-only options are dropped, together with their values
+///   when those could be mistaken for host flags (`-Xptxas -O3`).
+std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> arguments,
+                                                llvm::StringRef directory);
 
 /// What one `nvcc --dryrun` run reveals about the toolchain. The dryrun
 /// prints the whole compilation pipeline (host preprocess, cudafe++, device

--- a/src/command/nvcc.h
+++ b/src/command/nvcc.h
@@ -33,7 +33,9 @@ bool is_nvcc_probe_flag(llvm::StringRef arg);
 /// - `-Xcompiler` values unwrap into plain host flags, `-x cu` becomes
 ///   `-x cuda`, and macro-defining toggles (`--extended-lambda`,
 ///   `-rdc=true`, `-dc`, `-ewp`, `--default-stream per-thread`, ...) become
-///   their exact macro effect.
+///   their exact macro effect. `--use_fast_math` becomes clang's
+///   `-fgpu-approx-transcendentals`, which selects the same fast
+///   transcendentals in the math wrapper.
 /// - `--options-file` response files are expanded in place, resolved
 ///   against `directory` like a relative `-ccbin` — nvcc resolves both
 ///   against its working directory.
@@ -54,7 +56,8 @@ struct NVCCDryrunInfo {
     /// `targets/<triple>`).
     std::string cuda_path;
 
-    /// argv[0] of the host preprocess line — the compiler nvcc actually
+    /// argv[0] of the host preprocess line (or of the single host compile
+    /// line when the input is host-language) — the compiler nvcc actually
     /// drives, resolved from `-ccbin`, environment, or its defaults. Often
     /// a bare program name that only exists on `search_path`.
     std::string host_compiler;

--- a/src/command/nvcc.h
+++ b/src/command/nvcc.h
@@ -9,8 +9,9 @@
 
 namespace clice {
 
-/// nvcc options that select the toolchain itself (`-ccbin=<path>`,
-/// `--allow-unsupported-compiler`, `--target-directory=<name>`): clang's
+/// nvcc options only nvcc itself can resolve (`-ccbin=<path>`,
+/// `--allow-unsupported-compiler`, `--target-directory=<name>`, and
+/// non-numeric architecture selections like `-arch=native`): clang's
 /// option table has no spelling for them, so the translation re-emits them
 /// as normalized verbatim tokens. They survive CDB classification into the
 /// canonical command — keying the toolchain cache — and the NVCC query
@@ -26,7 +27,10 @@ bool is_nvcc_probe_flag(llvm::StringRef arg);
 ///   Only `arch=` clauses count — they name the virtual architecture the
 ///   device front end compiles for, while `code=` entries are ptxas targets
 ///   that never set `__CUDA_ARCH__`. The newest wins; at equal number
-///   'a' > 'f' > plain ('a' unlocks e.g. Hopper GMMA/TMA).
+///   'a' > 'f' > plain ('a' unlocks e.g. Hopper GMMA/TMA). A non-numeric
+///   `-arch` value (`native`, `all`, ...) persists as an `-arch=<value>`
+///   probe token instead — the dryrun resolves it to a concrete
+///   architecture.
 /// - Preprocessor options split their comma-separated values, short
 ///   spellings included: `-Ia,b` names two directories, `-DA=1,B=2` two
 ///   macros.

--- a/src/command/nvcc.h
+++ b/src/command/nvcc.h
@@ -41,8 +41,17 @@ bool is_nvcc_probe_flag(llvm::StringRef arg);
 ///   against its working directory.
 /// - Remaining nvcc-only options are dropped, together with their values
 ///   when those could be mistaken for host flags (`-Xptxas -O3`).
+///
+/// With `edit` set the flags are a config-rule edit appended after an
+/// already-translated base command, not a self-contained command: stateful
+/// options set to their default state emit the flags that cancel the base's
+/// translated state instead of nothing (`-rdc=false` becomes `-fno-gpu-rdc
+/// -U__CUDACC_RDC__`, `--default-stream=legacy` undefines the per-thread
+/// macro), and an architecture choice is preceded by `--no-offload-arch=all`
+/// because clang accumulates architectures where nvcc's are last-wins.
 std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> arguments,
-                                                llvm::StringRef directory);
+                                                llvm::StringRef directory,
+                                                bool edit = false);
 
 /// What one `nvcc --dryrun` run reveals about the toolchain. The dryrun
 /// prints the whole compilation pipeline (host preprocess, cudafe++, device

--- a/src/command/nvcc.h
+++ b/src/command/nvcc.h
@@ -47,9 +47,11 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
 /// preprocess, cicc, ...) without executing it — CMake detects CUDA
 /// toolchains from the same output.
 struct NVCCDryrunInfo {
-    /// The toolkit root (`TOP=` line), valid for clang's `--cuda-path`.
-    /// Deriving it from the nvcc binary's location instead is wrong for
-    /// split layouts (conda puts it under `targets/<triple>`).
+    /// The toolkit root (`TOP=` line, else derived from
+    /// `NVVMIR_LIBRARY_DIR=`), valid for clang's `--cuda-path`; empty when
+    /// the dryrun names neither. Deriving it from the nvcc binary's location
+    /// instead is wrong for split layouts (conda puts it under
+    /// `targets/<triple>`).
     std::string cuda_path;
 
     /// argv[0] of the host preprocess line — the compiler nvcc actually

--- a/src/command/nvcc.h
+++ b/src/command/nvcc.h
@@ -51,11 +51,21 @@ bool is_nvcc_probe_flag(llvm::StringRef arg);
 /// options set to their default state emit the flags that cancel the base's
 /// translated state instead of nothing (`-rdc=false` becomes `-fno-gpu-rdc
 /// -U__CUDACC_RDC__`, `--default-stream=legacy` undefines the per-thread
-/// macro), and an architecture choice is preceded by `--no-offload-arch=all`
-/// because clang accumulates architectures where nvcc's are last-wins.
+/// macro). An `-arch` choice is preceded by `--no-offload-arch=all` because
+/// clang accumulates architectures where nvcc's `-arch` is last-wins; a
+/// `-gencode` entry accumulates in nvcc too, so it emits its architecture
+/// bare and `collapse_gpu_arch_flags` resolves it against the base's.
 std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> arguments,
                                                 llvm::StringRef directory,
                                                 bool edit = false);
+
+/// Collapse the architecture flags of a combined command (translated base
+/// plus appended edits) so only the single best survives, extending the
+/// newest-wins policy of the translation across the append seam. Left
+/// accumulated, clang would build one device job per architecture in
+/// ascending order and the toolchain query reads the first — pinning the
+/// oldest architecture instead of the newest.
+void collapse_gpu_arch_flags(std::vector<const char*>& flags);
 
 /// What one `nvcc --dryrun` run reveals about the toolchain. The dryrun
 /// prints the whole compilation pipeline (host preprocess, cudafe++, device

--- a/src/command/nvcc.h
+++ b/src/command/nvcc.h
@@ -23,14 +23,15 @@ bool is_nvcc_probe_flag(llvm::StringRef arg);
 /// so the regular CDB classification (canonical / user-content / discarded)
 /// applies unchanged:
 ///
-/// - `-gencode`/`-arch` collapse to the single best `--cuda-gpu-arch=`.
-///   Only `arch=` clauses count — they name the virtual architecture the
-///   device front end compiles for, while `code=` entries are ptxas targets
-///   that never set `__CUDA_ARCH__`. The newest wins; at equal number
-///   'a' > 'f' > plain ('a' unlocks e.g. Hopper GMMA/TMA). A non-numeric
-///   `-arch` value (`native`, `all`, ...) persists as an `-arch=<value>`
-///   probe token instead — the dryrun resolves it to a concrete
-///   architecture.
+/// - The `-gencode` entries and the (last-wins) `-arch` choice — nvcc
+///   compiles their union, one device pass each — collapse to the single
+///   best `--cuda-gpu-arch=`. Only `arch=` clauses count: they name the
+///   virtual architecture the device front end compiles for, while `code=`
+///   entries are ptxas targets that never set `__CUDA_ARCH__`. The newest
+///   wins; at equal number 'a' > 'f' > plain ('a' unlocks e.g. Hopper
+///   GMMA/TMA). A non-numeric `-arch` value (`native`, `all`, ...)
+///   persists as an `-arch=<value>` probe token instead — the dryrun
+///   resolves it to a concrete architecture.
 /// - Preprocessor options split their comma-separated values, short
 ///   spellings included: `-Ia,b` names two directories, `-DA=1,B=2` two
 ///   macros.
@@ -51,10 +52,11 @@ bool is_nvcc_probe_flag(llvm::StringRef arg);
 /// options set to their default state emit the flags that cancel the base's
 /// translated state instead of nothing (`-rdc=false` becomes `-fno-gpu-rdc
 /// -U__CUDACC_RDC__`, `--default-stream=legacy` undefines the per-thread
-/// macro). An `-arch` choice is preceded by `--no-offload-arch=all` because
-/// clang accumulates architectures where nvcc's `-arch` is last-wins; a
-/// `-gencode` entry accumulates in nvcc too, so it emits its architecture
-/// bare and `collapse_gpu_arch_flags` resolves it against the base's.
+/// macro). An `-arch` edit reads as picking the view outright — nvcc
+/// itself would union it with the base's `-gencode` entries — and is
+/// preceded by `--no-offload-arch=all`; a `-gencode` entry accumulates
+/// like nvcc's own, emitted bare for `collapse_gpu_arch_flags` to resolve
+/// against the base's.
 std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> arguments,
                                                 llvm::StringRef directory,
                                                 bool edit = false);

--- a/src/command/toolchain.cpp
+++ b/src/command/toolchain.cpp
@@ -300,6 +300,12 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
         if(auto e = fs::remove(src_path))
             LOG_ERROR("Fail to remove temporary file: {}", e);
     });
+
+    /// .cuh is not a clang-known extension: without a language override the
+    /// probe counts as linker input and the driver builds no compile job.
+    if(ext == "cuh" && !ranges::any_of(args, [](llvm::StringRef arg) { return arg == "-x"; }))
+        args.append({"-x", "cuda"});
+
     args.emplace_back(src_path.c_str());
 
     auto family = Toolchain::driver_family(driver);

--- a/src/command/toolchain.cpp
+++ b/src/command/toolchain.cpp
@@ -471,7 +471,11 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
                         std::format("Unsupported nvcc host compiler: {}", host));
             }
 
-            cuda_args.push_back("--cuda-path=" + info->cuda_path);
+            /// Without a root from the dryrun, clang's own CUDA detection
+            /// (which knows the distro-specific install locations) is the
+            /// remaining chance.
+            if(!info->cuda_path.empty())
+                cuda_args.push_back("--cuda-path=" + info->cuda_path);
             /// A toolkit newer than the linked clang still parses, modulo
             /// missing feature macros; without this the version warning
             /// would land in every file's diagnostics.

--- a/src/command/toolchain.cpp
+++ b/src/command/toolchain.cpp
@@ -528,7 +528,9 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
                 if(!contains_prefix({"-std="}) && !info->cpp_dialect.empty())
                     cuda_args.push_back("-std=" + info->cpp_dialect);
 
-                if(!contains_prefix({"--cuda-gpu-arch=", "--offload-arch="}) &&
+                /// An `-arch=` probe token is an explicit selection too: its
+                /// resolution replaces it in place below.
+                if(!contains_prefix({"--cuda-gpu-arch=", "--offload-arch=", "-arch="}) &&
                    !info->default_arch.empty())
                     cuda_args.push_back("--cuda-gpu-arch=" + info->default_arch);
             } else {
@@ -539,8 +541,16 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
             }
 
             for(llvm::StringRef arg: llvm::ArrayRef(args).drop_front()) {
-                if(is_nvcc_probe_flag(arg))
+                if(is_nvcc_probe_flag(arg)) {
+                    /// The dryrun's resolution of an `-arch=<special>` token
+                    /// lands exactly where the token sat: an edit-appended
+                    /// selection carries `--no-offload-arch=all` right
+                    /// before it, and inserting the resolution any earlier
+                    /// would put it on the cleared side.
+                    if(cuda_input && arg.starts_with("-arch=") && !info->default_arch.empty())
+                        cuda_args.push_back("--cuda-gpu-arch=" + info->default_arch);
                     continue;
+                }
                 cuda_args.push_back(arg.str());
             }
 

--- a/src/command/toolchain.cpp
+++ b/src/command/toolchain.cpp
@@ -8,6 +8,7 @@
 
 #include "command/argument_parser.h"
 #include "command/command.h"
+#include "command/nvcc.h"
 #include "support/filesystem.h"
 #include "support/logging.h"
 
@@ -223,6 +224,39 @@ std::vector<std::string> parse_cc1_output(llvm::StringRef content) {
     return {};
 }
 
+/// The two flags that pin a gcc-style toolchain for our driver: the target
+/// triple and the gcc installation clang should derive its paths from.
+struct GCCToolchainFlags {
+    std::string target;
+    std::string install_dir;
+};
+
+kota::task<std::expected<GCCToolchainFlags, std::string>> query_gcc_flags(std::string driver) {
+    auto target = co_await execute_async({driver, "-dumpmachine"}, true);
+    if(!target)
+        co_return std::unexpected(std::move(target.error()));
+
+    auto search_dirs = co_await execute_async({driver, "-print-search-dirs"}, true);
+    if(!search_dirs)
+        co_return std::unexpected(std::move(search_dirs.error()));
+
+    std::string install_path;
+    llvm::SmallVector<llvm::StringRef, 5> lines;
+    llvm::StringRef(*search_dirs).split(lines, '\n', -1, false);
+    for(auto line: lines) {
+        line = line.trim();
+        if(line.consume_front_insensitive("install:")) {
+            install_path = line.trim().str();
+            break;
+        }
+    }
+
+    co_return GCCToolchainFlags{
+        .target = "--target=" + llvm::StringRef(*target).trim().str(),
+        .install_dir = "--gcc-install-dir=" + install_path,
+    };
+}
+
 kota::task<std::expected<std::vector<std::string>, std::string>>
     query_one(llvm::ArrayRef<const char*> arguments, llvm::StringRef file) {
     if(arguments.empty())
@@ -275,34 +309,14 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
         // Query g++ or mingw toolchain info. We detect the target and corresponding
         // gcc toolchain install path as default behavior.
         case CompilerFamily::GCC: {
-            std::string drv(driver.str());
-
-            auto target = co_await execute_async({drv, "-dumpmachine"}, true);
-            if(!target)
-                co_return std::unexpected(std::move(target.error()));
-
-            auto search_dirs = co_await execute_async({drv, "-print-search-dirs"}, true);
-            if(!search_dirs)
-                co_return std::unexpected(std::move(search_dirs.error()));
-
-            std::string install_path;
-            llvm::SmallVector<llvm::StringRef, 5> lines;
-            llvm::StringRef(*search_dirs).split(lines, '\n', -1, false);
-            for(auto line: lines) {
-                line = line.trim();
-                if(line.consume_front_insensitive("install:")) {
-                    install_path = line.trim().str();
-                    break;
-                }
-            }
-
-            auto target_flag = "--target=" + llvm::StringRef(*target).trim().str();
-            auto install_flag = "--gcc-install-dir=" + install_path;
+            auto gcc = co_await query_gcc_flags(driver.str());
+            if(!gcc)
+                co_return std::unexpected(std::move(gcc.error()));
 
             llvm::SmallVector<const char*, 256> gcc_args;
             gcc_args.emplace_back(driver.data());
-            gcc_args.emplace_back(target_flag.c_str());
-            gcc_args.emplace_back(install_flag.c_str());
+            gcc_args.emplace_back(gcc->target.c_str());
+            gcc_args.emplace_back(gcc->install_dir.c_str());
             gcc_args.append(args.begin() + 1, args.end());
 
             auto queried =
@@ -369,8 +383,149 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
             break;
         }
 
+        // Query nvcc by asking for its compilation pipeline: the dryrun
+        // names the toolkit root, the host compiler and the macros nvcc
+        // injects — none of which clang can derive on its own. The host
+        // toolchain is then pinned as in the GCC branch and our own driver
+        // builds the cc1 in CUDA mode.
+        case CompilerFamily::NVCC: {
+            /// Only a .cu input makes nvcc print the offload pipeline; the
+            /// shared probe follows the real file's extension.
+            llvm::SmallString<64> cu_probe;
+            if(auto e = fs::createTemporaryFile("query-toolchain", "cu", cu_probe))
+                co_return std::unexpected(
+                    std::format("Failed to create temp file: {}", e.message()));
+            auto cu_cleanup = llvm::make_scope_exit([&] {
+                if(auto e = fs::remove(cu_probe))
+                    LOG_ERROR("Fail to remove temporary file: {}", e);
+            });
+
+            std::vector<std::string> dryrun_args = {driver.str(),
+                                                    "--dryrun",
+                                                    "-c",
+                                                    std::string(cu_probe)};
+            for(llvm::StringRef arg: args) {
+                if(arg.starts_with(nvcc_ccbin_prefix))
+                    dryrun_args.push_back(arg.str());
+            }
+
+            auto dryrun = co_await execute_async(std::move(dryrun_args));
+            if(!dryrun)
+                co_return std::unexpected(std::move(dryrun.error()));
+
+            auto info = parse_nvcc_dryrun(*dryrun);
+            if(!info)
+                co_return std::unexpected(std::move(info.error()));
+
+            /// The dryrun spells the host compiler the way nvcc resolves it —
+            /// often a bare name that only exists on nvcc's own augmented
+            /// PATH. Try that PATH, then next to the nvcc binary, then ours.
+            std::string host = info->host_compiler;
+            if(!path::is_absolute(host)) {
+                std::string resolved_host;
+                for(auto& dir: info->search_path) {
+                    auto candidate = path::join(dir, host);
+                    if(fs::exists(candidate) && fs::can_execute(candidate)) {
+                        resolved_host = std::move(candidate);
+                        break;
+                    }
+                }
+                if(resolved_host.empty()) {
+                    auto sibling = path::join(path::parent_path(driver), host);
+                    if(fs::exists(sibling) && fs::can_execute(sibling))
+                        resolved_host = std::move(sibling);
+                }
+                if(resolved_host.empty()) {
+                    if(auto program = llvm::sys::findProgramByName(host))
+                        resolved_host = std::move(*program);
+                }
+                if(resolved_host.empty())
+                    co_return std::unexpected(
+                        std::format("Cannot find nvcc host compiler: {}", host));
+                host = std::move(resolved_host);
+            }
+
+            std::vector<std::string> cuda_args;
+            cuda_args.push_back(host);
+
+            switch(Toolchain::driver_family(host)) {
+                case CompilerFamily::GCC: {
+                    auto gcc = co_await query_gcc_flags(host);
+                    if(!gcc)
+                        co_return std::unexpected(std::move(gcc.error()));
+                    cuda_args.push_back(std::move(gcc->target));
+                    cuda_args.push_back(std::move(gcc->install_dir));
+                    break;
+                }
+                /// A clang host needs no pin: the in-process driver already
+                /// defaults to the running machine's triple.
+                case CompilerFamily::Clang: break;
+                default:
+                    co_return std::unexpected(
+                        std::format("Unsupported nvcc host compiler: {}", host));
+            }
+
+            cuda_args.push_back("--cuda-path=" + info->cuda_path);
+            /// A toolkit newer than the linked clang still parses, modulo
+            /// missing feature macros; without this the version warning
+            /// would land in every file's diagnostics.
+            cuda_args.push_back("--no-cuda-version-check");
+
+            auto contains_flag = [&](llvm::StringRef name) {
+                return ranges::any_of(args, [&](llvm::StringRef arg) { return arg == name; });
+            };
+            auto contains_prefix = [&](std::initializer_list<llvm::StringRef> prefixes) {
+                return ranges::any_of(args, [&](llvm::StringRef arg) {
+                    return ranges::any_of(prefixes, [&](llvm::StringRef prefix) {
+                        return arg.starts_with(prefix);
+                    });
+                });
+            };
+
+            /// Default to the device-side view: reading CUDA code means
+            /// reading the `__CUDA_ARCH__` world — CUTLASS keeps every
+            /// arch-specific path behind it, and the host pass grays them
+            /// all out. `--cuda-host-only` in the command (e.g. a config
+            /// rule append) flips a file to the host view instead.
+            bool host_view = contains_flag("--cuda-host-only");
+            if(!host_view && !contains_flag("--cuda-device-only"))
+                cuda_args.push_back("--cuda-device-only");
+
+            for(auto& define: host_view ? info->host_defines : info->device_defines)
+                cuda_args.push_back("-D" + define);
+
+            if(!contains_prefix({"-std="}) && !info->cpp_dialect.empty())
+                cuda_args.push_back("-std=" + info->cpp_dialect);
+
+            if(!contains_prefix({"--cuda-gpu-arch=", "--offload-arch="}) &&
+               !info->default_arch.empty())
+                cuda_args.push_back("--cuda-gpu-arch=" + info->default_arch);
+
+            for(llvm::StringRef arg: llvm::ArrayRef(args).drop_front()) {
+                if(arg.starts_with(nvcc_ccbin_prefix))
+                    continue;
+                cuda_args.push_back(arg.str());
+            }
+
+            std::vector<const char*> cuda_argv;
+            cuda_argv.reserve(cuda_args.size());
+            for(auto& arg: cuda_args)
+                cuda_argv.push_back(arg.c_str());
+
+            auto queried =
+                query_driver(cuda_argv, [&](const char* d, llvm::ArrayRef<const char*> cc1) {
+                    cc1_args.emplace_back(d);
+                    cc1_args.emplace_back("-cc1");
+                    for(auto arg: cc1)
+                        cc1_args.emplace_back(arg);
+                });
+            if(!queried)
+                co_return std::unexpected(std::move(queried.error()));
+            break;
+        }
+
         default: {
-            /// TODO: nvcc and intel compilers need further exploration.
+            /// TODO: intel compilers need further exploration.
             LOG_ERROR("Unsupported compiler family: {}, driver is {}",
                       kota::meta::enum_name(family),
                       driver);
@@ -540,6 +695,13 @@ Toolchain::ToolchainExtract Toolchain::extract_flags(llvm::StringRef file,
 
         result.key += std::to_string(arg.id);
         result.key += '\0';
+        /// All unknown options share one id; their identity is the spelling
+        /// (the NVCC translation carries `-ccbin=<path>` through here, and
+        /// two commands differing only in host compiler must not collide).
+        if(arg.id == option::OPT_UNKNOWN) {
+            result.key += arg.spelling;
+            result.key += '\0';
+        }
         for(auto value: arg.values) {
             result.key += value;
             result.key += '\0';

--- a/src/command/toolchain.cpp
+++ b/src/command/toolchain.cpp
@@ -405,7 +405,7 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
                                                     "-c",
                                                     std::string(cu_probe)};
             for(llvm::StringRef arg: args) {
-                if(arg.starts_with(nvcc_ccbin_prefix))
+                if(is_nvcc_probe_flag(arg))
                     dryrun_args.push_back(arg.str());
             }
 
@@ -502,7 +502,7 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
                 cuda_args.push_back("--cuda-gpu-arch=" + info->default_arch);
 
             for(llvm::StringRef arg: llvm::ArrayRef(args).drop_front()) {
-                if(arg.starts_with(nvcc_ccbin_prefix))
+                if(is_nvcc_probe_flag(arg))
                     continue;
                 cuda_args.push_back(arg.str());
             }

--- a/src/command/toolchain.cpp
+++ b/src/command/toolchain.cpp
@@ -2,6 +2,7 @@
 
 #include <expected>
 #include <format>
+#include <optional>
 #include <ranges>
 #include <string>
 #include <vector>
@@ -395,21 +396,34 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
         // toolchain is then pinned as in the GCC branch and our own driver
         // builds the cc1 in CUDA mode.
         case CompilerFamily::NVCC: {
-            /// Only a .cu input makes nvcc print the offload pipeline; the
-            /// shared probe follows the real file's extension.
-            llvm::SmallString<64> cu_probe;
-            if(auto e = fs::createTemporaryFile("query-toolchain", "cu", cu_probe))
+            /// nvcc only offloads CUDA-language inputs; a host-language
+            /// entry (`nvcc -c foo.cpp`, or an explicit `-x c++`) compiles
+            /// in a single host step. The dryrun probe follows the effective
+            /// language so it reports the pipeline the real file gets —
+            /// only a .cu input makes nvcc print the offload pipeline (the
+            /// shared probe keeps the real file's extension).
+            bool cuda_input = ext == "cu" || ext == "cuh";
+            for(std::size_t i = 0; i + 1 < args.size(); i += 1) {
+                if(llvm::StringRef(args[i]) == "-x")
+                    cuda_input = llvm::StringRef(args[i + 1]) == "cuda";
+            }
+            llvm::StringRef probe_ext = "cu";
+            if(!cuda_input)
+                probe_ext = (ext == "cu" || ext == "cuh") ? "cpp" : ext;
+
+            llvm::SmallString<64> nvcc_probe;
+            if(auto e = fs::createTemporaryFile("query-toolchain", probe_ext, nvcc_probe))
                 co_return std::unexpected(
                     std::format("Failed to create temp file: {}", e.message()));
-            auto cu_cleanup = llvm::make_scope_exit([&] {
-                if(auto e = fs::remove(cu_probe))
+            auto nvcc_cleanup = llvm::make_scope_exit([&] {
+                if(auto e = fs::remove(nvcc_probe))
                     LOG_ERROR("Fail to remove temporary file: {}", e);
             });
 
             std::vector<std::string> dryrun_args = {driver.str(),
                                                     "--dryrun",
                                                     "-c",
-                                                    std::string(cu_probe)};
+                                                    std::string(nvcc_probe)};
             for(llvm::StringRef arg: args) {
                 if(is_nvcc_probe_flag(arg))
                     dryrun_args.push_back(arg.str());
@@ -471,45 +485,58 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
                         std::format("Unsupported nvcc host compiler: {}", host));
             }
 
-            /// Without a root from the dryrun, clang's own CUDA detection
-            /// (which knows the distro-specific install locations) is the
-            /// remaining chance.
-            if(!info->cuda_path.empty())
-                cuda_args.push_back("--cuda-path=" + info->cuda_path);
-            /// A toolkit newer than the linked clang still parses, modulo
-            /// missing feature macros; without this the version warning
-            /// would land in every file's diagnostics.
-            cuda_args.push_back("--no-cuda-version-check");
+            if(cuda_input) {
+                /// Without a root from the dryrun, clang's own CUDA detection
+                /// (which knows the distro-specific install locations) is the
+                /// remaining chance.
+                if(!info->cuda_path.empty())
+                    cuda_args.push_back("--cuda-path=" + info->cuda_path);
+                /// A toolkit newer than the linked clang still parses, modulo
+                /// missing feature macros; without this the version warning
+                /// would land in every file's diagnostics.
+                cuda_args.push_back("--no-cuda-version-check");
 
-            auto contains_flag = [&](llvm::StringRef name) {
-                return ranges::any_of(args, [&](llvm::StringRef arg) { return arg == name; });
-            };
-            auto contains_prefix = [&](std::initializer_list<llvm::StringRef> prefixes) {
-                return ranges::any_of(args, [&](llvm::StringRef arg) {
-                    return ranges::any_of(prefixes, [&](llvm::StringRef prefix) {
-                        return arg.starts_with(prefix);
+                auto contains_prefix = [&](std::initializer_list<llvm::StringRef> prefixes) {
+                    return ranges::any_of(args, [&](llvm::StringRef arg) {
+                        return ranges::any_of(prefixes, [&](llvm::StringRef prefix) {
+                            return arg.starts_with(prefix);
+                        });
                     });
-                });
-            };
+                };
 
-            /// Default to the device-side view: reading CUDA code means
-            /// reading the `__CUDA_ARCH__` world — CUTLASS keeps every
-            /// arch-specific path behind it, and the host pass grays them
-            /// all out. `--cuda-host-only` in the command (e.g. a config
-            /// rule append) flips a file to the host view instead.
-            bool host_view = contains_flag("--cuda-host-only");
-            if(!host_view && !contains_flag("--cuda-device-only"))
-                cuda_args.push_back("--cuda-device-only");
+                /// Default to the device-side view: reading CUDA code means
+                /// reading the `__CUDA_ARCH__` world — CUTLASS keeps every
+                /// arch-specific path behind it, and the host pass grays them
+                /// all out. `--cuda-host-only` in the command (e.g. a config
+                /// rule append) flips a file to the host view instead; the
+                /// last selector wins, matching the driver's own reading of
+                /// the forwarded flags.
+                std::optional<bool> selected_host;
+                for(llvm::StringRef arg: args) {
+                    if(arg == "--cuda-host-only")
+                        selected_host = true;
+                    else if(arg == "--cuda-device-only")
+                        selected_host = false;
+                }
+                bool host_view = selected_host.value_or(false);
+                if(!selected_host.has_value())
+                    cuda_args.push_back("--cuda-device-only");
 
-            for(auto& define: host_view ? info->host_defines : info->device_defines)
-                cuda_args.push_back("-D" + define);
+                for(auto& define: host_view ? info->host_defines : info->device_defines)
+                    cuda_args.push_back("-D" + define);
 
-            if(!contains_prefix({"-std="}) && !info->cpp_dialect.empty())
-                cuda_args.push_back("-std=" + info->cpp_dialect);
+                if(!contains_prefix({"-std="}) && !info->cpp_dialect.empty())
+                    cuda_args.push_back("-std=" + info->cpp_dialect);
 
-            if(!contains_prefix({"--cuda-gpu-arch=", "--offload-arch="}) &&
-               !info->default_arch.empty())
-                cuda_args.push_back("--cuda-gpu-arch=" + info->default_arch);
+                if(!contains_prefix({"--cuda-gpu-arch=", "--offload-arch="}) &&
+                   !info->default_arch.empty())
+                    cuda_args.push_back("--cuda-gpu-arch=" + info->default_arch);
+            } else {
+                /// The single host step still carries nvcc's identity
+                /// macros (__NVCC__, version macros) — but no CUDA mode.
+                for(auto& define: info->host_defines)
+                    cuda_args.push_back("-D" + define);
+            }
 
             for(llvm::StringRef arg: llvm::ArrayRef(args).drop_front()) {
                 if(is_nvcc_probe_flag(arg))

--- a/tests/integration/compilation/nvcc.test.ts
+++ b/tests/integration/compilation/nvcc.test.ts
@@ -33,6 +33,39 @@ function capture(client: CliceClient): InactiveRegionsParams[] {
     return captured;
 }
 
+test.skipIf(!runsNvcc)("nvcc direct cuh entry", async ({ session }) => {
+    const { client, workspace } = session.tmp();
+    workspace.write(
+        "kernels.cuh",
+        "#pragma once\n" +
+            "__device__ inline float scale(float* p) { return p[threadIdx.x]; }\n" +
+            "#if defined(__CUDA_ARCH__)\n" +
+            "inline int device_world = 1;\n" +
+            "#else\n" +
+            "inline int host_world = 1;\n" +
+            "#endif\n",
+    );
+    workspace.write(
+        "compile_commands.json",
+        JSON.stringify([
+            {
+                directory: workspace.root,
+                file: workspace.path("kernels.cuh"),
+                command: `nvcc -c ${workspace.path("kernels.cuh")} -o kernels.o`,
+            },
+        ]),
+    );
+    const captured = capture(client);
+
+    await client.initialize(workspace);
+    const [uri] = await client.openAndWait("kernels.cuh");
+    client.assertCleanCompile(uri);
+
+    // The device view applies to the header exactly as it would to a .cu.
+    const regions = await waitRegions(captured);
+    expect(regions.map((r) => [r.start.line, r.end.line])).toEqual([[5, 6]]);
+});
+
 test.skipIf(!runsNvcc)("nvcc cuda device view", async ({ session }) => {
     const { client, workspace } = session.tmp();
     workspace.write(

--- a/tests/integration/compilation/nvcc.test.ts
+++ b/tests/integration/compilation/nvcc.test.ts
@@ -1,0 +1,80 @@
+/// Integration tests for nvcc compilation databases: the toolchain layer
+/// rewrites the nvcc command, probes the toolkit via `nvcc --dryrun`, and
+/// parses CUDA files in the device view by default. Windows hosts drive cl,
+/// which the query does not support yet.
+
+import { spawnSync } from "node:child_process";
+import type { Range } from "vscode-languageserver-protocol";
+import { asLocations, sleep, type CliceClient } from "@clice/tools/client";
+import { InactiveRegionsNotification, type InactiveRegionsParams } from "@clice/tools/protocol";
+import { expect, test } from "../fixtures.ts";
+
+const hasNvcc = spawnSync("nvcc", ["--version"], { stdio: "ignore" }).status === 0;
+const runsNvcc = hasNvcc && process.platform !== "win32";
+
+async function waitRegions(captured: InactiveRegionsParams[], timeout = 15_000): Promise<Range[]> {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+        const last = captured[captured.length - 1];
+        if (last && last.regions.length > 0) {
+            return last.regions;
+        }
+        await sleep(50);
+    }
+    const last = captured[captured.length - 1];
+    return last ? last.regions : [];
+}
+
+function capture(client: CliceClient): InactiveRegionsParams[] {
+    const captured: InactiveRegionsParams[] = [];
+    client.onNotification(InactiveRegionsNotification, (params) => {
+        captured.push(params);
+    });
+    return captured;
+}
+
+test.skipIf(!runsNvcc)("nvcc cuda device view", async ({ session }) => {
+    const { client, workspace } = session.tmp();
+    workspace.write(
+        "main.cu",
+        "__global__ void kern(float* p) { p[threadIdx.x] = 1.0f; }\n" +
+            "#if defined(__CUDA_ARCH__)\n" +
+            "int device_world = 1;\n" +
+            "#else\n" +
+            "int host_world = 1;\n" +
+            "#endif\n" +
+            "int main() {\n" +
+            "    float* d = nullptr;\n" +
+            "    cudaMalloc(&d, 16);\n" +
+            "    kern<<<1, 1>>>(d);\n" +
+            "    return 0;\n" +
+            "}\n",
+    );
+    workspace.write(
+        "compile_commands.json",
+        JSON.stringify([
+            {
+                directory: workspace.root,
+                file: workspace.path("main.cu"),
+                command:
+                    "nvcc -forward-unknown-to-host-compiler " +
+                    '"--generate-code=arch=compute_75,code=[compute_75,sm_75]" ' +
+                    `-x cu -c ${workspace.path("main.cu")} -o main.cu.o`,
+            },
+        ]),
+    );
+    const captured = capture(client);
+
+    await client.initialize(workspace);
+    const [uri] = await client.openAndWait("main.cu");
+    client.assertCleanCompile(uri);
+
+    // The launch site resolves into the kernel definition.
+    const locs = asLocations(await client.definitionAt(uri, 9, 4));
+    expect(locs.length).toBeGreaterThan(0);
+    expect(locs.some((loc) => loc.range.start.line === 0)).toBe(true);
+
+    // Device view: the host-side #else branch is the inactive one.
+    const regions = await waitRegions(captured);
+    expect(regions.map((r) => [r.start.line, r.end.line])).toEqual([[4, 5]]);
+});

--- a/tests/unit/command/command_tests.cpp
+++ b/tests/unit/command/command_tests.cpp
@@ -520,6 +520,21 @@ TEST_CASE(LoadErrorRecovery) {
     EXPECT_CONTAINS(print_argv(also.front().to_argv()), "-Wall");
 };
 
+TEST_CASE(LoadCudaHeader) {
+    /// .cuh entries are C-family despite clang's extension table; non-C
+    /// entries some build systems emit are skipped.
+    CompilationDatabase database;
+    auto count = load_json(database, R"([
+        {"directory": "/build", "file": "kernels.cuh",
+         "command": "nvcc -c kernels.cuh -o kernels.o"},
+        {"directory": "/build", "file": "app.rc",
+         "command": "rc /fo app.res app.rc"}
+    ])");
+
+    ASSERT_EQ(count, 1U);
+    EXPECT_TRUE(database.has_entry(path::join("/build", "kernels.cuh")));
+};
+
 TEST_CASE(LoadEmptyCommand) {
     /// Whitespace-only or empty "command" should not crash.
     CompilationDatabase database;

--- a/tests/unit/command/command_tests.cpp
+++ b/tests/unit/command/command_tests.cpp
@@ -158,6 +158,17 @@ TEST_CASE(DefaultFallback) {
     auto h_results = database.lookup("foo.h", options);
     ASSERT_EQ(h_results.front().to_argv().size(), 2U);
     ASSERT_EQ(h_results.front().to_argv()[0], "clang"sv);
+
+    /// CUDA files pin cuda mode and the device-side view NVCC-backed
+    /// commands default to.
+    for(llvm::StringRef cuda_file: {"kern.cu", "kernels.cuh"}) {
+        auto cu_argv = database.lookup(cuda_file, options).front().to_argv();
+        ASSERT_EQ(cu_argv.size(), 6U);
+        ASSERT_EQ(cu_argv[0], "clang++"sv);
+        ASSERT_EQ(cu_argv[2], "-x"sv);
+        ASSERT_EQ(cu_argv[3], "cuda"sv);
+        ASSERT_EQ(cu_argv[4], "--cuda-device-only"sv);
+    }
 };
 
 TEST_CASE(FallbackAppliesAppend) {

--- a/tests/unit/command/nvcc_tests.cpp
+++ b/tests/unit/command/nvcc_tests.cpp
@@ -93,9 +93,11 @@ TEST_CASE(ProbeFlagsCarried) {
     auto args = translate(
         {"nvcc", "-allow-unsupported-compiler", "-target-dir", "sbsa-linux", "-ccbin", "tools/g++"},
         "/base");
-    for(llvm::StringRef flag: {"--allow-unsupported-compiler",
-                               "--target-directory=sbsa-linux",
-                               "-ccbin=/base/tools/g++"}) {
+    // The join spells the separator natively, so the expectation must too.
+    auto anchored = "-ccbin=" + path::join("/base", "tools/g++");
+    for(llvm::StringRef flag: {llvm::StringRef("--allow-unsupported-compiler"),
+                               llvm::StringRef("--target-directory=sbsa-linux"),
+                               llvm::StringRef(anchored)}) {
         EXPECT_TRUE(contains(args, flag));
         EXPECT_TRUE(is_nvcc_probe_flag(flag));
     }
@@ -203,12 +205,13 @@ TEST_CASE(ListValuesSplit) {
         EXPECT_TRUE(llvm::StringRef(joined).contains(piece));
     }
 
-    // Backslash escapes the next character unconditionally: `\,` is a
-    // literal comma, `\\,` is a trailing backslash then a separator.
+    // `\,` reads as a literal comma; other backslashes stay verbatim so
+    // native Windows paths survive (deliberately shallower than nvcc's
+    // Linux-side escape processing, which consumes every backslash).
     EXPECT_TRUE(contains(translate({"nvcc", R"(-DP=a\,b)"}), "P=a,b"));
-    auto parity = translate({"nvcc", R"(-DQ=a\\,b)"});
-    EXPECT_TRUE(contains(parity, R"(Q=a\)"));
-    EXPECT_TRUE(contains(parity, "b"));
+    auto windows = translate({"nvcc", R"(-IC:\inc,D:\other)"});
+    EXPECT_TRUE(contains(windows, R"(C:\inc)"));
+    EXPECT_TRUE(contains(windows, R"(D:\other)"));
 }
 
 TEST_CASE(OptionsFileExpanded) {
@@ -241,7 +244,7 @@ constexpr static llvm::StringRef fake_dryrun = R"(#$ _NVVM_BRANCH_=nvvm
 #$ TOP=/opt/cuda/targets/x86_64-linux
 #$ NVVMIR_LIBRARY_DIR=/opt/cuda/targets/x86_64-linux/nvvm/libdevice
 #$ LD_LIBRARY_PATH=/opt/cuda/targets/x86_64-linux/lib:
-#$ PATH=/opt/cuda/targets/x86_64-linux/bin:/opt/host/bin:/usr/bin
+#$ PATH=/opt/host/bin
 #$ INCLUDES="-I/opt/cuda/targets/x86_64-linux/include"
 #$ g++ -D__CUDA_ARCH_LIST__=520 -D__NV_LEGACY_LAUNCH -E -x c++ -D__CUDACC__ -D__NVCC__ "-I/opt/cuda/targets/x86_64-linux/include" -D__CUDACC_VER_MAJOR__=12 -D__CUDACC_VER_MINOR__=9 -include "cuda_runtime.h" -m64 "/tmp/a.cu" -o "/tmp/a.cpp4.ii"
 #$ cudafe++ --c++17 --gnu_version=140400 "/tmp/a.cpp4.ii"

--- a/tests/unit/command/nvcc_tests.cpp
+++ b/tests/unit/command/nvcc_tests.cpp
@@ -152,6 +152,14 @@ TEST_CASE(MacroToggles) {
     EXPECT_FALSE(contains(debug, "-G"));
     EXPECT_TRUE(contains(translate({"nvcc", "--device-debug"}), "-D__CUDACC_DEBUG__"));
 
+    // Fast math becomes clang's approx-transcendentals flag, which selects
+    // the same fast variants in the math wrapper.
+    for(const char* spelling: {"--use_fast_math", "-use_fast_math"}) {
+        auto fast = translate({"nvcc", spelling});
+        EXPECT_TRUE(contains(fast, "-fgpu-approx-transcendentals"));
+        EXPECT_FALSE(contains(fast, spelling));
+    }
+
     // Stateful options are last-wins, matching nvcc.
     EXPECT_FALSE(contains(translate({"nvcc", "-rdc=true", "-rdc=false"}), "-fgpu-rdc"));
     auto stream = translate({"nvcc", "-default-stream=per-thread", "-default-stream=legacy"});
@@ -310,6 +318,23 @@ TEST_CASE(DryrunRejectsIncomplete) {
     EXPECT_FALSE(parse_nvcc_dryrun("#$ TOP=/opt/cuda").has_value());
 }
 
+TEST_CASE(DryrunHostOnly) {
+    // A host-language input (nvcc -c foo.cpp) has no preprocess stage: the
+    // single host compile line names the compiler, and its defines survive
+    // unfiltered — outside CUDA mode clang derives none of them.
+    constexpr llvm::StringRef host_only = R"(#$ TOP=/opt/cuda
+#$ INCLUDES="-I/opt/cuda/include"
+#$ g++ -D__CUDA_ARCH_LIST__=520 -c -x c++ -D__NVCC__ -D__CUDACC_VER_MAJOR__=12 -m64 "/tmp/a.cpp" -o "/tmp/a.o"
+)";
+    auto info = parse_nvcc_dryrun(host_only);
+    ASSERT_TRUE(info.has_value());
+    EXPECT_EQ(info->host_compiler, "g++");
+    EXPECT_TRUE(std::ranges::contains(info->host_defines, "__NVCC__"));
+    EXPECT_TRUE(std::ranges::contains(info->host_defines, "__CUDA_ARCH_LIST__=520"));
+    EXPECT_TRUE(std::ranges::contains(info->host_defines, "__CUDACC_VER_MAJOR__=12"));
+    EXPECT_TRUE(info->device_defines.empty());
+}
+
 TEST_CASE(DryrunTopFallback) {
     // A wrapper may swallow TOP=; NVVMIR_LIBRARY_DIR is <root>/nvvm/libdevice.
     constexpr llvm::StringRef no_top = R"(#$ NVVMIR_LIBRARY_DIR=/opt/cuda/nvvm/libdevice
@@ -369,6 +394,70 @@ TEST_CASE(DatabaseTranslatesNVCC) {
     for(llvm::StringRef flag: flags) {
         EXPECT_FALSE(flag.starts_with("--generate-code"));
     }
+}
+
+TEST_CASE(RuleFlagsTranslated) {
+    CompilationDatabase db;
+    std::vector<const char*> arguments = {"nvcc",
+                                          "--generate-code=arch=compute_75,code=sm_75",
+                                          "-c",
+                                          "/tmp/kern.cu"};
+    db.add_command("/tmp", "/tmp/kern.cu", arguments);
+
+    // Config rule flags for an NVCC entry go through the same translation
+    // as the command: the remove matches the arch through its translated
+    // spelling and the append reaches clang translated, not as raw nvcc
+    // tokens.
+    CommandOptions options;
+    llvm::SmallVector<std::string> remove = {"-gencode", "arch=compute_75,code=sm_75"};
+    options.remove = remove;
+    llvm::SmallVector<std::string> append = {"--extended-lambda",
+                                             "--generate-code=arch=compute_90a,code=sm_90a"};
+    options.append = append;
+
+    auto commands = db.lookup("/tmp/kern.cu", options);
+    ASSERT_EQ(commands.size(), std::size_t(1));
+
+    auto& flags = commands[0].resolved.flags;
+    auto has = [&](llvm::StringRef flag) {
+        return std::ranges::contains(flags, flag);
+    };
+    EXPECT_FALSE(has("--offload-arch=sm_75"));
+    EXPECT_TRUE(has("--cuda-gpu-arch=sm_90a"));
+    EXPECT_TRUE(has("-D__CUDACC_EXTENDED_LAMBDA__"));
+    for(llvm::StringRef flag: flags) {
+        EXPECT_FALSE(flag.starts_with("--generate-code"));
+        EXPECT_FALSE(flag.starts_with("--extended-lambda"));
+    }
+}
+
+TEST_CASE(RemoveMatchesUnknownSpelling) {
+    CompilationDatabase db;
+    std::vector<const char*> arguments = {"nvcc",
+                                          "-ccbin=/usr/bin/g++-12",
+                                          "-allow-unsupported-compiler",
+                                          "-target-dir",
+                                          "sbsa-linux",
+                                          "-c",
+                                          "/tmp/kern.cu"};
+    db.add_command("/tmp", "/tmp/kern.cu", arguments);
+
+    CommandOptions options;
+    llvm::SmallVector<std::string> remove = {"--allow-unsupported-compiler"};
+    options.remove = remove;
+
+    auto commands = db.lookup("/tmp/kern.cu", options);
+    ASSERT_EQ(commands.size(), std::size_t(1));
+
+    // Probe flags all parse as the shared unknown id; removal keys on the
+    // spelling, so the other probe tokens survive.
+    auto& flags = commands[0].resolved.flags;
+    auto has = [&](llvm::StringRef flag) {
+        return std::ranges::contains(flags, flag);
+    };
+    EXPECT_FALSE(has("--allow-unsupported-compiler"));
+    EXPECT_TRUE(has("-ccbin=/usr/bin/g++-12"));
+    EXPECT_TRUE(has("--target-directory=sbsa-linux"));
 }
 
 };  // TEST_SUITE(NVCCTests)

--- a/tests/unit/command/nvcc_tests.cpp
+++ b/tests/unit/command/nvcc_tests.cpp
@@ -149,6 +149,14 @@ TEST_CASE(MacroToggles) {
     auto undef = llvm::join(translate({"nvcc", "-dc", "-U__CUDACC_RDC__"}), " ");
     EXPECT_TRUE(llvm::StringRef(undef).find("-D__CUDACC_RDC__") <
                 llvm::StringRef(undef).find("-U __CUDACC_RDC__"));
+
+    // The stream macro is nvcc's one exception: it lands after user flags,
+    // so their -U cannot undo it.
+    auto stream_undef = llvm::join(
+        translate({"nvcc", "-default-stream=per-thread", "-UCUDA_API_PER_THREAD_DEFAULT_STREAM"}),
+        " ");
+    EXPECT_TRUE(llvm::StringRef(stream_undef).find("-U CUDA_API_PER_THREAD_DEFAULT_STREAM") <
+                llvm::StringRef(stream_undef).find("-DCUDA_API_PER_THREAD_DEFAULT_STREAM=1"));
 }
 
 TEST_CASE(PairedValueDrops) {

--- a/tests/unit/command/nvcc_tests.cpp
+++ b/tests/unit/command/nvcc_tests.cpp
@@ -14,8 +14,9 @@ using namespace std::string_view_literals;
 TEST_SUITE(NVCCTests) {
 
 std::vector<std::string> translate(std::vector<const char*> arguments,
-                                   llvm::StringRef directory = "") {
-    return translate_nvcc_command(arguments, directory);
+                                   llvm::StringRef directory = "",
+                                   bool edit = false) {
+    return translate_nvcc_command(arguments, directory, edit);
 }
 
 bool contains(llvm::ArrayRef<std::string> arguments, llvm::StringRef flag) {
@@ -275,6 +276,36 @@ TEST_CASE(StdNormalized) {
     EXPECT_TRUE(contains(translate({"nvcc", "--std=c++20"}), "-std=c++20"));
 }
 
+TEST_CASE(EditEmitsStateOverrides) {
+    // An edit lands after an already-translated base command: explicitly
+    // disabled stateful options must cancel the base's translated state,
+    // while a standalone command emits nothing for the default state.
+    auto off = translate({"nvcc", "-rdc=false", "--default-stream=legacy"}, "", true);
+    EXPECT_TRUE(contains(off, "-fno-gpu-rdc"));
+    EXPECT_TRUE(contains(off, "-U__CUDACC_RDC__"));
+    EXPECT_TRUE(contains(off, "-UCUDA_API_PER_THREAD_DEFAULT_STREAM"));
+
+    auto standalone = translate({"nvcc", "-rdc=false", "--default-stream=legacy"});
+    EXPECT_FALSE(contains(standalone, "-fno-gpu-rdc"));
+    EXPECT_FALSE(contains(standalone, "-U__CUDACC_RDC__"));
+    EXPECT_FALSE(contains(standalone, "-UCUDA_API_PER_THREAD_DEFAULT_STREAM"));
+
+    // Untouched state stays silent even as an edit.
+    auto untouched = translate({"nvcc", "-DX"}, "", true);
+    EXPECT_FALSE(contains(untouched, "-fno-gpu-rdc"));
+    EXPECT_FALSE(contains(untouched, "-U__CUDACC_RDC__"));
+    EXPECT_FALSE(contains(untouched, "-UCUDA_API_PER_THREAD_DEFAULT_STREAM"));
+    EXPECT_FALSE(contains(untouched, "--no-offload-arch=all"));
+
+    // clang accumulates --cuda-gpu-arch while nvcc's -arch is last-wins: an
+    // arch edit clears the base architectures right before its own choice.
+    auto arch = translate({"nvcc", "-arch=sm_80"}, "", true);
+    auto clear = std::ranges::find(arch, "--no-offload-arch=all");
+    ASSERT_TRUE(clear != arch.end() && clear + 1 != arch.end());
+    EXPECT_EQ(*(clear + 1), "--cuda-gpu-arch=sm_80"sv);
+    EXPECT_FALSE(contains(translate({"nvcc", "-arch=sm_80"}), "--no-offload-arch=all"));
+}
+
 constexpr static llvm::StringRef fake_dryrun = R"(#$ _NVVM_BRANCH_=nvvm
 #$ _SPACE_=
 #$ TOP=/opt/cuda/targets/x86_64-linux
@@ -429,6 +460,95 @@ TEST_CASE(RuleFlagsTranslated) {
         EXPECT_FALSE(flag.starts_with("--generate-code"));
         EXPECT_FALSE(flag.starts_with("--extended-lambda"));
     }
+}
+
+TEST_CASE(AppendOverridesBase) {
+    CompilationDatabase db;
+    std::vector<const char*> arguments =
+        {"nvcc", "-rdc=true", "-default-stream=per-thread", "-arch=sm_75", "-c", "/tmp/kern.cu"};
+    db.add_command("/tmp", "/tmp/kern.cu", arguments);
+
+    // NVCC's stateful options are last-wins across the whole command, so an
+    // appended disable must beat the state the base already translated.
+    CommandOptions options;
+    llvm::SmallVector<std::string> append = {"-rdc=false",
+                                             "--default-stream=legacy",
+                                             "-arch=sm_80"};
+    options.append = append;
+
+    auto commands = db.lookup("/tmp/kern.cu", options);
+    ASSERT_EQ(commands.size(), std::size_t(1));
+
+    auto& flags = commands[0].resolved.flags;
+    auto index_of = [&](llvm::StringRef flag) {
+        return std::ranges::find(flags,
+                                 flag,
+                                 [](const char* arg) { return llvm::StringRef(arg); }) -
+               flags.begin();
+    };
+    auto count = std::ptrdiff_t(flags.size());
+
+    // rdc: the appended negation follows the base's enable, so clang's own
+    // last-wins turns it off and undefines the macro the base defined.
+    EXPECT_TRUE(index_of("-fgpu-rdc") < index_of("-fno-gpu-rdc"));
+    EXPECT_TRUE(index_of("-fno-gpu-rdc") < count);
+    EXPECT_TRUE(index_of("__CUDACC_RDC__") < index_of("-U__CUDACC_RDC__"));
+    EXPECT_TRUE(index_of("-U__CUDACC_RDC__") < count);
+
+    // stream: undef after the base's define.
+    EXPECT_TRUE(index_of("CUDA_API_PER_THREAD_DEFAULT_STREAM=1") <
+                index_of("-UCUDA_API_PER_THREAD_DEFAULT_STREAM"));
+    EXPECT_TRUE(index_of("-UCUDA_API_PER_THREAD_DEFAULT_STREAM") < count);
+
+    // arch: the base's architecture is cleared before the appended one, not
+    // accumulated into a second device pass.
+    EXPECT_TRUE(index_of("--offload-arch=sm_75") < index_of("--no-offload-arch=all"));
+    EXPECT_TRUE(index_of("--no-offload-arch=all") < index_of("--cuda-gpu-arch=sm_80"));
+    EXPECT_TRUE(index_of("--cuda-gpu-arch=sm_80") < count);
+}
+
+TEST_CASE(WildcardRemoveClearsArch) {
+    CompilationDatabase db;
+    std::vector<const char*> gencode = {"nvcc",
+                                        "--generate-code=arch=compute_75,code=sm_75",
+                                        "-c",
+                                        "/tmp/kern.cu"};
+    db.add_command("/tmp", "/tmp/kern.cu", gencode);
+    std::vector<const char*> arch = {"nvcc", "-arch=sm_80", "-c", "/tmp/other.cu"};
+    db.add_command("/tmp", "/tmp/other.cu", arch);
+
+    auto arch_flags = [&](llvm::StringRef file, const CommandOptions& options) {
+        auto commands = db.lookup(file, options);
+        std::vector<std::string> result;
+        for(llvm::StringRef flag: commands[0].resolved.flags) {
+            if(flag.contains("arch")) {
+                result.push_back(flag.str());
+            }
+        }
+        return result;
+    };
+
+    EXPECT_TRUE(std::ranges::contains(arch_flags("/tmp/kern.cu", {}), "--offload-arch=sm_75"));
+    EXPECT_TRUE(std::ranges::contains(arch_flags("/tmp/other.cu", {}), "--offload-arch=sm_80"));
+
+    // The wildcard names no concrete architecture, so it cannot translate to
+    // a matching flag itself — it must still clear whatever the base carries.
+    CommandOptions options;
+    llvm::SmallVector<std::string> remove = {"--generate-code=*"};
+    options.remove = remove;
+    EXPECT_TRUE(arch_flags("/tmp/kern.cu", options).empty());
+
+    llvm::SmallVector<std::string> separate = {"-arch", "*"};
+    options.remove = separate;
+    EXPECT_TRUE(arch_flags("/tmp/other.cu", options).empty());
+
+    // Removes edit the base before appends land: replacing the architecture
+    // through remove-wildcard + append keeps the appended one.
+    llvm::SmallVector<std::string> append = {"-gencode=arch=compute_90a,code=sm_90a"};
+    options.append = append;
+    auto replaced = arch_flags("/tmp/other.cu", options);
+    EXPECT_FALSE(std::ranges::contains(replaced, "--offload-arch=sm_80"));
+    EXPECT_TRUE(std::ranges::contains(replaced, "--cuda-gpu-arch=sm_90a"));
 }
 
 TEST_CASE(RemoveMatchesUnknownSpelling) {

--- a/tests/unit/command/nvcc_tests.cpp
+++ b/tests/unit/command/nvcc_tests.cpp
@@ -101,8 +101,13 @@ TEST_CASE(ProbeFlagsCarried) {
     }
     EXPECT_FALSE(is_nvcc_probe_flag("-I/base"));
 
-    // A bare name resolves on PATH like nvcc would — never anchored.
+    // A bare name resolves on PATH like nvcc would — never anchored — while
+    // dot-relative values are directory-relative.
     EXPECT_TRUE(contains(translate({"nvcc", "-ccbin=g++-13"}, "/base"), "-ccbin=g++-13"));
+    auto dot = translate({"nvcc", "-ccbin=."}, "/base");
+    EXPECT_TRUE(std::ranges::any_of(dot, [](llvm::StringRef arg) {
+        return arg.starts_with("-ccbin=/base");
+    }));
 }
 
 TEST_CASE(XcompilerUnwrapped) {
@@ -138,6 +143,12 @@ TEST_CASE(MacroToggles) {
     EXPECT_FALSE(contains(translate({"nvcc", "-rdc=true", "-rdc=false"}), "-fgpu-rdc"));
     auto stream = translate({"nvcc", "-default-stream=per-thread", "-default-stream=legacy"});
     EXPECT_FALSE(contains(stream, "-DCUDA_API_PER_THREAD_DEFAULT_STREAM=1"));
+
+    // Synthetic macros render ahead of user flags, so a later -U can undo
+    // them the way it does under nvcc.
+    auto undef = llvm::join(translate({"nvcc", "-dc", "-U__CUDACC_RDC__"}), " ");
+    EXPECT_TRUE(llvm::StringRef(undef).find("-D__CUDACC_RDC__") <
+                llvm::StringRef(undef).find("-U __CUDACC_RDC__"));
 }
 
 TEST_CASE(PairedValueDrops) {
@@ -184,9 +195,12 @@ TEST_CASE(ListValuesSplit) {
         EXPECT_TRUE(llvm::StringRef(joined).contains(piece));
     }
 
-    // `\,` is nvcc's escape for a literal comma inside a value.
-    auto escaped = translate({"nvcc", R"(-DP=a\,b)"});
-    EXPECT_TRUE(contains(escaped, "P=a,b"));
+    // Backslash escapes the next character unconditionally: `\,` is a
+    // literal comma, `\\,` is a trailing backslash then a separator.
+    EXPECT_TRUE(contains(translate({"nvcc", R"(-DP=a\,b)"}), "P=a,b"));
+    auto parity = translate({"nvcc", R"(-DQ=a\\,b)"});
+    EXPECT_TRUE(contains(parity, R"(Q=a\)"));
+    EXPECT_TRUE(contains(parity, "b"));
 }
 
 TEST_CASE(OptionsFileExpanded) {

--- a/tests/unit/command/nvcc_tests.cpp
+++ b/tests/unit/command/nvcc_tests.cpp
@@ -4,6 +4,7 @@
 #include "command/command.h"
 #include "command/nvcc.h"
 #include "command/toolchain.h"
+#include "support/filesystem.h"
 
 namespace clice::testing {
 namespace {
@@ -12,8 +13,9 @@ using namespace std::string_view_literals;
 
 TEST_SUITE(NVCCTests) {
 
-std::vector<std::string> translate(std::vector<const char*> arguments) {
-    return translate_nvcc_command(arguments).arguments;
+std::vector<std::string> translate(std::vector<const char*> arguments,
+                                   llvm::StringRef directory = "") {
+    return translate_nvcc_command(arguments, directory);
 }
 
 bool contains(llvm::ArrayRef<std::string> arguments, llvm::StringRef flag) {
@@ -34,7 +36,7 @@ TEST_CASE(TranslateCMakeShape) {
 
     EXPECT_EQ(args[0], "nvcc"sv);
     EXPECT_TRUE(contains(args, "--cuda-gpu-arch=sm_75"));
-    EXPECT_TRUE(contains(args, "-DMY_FLAG=1"));
+    EXPECT_TRUE(contains(args, "MY_FLAG=1"));
     EXPECT_TRUE(contains(args, "-x"));
     EXPECT_TRUE(contains(args, "cuda"));
     EXPECT_FALSE(contains(args, "cu"));
@@ -44,35 +46,52 @@ TEST_CASE(TranslateCMakeShape) {
 }
 
 TEST_CASE(GencodeSelectsBest) {
-    // The newest architecture wins; 'a' outranks 'f' and plain at the same
-    // number; lto_ entries are intermediates, not architectures.
-    auto args = translate({"nvcc",
-                           "-gencode",
-                           "arch=compute_75,code=sm_75",
-                           "-gencode",
-                           "arch=compute_90a,code=[compute_90a,sm_90a,lto_120]",
-                           "-gencode=arch=compute_80,code=sm_80"});
-    EXPECT_TRUE(contains(args, "--cuda-gpu-arch=sm_90a"));
+    // Only arch= clauses count: code= entries are ptxas targets and never
+    // set __CUDA_ARCH__ (arch=compute_75,code=sm_90 preprocesses as 750).
+    auto mismatch = translate({"nvcc", "-gencode", "arch=compute_75,code=sm_90"});
+    EXPECT_TRUE(contains(mismatch, "--cuda-gpu-arch=sm_75"));
 
-    auto compute_only = translate({"nvcc", "-arch=compute_86"});
-    EXPECT_TRUE(contains(compute_only, "--cuda-gpu-arch=sm_86"));
+    // The newest architecture wins; 'a' outranks plain at the same number;
+    // lto_ entries are intermediates, not architectures.
+    auto multi = translate({"nvcc",
+                            "-gencode",
+                            "arch=compute_75,code=sm_75",
+                            "-gencode=arch=compute_90a,code=[compute_90a,sm_90a,lto_120]"});
+    EXPECT_TRUE(contains(multi, "--cuda-gpu-arch=sm_90a"));
 
-    auto family = translate({"nvcc", "-code=sm_100f,sm_100"});
-    EXPECT_TRUE(contains(family, "--cuda-gpu-arch=sm_100f"));
+    EXPECT_TRUE(contains(translate({"nvcc", "-arch=compute_86"}), "--cuda-gpu-arch=sm_86"));
+    EXPECT_TRUE(contains(translate({"nvcc", "-arch=sm_100f"}), "--cuda-gpu-arch=sm_100f"));
 
-    EXPECT_FALSE(contains(translate({"nvcc", "-c", "a.cu"}), "--cuda-gpu-arch=sm_52"));
+    // Bare -code and arch-less commands pin no architecture.
+    for(auto& args: {translate({"nvcc", "-code=sm_90"}), translate({"nvcc", "-c", "a.cu"})}) {
+        for(llvm::StringRef arg: args) {
+            EXPECT_FALSE(arg.starts_with("--cuda-gpu-arch="));
+        }
+    }
 }
 
 TEST_CASE(CcbinBecomesToken) {
-    for(auto arguments: {
-            std::vector<const char*>{"nvcc", "-ccbin", "/usr/bin/g++-12"},
-            std::vector<const char*>{"nvcc", "-ccbin=/usr/bin/g++-12"},
-            std::vector<const char*>{"nvcc", "--compiler-bindir", "/usr/bin/g++-12"}
-    }) {
+    for(auto arguments: {std::vector<const char*>{"nvcc", "-ccbin", "/usr/bin/g++-12"},
+                         std::vector<const char*>{"nvcc", "-ccbin=/usr/bin/g++-12"},
+                         std::vector<const char*>{"nvcc", "--compiler-bindir", "/usr/bin/g++-12"}}) {
         auto args = translate(arguments);
         EXPECT_TRUE(contains(args, "-ccbin=/usr/bin/g++-12"));
         EXPECT_FALSE(contains(args, "/usr/bin/g++-12"));
     }
+}
+
+TEST_CASE(ProbeFlagsCarried) {
+    // Toolchain-selecting options become normalized verbatim tokens; a
+    // relative -ccbin anchors to the compile directory like nvcc would.
+    auto args = translate(
+        {"nvcc", "-allow-unsupported-compiler", "-target-dir", "sbsa-linux", "-ccbin", "tools/g++"},
+        "/base");
+    for(llvm::StringRef flag:
+        {"--allow-unsupported-compiler", "--target-directory=sbsa-linux", "-ccbin=/base/tools/g++"}) {
+        EXPECT_TRUE(contains(args, flag));
+        EXPECT_TRUE(is_nvcc_probe_flag(flag));
+    }
+    EXPECT_FALSE(is_nvcc_probe_flag("-I/base"));
 }
 
 TEST_CASE(XcompilerUnwrapped) {
@@ -96,15 +115,19 @@ TEST_CASE(MacroToggles) {
     EXPECT_TRUE(contains(args, "-D__CUDACC_RDC__"));
     EXPECT_TRUE(contains(args, "-DCUDA_API_PER_THREAD_DEFAULT_STREAM=1"));
 
-    auto off = translate({"nvcc", "-rdc=false"});
-    EXPECT_FALSE(contains(off, "-fgpu-rdc"));
+    EXPECT_FALSE(contains(translate({"nvcc", "-rdc=false"}), "-fgpu-rdc"));
+
+    // Separate compilation implies -rdc=true; -ewp has its own macro.
+    auto dc = translate({"nvcc", "-dc"});
+    EXPECT_TRUE(contains(dc, "-fgpu-rdc"));
+    EXPECT_TRUE(contains(dc, "-D__CUDACC_RDC__"));
+    EXPECT_TRUE(contains(translate({"nvcc", "--extensible-whole-program"}), "-D__CUDACC_EWP__"));
 }
 
 TEST_CASE(PairedValueDrops) {
     // The wrapped values would parse as host flags on their own; bare
     // nvcc-only flags pass through for the CDB classification to discard.
-    auto args = translate(
-        {"nvcc", "-Xptxas", "-O3", "-t", "4", "--options-file", "extra.rsp", "-lineinfo"});
+    auto args = translate({"nvcc", "-Xptxas", "-O3", "-t", "4", "-lineinfo"});
     std::vector<std::string> expected = {"nvcc", "-lineinfo"};
     EXPECT_EQ(args, expected);
 }
@@ -124,6 +147,39 @@ TEST_CASE(LongFormAliases) {
     EXPECT_TRUE(llvm::StringRef(joined).contains("-U BAR"));
     EXPECT_TRUE(llvm::StringRef(joined).contains("-include config.h"));
     EXPECT_TRUE(llvm::StringRef(joined).contains("-isystem /opt/sys"));
+}
+
+TEST_CASE(ListValuesSplit) {
+    // nvcc splits every preprocessor value on commas, short spellings
+    // included: -Ia,b preprocesses with two include directories.
+    auto args = translate(
+        {"nvcc", "-Ia,b", "-DA=1,B=2", "-U", "X,Y", "-isystem=s1,s2", "-include", "h1.h,h2.h"});
+    auto joined = llvm::join(args, " ");
+    for(llvm::StringRef piece:
+        {"-I a", "-I b", "-D A=1", "-D B=2", "-U X", "-U Y", "-isystem s1", "-isystem s2",
+         "-include h1.h", "-include h2.h"}) {
+        EXPECT_TRUE(llvm::StringRef(joined).contains(piece));
+    }
+}
+
+TEST_CASE(OptionsFileExpanded) {
+    auto file = fs::createTemporaryFile("clice-nvcc", "rsp");
+    ASSERT_TRUE(file.has_value());
+    ASSERT_TRUE(fs::write(*file, "-Igenerated -DAPI=2 -std=c++20\n"));
+
+    auto args = translate({"nvcc", "--options-file", file->c_str()});
+    auto joined = llvm::join(args, " ");
+    EXPECT_TRUE(llvm::StringRef(joined).contains("-I generated"));
+    EXPECT_TRUE(llvm::StringRef(joined).contains("-D API=2"));
+    EXPECT_TRUE(contains(args, "-std=c++20"));
+    EXPECT_FALSE(contains(args, "--options-file"));
+
+    // An unreadable file drops with a warning; the rest of the command
+    // still translates.
+    auto missing = translate({"nvcc", "--options-file=missing.rsp", "-DX"}, "/clice-nonexistent");
+    EXPECT_TRUE(contains(missing, "X"));
+
+    fs::remove(*file);
 }
 
 TEST_CASE(StdNormalized) {
@@ -189,6 +245,7 @@ TEST_CASE(DatabaseTranslatesNVCC) {
                                           "-DMY_FLAG=1",
                                           "--generate-code=arch=compute_75,code=[compute_75,sm_75]",
                                           "-ccbin=/usr/bin/g++-12",
+                                          "-allow-unsupported-compiler",
                                           "-x",
                                           "cu",
                                           "-c",
@@ -207,6 +264,7 @@ TEST_CASE(DatabaseTranslatesNVCC) {
     // --cuda-gpu-arch renders through its unaliased spelling.
     EXPECT_TRUE(has("--offload-arch=sm_75"));
     EXPECT_TRUE(has("-ccbin=/usr/bin/g++-12"));
+    EXPECT_TRUE(has("--allow-unsupported-compiler"));
     EXPECT_TRUE(has("-x"));
     EXPECT_TRUE(has("cuda"));
     EXPECT_TRUE(has("MY_FLAG=1"));

--- a/tests/unit/command/nvcc_tests.cpp
+++ b/tests/unit/command/nvcc_tests.cpp
@@ -145,6 +145,13 @@ TEST_CASE(MacroToggles) {
     EXPECT_TRUE(contains(dc, "-D__CUDACC_RDC__"));
     EXPECT_TRUE(contains(translate({"nvcc", "--extensible-whole-program"}), "-D__CUDACC_EWP__"));
 
+    // Device debug becomes its macro; -G must not survive, clang reads it
+    // as the small-data-threshold option.
+    auto debug = translate({"nvcc", "-G"});
+    EXPECT_TRUE(contains(debug, "-D__CUDACC_DEBUG__"));
+    EXPECT_FALSE(contains(debug, "-G"));
+    EXPECT_TRUE(contains(translate({"nvcc", "--device-debug"}), "-D__CUDACC_DEBUG__"));
+
     // Stateful options are last-wins, matching nvcc.
     EXPECT_FALSE(contains(translate({"nvcc", "-rdc=true", "-rdc=false"}), "-fgpu-rdc"));
     auto stream = translate({"nvcc", "-default-stream=per-thread", "-default-stream=legacy"});
@@ -229,6 +236,7 @@ TEST_CASE(OptionsFileExpanded) {
     EXPECT_TRUE(llvm::StringRef(joined).contains("-D API=2"));
     EXPECT_TRUE(contains(args, "-std=c++20"));
     EXPECT_FALSE(contains(args, "--options-file"));
+    EXPECT_FALSE(llvm::StringRef(joined).contains(*file));
 
     // The value is a comma-separated file list: every element expands.
     auto second = fs::createTemporaryFile("clice-nvcc", "rsp");
@@ -239,11 +247,16 @@ TEST_CASE(OptionsFileExpanded) {
     auto both = llvm::join(translate({"nvcc", "-optf", pair.c_str()}), " ");
     EXPECT_TRUE(llvm::StringRef(both).contains("-D API=2"));
     EXPECT_TRUE(llvm::StringRef(both).contains("-D FROM_SECOND=2"));
+    EXPECT_FALSE(llvm::StringRef(both).contains("-optf"));
+    EXPECT_FALSE(llvm::StringRef(both).contains(*file));
+    EXPECT_FALSE(llvm::StringRef(both).contains(*second));
 
     // An unreadable file drops with a warning; the rest of the command
     // still translates.
     auto missing = translate({"nvcc", "--options-file=missing.rsp", "-DX"}, "/clice-nonexistent");
     EXPECT_TRUE(contains(missing, "X"));
+    EXPECT_FALSE(contains(missing, "--options-file=missing.rsp"));
+    EXPECT_FALSE(contains(missing, "missing.rsp"));
 
     fs::remove(*file);
     fs::remove(*second);

--- a/tests/unit/command/nvcc_tests.cpp
+++ b/tests/unit/command/nvcc_tests.cpp
@@ -118,6 +118,10 @@ TEST_CASE(XcompilerUnwrapped) {
     EXPECT_TRUE(contains(args, "-pthread"));
     EXPECT_TRUE(contains(args, "-Wall"));
     EXPECT_FALSE(contains(args, "-Xcompiler"));
+
+    // The value follows the same `\,` escape as every other list option.
+    auto escaped = translate({"nvcc", R"(-Xcompiler=-Wl\,-z\,defs)"});
+    EXPECT_TRUE(contains(escaped, "-Wl,-z,defs"));
 }
 
 TEST_CASE(MacroToggles) {
@@ -226,12 +230,23 @@ TEST_CASE(OptionsFileExpanded) {
     EXPECT_TRUE(contains(args, "-std=c++20"));
     EXPECT_FALSE(contains(args, "--options-file"));
 
+    // The value is a comma-separated file list: every element expands.
+    auto second = fs::createTemporaryFile("clice-nvcc", "rsp");
+    ASSERT_TRUE(second.has_value());
+    ASSERT_TRUE(fs::write(*second, "-DFROM_SECOND=2\n"));
+
+    auto pair = *file + "," + *second;
+    auto both = llvm::join(translate({"nvcc", "-optf", pair.c_str()}), " ");
+    EXPECT_TRUE(llvm::StringRef(both).contains("-D API=2"));
+    EXPECT_TRUE(llvm::StringRef(both).contains("-D FROM_SECOND=2"));
+
     // An unreadable file drops with a warning; the rest of the command
     // still translates.
     auto missing = translate({"nvcc", "--options-file=missing.rsp", "-DX"}, "/clice-nonexistent");
     EXPECT_TRUE(contains(missing, "X"));
 
     fs::remove(*file);
+    fs::remove(*second);
 }
 
 TEST_CASE(StdNormalized) {
@@ -280,6 +295,23 @@ TEST_CASE(DryrunParsed) {
 TEST_CASE(DryrunRejectsIncomplete) {
     EXPECT_FALSE(parse_nvcc_dryrun("#$ PATH=/usr/bin").has_value());
     EXPECT_FALSE(parse_nvcc_dryrun("#$ TOP=/opt/cuda").has_value());
+}
+
+TEST_CASE(DryrunTopFallback) {
+    // A wrapper may swallow TOP=; NVVMIR_LIBRARY_DIR is <root>/nvvm/libdevice.
+    constexpr llvm::StringRef no_top = R"(#$ NVVMIR_LIBRARY_DIR=/opt/cuda/nvvm/libdevice
+#$ g++ -D__CUDACC_VER_MAJOR__=12 -E -x c++ "/tmp/a.cu" -o "/tmp/a.ii"
+)";
+    auto info = parse_nvcc_dryrun(no_top);
+    ASSERT_TRUE(info.has_value());
+    EXPECT_EQ(info->cuda_path, "/opt/cuda");
+
+    // With neither line the toolchain still resolves; CUDA detection is
+    // left to clang's own search.
+    auto bare = parse_nvcc_dryrun(R"(#$ g++ -E -x c++ "/tmp/a.cu")");
+    ASSERT_TRUE(bare.has_value());
+    EXPECT_TRUE(bare->cuda_path.empty());
+    EXPECT_EQ(bare->host_compiler, "g++");
 }
 
 TEST_CASE(CcbinAffectsKey) {

--- a/tests/unit/command/nvcc_tests.cpp
+++ b/tests/unit/command/nvcc_tests.cpp
@@ -62,6 +62,11 @@ TEST_CASE(GencodeSelectsBest) {
     EXPECT_TRUE(contains(translate({"nvcc", "-arch=compute_86"}), "--cuda-gpu-arch=sm_86"));
     EXPECT_TRUE(contains(translate({"nvcc", "-arch=sm_100f"}), "--cuda-gpu-arch=sm_100f"));
 
+    // -arch is a scalar option: the last one wins, unlike -gencode which
+    // accumulates.
+    auto repeated = translate({"nvcc", "-arch=compute_80", "-arch=compute_75"});
+    EXPECT_TRUE(contains(repeated, "--cuda-gpu-arch=sm_75"));
+
     // Bare -code and arch-less commands pin no architecture.
     for(auto& args: {translate({"nvcc", "-code=sm_90"}), translate({"nvcc", "-c", "a.cu"})}) {
         for(llvm::StringRef arg: args) {
@@ -95,6 +100,9 @@ TEST_CASE(ProbeFlagsCarried) {
         EXPECT_TRUE(is_nvcc_probe_flag(flag));
     }
     EXPECT_FALSE(is_nvcc_probe_flag("-I/base"));
+
+    // A bare name resolves on PATH like nvcc would — never anchored.
+    EXPECT_TRUE(contains(translate({"nvcc", "-ccbin=g++-13"}, "/base"), "-ccbin=g++-13"));
 }
 
 TEST_CASE(XcompilerUnwrapped) {
@@ -125,6 +133,11 @@ TEST_CASE(MacroToggles) {
     EXPECT_TRUE(contains(dc, "-fgpu-rdc"));
     EXPECT_TRUE(contains(dc, "-D__CUDACC_RDC__"));
     EXPECT_TRUE(contains(translate({"nvcc", "--extensible-whole-program"}), "-D__CUDACC_EWP__"));
+
+    // Stateful options are last-wins, matching nvcc.
+    EXPECT_FALSE(contains(translate({"nvcc", "-rdc=true", "-rdc=false"}), "-fgpu-rdc"));
+    auto stream = translate({"nvcc", "-default-stream=per-thread", "-default-stream=legacy"});
+    EXPECT_FALSE(contains(stream, "-DCUDA_API_PER_THREAD_DEFAULT_STREAM=1"));
 }
 
 TEST_CASE(PairedValueDrops) {
@@ -170,6 +183,10 @@ TEST_CASE(ListValuesSplit) {
                                 "-include h2.h"}) {
         EXPECT_TRUE(llvm::StringRef(joined).contains(piece));
     }
+
+    // `\,` is nvcc's escape for a literal comma inside a value.
+    auto escaped = translate({"nvcc", R"(-DP=a\,b)"});
+    EXPECT_TRUE(contains(escaped, "P=a,b"));
 }
 
 TEST_CASE(OptionsFileExpanded) {

--- a/tests/unit/command/nvcc_tests.cpp
+++ b/tests/unit/command/nvcc_tests.cpp
@@ -76,6 +76,16 @@ TEST_CASE(GencodeSelectsBest) {
     }
 }
 
+TEST_CASE(ArchGencodeUnion) {
+    // nvcc accepts -arch next to -gencode and compiles their union, one
+    // device pass each — the newest wins whichever side carries it.
+    auto arch_newer = translate({"nvcc", "-gencode=arch=compute_75,code=sm_75", "-arch=sm_90"});
+    EXPECT_TRUE(contains(arch_newer, "--cuda-gpu-arch=sm_90"));
+
+    auto gencode_newer = translate({"nvcc", "-arch=sm_75", "-gencode=arch=compute_90,code=sm_90"});
+    EXPECT_TRUE(contains(gencode_newer, "--cuda-gpu-arch=sm_90"));
+}
+
 TEST_CASE(SpecialArchCarried) {
     // Non-numeric selections only nvcc can resolve persist as probe tokens
     // for the dryrun instead of vanishing into no architecture at all.
@@ -332,6 +342,23 @@ TEST_CASE(OptimizeNormalized) {
     EXPECT_TRUE(contains(translate({"nvcc", "--optimize=3"}), "-O3"));
     EXPECT_TRUE(contains(translate({"nvcc", "-O", "2"}), "-O2"));
     EXPECT_TRUE(contains(translate({"nvcc", "-O3"}), "-O3"));
+
+    // Joined -O3 is nvcc's own option too, last-wins like the long form.
+    auto repeated = translate({"nvcc", "-O2", "--optimize=3"});
+    EXPECT_TRUE(contains(repeated, "-O3"));
+    EXPECT_FALSE(contains(repeated, "-O2"));
+}
+
+TEST_CASE(HostFlagsFollowXcompiler) {
+    // nvcc places its own -O/-m after the -Xcompiler payloads on the host
+    // line, beating them regardless of input order.
+    auto find_order = [](std::vector<std::string> args, llvm::StringRef a, llvm::StringRef b) {
+        auto joined = llvm::join(args, " ");
+        return llvm::StringRef(joined).find(a) < llvm::StringRef(joined).find(b);
+    };
+    EXPECT_TRUE(find_order(translate({"nvcc", "--optimize=3", "-Xcompiler=-O0"}), "-O0", "-O3"));
+    EXPECT_TRUE(find_order(translate({"nvcc", "-O3", "-Xcompiler=-O0"}), "-O0", "-O3"));
+    EXPECT_TRUE(find_order(translate({"nvcc", "--machine=64", "-Xcompiler=-m32"}), "-m32", "-m64"));
 }
 
 TEST_CASE(DisableWarningsMapped) {
@@ -355,6 +382,17 @@ TEST_CASE(EditEmitsStateOverrides) {
     EXPECT_FALSE(contains(standalone, "-fno-gpu-rdc"));
     EXPECT_FALSE(contains(standalone, "-U__CUDACC_RDC__"));
     EXPECT_FALSE(contains(standalone, "-UCUDA_API_PER_THREAD_DEFAULT_STREAM"));
+
+    // The cancellations render ahead of the segment's own flags: an
+    // explicit -D of the macro inside the edit survives them, like it
+    // survives nvcc's absent injection.
+    auto explicit_d = llvm::join(
+        translate({"nvcc", "-DCUDA_API_PER_THREAD_DEFAULT_STREAM=7", "--default-stream=legacy"},
+                  "",
+                  true),
+        " ");
+    EXPECT_TRUE(llvm::StringRef(explicit_d).find("-UCUDA_API_PER_THREAD_DEFAULT_STREAM") <
+                llvm::StringRef(explicit_d).find("CUDA_API_PER_THREAD_DEFAULT_STREAM=7"));
 
     // Untouched state stays silent even as an edit.
     auto untouched = translate({"nvcc", "-DX"}, "", true);
@@ -627,6 +665,42 @@ TEST_CASE(GencodeAppendAccumulates) {
     EXPECT_FALSE(std::ranges::contains(switched, "--offload-arch=sm_90"));
 }
 
+TEST_CASE(CollapseHonorsNegatives) {
+    // A specific --no-offload-arch erases only its matches from the ranking;
+    // the negated flag pair stays for clang to consume, and the newest of
+    // the survivors wins.
+    std::vector<const char*> flags = {"clang",
+                                      "--cuda-gpu-arch=sm_90",
+                                      "--no-offload-arch=sm_90",
+                                      "--cuda-gpu-arch=sm_75",
+                                      "--cuda-gpu-arch=sm_86"};
+    collapse_gpu_arch_flags(flags);
+    std::vector<std::string> collapsed(flags.begin(), flags.end());
+    std::vector<std::string> expected = {"clang",
+                                         "--cuda-gpu-arch=sm_90",
+                                         "--no-offload-arch=sm_90",
+                                         "--cuda-gpu-arch=sm_86"};
+    EXPECT_EQ(collapsed, expected);
+
+    // A single survivor leaves nothing to collapse.
+    std::vector<const char*> single = {"clang",
+                                       "--cuda-gpu-arch=sm_90",
+                                       "--no-offload-arch=sm_90",
+                                       "--cuda-gpu-arch=sm_75"};
+    auto kept = single;
+    collapse_gpu_arch_flags(single);
+    EXPECT_EQ(single, kept);
+
+    // An unrankable negative leaves the whole command to clang.
+    std::vector<const char*> native = {"clang",
+                                       "--cuda-gpu-arch=sm_90",
+                                       "--no-offload-arch=native",
+                                       "--cuda-gpu-arch=sm_75"};
+    auto untouched = native;
+    collapse_gpu_arch_flags(native);
+    EXPECT_EQ(native, untouched);
+}
+
 TEST_CASE(WildcardRemoveClearsArch) {
     CompilationDatabase db;
     std::vector<const char*> gencode = {"nvcc",
@@ -702,6 +776,36 @@ TEST_CASE(RemoveMatchesUnknownSpelling) {
     EXPECT_FALSE(has("--allow-unsupported-compiler"));
     EXPECT_TRUE(has("-ccbin=/usr/bin/g++-12"));
     EXPECT_TRUE(has("--target-directory=sbsa-linux"));
+}
+
+TEST_CASE(RemoveListAlternatives) {
+    CompilationDatabase db;
+    std::vector<const char*> arguments = {"nvcc",
+                                          "-ccbin=/usr/bin/g++-12",
+                                          "-default-stream=per-thread",
+                                          "-c",
+                                          "/tmp/kern.cu"};
+    db.add_command("/tmp", "/tmp/kern.cu", arguments);
+
+    // Remove patterns are alternatives, not one command: every value of the
+    // same stateful option becomes a pattern, where nvcc's last-wins over
+    // the whole list would keep only the final one and leave the base's
+    // g++-12 token in place.
+    CommandOptions options;
+    llvm::SmallVector<std::string> remove = {"-ccbin=/usr/bin/g++-13",
+                                             "-ccbin=/usr/bin/g++-12",
+                                             "--default-stream=per-thread"};
+    options.remove = remove;
+
+    auto commands = db.lookup("/tmp/kern.cu", options);
+    ASSERT_EQ(commands.size(), std::size_t(1));
+
+    auto& flags = commands[0].resolved.flags;
+    auto has = [&](llvm::StringRef flag) {
+        return std::ranges::contains(flags, flag);
+    };
+    EXPECT_FALSE(has("-ccbin=/usr/bin/g++-12"));
+    EXPECT_FALSE(has("CUDA_API_PER_THREAD_DEFAULT_STREAM=1"));
 }
 
 TEST_CASE(WildcardRemovesProbeValue) {

--- a/tests/unit/command/nvcc_tests.cpp
+++ b/tests/unit/command/nvcc_tests.cpp
@@ -370,6 +370,12 @@ TEST_CASE(EditEmitsStateOverrides) {
     ASSERT_TRUE(clear != arch.end() && clear + 1 != arch.end());
     EXPECT_EQ(*(clear + 1), "--cuda-gpu-arch=sm_80"sv);
     EXPECT_FALSE(contains(translate({"nvcc", "-arch=sm_80"}), "--no-offload-arch=all"));
+
+    // -gencode accumulates in nvcc, so as an edit it adds its architecture
+    // without erasing the base's.
+    auto gencode = translate({"nvcc", "-gencode=arch=compute_75,code=sm_75"}, "", true);
+    EXPECT_TRUE(contains(gencode, "--cuda-gpu-arch=sm_75"));
+    EXPECT_FALSE(contains(gencode, "--no-offload-arch=all"));
 }
 
 constexpr static llvm::StringRef fake_dryrun = R"(#$ _NVVM_BRANCH_=nvvm
@@ -581,6 +587,44 @@ TEST_CASE(AppendOverridesBase) {
     EXPECT_TRUE(index_of("--offload-arch=sm_75") < index_of("--no-offload-arch=all"));
     EXPECT_TRUE(index_of("--no-offload-arch=all") < index_of("--cuda-gpu-arch=sm_80"));
     EXPECT_TRUE(index_of("--cuda-gpu-arch=sm_80") < count);
+}
+
+TEST_CASE(GencodeAppendAccumulates) {
+    CompilationDatabase db;
+    std::vector<const char*> arguments = {"nvcc",
+                                          "--generate-code=arch=compute_90,code=sm_90",
+                                          "-c",
+                                          "/tmp/kern.cu"};
+    db.add_command("/tmp", "/tmp/kern.cu", arguments);
+
+    auto arch_flags = [&](llvm::ArrayRef<std::string> append) {
+        CommandOptions options;
+        options.append = append;
+        auto commands = db.lookup("/tmp/kern.cu", options);
+        std::vector<std::string> result;
+        for(llvm::StringRef flag: commands[0].resolved.flags) {
+            if(flag.contains("arch")) {
+                result.push_back(flag.str());
+            }
+        }
+        return result;
+    };
+
+    // Appended -gencode entries accumulate onto the base's like nvcc's own,
+    // and the newest architecture keeps winning: an older append changes
+    // nothing.
+    llvm::SmallVector<std::string> older = {"-gencode=arch=compute_75,code=sm_75"};
+    auto kept = arch_flags(older);
+    EXPECT_TRUE(std::ranges::contains(kept, "--offload-arch=sm_90"));
+    EXPECT_FALSE(std::ranges::contains(kept, "--cuda-gpu-arch=sm_75"));
+    EXPECT_FALSE(std::ranges::contains(kept, "--no-offload-arch=all"));
+
+    // A newer append takes over — by numeric rank, not string order, which
+    // would sort sm_100a below sm_90.
+    llvm::SmallVector<std::string> newer = {"-gencode=arch=compute_100a,code=sm_100a"};
+    auto switched = arch_flags(newer);
+    EXPECT_TRUE(std::ranges::contains(switched, "--cuda-gpu-arch=sm_100a"));
+    EXPECT_FALSE(std::ranges::contains(switched, "--offload-arch=sm_90"));
 }
 
 TEST_CASE(WildcardRemoveClearsArch) {

--- a/tests/unit/command/nvcc_tests.cpp
+++ b/tests/unit/command/nvcc_tests.cpp
@@ -1,0 +1,221 @@
+#include <algorithm>
+
+#include "test/test.h"
+#include "command/command.h"
+#include "command/nvcc.h"
+#include "command/toolchain.h"
+
+namespace clice::testing {
+namespace {
+
+using namespace std::string_view_literals;
+
+TEST_SUITE(NVCCTests) {
+
+std::vector<std::string> translate(std::vector<const char*> arguments) {
+    return translate_nvcc_command(arguments).arguments;
+}
+
+bool contains(llvm::ArrayRef<std::string> arguments, llvm::StringRef flag) {
+    return std::ranges::contains(arguments, flag);
+}
+
+TEST_CASE(TranslateCMakeShape) {
+    auto args = translate({"nvcc",
+                           "-forward-unknown-to-host-compiler",
+                           "-DMY_FLAG=1",
+                           "--generate-code=arch=compute_75,code=[compute_75,sm_75]",
+                           "-x",
+                           "cu",
+                           "-c",
+                           "kern.cu",
+                           "-o",
+                           "kern.cu.o"});
+
+    EXPECT_EQ(args[0], "nvcc"sv);
+    EXPECT_TRUE(contains(args, "--cuda-gpu-arch=sm_75"));
+    EXPECT_TRUE(contains(args, "-DMY_FLAG=1"));
+    EXPECT_TRUE(contains(args, "-x"));
+    EXPECT_TRUE(contains(args, "cuda"));
+    EXPECT_FALSE(contains(args, "cu"));
+    for(llvm::StringRef arg: args) {
+        EXPECT_FALSE(arg.starts_with("--generate-code"));
+    }
+}
+
+TEST_CASE(GencodeSelectsBest) {
+    // The newest architecture wins; 'a' outranks 'f' and plain at the same
+    // number; lto_ entries are intermediates, not architectures.
+    auto args = translate({"nvcc",
+                           "-gencode",
+                           "arch=compute_75,code=sm_75",
+                           "-gencode",
+                           "arch=compute_90a,code=[compute_90a,sm_90a,lto_120]",
+                           "-gencode=arch=compute_80,code=sm_80"});
+    EXPECT_TRUE(contains(args, "--cuda-gpu-arch=sm_90a"));
+
+    auto compute_only = translate({"nvcc", "-arch=compute_86"});
+    EXPECT_TRUE(contains(compute_only, "--cuda-gpu-arch=sm_86"));
+
+    auto family = translate({"nvcc", "-code=sm_100f,sm_100"});
+    EXPECT_TRUE(contains(family, "--cuda-gpu-arch=sm_100f"));
+
+    EXPECT_FALSE(contains(translate({"nvcc", "-c", "a.cu"}), "--cuda-gpu-arch=sm_52"));
+}
+
+TEST_CASE(CcbinBecomesToken) {
+    for(auto arguments: {
+            std::vector<const char*>{"nvcc", "-ccbin", "/usr/bin/g++-12"},
+            std::vector<const char*>{"nvcc", "-ccbin=/usr/bin/g++-12"},
+            std::vector<const char*>{"nvcc", "--compiler-bindir", "/usr/bin/g++-12"}
+    }) {
+        auto args = translate(arguments);
+        EXPECT_TRUE(contains(args, "-ccbin=/usr/bin/g++-12"));
+        EXPECT_FALSE(contains(args, "/usr/bin/g++-12"));
+    }
+}
+
+TEST_CASE(XcompilerUnwrapped) {
+    auto args = translate({"nvcc", "-Xcompiler=-fPIC,-pthread", "-Xcompiler", "-Wall"});
+    EXPECT_TRUE(contains(args, "-fPIC"));
+    EXPECT_TRUE(contains(args, "-pthread"));
+    EXPECT_TRUE(contains(args, "-Wall"));
+    EXPECT_FALSE(contains(args, "-Xcompiler"));
+}
+
+TEST_CASE(MacroToggles) {
+    auto args = translate({"nvcc",
+                           "--expt-relaxed-constexpr",
+                           "--extended-lambda",
+                           "-rdc=true",
+                           "-default-stream",
+                           "per-thread"});
+    EXPECT_TRUE(contains(args, "-D__CUDACC_RELAXED_CONSTEXPR__"));
+    EXPECT_TRUE(contains(args, "-D__CUDACC_EXTENDED_LAMBDA__"));
+    EXPECT_TRUE(contains(args, "-fgpu-rdc"));
+    EXPECT_TRUE(contains(args, "-D__CUDACC_RDC__"));
+    EXPECT_TRUE(contains(args, "-DCUDA_API_PER_THREAD_DEFAULT_STREAM=1"));
+
+    auto off = translate({"nvcc", "-rdc=false"});
+    EXPECT_FALSE(contains(off, "-fgpu-rdc"));
+}
+
+TEST_CASE(PairedValueDrops) {
+    // The wrapped values would parse as host flags on their own; bare
+    // nvcc-only flags pass through for the CDB classification to discard.
+    auto args = translate(
+        {"nvcc", "-Xptxas", "-O3", "-t", "4", "--options-file", "extra.rsp", "-lineinfo"});
+    std::vector<std::string> expected = {"nvcc", "-lineinfo"};
+    EXPECT_EQ(args, expected);
+}
+
+TEST_CASE(LongFormAliases) {
+    auto args = translate({"nvcc",
+                           "--include-path=/opt/inc",
+                           "--define-macro",
+                           "FOO=1",
+                           "--undefine-macro=BAR",
+                           "--pre-include",
+                           "config.h",
+                           "--system-include=/opt/sys"});
+    auto joined = llvm::join(args, " ");
+    EXPECT_TRUE(llvm::StringRef(joined).contains("-I /opt/inc"));
+    EXPECT_TRUE(llvm::StringRef(joined).contains("-D FOO=1"));
+    EXPECT_TRUE(llvm::StringRef(joined).contains("-U BAR"));
+    EXPECT_TRUE(llvm::StringRef(joined).contains("-include config.h"));
+    EXPECT_TRUE(llvm::StringRef(joined).contains("-isystem /opt/sys"));
+}
+
+TEST_CASE(StdNormalized) {
+    EXPECT_TRUE(contains(translate({"nvcc", "-std", "c++17"}), "-std=c++17"));
+    EXPECT_TRUE(contains(translate({"nvcc", "--std=c++20"}), "-std=c++20"));
+}
+
+constexpr static llvm::StringRef fake_dryrun = R"(#$ _NVVM_BRANCH_=nvvm
+#$ _SPACE_=
+#$ TOP=/opt/cuda/targets/x86_64-linux
+#$ NVVMIR_LIBRARY_DIR=/opt/cuda/targets/x86_64-linux/nvvm/libdevice
+#$ LD_LIBRARY_PATH=/opt/cuda/targets/x86_64-linux/lib:
+#$ PATH=/opt/cuda/targets/x86_64-linux/bin:/opt/host/bin:/usr/bin
+#$ INCLUDES="-I/opt/cuda/targets/x86_64-linux/include"
+#$ g++ -D__CUDA_ARCH_LIST__=520 -D__NV_LEGACY_LAUNCH -E -x c++ -D__CUDACC__ -D__NVCC__ "-I/opt/cuda/targets/x86_64-linux/include" -D__CUDACC_VER_MAJOR__=12 -D__CUDACC_VER_MINOR__=9 -include "cuda_runtime.h" -m64 "/tmp/a.cu" -o "/tmp/a.cpp4.ii"
+#$ cudafe++ --c++17 --gnu_version=140400 "/tmp/a.cpp4.ii"
+#$ g++ -D__CUDA_ARCH__=520 -D__CUDA_ARCH_LIST__=520 -D__NV_LEGACY_LAUNCH -E -x c++ -DCUDA_DOUBLE_MATH_FUNCTIONS -D__CUDACC__ -D__NVCC__ -D__CUDACC_VER_MAJOR__=12 -D__CUDACC_VER_MINOR__=9 -include "cuda_runtime.h" -m64 "/tmp/a.cu" -o "/tmp/a.cpp1.ii"
+#$ cicc --c++17 --gnu_version=140400 -arch compute_52 -m64 "/tmp/a.cpp1.ii" -o "/tmp/a.ptx"
+#$ ptxas -arch=sm_52 -m64 "/tmp/a.ptx" -o "/tmp/a.cubin"
+)";
+
+TEST_CASE(DryrunParsed) {
+    auto info = parse_nvcc_dryrun(fake_dryrun);
+    ASSERT_TRUE(info.has_value());
+
+    EXPECT_EQ(info->cuda_path, "/opt/cuda/targets/x86_64-linux");
+    EXPECT_EQ(info->host_compiler, "g++");
+    EXPECT_EQ(info->cpp_dialect, "c++17");
+    EXPECT_EQ(info->default_arch, "sm_52");
+    EXPECT_TRUE(std::ranges::contains(info->search_path, "/opt/host/bin"));
+
+    // clang derives the blocklisted three itself; the rest must survive.
+    for(auto defines: {&info->host_defines, &info->device_defines}) {
+        EXPECT_TRUE(std::ranges::contains(*defines, "__CUDACC_VER_MAJOR__=12"));
+        EXPECT_TRUE(std::ranges::contains(*defines, "__NV_LEGACY_LAUNCH"));
+        EXPECT_FALSE(std::ranges::contains(*defines, "__CUDACC__"));
+        for(llvm::StringRef define: *defines) {
+            EXPECT_FALSE(define.starts_with("__CUDA_ARCH__"));
+            EXPECT_FALSE(define.starts_with("__CUDA_ARCH_LIST__"));
+        }
+    }
+    EXPECT_TRUE(std::ranges::contains(info->device_defines, "CUDA_DOUBLE_MATH_FUNCTIONS"));
+    EXPECT_FALSE(std::ranges::contains(info->host_defines, "CUDA_DOUBLE_MATH_FUNCTIONS"));
+}
+
+TEST_CASE(DryrunRejectsIncomplete) {
+    EXPECT_FALSE(parse_nvcc_dryrun("#$ PATH=/usr/bin").has_value());
+    EXPECT_FALSE(parse_nvcc_dryrun("#$ TOP=/opt/cuda").has_value());
+}
+
+TEST_CASE(CcbinAffectsKey) {
+    Toolchain tc;
+    std::vector<const char*> a = {"nvcc", "-ccbin=/usr/bin/g++-12"};
+    std::vector<const char*> b = {"nvcc", "-ccbin=/usr/bin/g++-13"};
+    EXPECT_NE(tc.cache_key("/tmp/a.cu", a), tc.cache_key("/tmp/a.cu", b));
+    EXPECT_EQ(tc.cache_key("/tmp/a.cu", a), tc.cache_key("/tmp/a.cu", a));
+}
+
+TEST_CASE(DatabaseTranslatesNVCC) {
+    CompilationDatabase db;
+    std::vector<const char*> arguments = {"nvcc",
+                                          "-forward-unknown-to-host-compiler",
+                                          "-DMY_FLAG=1",
+                                          "--generate-code=arch=compute_75,code=[compute_75,sm_75]",
+                                          "-ccbin=/usr/bin/g++-12",
+                                          "-x",
+                                          "cu",
+                                          "-c",
+                                          "/tmp/kern.cu",
+                                          "-o",
+                                          "kern.cu.o"};
+    db.add_command("/tmp", "/tmp/kern.cu", arguments);
+
+    auto commands = db.lookup("/tmp/kern.cu");
+    ASSERT_EQ(commands.size(), std::size_t(1));
+
+    auto& flags = commands[0].resolved.flags;
+    auto has = [&](llvm::StringRef flag) {
+        return std::ranges::contains(flags, flag);
+    };
+    // --cuda-gpu-arch renders through its unaliased spelling.
+    EXPECT_TRUE(has("--offload-arch=sm_75"));
+    EXPECT_TRUE(has("-ccbin=/usr/bin/g++-12"));
+    EXPECT_TRUE(has("-x"));
+    EXPECT_TRUE(has("cuda"));
+    EXPECT_TRUE(has("MY_FLAG=1"));
+    EXPECT_FALSE(has("-forward-unknown-to-host-compiler"));
+    for(llvm::StringRef flag: flags) {
+        EXPECT_FALSE(flag.starts_with("--generate-code"));
+    }
+}
+
+};  // TEST_SUITE(NVCCTests)
+}  // namespace
+}  // namespace clice::testing

--- a/tests/unit/command/nvcc_tests.cpp
+++ b/tests/unit/command/nvcc_tests.cpp
@@ -71,9 +71,11 @@ TEST_CASE(GencodeSelectsBest) {
 }
 
 TEST_CASE(CcbinBecomesToken) {
-    for(auto arguments: {std::vector<const char*>{"nvcc", "-ccbin", "/usr/bin/g++-12"},
-                         std::vector<const char*>{"nvcc", "-ccbin=/usr/bin/g++-12"},
-                         std::vector<const char*>{"nvcc", "--compiler-bindir", "/usr/bin/g++-12"}}) {
+    for(auto arguments: {
+            std::vector<const char*>{"nvcc", "-ccbin", "/usr/bin/g++-12"},
+            std::vector<const char*>{"nvcc", "-ccbin=/usr/bin/g++-12"},
+            std::vector<const char*>{"nvcc", "--compiler-bindir", "/usr/bin/g++-12"}
+    }) {
         auto args = translate(arguments);
         EXPECT_TRUE(contains(args, "-ccbin=/usr/bin/g++-12"));
         EXPECT_FALSE(contains(args, "/usr/bin/g++-12"));
@@ -86,8 +88,9 @@ TEST_CASE(ProbeFlagsCarried) {
     auto args = translate(
         {"nvcc", "-allow-unsupported-compiler", "-target-dir", "sbsa-linux", "-ccbin", "tools/g++"},
         "/base");
-    for(llvm::StringRef flag:
-        {"--allow-unsupported-compiler", "--target-directory=sbsa-linux", "-ccbin=/base/tools/g++"}) {
+    for(llvm::StringRef flag: {"--allow-unsupported-compiler",
+                               "--target-directory=sbsa-linux",
+                               "-ccbin=/base/tools/g++"}) {
         EXPECT_TRUE(contains(args, flag));
         EXPECT_TRUE(is_nvcc_probe_flag(flag));
     }
@@ -155,9 +158,16 @@ TEST_CASE(ListValuesSplit) {
     auto args = translate(
         {"nvcc", "-Ia,b", "-DA=1,B=2", "-U", "X,Y", "-isystem=s1,s2", "-include", "h1.h,h2.h"});
     auto joined = llvm::join(args, " ");
-    for(llvm::StringRef piece:
-        {"-I a", "-I b", "-D A=1", "-D B=2", "-U X", "-U Y", "-isystem s1", "-isystem s2",
-         "-include h1.h", "-include h2.h"}) {
+    for(llvm::StringRef piece: {"-I a",
+                                "-I b",
+                                "-D A=1",
+                                "-D B=2",
+                                "-U X",
+                                "-U Y",
+                                "-isystem s1",
+                                "-isystem s2",
+                                "-include h1.h",
+                                "-include h2.h"}) {
         EXPECT_TRUE(llvm::StringRef(joined).contains(piece));
     }
 }

--- a/tests/unit/command/nvcc_tests.cpp
+++ b/tests/unit/command/nvcc_tests.cpp
@@ -76,6 +76,36 @@ TEST_CASE(GencodeSelectsBest) {
     }
 }
 
+TEST_CASE(SpecialArchCarried) {
+    // Non-numeric selections only nvcc can resolve persist as probe tokens
+    // for the dryrun instead of vanishing into no architecture at all.
+    for(auto arguments: {
+            std::vector<const char*>{"nvcc", "-arch=native"},
+            std::vector<const char*>{"nvcc", "-arch", "native"},
+            std::vector<const char*>{"nvcc", "--gpu-architecture=native"}
+    }) {
+        auto args = translate(arguments);
+        EXPECT_TRUE(contains(args, "-arch=native"));
+        EXPECT_FALSE(contains(args, "native"));
+    }
+    EXPECT_TRUE(is_nvcc_probe_flag("-arch=native"));
+    EXPECT_TRUE(contains(translate({"nvcc", "-arch=all"}), "-arch=all"));
+
+    // -arch stays last-wins across numeric and special values.
+    auto numeric_wins = translate({"nvcc", "-arch=native", "-arch=sm_80"});
+    EXPECT_TRUE(contains(numeric_wins, "--cuda-gpu-arch=sm_80"));
+    EXPECT_FALSE(contains(numeric_wins, "-arch=native"));
+    auto special_wins = translate({"nvcc", "-arch=sm_80", "-arch=native"});
+    EXPECT_TRUE(contains(special_wins, "-arch=native"));
+    EXPECT_FALSE(contains(special_wins, "--cuda-gpu-arch=sm_80"));
+
+    // As an edit it clears the base architectures like a numeric choice.
+    auto edit = translate({"nvcc", "-arch=native"}, "", true);
+    auto clear = std::ranges::find(edit, "--no-offload-arch=all");
+    ASSERT_TRUE(clear != edit.end() && clear + 1 != edit.end());
+    EXPECT_EQ(*(clear + 1), "-arch=native"sv);
+}
+
 TEST_CASE(CcbinBecomesToken) {
     for(auto arguments: {
             std::vector<const char*>{"nvcc", "-ccbin", "/usr/bin/g++-12"},
@@ -276,6 +306,42 @@ TEST_CASE(StdNormalized) {
     EXPECT_TRUE(contains(translate({"nvcc", "--std=c++20"}), "-std=c++20"));
 }
 
+TEST_CASE(MachineNormalized) {
+    for(auto arguments: {
+            std::vector<const char*>{"nvcc", "--machine=64"},
+            std::vector<const char*>{"nvcc", "--machine", "64"},
+            std::vector<const char*>{"nvcc", "-m=64"},
+            std::vector<const char*>{"nvcc", "-m", "64"}
+    }) {
+        auto args = translate(arguments);
+        EXPECT_TRUE(contains(args, "-m64"));
+        EXPECT_FALSE(contains(args, "64"));
+    }
+    EXPECT_TRUE(contains(translate({"nvcc", "--machine=32"}), "-m32"));
+
+    // The joined short form is already clang's own spelling.
+    EXPECT_TRUE(contains(translate({"nvcc", "-m64"}), "-m64"));
+
+    // A value nvcc rejects pins no machine model.
+    auto invalid = translate({"nvcc", "--machine=16"});
+    EXPECT_FALSE(contains(invalid, "-m16"));
+    EXPECT_FALSE(contains(invalid, "--machine=16"));
+}
+
+TEST_CASE(OptimizeNormalized) {
+    EXPECT_TRUE(contains(translate({"nvcc", "--optimize=3"}), "-O3"));
+    EXPECT_TRUE(contains(translate({"nvcc", "-O", "2"}), "-O2"));
+    EXPECT_TRUE(contains(translate({"nvcc", "-O3"}), "-O3"));
+}
+
+TEST_CASE(DisableWarningsMapped) {
+    for(const char* spelling: {"--disable-warnings", "-disable-warnings"}) {
+        auto args = translate({"nvcc", spelling});
+        EXPECT_TRUE(contains(args, "-w"));
+        EXPECT_FALSE(contains(args, spelling));
+    }
+}
+
 TEST_CASE(EditEmitsStateOverrides) {
     // An edit lands after an already-translated base command: explicitly
     // disabled stateful options must cancel the base's translated state,
@@ -342,6 +408,16 @@ TEST_CASE(DryrunParsed) {
     }
     EXPECT_TRUE(std::ranges::contains(info->device_defines, "CUDA_DOUBLE_MATH_FUNCTIONS"));
     EXPECT_FALSE(std::ranges::contains(info->host_defines, "CUDA_DOUBLE_MATH_FUNCTIONS"));
+
+    // A probe carrying -arch=all runs one cicc per architecture; the newest
+    // wins regardless of emission order.
+    constexpr llvm::StringRef multi = R"(#$ g++ -E -x c++ "/tmp/a.cu" -o "/tmp/a.ii"
+#$ cicc --c++17 -arch compute_90 "/tmp/a.cpp1.ii" -o "/tmp/a.ptx"
+#$ cicc --c++17 -arch compute_75 "/tmp/a.cpp1.ii" -o "/tmp/b.ptx"
+)";
+    auto multi_info = parse_nvcc_dryrun(multi);
+    ASSERT_TRUE(multi_info.has_value());
+    EXPECT_EQ(multi_info->default_arch, "sm_90");
 }
 
 TEST_CASE(DryrunRejectsIncomplete) {
@@ -516,6 +592,8 @@ TEST_CASE(WildcardRemoveClearsArch) {
     db.add_command("/tmp", "/tmp/kern.cu", gencode);
     std::vector<const char*> arch = {"nvcc", "-arch=sm_80", "-c", "/tmp/other.cu"};
     db.add_command("/tmp", "/tmp/other.cu", arch);
+    std::vector<const char*> native = {"nvcc", "-arch=native", "-c", "/tmp/native.cu"};
+    db.add_command("/tmp", "/tmp/native.cu", native);
 
     auto arch_flags = [&](llvm::StringRef file, const CommandOptions& options) {
         auto commands = db.lookup(file, options);
@@ -530,9 +608,10 @@ TEST_CASE(WildcardRemoveClearsArch) {
 
     EXPECT_TRUE(std::ranges::contains(arch_flags("/tmp/kern.cu", {}), "--offload-arch=sm_75"));
     EXPECT_TRUE(std::ranges::contains(arch_flags("/tmp/other.cu", {}), "--offload-arch=sm_80"));
+    EXPECT_TRUE(std::ranges::contains(arch_flags("/tmp/native.cu", {}), "-arch=native"));
 
-    // The wildcard names no concrete architecture, so it cannot translate to
-    // a matching flag itself — it must still clear whatever the base carries.
+    // The wildcard must clear whichever form the base carries: numeric archs
+    // translate to --offload-arch, non-numeric ones persist as probe tokens.
     CommandOptions options;
     llvm::SmallVector<std::string> remove = {"--generate-code=*"};
     options.remove = remove;
@@ -541,6 +620,7 @@ TEST_CASE(WildcardRemoveClearsArch) {
     llvm::SmallVector<std::string> separate = {"-arch", "*"};
     options.remove = separate;
     EXPECT_TRUE(arch_flags("/tmp/other.cu", options).empty());
+    EXPECT_TRUE(arch_flags("/tmp/native.cu", options).empty());
 
     // Removes edit the base before appends land: replacing the architecture
     // through remove-wildcard + append keeps the appended one.
@@ -578,6 +658,36 @@ TEST_CASE(RemoveMatchesUnknownSpelling) {
     EXPECT_FALSE(has("--allow-unsupported-compiler"));
     EXPECT_TRUE(has("-ccbin=/usr/bin/g++-12"));
     EXPECT_TRUE(has("--target-directory=sbsa-linux"));
+}
+
+TEST_CASE(WildcardRemovesProbeValue) {
+    CompilationDatabase db;
+    std::vector<const char*> arguments =
+        {"nvcc", "-ccbin=/usr/bin/g++-12", "-target-dir", "sbsa-linux", "-c", "/tmp/kern.cu"};
+    db.add_command("/tmp", "/tmp/kern.cu", arguments);
+
+    auto probe_flags = [&](llvm::ArrayRef<std::string> remove) {
+        CommandOptions options;
+        options.remove = remove;
+        auto commands = db.lookup("/tmp/kern.cu", options);
+        std::vector<std::string> result;
+        for(llvm::StringRef flag: commands[0].resolved.flags) {
+            if(is_nvcc_probe_flag(flag)) {
+                result.push_back(flag.str());
+            }
+        }
+        return result;
+    };
+
+    // A probe token's identity is its whole spelling; `=*` wildcards the
+    // value so the rule clears the concrete host compiler it never spelled.
+    llvm::SmallVector<std::string> ccbin = {"-ccbin=*"};
+    std::vector<std::string> target_only = {"--target-directory=sbsa-linux"};
+    EXPECT_EQ(probe_flags(ccbin), target_only);
+
+    llvm::SmallVector<std::string> target = {"--target-directory=*"};
+    std::vector<std::string> ccbin_only = {"-ccbin=/usr/bin/g++-12"};
+    EXPECT_EQ(probe_flags(target), ccbin_only);
 }
 
 };  // TEST_SUITE(NVCCTests)

--- a/tests/unit/command/toolchain_tests.cpp
+++ b/tests/unit/command/toolchain_tests.cpp
@@ -212,6 +212,26 @@ TEST_CASE(NVCCViewSelector, skip = !(CIEnvironment && Linux)) {
     EXPECT_FALSE(has_define(*host, "CUDA_DOUBLE_MATH_FUNCTIONS"));
 };
 
+TEST_CASE(NVCCArchEdit, skip = !(CIEnvironment && Linux)) {
+    auto file = fs::createTemporaryFile("clice", "cu");
+    if(!file) {
+        LOG_ERROR_RET(void(), "{}", file.error());
+    }
+
+    // An edit-appended -arch=<special> arrives as `--no-offload-arch=all`
+    // plus the probe token; the dryrun's resolution must land after the
+    // clear, or clang erases it again and falls back to its sm_52 default.
+    // -arch=all runs one cicc per toolkit architecture and the newest wins.
+    auto result = Toolchain::query(
+        {"nvcc", "--no-offload-arch=all", "-arch=all", "-resource-dir", resource_dir().data()},
+        file->c_str());
+    ASSERT_TRUE(result.has_value());
+
+    auto cpu = std::ranges::find(*result, "-target-cpu");
+    ASSERT_TRUE(cpu != result->end() && cpu + 1 != result->end());
+    EXPECT_NE(*(cpu + 1), "sm_52"sv);
+};
+
 TEST_CASE(NVCCHostInput, skip = !(CIEnvironment && Linux)) {
     auto file = fs::createTemporaryFile("clice", "cpp");
     if(!file) {

--- a/tests/unit/command/toolchain_tests.cpp
+++ b/tests/unit/command/toolchain_tests.cpp
@@ -141,6 +141,9 @@ TEST_CASE(NVCC, skip = !(CIEnvironment && Linux)) {
         params.arguments.push_back(arg.c_str());
     }
     params.add_remapped_file(file->c_str(), R"(
+            #ifndef __CUDACC__
+            #error clang's CUDA wrapper presents __CUDACC__ to user code
+            #endif
             __global__ void kern(float* p) { p[threadIdx.x] = 1.0f; }
             int main() {
                 float* d = nullptr;
@@ -174,6 +177,65 @@ TEST_CASE(NVCCCudaHeader, skip = !(CIEnvironment && Linux)) {
     }
     params.add_remapped_file(file->c_str(), R"(
             __device__ float scale(float* p) { return p[threadIdx.x]; }
+        )");
+
+    auto unit = compile(params);
+    ASSERT_TRUE(unit.completed());
+    ASSERT_TRUE(unit.diagnostics().empty());
+};
+
+TEST_CASE(NVCCViewSelector, skip = !(CIEnvironment && Linux)) {
+    auto file = fs::createTemporaryFile("clice", "cu");
+    if(!file) {
+        LOG_ERROR_RET(void(), "{}", file.error());
+    }
+
+    auto has_define = [](llvm::ArrayRef<std::string> args, llvm::StringRef name) {
+        return std::ranges::any_of(args, [&](llvm::StringRef arg) { return arg.contains(name); });
+    };
+
+    // The last view selector wins, as in clang's driver, and the injected
+    // defines follow the selected pass (CUDA_DOUBLE_MATH_FUNCTIONS appears
+    // only on nvcc's device preprocess line).
+    auto device = Toolchain::query(
+        {"nvcc", "--cuda-host-only", "--cuda-device-only", "-resource-dir", resource_dir().data()},
+        file->c_str());
+    ASSERT_TRUE(device.has_value());
+    EXPECT_TRUE(std::ranges::contains(*device, "-fcuda-is-device"));
+    EXPECT_TRUE(has_define(*device, "CUDA_DOUBLE_MATH_FUNCTIONS"));
+
+    auto host = Toolchain::query(
+        {"nvcc", "--cuda-device-only", "--cuda-host-only", "-resource-dir", resource_dir().data()},
+        file->c_str());
+    ASSERT_TRUE(host.has_value());
+    EXPECT_FALSE(std::ranges::contains(*host, "-fcuda-is-device"));
+    EXPECT_FALSE(has_define(*host, "CUDA_DOUBLE_MATH_FUNCTIONS"));
+};
+
+TEST_CASE(NVCCHostInput, skip = !(CIEnvironment && Linux)) {
+    auto file = fs::createTemporaryFile("clice", "cpp");
+    if(!file) {
+        LOG_ERROR_RET(void(), "{}", file.error());
+    }
+
+    // A host-language input compiles in a single host step: no CUDA mode,
+    // but nvcc's injected identity macros still apply.
+    auto result = Toolchain::query({"nvcc", "-resource-dir", resource_dir().data()}, file->c_str());
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FALSE(std::ranges::contains(*result, "-fcuda-is-device"));
+
+    CompilationParams params;
+    for(auto& arg: *result) {
+        params.arguments.push_back(arg.c_str());
+    }
+    params.add_remapped_file(file->c_str(), R"(
+            #ifndef __NVCC__
+            #error the host step keeps nvcc's identity macros
+            #endif
+            #ifdef __CUDACC__
+            #error a host-language input is not a CUDA compile
+            #endif
+            int main() { return 0; }
         )");
 
     auto unit = compile(params);

--- a/tests/unit/command/toolchain_tests.cpp
+++ b/tests/unit/command/toolchain_tests.cpp
@@ -155,6 +155,32 @@ TEST_CASE(NVCC, skip = !(CIEnvironment && Linux)) {
     ASSERT_TRUE(unit.diagnostics().empty());
 };
 
+TEST_CASE(NVCCCudaHeader, skip = !(CIEnvironment && Linux)) {
+    auto file = fs::createTemporaryFile("clice", "cuh");
+    if(!file) {
+        LOG_ERROR_RET(void(), "{}", file.error());
+    }
+
+    auto result = Toolchain::query({"nvcc", "-resource-dir", resource_dir().data()}, file->c_str());
+    ASSERT_TRUE(result.has_value());
+
+    ASSERT_TRUE(result->size() > 2);
+    ASSERT_EQ((*result)[1], "-cc1"sv);
+    EXPECT_TRUE(std::ranges::contains(*result, "-fcuda-is-device"));
+
+    CompilationParams params;
+    for(auto& arg: *result) {
+        params.arguments.push_back(arg.c_str());
+    }
+    params.add_remapped_file(file->c_str(), R"(
+            __device__ float scale(float* p) { return p[threadIdx.x]; }
+        )");
+
+    auto unit = compile(params);
+    ASSERT_TRUE(unit.completed());
+    ASSERT_TRUE(unit.diagnostics().empty());
+};
+
 TEST_CASE(InitiallyEmpty) {
     Toolchain tc;
     EXPECT_FALSE(tc.has_cache());

--- a/tests/unit/command/toolchain_tests.cpp
+++ b/tests/unit/command/toolchain_tests.cpp
@@ -121,6 +121,40 @@ TEST_CASE(Zig, skip = !CIEnvironment) {
     // TODO: add Zig toolchain test when available in CI.
 }
 
+TEST_CASE(NVCC, skip = !(CIEnvironment && Linux)) {
+    auto file = fs::createTemporaryFile("clice", "cu");
+    if(!file) {
+        LOG_ERROR_RET(void(), "{}", file.error());
+    }
+
+    auto result = Toolchain::query({"nvcc", "-resource-dir", resource_dir().data()}, file->c_str());
+    ASSERT_TRUE(result.has_value());
+
+    ASSERT_TRUE(result->size() > 2);
+    ASSERT_EQ((*result)[1], "-cc1"sv);
+
+    // The default view is the device pass — the __CUDA_ARCH__ world.
+    EXPECT_TRUE(std::ranges::contains(*result, "-fcuda-is-device"));
+
+    CompilationParams params;
+    for(auto& arg: *result) {
+        params.arguments.push_back(arg.c_str());
+    }
+    params.add_remapped_file(file->c_str(), R"(
+            __global__ void kern(float* p) { p[threadIdx.x] = 1.0f; }
+            int main() {
+                float* d = nullptr;
+                cudaMalloc(&d, 16);
+                kern<<<1, 1>>>(d);
+                return 0;
+            }
+        )");
+
+    auto unit = compile(params);
+    ASSERT_TRUE(unit.completed());
+    ASSERT_TRUE(unit.diagnostics().empty());
+};
+
 TEST_CASE(InitiallyEmpty) {
     Toolchain tc;
     EXPECT_FALSE(tc.has_cache());


### PR DESCRIPTION
## Related issue

Closes #86

## What changed

nvcc compilation databases now work end to end: a `.cu` entry driven by nvcc resolves to a clang CUDA invocation and gets full language features.

- **Command translation** (`src/command/nvcc.h/.cpp`): nvcc-only spellings are rewritten into flags clang's option table parses, before the regular CDB classification runs. `-gencode`/`-arch`/`-code` collapse to the single best `--cuda-gpu-arch=` (newest wins; `a` > `f` > plain at equal number, so `sm_90a` unlocks Hopper GMMA/TMA), `-x cu` becomes `-x cuda`, `-Xcompiler` values unwrap into plain host flags, long-form preprocessor aliases (`--include-path`, `--define-macro`, ...) become their short spellings, macro toggles (`--expt-relaxed-constexpr`, `--extended-lambda`, `-rdc=true`, `--default-stream per-thread`) become their exact `-D` effect, and wrapper options whose values could be mistaken for host flags (`-Xptxas -O3`) are dropped in pairs. The host compiler from `-ccbin` travels as a verbatim `-ccbin=<path>` token — clang has no spelling for it — and participates in the toolchain cache key.
- **Toolchain query** (`src/command/toolchain.cpp`): the NVCC branch runs `nvcc --dryrun` once per unique toolchain and parses what CMake's own CUDA detection parses: the toolkit root (`TOP=`, which is not derivable from the nvcc binary location — conda-style layouts put it under `targets/<triple>`), the host compiler (resolved against nvcc's own augmented `PATH`), nvcc's default dialect and architecture, and the macros nvcc injects (`__CUDACC_VER_MAJOR__`, ...). clang never defines those, yet real CUDA libraries gate on them — CUTLASS keeps every SM90 code path invisible without them. The host toolchain is then pinned exactly like the GCC branch (`-dumpmachine` / `-print-search-dirs`) and the in-process clang driver produces the cc1.
- **Device view by default**: CUDA files parse as the device pass — reading CUDA code means reading the `__CUDA_ARCH__` world, and the host pass grays every arch-gated implementation out. clang parses host and device code in either pass, so navigation and diagnostics in host code keep working; only `#ifndef __CUDA_ARCH__` regions become the inactive ones. Appending `--cuda-host-only` to a command (e.g. via a config rule) flips a file to the host view.
- **Fallback commands**: `.cu`/`.cuh` files without a CDB entry synthesize `clang++ -std=c++20 -x cuda` — `.cuh` is not a clang-known extension, and without `-x` the driver classifies it as linker input and builds no compile job at all.
- **CI**: Linux jobs install `cuda-nvcc` plus the toolkit headers via pixi (no GPU needed — compilation and the dryrun probe are pure CPU), so the real-toolchain tests run there.

Deliberately out of scope for now: nvcc with an MSVC host (`cl`) fails with a clear error; multi-arch entries parse the newest architecture only (surfacing every `-gencode` arch as its own view belongs to the context-model work); `-arch=all/all-major/native` fall back to nvcc's default architecture, since their expansion depends on the machine; `--options-file` contents are read at CDB load, so regenerating only the response file without touching the CDB needs a reload to be picked up (clang-style `@file` doesn't have this problem because the driver re-expands it on every compile); compiler launchers (`ccache nvcc ...`) and CDB-relative driver paths are pre-existing gaps shared with every compiler family.

## Tests

- Unit: translation cases (arch selection including `sm_90a`/`sm_100f` suffixes and `lto_` exclusion, `-Xcompiler` unwrap, ccbin token, paired value drops, long-form aliases), dryrun parsing against canned real nvcc output, cache-key separation by ccbin, CDB-level ingestion assertions, and a real `Toolchain::query` + kernel compile (CI Linux, device view asserted).
- Integration: a real server over an nvcc CDB — clean compile, go-to-definition from a `<<<1, 1>>>` launch into the kernel, and inactive regions pinning the `#else` host branch as the gray one. Skipped where nvcc is absent; runs on Linux CI.
- Verified end to end against CUTLASS: with a `-gencode arch=compute_90a,code=sm_90a` entry, `CUTE_ARCH_TMA_SM90_ENABLED` code is live and a TU using the TMA headers parses with zero diagnostics.
- All four suites green locally on RelWithDebInfo and Debug (ASan + assertions), including the CI-gated NVCC cases force-run under ASan; `npm run check` clean.
