### PR TITLE
feat(config): generated configuration docs and JSON schema

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,11 @@ jobs:
               - '.github/workflows/main.yml'
             cmake:
               - 'CMakeLists.txt'
+              # Generated docs and the committed schema are verified against
+              # the built binary, so edits to them must run native-test.
+              - 'docs/public/clice-config.schema.json'
+              - 'docs/en/guide/configuration.md'
+              - 'docs/en/features/**'
               - 'src/**'
               - 'include/**'
               - 'tests/**'

--- a/.github/workflows/native-test.yml
+++ b/.github/workflows/native-test.yml
@@ -101,6 +101,18 @@ jobs:
         timeout-minutes: 20
         run: pixi run -e test-run snap-test ${{ matrix.build_type }}
 
+      # The committed config schema must match the binary that just built
+      # (the dump needs clice itself), and the generated doc regions must
+      # match their sources. One leg suffices — the outputs are
+      # machine-independent by construction.
+      - name: Generated docs check
+        if: ${{ matrix.os == 'ubuntu-24.04' && matrix.build_type == 'RelWithDebInfo' }}
+        run: |
+          build/RelWithDebInfo/bin/clice inspect --config-schema > docs/public/clice-config.schema.json
+          git diff --exit-code -- docs/public/clice-config.schema.json
+          pixi run -- node tools/feature_docs.ts check
+          pixi run -- node tools/config_docs.ts check
+
       # Package the exact binary the suites above just validated. These
       # artifacts are what releases promote — there is no separate release
       # build.

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -256,7 +256,7 @@ Complete keywords as snippets (not yet implemented).
 | ------ | ------- |
 | `bool` | `false` |
 
-Insert function arguments as a snippet when completing a call; applies to individually listed overloads, so it requires `bundle_overloads = false`.
+Insert function arguments as a snippet when completing a call. For functions this applies to individually listed overloads, so it requires `bundle_overloads = false`; function-like macros have no overload sets and always take the snippet.
 
 ### `code_completion.enable_template_arguments_snippet`
 

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -68,9 +68,9 @@ Index persistence backend: "lmdb" (single database file) or "files" (one file pe
 
 ### `project.idle_timeout_ms`
 
-| Type  | Default |
-| ----- | ------- |
-| `int` | `3000`  |
+| Type     | Default |
+| -------- | ------- |
+| `uint32` | `3000`  |
 
 Idle delay in milliseconds before background indexing starts.
 
@@ -104,7 +104,7 @@ Initial number of stateless workers — they handle ephemeral tasks (PCH/PCM bui
 | -------- | ------- |
 | `uint32` | `1`     |
 
-Lower bound for dynamic stateless-worker scaling.
+Lower bound for dynamic stateless-worker scaling; `0` is invalid and falls back to the default.
 
 ### `project.max_stateless_worker_count`
 
@@ -112,7 +112,7 @@ Lower bound for dynamic stateless-worker scaling.
 | -------- | ------- |
 | `uint32` | —       |
 
-Upper bound for dynamic stateless-worker scaling; defaults to the machine's parallelism.
+Upper bound for dynamic stateless-worker scaling; `0` means the machine's parallelism, which is also the default.
 
 ### `project.worker_memory_limit`
 

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -48,7 +48,7 @@ Directory for log files; empty derives `${cache_dir}/logs`. Each server session 
 | ----------------- | ------- |
 | `array of string` | `[]`    |
 
-Paths searched for compile_commands.json — file paths, or directories to look inside. Empty searches the workspace root and then each of its immediate subdirectories, first hit wins.
+Paths searched for compile_commands.json — file paths, or directories to look inside. When these all miss — or the list is empty — the workspace root and then each of its immediate subdirectories are searched.
 
 ### `project.enable_indexing`
 
@@ -72,7 +72,7 @@ Index persistence backend: "lmdb" (single database file) or "files" (one file pe
 | ----- | ------- |
 | `int` | `3000`  |
 
-Idle delay in milliseconds after the last edit before background indexing starts.
+Idle delay in milliseconds before background indexing starts.
 
 ### `project.test_hooks`
 
@@ -88,7 +88,7 @@ Enable the clice/internal test hooks used by the test harness.
 | -------- | ------- |
 | `uint32` | `2`     |
 
-Number of stateful workers — they hold ASTs in memory and serve queries (hover, semantic tokens, ...).
+Number of stateful workers — they hold ASTs in memory and serve queries (hover, semantic tokens, ...); `0` is invalid and falls back to the default.
 
 ### `project.stateless_worker_count`
 
@@ -96,7 +96,7 @@ Number of stateful workers — they hold ASTs in memory and serve queries (hover
 | -------- | ------- |
 | `uint32` | —       |
 
-Initial number of stateless workers — they handle ephemeral tasks (PCH/PCM builds, completion, signature help); defaults to half the machine's parallelism, at least 2.
+Initial number of stateless workers — they handle ephemeral tasks (PCH/PCM builds, completion, signature help); defaults to half the machine's parallelism, at least 2. `0` is invalid and falls back to that default.
 
 ### `project.min_stateless_worker_count`
 
@@ -120,7 +120,7 @@ Upper bound for dynamic stateless-worker scaling; defaults to the machine's para
 | -------- | ------------ |
 | `uint64` | `4294967296` |
 
-Per-stateful-worker memory limit in bytes. Not yet enforced: parsed, but memory-based eviction is not implemented.
+Per-stateful-worker memory limit in bytes; `0` is invalid and falls back to the default. Not yet enforced: parsed, but memory-based eviction is not implemented.
 
 <!-- END GENERATED CONFIG -->
 
@@ -232,7 +232,7 @@ Show the default arguments a call omitted, abbreviated when long.
 | -------- | ------- |
 | `uint32` | `32`    |
 
-Character budget for rendered hint text (deduced types, default arguments); longer text is abbreviated. `0` means no limit.
+Byte budget for rendered hint text: over-long deduced types fall back to a sugared spelling or are dropped, over-long default arguments are abbreviated. `0` means no limit.
 
 <!-- END GENERATED CONFIG -->
 
@@ -256,7 +256,7 @@ Complete keywords as snippets (not yet implemented).
 | ------ | ------- |
 | `bool` | `false` |
 
-Insert function arguments as a snippet on completion.
+Insert function arguments as a snippet when completing a call; applies to individually listed overloads, so it requires `bundle_overloads = false`.
 
 ### `code_completion.enable_template_arguments_snippet`
 
@@ -304,7 +304,7 @@ Maximum number of completion items (not yet implemented).
 | ----------------- | ------- |
 | `array of string` | `[]`    |
 
-Glob patterns selecting the files this rule applies to: `*` matches within a path segment, `?` a single character, `**` any number of segments, `{a,b}` alternatives, `[0-9]` a character range, `[!...]` a negated range.
+Glob patterns selecting the files this rule applies to: `*` matches within a path segment (a pattern of just `*` matches any path), `?` a single character, `**` any number of segments, `{a,b}` alternatives, `[0-9]` a character range, `[!...]` a negated range.
 
 ### `[rules].append`
 

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -4,6 +4,8 @@ clice reads configuration from `clice.toml` in the workspace root, or from `.cli
 
 Configuration is read once at server startup. Changing it — either file — requires restarting the server; there is no hot reload.
 
+A JSON schema of the whole configuration is published at [`clice-config.schema.json`](/clice-config.schema.json); editors that validate TOML or JSON against a schema can point at it.
+
 ## Variable Substitution
 
 The following variable is supported in string values:
@@ -14,29 +16,31 @@ The following variable is supported in string values:
 
 ## Project
 
+<!-- BEGIN GENERATED CONFIG: project -->
+
 ### `project.clang_tidy`
 
 | Type   | Default |
 | ------ | ------- |
 | `bool` | `false` |
 
-Enable experimental clang-tidy diagnostics. **Not yet wired** — the option is parsed but has no effect currently.
+Run clang-tidy alongside compiler diagnostics. Not yet wired: the option is parsed but has no effect.
 
 ### `project.cache_dir`
 
-| Type     | Default                                                             |
-| -------- | ------------------------------------------------------------------- |
-| `string` | `$XDG_CACHE_HOME/clice/<workspace>-<hash>` or `${workspace}/.clice` |
+| Type     | Default |
+| -------- | ------- |
+| `string` | `""`    |
 
-Directory for the unified on-disk cache (PCH, PCM, and index artifacts all live here). The default uses XDG_CACHE_HOME (or `~/.cache`) with a per-workspace subdirectory named after the workspace directory plus a short hash, e.g. `~/.cache/clice/myproject-1a2b3c4d`. Falls back to `${workspace}/.clice` if the XDG directory cannot be created. The resolved paths are printed at startup in the effective configuration dump (visible in your editor's clice output panel).
+Directory for the unified on-disk cache (PCH, PCM and index artifacts). Empty derives it from XDG_CACHE_HOME (or `~/.cache`) with a per-workspace subdirectory named after the workspace plus a short hash, falling back to `${workspace}/.clice`; the resolved path is printed at startup.
 
 ### `project.logging_dir`
 
-| Type     | Default             |
-| -------- | ------------------- |
-| `string` | `${cache_dir}/logs` |
+| Type     | Default |
+| -------- | ------- |
+| `string` | `""`    |
 
-Directory for log files. Each server session logs into its own timestamped subdirectory; the startup log line `Session log directory:` shows the exact path.
+Directory for log files; empty derives `${cache_dir}/logs`. Each server session logs into its own timestamped subdirectory.
 
 ### `project.compile_commands_paths`
 
@@ -44,7 +48,7 @@ Directory for log files. Each server session logs into its own timestamped subdi
 | ----------------- | ------- |
 | `array of string` | `[]`    |
 
-Paths to search for `compile_commands.json` files. Entries can be direct file paths or directories (clice looks for `compile_commands.json` inside). When empty (the default), clice searches the workspace root and then each of its immediate subdirectories, using the first `compile_commands.json` it finds.
+Paths searched for compile_commands.json — file paths, or directories to look inside. Empty searches the workspace root and then each of its immediate subdirectories, first hit wins.
 
 ### `project.enable_indexing`
 
@@ -52,7 +56,15 @@ Paths to search for `compile_commands.json` files. Entries can be direct file pa
 | ------ | ------- |
 | `bool` | `true`  |
 
-Enable background indexing for cross-TU features (find references, workspace symbols, etc.).
+Build the background index that serves cross-TU features (find references, workspace symbols, ...).
+
+### `project.index_db`
+
+| Type     | Default  |
+| -------- | -------- |
+| `string` | `"lmdb"` |
+
+Index persistence backend: "lmdb" (single database file) or "files" (one file per blob).
 
 ### `project.idle_timeout_ms`
 
@@ -60,7 +72,15 @@ Enable background indexing for cross-TU features (find references, workspace sym
 | ----- | ------- |
 | `int` | `3000`  |
 
-Idle time (milliseconds) before starting background indexing after the last edit.
+Idle delay in milliseconds after the last edit before background indexing starts.
+
+### `project.test_hooks`
+
+| Type   | Default |
+| ------ | ------- |
+| `bool` | `false` |
+
+Enable the clice/internal test hooks used by the test harness.
 
 ### `project.stateful_worker_count`
 
@@ -68,43 +88,47 @@ Idle time (milliseconds) before starting background indexing after the last edit
 | -------- | ------- |
 | `uint32` | `2`     |
 
-Number of stateful worker processes. These hold ASTs in memory and serve queries (hover, semantic tokens, etc.).
+Number of stateful workers — they hold ASTs in memory and serve queries (hover, semantic tokens, ...).
 
 ### `project.stateless_worker_count`
 
-| Type     | Default           |
-| -------- | ----------------- |
-| `uint32` | `max(cores/2, 2)` |
+| Type     | Default |
+| -------- | ------- |
+| `uint32` | —       |
 
-Number of stateless worker processes spawned at startup. These handle ephemeral tasks (PCH/PCM builds, completion, signature help).
+Initial number of stateless workers — they handle ephemeral tasks (PCH/PCM builds, completion, signature help); defaults to half the machine's parallelism, at least 2.
 
 ### `project.min_stateless_worker_count`
 
-| Type     | Default    |
-| -------- | ---------- |
-| `uint32` | `0` (auto) |
+| Type     | Default |
+| -------- | ------- |
+| `uint32` | `1`     |
 
-Lower bound for dynamic scale-down of stateless workers. `0` resolves to an automatic minimum.
+Lower bound for dynamic stateless-worker scaling.
 
 ### `project.max_stateless_worker_count`
 
-| Type     | Default    |
-| -------- | ---------- |
-| `uint32` | `0` (auto) |
+| Type     | Default |
+| -------- | ------- |
+| `uint32` | —       |
 
-Upper bound for dynamic scale-up of stateless workers. `0` resolves to the CPU core count.
+Upper bound for dynamic stateless-worker scaling; defaults to the machine's parallelism.
 
 ### `project.worker_memory_limit`
 
-| Type     | Default             |
-| -------- | ------------------- |
-| `uint64` | `4294967296` (4 GB) |
+| Type     | Default      |
+| -------- | ------------ |
+| `uint64` | `4294967296` |
 
-Per-worker memory limit in bytes. **Not yet enforced** — the option is parsed but memory-based eviction/restart is not implemented yet.
+Per-stateful-worker memory limit in bytes. Not yet enforced: parsed, but memory-based eviction is not implemented.
+
+<!-- END GENERATED CONFIG -->
 
 ## Tracker
 
 The file tracker polls for changes that happen outside the editor (a `git checkout`, a regenerated `compile_commands.json`, code generators writing headers) so the server picks them up without a restart. Setting an interval to `0` disables that polling loop.
+
+<!-- BEGIN GENERATED CONFIG: tracker -->
 
 ### `tracker.cdb_poll_seconds`
 
@@ -112,7 +136,7 @@ The file tracker polls for changes that happen outside the editor (a `git checko
 | -------- | ------- |
 | `uint32` | `3`     |
 
-Interval for re-checking the compilation database file.
+Compilation database poll interval in seconds; 0 disables polling.
 
 ### `tracker.workspace_poll_seconds`
 
@@ -120,11 +144,15 @@ Interval for re-checking the compilation database file.
 | -------- | ------- |
 | `uint32` | `30`    |
 
-Interval for sweeping workspace files for on-disk changes.
+Workspace file sweep interval in seconds; 0 disables polling.
+
+<!-- END GENERATED CONFIG -->
 
 ## Hover
 
-The `[hover]` section controls how hover cards render. Changes take effect after a server restart.
+The `[hover]` section controls how hover cards render.
+
+<!-- BEGIN GENERATED CONFIG: hover -->
 
 ### `hover.parse_comment_as_markdown`
 
@@ -132,7 +160,7 @@ The `[hover]` section controls how hover cards render. Changes take effect after
 | ------ | ------- |
 | `bool` | `true`  |
 
-Render the hover card as markdown. `false` produces plain text for clients that cannot display markdown.
+Render the hover card as markdown; `false` produces plain text for clients that cannot display it.
 
 ### `hover.show_aka`
 
@@ -142,9 +170,13 @@ Render the hover card as markdown. `false` produces plain text for clients that 
 
 Show the desugared form of a type, e.g. `vector<int>::size_type (aka unsigned long)`.
 
+<!-- END GENERATED CONFIG -->
+
 ## Inlay Hints
 
-The `[inlay_hints]` section controls which inlay hint categories the server produces. Configuration changes take effect after a server restart; a client-side refresh then requests hints with the updated values. No recompile is involved.
+The `[inlay_hints]` section controls which inlay hint categories the server produces. A client-side refresh then requests hints with the updated values; no recompile is involved.
+
+<!-- BEGIN GENERATED CONFIG: inlay_hints -->
 
 ### `inlay_hints.enabled`
 
@@ -168,7 +200,7 @@ Parameter name hints at call sites, e.g. `draw(width: 800, height: 600)`, includ
 | ------ | ------- |
 | `bool` | `true`  |
 
-Deduced type hints for `auto` variables, structured bindings, and deduced return types.
+Deduced type hints for `auto` variables, structured bindings and deduced return types.
 
 ### `inlay_hints.designators`
 
@@ -176,7 +208,7 @@ Deduced type hints for `auto` variables, structured bindings, and deduced return
 | ------ | ------- |
 | `bool` | `true`  |
 
-Field designator hints in aggregate initialization, e.g. `Point{.x=1, .y=2}` for `Point{1, 2}`.
+Field designator hints in aggregate initialization, e.g. `.x=` and `.y=` in `Point{1, 2}`.
 
 ### `inlay_hints.block_end`
 
@@ -200,11 +232,71 @@ Show the default arguments a call omitted, abbreviated when long.
 | -------- | ------- |
 | `uint32` | `32`    |
 
-Maximum length for printed type names; longer types fall back to a sugared spelling or are dropped. `0` means no limit.
+Character budget for rendered hint text (deduced types, default arguments); longer text is abbreviated. `0` means no limit.
+
+<!-- END GENERATED CONFIG -->
+
+## Code Completion
+
+The `[code_completion]` section controls completion item assembly.
+
+<!-- BEGIN GENERATED CONFIG: code_completion -->
+
+### `code_completion.enable_keyword_snippet`
+
+| Type   | Default |
+| ------ | ------- |
+| `bool` | `false` |
+
+Complete keywords as snippets (not yet implemented).
+
+### `code_completion.enable_function_arguments_snippet`
+
+| Type   | Default |
+| ------ | ------- |
+| `bool` | `false` |
+
+Insert function arguments as a snippet on completion.
+
+### `code_completion.enable_template_arguments_snippet`
+
+| Type   | Default |
+| ------ | ------- |
+| `bool` | `false` |
+
+Insert template arguments as a snippet on completion (not yet implemented).
+
+### `code_completion.insert_paren_in_function_call`
+
+| Type   | Default |
+| ------ | ------- |
+| `bool` | `false` |
+
+Insert parentheses when completing a function call (not yet implemented).
+
+### `code_completion.bundle_overloads`
+
+| Type   | Default |
+| ------ | ------- |
+| `bool` | `true`  |
+
+Collapse an overload set into a single completion item.
+
+### `code_completion.limit`
+
+| Type     | Default |
+| -------- | ------- |
+| `uint32` | `0`     |
+
+Maximum number of completion items (not yet implemented).
+
+<!-- END GENERATED CONFIG -->
 
 ## Rules
 
 `[[rules]]` is an array of rule objects. Rules are matched in declaration order — later rules override earlier ones.
+
+<!-- BEGIN GENERATED CONFIG: rules -->
 
 ### `[rules].patterns`
 
@@ -212,14 +304,7 @@ Maximum length for printed type names; longer types fall back to a sugared spell
 | ----------------- | ------- |
 | `array of string` | `[]`    |
 
-Glob patterns for matching file paths:
-
-- `*` — matches one or more characters in a path segment
-- `?` — matches a single character in a path segment
-- `**` — matches any number of path segments, including zero
-- `{}` — groups conditions (e.g., `**/*.{h,cpp}`)
-- `[]` — character range (e.g., `example.[0-9]`)
-- `[!...]` — negated character range
+Glob patterns selecting the files this rule applies to: `*` matches within a path segment, `?` a single character, `**` any number of segments, `{a,b}` alternatives, `[0-9]` a character range, `[!...]` a negated range.
 
 ### `[rules].append`
 
@@ -227,7 +312,7 @@ Glob patterns for matching file paths:
 | ----------------- | ------- |
 | `array of string` | `[]`    |
 
-Flags to append to the compilation command. Example: `["-std=c++20", "-DNDEBUG"]`.
+Compilation flags appended for matching files, e.g. `["-std=c++20", "-DNDEBUG"]`.
 
 ### `[rules].remove`
 
@@ -235,7 +320,9 @@ Flags to append to the compilation command. Example: `["-std=c++20", "-DNDEBUG"]
 | ----------------- | ------- |
 | `array of string` | `[]`    |
 
-Flags to remove from the compilation command. Example: `["-Wall", "-Werror"]`.
+Compilation flags removed for matching files, e.g. `["-Wall"]`.
+
+<!-- END GENERATED CONFIG -->
 
 ## Example
 

--- a/docs/public/clice-config.schema.json
+++ b/docs/public/clice-config.schema.json
@@ -69,6 +69,7 @@
             "default": []
         }
     },
+    "additionalProperties": false,
     "$defs": {
         "ProjectConfig": {
             "type": "object",
@@ -120,14 +121,14 @@
                 },
                 "stateful_worker_count": {
                     "type": "integer",
-                    "minimum": 0,
+                    "minimum": 1,
                     "maximum": 4294967295,
                     "description": "Number of stateful workers — they hold ASTs in memory and serve queries (hover, semantic tokens, ...); `0` is invalid and falls back to the default.",
                     "default": 2
                 },
                 "stateless_worker_count": {
                     "type": "integer",
-                    "minimum": 0,
+                    "minimum": 1,
                     "maximum": 4294967295,
                     "description": "Initial number of stateless workers — they handle ephemeral tasks (PCH/PCM builds, completion, signature help); defaults to half the machine's parallelism, at least 2. `0` is invalid and falls back to that default."
                 },
@@ -146,12 +147,13 @@
                 },
                 "worker_memory_limit": {
                     "type": "integer",
-                    "minimum": 0,
+                    "minimum": 1,
                     "maximum": 18446744073709551615,
                     "description": "Per-stateful-worker memory limit in bytes; `0` is invalid and falls back to the default. Not yet enforced: parsed, but memory-based eviction is not implemented.",
                     "default": 4294967296
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "TrackerConfig": {
             "type": "object",
@@ -170,7 +172,8 @@
                     "description": "Workspace file sweep interval in seconds; 0 disables polling.",
                     "default": 30
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "HoverOptions": {
             "type": "object",
@@ -185,7 +188,8 @@
                     "description": "Show the desugared form of a type, e.g. `vector<int>::size_type (aka unsigned long)`.",
                     "default": true
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "InlayHintsOptions": {
             "type": "object",
@@ -227,7 +231,8 @@
                     "description": "Byte budget for rendered hint text: over-long deduced types fall back to a sugared spelling or are dropped, over-long default arguments are abbreviated. `0` means no limit.",
                     "default": 32
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "CodeCompletionOptions": {
             "type": "object",
@@ -239,7 +244,7 @@
                 },
                 "enable_function_arguments_snippet": {
                     "type": "boolean",
-                    "description": "Insert function arguments as a snippet when completing a call; applies to individually listed overloads, so it requires `bundle_overloads = false`.",
+                    "description": "Insert function arguments as a snippet when completing a call. For functions this applies to individually listed overloads, so it requires `bundle_overloads = false`; function-like macros have no overload sets and always take the snippet.",
                     "default": false
                 },
                 "enable_template_arguments_snippet": {
@@ -264,7 +269,8 @@
                     "description": "Maximum number of completion items (not yet implemented).",
                     "default": 0
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "ConfigRule": {
             "type": "object",
@@ -293,7 +299,8 @@
                     "description": "Compilation flags removed for matching files, e.g. `[\"-Wall\"]`.",
                     "default": []
                 }
-            }
+            },
+            "additionalProperties": false
         }
     }
 }

--- a/docs/public/clice-config.schema.json
+++ b/docs/public/clice-config.schema.json
@@ -1,299 +1,300 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
-  "properties": {
-    "project": {
-      "$ref": "#/$defs/ProjectConfig",
-      "description": "The [project] section: project-wide server options.",
-      "default": {
-        "clang_tidy": false,
-        "cache_dir": "",
-        "logging_dir": "",
-        "compile_commands_paths": [],
-        "enable_indexing": true,
-        "index_db": "lmdb",
-        "idle_timeout_ms": 3000,
-        "test_hooks": false,
-        "stateful_worker_count": 2,
-        "min_stateless_worker_count": 1,
-        "worker_memory_limit": 4294967296
-      }
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "project": {
+            "$ref": "#/$defs/ProjectConfig",
+            "description": "The [project] section: project-wide server options.",
+            "default": {
+                "clang_tidy": false,
+                "cache_dir": "",
+                "logging_dir": "",
+                "compile_commands_paths": [],
+                "enable_indexing": true,
+                "index_db": "lmdb",
+                "idle_timeout_ms": 3000,
+                "test_hooks": false,
+                "stateful_worker_count": 2,
+                "min_stateless_worker_count": 1,
+                "worker_memory_limit": 4294967296
+            }
+        },
+        "tracker": {
+            "$ref": "#/$defs/TrackerConfig",
+            "description": "The [tracker] section: file tracker poll intervals.",
+            "default": {
+                "cdb_poll_seconds": 3,
+                "workspace_poll_seconds": 30
+            }
+        },
+        "hover": {
+            "$ref": "#/$defs/HoverOptions",
+            "description": "The [hover] section: hover rendering options.",
+            "default": {
+                "parse_comment_as_markdown": true,
+                "show_aka": true
+            }
+        },
+        "inlay_hints": {
+            "$ref": "#/$defs/InlayHintsOptions",
+            "description": "The [inlay_hints] section: inlay hint options.",
+            "default": {
+                "enabled": true,
+                "parameters": true,
+                "deduced_types": true,
+                "designators": true,
+                "block_end": false,
+                "default_arguments": false,
+                "type_name_limit": 32
+            }
+        },
+        "code_completion": {
+            "$ref": "#/$defs/CodeCompletionOptions",
+            "description": "The [code_completion] section: code completion options.",
+            "default": {
+                "enable_keyword_snippet": false,
+                "enable_function_arguments_snippet": false,
+                "enable_template_arguments_snippet": false,
+                "insert_paren_in_function_call": false,
+                "bundle_overloads": true,
+                "limit": 0
+            }
+        },
+        "rules": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/ConfigRule"
+            },
+            "description": "File-pattern rules that adjust compilation flags ([[rules]] in clice.toml).",
+            "default": []
+        }
     },
-    "tracker": {
-      "$ref": "#/$defs/TrackerConfig",
-      "description": "The [tracker] section: file tracker poll intervals.",
-      "default": {
-        "cdb_poll_seconds": 3,
-        "workspace_poll_seconds": 30
-      }
-    },
-    "hover": {
-      "$ref": "#/$defs/HoverOptions",
-      "description": "The [hover] section: hover rendering options.",
-      "default": {
-        "parse_comment_as_markdown": true,
-        "show_aka": true
-      }
-    },
-    "inlay_hints": {
-      "$ref": "#/$defs/InlayHintsOptions",
-      "description": "The [inlay_hints] section: inlay hint options.",
-      "default": {
-        "enabled": true,
-        "parameters": true,
-        "deduced_types": true,
-        "designators": true,
-        "block_end": false,
-        "default_arguments": false,
-        "type_name_limit": 32
-      }
-    },
-    "code_completion": {
-      "$ref": "#/$defs/CodeCompletionOptions",
-      "description": "The [code_completion] section: code completion options.",
-      "default": {
-        "enable_keyword_snippet": false,
-        "enable_function_arguments_snippet": false,
-        "enable_template_arguments_snippet": false,
-        "insert_paren_in_function_call": false,
-        "bundle_overloads": true,
-        "limit": 0
-      }
-    },
-    "rules": {
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/ConfigRule"
-      },
-      "description": "File-pattern rules that adjust compilation flags ([[rules]] in clice.toml).",
-      "default": []
+    "$defs": {
+        "ProjectConfig": {
+            "type": "object",
+            "properties": {
+                "clang_tidy": {
+                    "type": "boolean",
+                    "description": "Run clang-tidy alongside compiler diagnostics. Not yet wired: the option is parsed but has no effect.",
+                    "default": false
+                },
+                "cache_dir": {
+                    "type": "string",
+                    "description": "Directory for the unified on-disk cache (PCH, PCM and index artifacts). Empty derives it from XDG_CACHE_HOME (or `~/.cache`) with a per-workspace subdirectory named after the workspace plus a short hash, falling back to `${workspace}/.clice`; the resolved path is printed at startup.",
+                    "default": ""
+                },
+                "logging_dir": {
+                    "type": "string",
+                    "description": "Directory for log files; empty derives `${cache_dir}/logs`. Each server session logs into its own timestamped subdirectory.",
+                    "default": ""
+                },
+                "compile_commands_paths": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Paths searched for compile_commands.json — file paths, or directories to look inside. When these all miss — or the list is empty — the workspace root and then each of its immediate subdirectories are searched.",
+                    "default": []
+                },
+                "enable_indexing": {
+                    "type": "boolean",
+                    "description": "Build the background index that serves cross-TU features (find references, workspace symbols, ...).",
+                    "default": true
+                },
+                "index_db": {
+                    "type": "string",
+                    "description": "Index persistence backend: \"lmdb\" (single database file) or \"files\" (one file per blob).",
+                    "default": "lmdb"
+                },
+                "idle_timeout_ms": {
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647,
+                    "description": "Idle delay in milliseconds before background indexing starts.",
+                    "default": 3000
+                },
+                "test_hooks": {
+                    "type": "boolean",
+                    "description": "Enable the clice/internal test hooks used by the test harness.",
+                    "default": false
+                },
+                "stateful_worker_count": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 4294967295,
+                    "description": "Number of stateful workers — they hold ASTs in memory and serve queries (hover, semantic tokens, ...); `0` is invalid and falls back to the default.",
+                    "default": 2
+                },
+                "stateless_worker_count": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 4294967295,
+                    "description": "Initial number of stateless workers — they handle ephemeral tasks (PCH/PCM builds, completion, signature help); defaults to half the machine's parallelism, at least 2. `0` is invalid and falls back to that default."
+                },
+                "min_stateless_worker_count": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 4294967295,
+                    "description": "Lower bound for dynamic stateless-worker scaling.",
+                    "default": 1
+                },
+                "max_stateless_worker_count": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 4294967295,
+                    "description": "Upper bound for dynamic stateless-worker scaling; defaults to the machine's parallelism."
+                },
+                "worker_memory_limit": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 18446744073709551615,
+                    "description": "Per-stateful-worker memory limit in bytes; `0` is invalid and falls back to the default. Not yet enforced: parsed, but memory-based eviction is not implemented.",
+                    "default": 4294967296
+                }
+            }
+        },
+        "TrackerConfig": {
+            "type": "object",
+            "properties": {
+                "cdb_poll_seconds": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 4294967295,
+                    "description": "Compilation database poll interval in seconds; 0 disables polling.",
+                    "default": 3
+                },
+                "workspace_poll_seconds": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 4294967295,
+                    "description": "Workspace file sweep interval in seconds; 0 disables polling.",
+                    "default": 30
+                }
+            }
+        },
+        "HoverOptions": {
+            "type": "object",
+            "properties": {
+                "parse_comment_as_markdown": {
+                    "type": "boolean",
+                    "description": "Render the hover card as markdown; `false` produces plain text for clients that cannot display it.",
+                    "default": true
+                },
+                "show_aka": {
+                    "type": "boolean",
+                    "description": "Show the desugared form of a type, e.g. `vector<int>::size_type (aka unsigned long)`.",
+                    "default": true
+                }
+            }
+        },
+        "InlayHintsOptions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Master switch: `false` disables all inlay hints.",
+                    "default": true
+                },
+                "parameters": {
+                    "type": "boolean",
+                    "description": "Parameter name hints at call sites, e.g. `draw(width: 800, height: 600)`, including `&` markers for arguments passed by mutable reference.",
+                    "default": true
+                },
+                "deduced_types": {
+                    "type": "boolean",
+                    "description": "Deduced type hints for `auto` variables, structured bindings and deduced return types.",
+                    "default": true
+                },
+                "designators": {
+                    "type": "boolean",
+                    "description": "Field designator hints in aggregate initialization, e.g. `.x=` and `.y=` in `Point{1, 2}`.",
+                    "default": true
+                },
+                "block_end": {
+                    "type": "boolean",
+                    "description": "`// name` hints after the closing brace of long blocks (functions, types, namespaces, control flow).",
+                    "default": false
+                },
+                "default_arguments": {
+                    "type": "boolean",
+                    "description": "Show the default arguments a call omitted, abbreviated when long.",
+                    "default": false
+                },
+                "type_name_limit": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 4294967295,
+                    "description": "Byte budget for rendered hint text: over-long deduced types fall back to a sugared spelling or are dropped, over-long default arguments are abbreviated. `0` means no limit.",
+                    "default": 32
+                }
+            }
+        },
+        "CodeCompletionOptions": {
+            "type": "object",
+            "properties": {
+                "enable_keyword_snippet": {
+                    "type": "boolean",
+                    "description": "Complete keywords as snippets (not yet implemented).",
+                    "default": false
+                },
+                "enable_function_arguments_snippet": {
+                    "type": "boolean",
+                    "description": "Insert function arguments as a snippet when completing a call; applies to individually listed overloads, so it requires `bundle_overloads = false`.",
+                    "default": false
+                },
+                "enable_template_arguments_snippet": {
+                    "type": "boolean",
+                    "description": "Insert template arguments as a snippet on completion (not yet implemented).",
+                    "default": false
+                },
+                "insert_paren_in_function_call": {
+                    "type": "boolean",
+                    "description": "Insert parentheses when completing a function call (not yet implemented).",
+                    "default": false
+                },
+                "bundle_overloads": {
+                    "type": "boolean",
+                    "description": "Collapse an overload set into a single completion item.",
+                    "default": true
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 4294967295,
+                    "description": "Maximum number of completion items (not yet implemented).",
+                    "default": 0
+                }
+            }
+        },
+        "ConfigRule": {
+            "type": "object",
+            "properties": {
+                "patterns": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Glob patterns selecting the files this rule applies to: `*` matches within a path segment (a pattern of just `*` matches any path), `?` a single character, `**` any number of segments, `{a,b}` alternatives, `[0-9]` a character range, `[!...]` a negated range.",
+                    "default": []
+                },
+                "append": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Compilation flags appended for matching files, e.g. `[\"-std=c++20\", \"-DNDEBUG\"]`.",
+                    "default": []
+                },
+                "remove": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Compilation flags removed for matching files, e.g. `[\"-Wall\"]`.",
+                    "default": []
+                }
+            }
+        }
     }
-  },
-  "$defs": {
-    "ProjectConfig": {
-      "type": "object",
-      "properties": {
-        "clang_tidy": {
-          "type": "boolean",
-          "description": "Run clang-tidy alongside compiler diagnostics. Not yet wired: the option is parsed but has no effect.",
-          "default": false
-        },
-        "cache_dir": {
-          "type": "string",
-          "description": "Directory for the unified on-disk cache (PCH, PCM and index artifacts). Empty derives it from XDG_CACHE_HOME (or `~/.cache`) with a per-workspace subdirectory named after the workspace plus a short hash, falling back to `${workspace}/.clice`; the resolved path is printed at startup.",
-          "default": ""
-        },
-        "logging_dir": {
-          "type": "string",
-          "description": "Directory for log files; empty derives `${cache_dir}/logs`. Each server session logs into its own timestamped subdirectory.",
-          "default": ""
-        },
-        "compile_commands_paths": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Paths searched for compile_commands.json — file paths, or directories to look inside. Empty searches the workspace root and then each of its immediate subdirectories, first hit wins.",
-          "default": []
-        },
-        "enable_indexing": {
-          "type": "boolean",
-          "description": "Build the background index that serves cross-TU features (find references, workspace symbols, ...).",
-          "default": true
-        },
-        "index_db": {
-          "type": "string",
-          "description": "Index persistence backend: \"lmdb\" (single database file) or \"files\" (one file per blob).",
-          "default": "lmdb"
-        },
-        "idle_timeout_ms": {
-          "type": "integer",
-          "minimum": -2147483648,
-          "maximum": 2147483647,
-          "description": "Idle delay in milliseconds after the last edit before background indexing starts.",
-          "default": 3000
-        },
-        "test_hooks": {
-          "type": "boolean",
-          "description": "Enable the clice/internal test hooks used by the test harness.",
-          "default": false
-        },
-        "stateful_worker_count": {
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 4294967295,
-          "description": "Number of stateful workers — they hold ASTs in memory and serve queries (hover, semantic tokens, ...).",
-          "default": 2
-        },
-        "stateless_worker_count": {
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 4294967295,
-          "description": "Initial number of stateless workers — they handle ephemeral tasks (PCH/PCM builds, completion, signature help); defaults to half the machine's parallelism, at least 2."
-        },
-        "min_stateless_worker_count": {
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 4294967295,
-          "description": "Lower bound for dynamic stateless-worker scaling.",
-          "default": 1
-        },
-        "max_stateless_worker_count": {
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 4294967295,
-          "description": "Upper bound for dynamic stateless-worker scaling; defaults to the machine's parallelism."
-        },
-        "worker_memory_limit": {
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 18446744073709551615,
-          "description": "Per-stateful-worker memory limit in bytes. Not yet enforced: parsed, but memory-based eviction is not implemented.",
-          "default": 4294967296
-        }
-      }
-    },
-    "TrackerConfig": {
-      "type": "object",
-      "properties": {
-        "cdb_poll_seconds": {
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 4294967295,
-          "description": "Compilation database poll interval in seconds; 0 disables polling.",
-          "default": 3
-        },
-        "workspace_poll_seconds": {
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 4294967295,
-          "description": "Workspace file sweep interval in seconds; 0 disables polling.",
-          "default": 30
-        }
-      }
-    },
-    "HoverOptions": {
-      "type": "object",
-      "properties": {
-        "parse_comment_as_markdown": {
-          "type": "boolean",
-          "description": "Render the hover card as markdown; `false` produces plain text for clients that cannot display it.",
-          "default": true
-        },
-        "show_aka": {
-          "type": "boolean",
-          "description": "Show the desugared form of a type, e.g. `vector<int>::size_type (aka unsigned long)`.",
-          "default": true
-        }
-      }
-    },
-    "InlayHintsOptions": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Master switch: `false` disables all inlay hints.",
-          "default": true
-        },
-        "parameters": {
-          "type": "boolean",
-          "description": "Parameter name hints at call sites, e.g. `draw(width: 800, height: 600)`, including `&` markers for arguments passed by mutable reference.",
-          "default": true
-        },
-        "deduced_types": {
-          "type": "boolean",
-          "description": "Deduced type hints for `auto` variables, structured bindings and deduced return types.",
-          "default": true
-        },
-        "designators": {
-          "type": "boolean",
-          "description": "Field designator hints in aggregate initialization, e.g. `.x=` and `.y=` in `Point{1, 2}`.",
-          "default": true
-        },
-        "block_end": {
-          "type": "boolean",
-          "description": "`// name` hints after the closing brace of long blocks (functions, types, namespaces, control flow).",
-          "default": false
-        },
-        "default_arguments": {
-          "type": "boolean",
-          "description": "Show the default arguments a call omitted, abbreviated when long.",
-          "default": false
-        },
-        "type_name_limit": {
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 4294967295,
-          "description": "Character budget for rendered hint text (deduced types, default arguments); longer text is abbreviated. `0` means no limit.",
-          "default": 32
-        }
-      }
-    },
-    "CodeCompletionOptions": {
-      "type": "object",
-      "properties": {
-        "enable_keyword_snippet": {
-          "type": "boolean",
-          "description": "Complete keywords as snippets (not yet implemented).",
-          "default": false
-        },
-        "enable_function_arguments_snippet": {
-          "type": "boolean",
-          "description": "Insert function arguments as a snippet on completion.",
-          "default": false
-        },
-        "enable_template_arguments_snippet": {
-          "type": "boolean",
-          "description": "Insert template arguments as a snippet on completion (not yet implemented).",
-          "default": false
-        },
-        "insert_paren_in_function_call": {
-          "type": "boolean",
-          "description": "Insert parentheses when completing a function call (not yet implemented).",
-          "default": false
-        },
-        "bundle_overloads": {
-          "type": "boolean",
-          "description": "Collapse an overload set into a single completion item.",
-          "default": true
-        },
-        "limit": {
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 4294967295,
-          "description": "Maximum number of completion items (not yet implemented).",
-          "default": 0
-        }
-      }
-    },
-    "ConfigRule": {
-      "type": "object",
-      "properties": {
-        "patterns": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Glob patterns selecting the files this rule applies to: `*` matches within a path segment, `?` a single character, `**` any number of segments, `{a,b}` alternatives, `[0-9]` a character range, `[!...]` a negated range.",
-          "default": []
-        },
-        "append": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Compilation flags appended for matching files, e.g. `[\"-std=c++20\", \"-DNDEBUG\"]`.",
-          "default": []
-        },
-        "remove": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Compilation flags removed for matching files, e.g. `[\"-Wall\"]`.",
-          "default": []
-        }
-      }
-    }
-  }
 }
+

--- a/docs/public/clice-config.schema.json
+++ b/docs/public/clice-config.schema.json
@@ -1,0 +1,299 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "project": {
+      "$ref": "#/$defs/ProjectConfig",
+      "description": "The [project] section: project-wide server options.",
+      "default": {
+        "clang_tidy": false,
+        "cache_dir": "",
+        "logging_dir": "",
+        "compile_commands_paths": [],
+        "enable_indexing": true,
+        "index_db": "lmdb",
+        "idle_timeout_ms": 3000,
+        "test_hooks": false,
+        "stateful_worker_count": 2,
+        "min_stateless_worker_count": 1,
+        "worker_memory_limit": 4294967296
+      }
+    },
+    "tracker": {
+      "$ref": "#/$defs/TrackerConfig",
+      "description": "The [tracker] section: file tracker poll intervals.",
+      "default": {
+        "cdb_poll_seconds": 3,
+        "workspace_poll_seconds": 30
+      }
+    },
+    "hover": {
+      "$ref": "#/$defs/HoverOptions",
+      "description": "The [hover] section: hover rendering options.",
+      "default": {
+        "parse_comment_as_markdown": true,
+        "show_aka": true
+      }
+    },
+    "inlay_hints": {
+      "$ref": "#/$defs/InlayHintsOptions",
+      "description": "The [inlay_hints] section: inlay hint options.",
+      "default": {
+        "enabled": true,
+        "parameters": true,
+        "deduced_types": true,
+        "designators": true,
+        "block_end": false,
+        "default_arguments": false,
+        "type_name_limit": 32
+      }
+    },
+    "code_completion": {
+      "$ref": "#/$defs/CodeCompletionOptions",
+      "description": "The [code_completion] section: code completion options.",
+      "default": {
+        "enable_keyword_snippet": false,
+        "enable_function_arguments_snippet": false,
+        "enable_template_arguments_snippet": false,
+        "insert_paren_in_function_call": false,
+        "bundle_overloads": true,
+        "limit": 0
+      }
+    },
+    "rules": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ConfigRule"
+      },
+      "description": "File-pattern rules that adjust compilation flags ([[rules]] in clice.toml).",
+      "default": []
+    }
+  },
+  "$defs": {
+    "ProjectConfig": {
+      "type": "object",
+      "properties": {
+        "clang_tidy": {
+          "type": "boolean",
+          "description": "Run clang-tidy alongside compiler diagnostics. Not yet wired: the option is parsed but has no effect.",
+          "default": false
+        },
+        "cache_dir": {
+          "type": "string",
+          "description": "Directory for the unified on-disk cache (PCH, PCM and index artifacts). Empty derives it from XDG_CACHE_HOME (or `~/.cache`) with a per-workspace subdirectory named after the workspace plus a short hash, falling back to `${workspace}/.clice`; the resolved path is printed at startup.",
+          "default": ""
+        },
+        "logging_dir": {
+          "type": "string",
+          "description": "Directory for log files; empty derives `${cache_dir}/logs`. Each server session logs into its own timestamped subdirectory.",
+          "default": ""
+        },
+        "compile_commands_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Paths searched for compile_commands.json — file paths, or directories to look inside. Empty searches the workspace root and then each of its immediate subdirectories, first hit wins.",
+          "default": []
+        },
+        "enable_indexing": {
+          "type": "boolean",
+          "description": "Build the background index that serves cross-TU features (find references, workspace symbols, ...).",
+          "default": true
+        },
+        "index_db": {
+          "type": "string",
+          "description": "Index persistence backend: \"lmdb\" (single database file) or \"files\" (one file per blob).",
+          "default": "lmdb"
+        },
+        "idle_timeout_ms": {
+          "type": "integer",
+          "minimum": -2147483648,
+          "maximum": 2147483647,
+          "description": "Idle delay in milliseconds after the last edit before background indexing starts.",
+          "default": 3000
+        },
+        "test_hooks": {
+          "type": "boolean",
+          "description": "Enable the clice/internal test hooks used by the test harness.",
+          "default": false
+        },
+        "stateful_worker_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 4294967295,
+          "description": "Number of stateful workers — they hold ASTs in memory and serve queries (hover, semantic tokens, ...).",
+          "default": 2
+        },
+        "stateless_worker_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 4294967295,
+          "description": "Initial number of stateless workers — they handle ephemeral tasks (PCH/PCM builds, completion, signature help); defaults to half the machine's parallelism, at least 2."
+        },
+        "min_stateless_worker_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 4294967295,
+          "description": "Lower bound for dynamic stateless-worker scaling.",
+          "default": 1
+        },
+        "max_stateless_worker_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 4294967295,
+          "description": "Upper bound for dynamic stateless-worker scaling; defaults to the machine's parallelism."
+        },
+        "worker_memory_limit": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615,
+          "description": "Per-stateful-worker memory limit in bytes. Not yet enforced: parsed, but memory-based eviction is not implemented.",
+          "default": 4294967296
+        }
+      }
+    },
+    "TrackerConfig": {
+      "type": "object",
+      "properties": {
+        "cdb_poll_seconds": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 4294967295,
+          "description": "Compilation database poll interval in seconds; 0 disables polling.",
+          "default": 3
+        },
+        "workspace_poll_seconds": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 4294967295,
+          "description": "Workspace file sweep interval in seconds; 0 disables polling.",
+          "default": 30
+        }
+      }
+    },
+    "HoverOptions": {
+      "type": "object",
+      "properties": {
+        "parse_comment_as_markdown": {
+          "type": "boolean",
+          "description": "Render the hover card as markdown; `false` produces plain text for clients that cannot display it.",
+          "default": true
+        },
+        "show_aka": {
+          "type": "boolean",
+          "description": "Show the desugared form of a type, e.g. `vector<int>::size_type (aka unsigned long)`.",
+          "default": true
+        }
+      }
+    },
+    "InlayHintsOptions": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Master switch: `false` disables all inlay hints.",
+          "default": true
+        },
+        "parameters": {
+          "type": "boolean",
+          "description": "Parameter name hints at call sites, e.g. `draw(width: 800, height: 600)`, including `&` markers for arguments passed by mutable reference.",
+          "default": true
+        },
+        "deduced_types": {
+          "type": "boolean",
+          "description": "Deduced type hints for `auto` variables, structured bindings and deduced return types.",
+          "default": true
+        },
+        "designators": {
+          "type": "boolean",
+          "description": "Field designator hints in aggregate initialization, e.g. `.x=` and `.y=` in `Point{1, 2}`.",
+          "default": true
+        },
+        "block_end": {
+          "type": "boolean",
+          "description": "`// name` hints after the closing brace of long blocks (functions, types, namespaces, control flow).",
+          "default": false
+        },
+        "default_arguments": {
+          "type": "boolean",
+          "description": "Show the default arguments a call omitted, abbreviated when long.",
+          "default": false
+        },
+        "type_name_limit": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 4294967295,
+          "description": "Character budget for rendered hint text (deduced types, default arguments); longer text is abbreviated. `0` means no limit.",
+          "default": 32
+        }
+      }
+    },
+    "CodeCompletionOptions": {
+      "type": "object",
+      "properties": {
+        "enable_keyword_snippet": {
+          "type": "boolean",
+          "description": "Complete keywords as snippets (not yet implemented).",
+          "default": false
+        },
+        "enable_function_arguments_snippet": {
+          "type": "boolean",
+          "description": "Insert function arguments as a snippet on completion.",
+          "default": false
+        },
+        "enable_template_arguments_snippet": {
+          "type": "boolean",
+          "description": "Insert template arguments as a snippet on completion (not yet implemented).",
+          "default": false
+        },
+        "insert_paren_in_function_call": {
+          "type": "boolean",
+          "description": "Insert parentheses when completing a function call (not yet implemented).",
+          "default": false
+        },
+        "bundle_overloads": {
+          "type": "boolean",
+          "description": "Collapse an overload set into a single completion item.",
+          "default": true
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 4294967295,
+          "description": "Maximum number of completion items (not yet implemented).",
+          "default": 0
+        }
+      }
+    },
+    "ConfigRule": {
+      "type": "object",
+      "properties": {
+        "patterns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Glob patterns selecting the files this rule applies to: `*` matches within a path segment, `?` a single character, `**` any number of segments, `{a,b}` alternatives, `[0-9]` a character range, `[!...]` a negated range.",
+          "default": []
+        },
+        "append": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Compilation flags appended for matching files, e.g. `[\"-std=c++20\", \"-DNDEBUG\"]`.",
+          "default": []
+        },
+        "remove": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Compilation flags removed for matching files, e.g. `[\"-Wall\"]`.",
+          "default": []
+        }
+      }
+    }
+  }
+}

--- a/docs/public/clice-config.schema.json
+++ b/docs/public/clice-config.schema.json
@@ -105,12 +105,16 @@
                 "index_db": {
                     "type": "string",
                     "description": "Index persistence backend: \"lmdb\" (single database file) or \"files\" (one file per blob).",
-                    "default": "lmdb"
+                    "default": "lmdb",
+                    "enum": [
+                        "lmdb",
+                        "files"
+                    ]
                 },
                 "idle_timeout_ms": {
                     "type": "integer",
-                    "minimum": -2147483648,
-                    "maximum": 2147483647,
+                    "minimum": 0,
+                    "maximum": 4294967295,
                     "description": "Idle delay in milliseconds before background indexing starts.",
                     "default": 3000
                 },
@@ -134,16 +138,16 @@
                 },
                 "min_stateless_worker_count": {
                     "type": "integer",
-                    "minimum": 0,
+                    "minimum": 1,
                     "maximum": 4294967295,
-                    "description": "Lower bound for dynamic stateless-worker scaling.",
+                    "description": "Lower bound for dynamic stateless-worker scaling; `0` is invalid and falls back to the default.",
                     "default": 1
                 },
                 "max_stateless_worker_count": {
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 4294967295,
-                    "description": "Upper bound for dynamic stateless-worker scaling; defaults to the machine's parallelism."
+                    "description": "Upper bound for dynamic stateless-worker scaling; `0` means the machine's parallelism, which is also the default."
                 },
                 "worker_memory_limit": {
                     "type": "integer",

--- a/pixi.toml
+++ b/pixi.toml
@@ -339,7 +339,7 @@ format-python = "ruff format ."
 format-lua = "stylua ."
 format-web = "fd -H -e js -e mjs -e ts -e css -x prettier --write"
 format-markdown = "fd -H -e md -x prettier --write"
-format-json = "fd -H -e json -E package-lock.json -x prettier --write"
+format-json = "fd -H -e json -E package-lock.json -E clice-config.schema.json -x prettier --write"
 format-toml = "fd -H -e toml -x tombi format"
 format-yaml = """
 fd -H -e yaml -e yml -E '*.snap.yml' -x prettier --write && \

--- a/src/driver/inspect.cc
+++ b/src/driver/inspect.cc
@@ -11,6 +11,7 @@
 #include "feature/feature.h"
 #include "index/shard.h"
 #include "index/tu_index.h"
+#include "server/state/config.h"
 #include "support/filesystem.h"
 #include "syntax/annotation.h"
 #include "syntax/scan.h"
@@ -43,6 +44,11 @@ namespace {
 struct InspectOptions {
     DecoFlag(names = {"-h", "--help"}, help = "Show help", required = false)
     help;
+
+    DecoFlag(names = {"--config-schema"},
+             help = "Print the JSON schema of the clice configuration and exit",
+             required = false)
+    config_schema;
 
     DecoInput(meta_var = "<FEATURE> <PATH>",
               help =
@@ -1016,6 +1022,17 @@ void add_inspect(kota::deco::cli::SubCommander& root, int& exit_code) {
            if(opts.help) {
                auto help = make_command();
                print_usage(help);
+               exit_code = 0;
+               return;
+           }
+           // A mode flag like --help: ignores feature/path inputs.
+           if(opts.config_schema) {
+               auto schema = Config::json_schema();
+               if(!schema) {
+                   LOG_ERROR("config schema generation failed: {}", schema.error());
+                   return;
+               }
+               std::println("{}", *schema);
                exit_code = 0;
                return;
            }

--- a/src/feature/feature.h
+++ b/src/feature/feature.h
@@ -91,7 +91,10 @@ struct CodeCompletionOptions {
     <bool> enable_keyword_snippet = false;
 
     KOTATSU_ANNOTATE(defaulted = true,
-                     description = "Insert function arguments as a snippet on completion.")
+                     description =
+                         "Insert function arguments as a snippet when completing "
+                         "a call; applies to individually listed overloads, so it "
+                         "requires `bundle_overloads = false`.")
     <bool> enable_function_arguments_snippet = false;
 
     KOTATSU_ANNOTATE(defaulted = true,
@@ -269,9 +272,10 @@ struct InlayHintsOptions {
 
     KOTATSU_ANNOTATE(defaulted = true,
                      description =
-                         "Character budget for rendered hint text (deduced types, "
-                         "default arguments); longer text is abbreviated. `0` "
-                         "means no limit.")
+                         "Byte budget for rendered hint text: over-long deduced "
+                         "types fall back to a sugared spelling or are dropped, "
+                         "over-long default arguments are abbreviated. `0` means "
+                         "no limit.")
     <std::uint32_t> type_name_limit = 32;
 };
 

--- a/src/feature/feature.h
+++ b/src/feature/feature.h
@@ -93,8 +93,10 @@ struct CodeCompletionOptions {
     KOTATSU_ANNOTATE(defaulted = true,
                      description =
                          "Insert function arguments as a snippet when completing "
-                         "a call; applies to individually listed overloads, so it "
-                         "requires `bundle_overloads = false`.")
+                         "a call. For functions this applies to individually "
+                         "listed overloads, so it requires `bundle_overloads = "
+                         "false`; function-like macros have no overload sets and "
+                         "always take the snippet.")
     <bool> enable_function_arguments_snippet = false;
 
     KOTATSU_ANNOTATE(defaulted = true,

--- a/src/feature/feature.h
+++ b/src/feature/feature.h
@@ -118,7 +118,9 @@ struct CodeCompletionOptions {
 /// Corresponds to the `[hover]` section in clice.toml.
 struct HoverOptions {
     KOTATSU_ANNOTATE(defaulted = true,
-                     description = "Render the hover card as markdown rather than plain text.")
+                     description =
+                         "Render the hover card as markdown; `false` produces "
+                         "plain text for clients that cannot display it.")
     <bool> parse_comment_as_markdown = true;
 
     KOTATSU_ANNOTATE(defaulted = true,
@@ -230,31 +232,46 @@ void parse_documentation(llvm::StringRef input, markup::Document& output);
 
 /// Corresponds to the `[inlay_hints]` section in clice.toml.
 struct InlayHintsOptions {
-    KOTATSU_ANNOTATE(defaulted = true, description = "Master switch for inlay hints.")
+    KOTATSU_ANNOTATE(defaulted = true,
+                     description = "Master switch: `false` disables all inlay hints.")
     <bool> enabled = true;
 
-    KOTATSU_ANNOTATE(defaulted = true, description = "Show parameter name hints at call sites.")
+    KOTATSU_ANNOTATE(defaulted = true,
+                     description =
+                         "Parameter name hints at call sites, e.g. `draw(width: "
+                         "800, height: 600)`, including `&` markers for arguments "
+                         "passed by mutable reference.")
     <bool> parameters = true;
 
     KOTATSU_ANNOTATE(defaulted = true,
-                     description = "Show deduced types for `auto` and templated declarations.")
+                     description =
+                         "Deduced type hints for `auto` variables, structured "
+                         "bindings and deduced return types.")
     <bool> deduced_types = true;
 
     KOTATSU_ANNOTATE(defaulted = true,
-                     description = "Show designators in aggregate initialization.")
+                     description =
+                         "Field designator hints in aggregate initialization, "
+                         "e.g. `.x=` and `.y=` in `Point{1, 2}`.")
     <bool> designators = true;
 
     KOTATSU_ANNOTATE(defaulted = true,
-                     description = "Show a hint naming the construct after a closing brace.")
+                     description =
+                         "`// name` hints after the closing brace of long blocks "
+                         "(functions, types, namespaces, control flow).")
     <bool> block_end = false;
 
-    KOTATSU_ANNOTATE(defaulted = true, description = "Show omitted default arguments.")
+    KOTATSU_ANNOTATE(defaulted = true,
+                     description =
+                         "Show the default arguments a call omitted, abbreviated "
+                         "when long.")
     <bool> default_arguments = false;
 
     KOTATSU_ANNOTATE(defaulted = true,
                      description =
-                         "Character budget for a rendered type name; longer names "
-                         "are truncated; 0 means no limit.")
+                         "Character budget for rendered hint text (deduced types, "
+                         "default arguments); longer text is abbreviated. `0` "
+                         "means no limit.")
     <std::uint32_t> type_name_limit = 32;
 };
 

--- a/src/server/state/config.cpp
+++ b/src/server/state/config.cpp
@@ -1,6 +1,7 @@
 #include "server/state/config.h"
 
 #include <algorithm>
+#include <array>
 
 #include "feature/feature.h"
 #include "support/filesystem.h"
@@ -8,6 +9,7 @@
 
 #include "kota/async/io/system.h"
 #include "kota/codec/json/json.h"
+#include "kota/codec/json/schema.h"
 #include "kota/codec/toml/toml.h"
 #include "kota/support/glob_pattern.h"
 #include "llvm/Support/FileSystem.h"
@@ -269,6 +271,74 @@ Config Config::load_from_workspace(llvm::StringRef workspace_root,
         config.finalize(workspace_root);
     }
     return config;
+}
+
+constexpr std::array MACHINE_DERIVED_FIELDS = {"stateless_worker_count",
+                                               "max_stateless_worker_count"};
+
+/// Scrub the machine-derived fields out of a `default` object: sections
+/// carry whole-object defaults, so the values appear below `default`
+/// keys too, not only in the fields' own schemas.
+static void remove_machine_fields(kota::codec::dyn::Value& value) {
+    if(auto* object = value.get_object()) {
+        for(auto field: MACHINE_DERIVED_FIELDS) {
+            object->remove(field);
+        }
+        for(auto& [key, child]: *object) {
+            remove_machine_fields(child);
+        }
+    } else if(auto* array = value.get_array()) {
+        for(auto& child: *array) {
+            remove_machine_fields(child);
+        }
+    }
+}
+
+/// Drop the `default` annotations whose fresh value depends on the
+/// running machine: a committed schema must be byte-identical on every
+/// host, and the affected fields' descriptions state the derivation
+/// instead.
+static void strip_machine_defaults(kota::codec::dyn::Value& value) {
+    if(auto* object = value.get_object()) {
+        for(auto& [key, child]: *object) {
+            if(key == "properties") {
+                if(auto* properties = child.get_object()) {
+                    for(auto field: MACHINE_DERIVED_FIELDS) {
+                        if(auto* schema = properties->find(field)) {
+                            if(auto* field_object = schema->get_object()) {
+                                field_object->remove("default");
+                            }
+                        }
+                    }
+                }
+            } else if(key == "default") {
+                remove_machine_fields(child);
+            }
+            strip_machine_defaults(child);
+        }
+    } else if(auto* array = value.get_array()) {
+        for(auto& child: *array) {
+            strip_machine_defaults(child);
+        }
+    }
+}
+
+std::expected<std::string, std::string> Config::json_schema() {
+    auto schema = kota::codec::json::schema<Config>();
+    if(!schema) {
+        return std::unexpected(schema.error().message);
+    }
+    strip_machine_defaults(*schema);
+
+    auto compact = kota::codec::json::to_string(std::move(*schema));
+    if(!compact) {
+        return std::unexpected(compact.error().message);
+    }
+    auto pretty = kota::codec::json::prettify(*compact);
+    if(!pretty) {
+        return std::unexpected(pretty.error().message);
+    }
+    return std::move(*pretty);
 }
 
 }  // namespace clice

--- a/src/server/state/config.cpp
+++ b/src/server/state/config.cpp
@@ -171,7 +171,10 @@ void Config::match_rules(llvm::StringRef file_path,
     }
 }
 
-/// Codec config for the strict validation pass: reject unknown keys.
+/// Codec config that rejects unknown keys: the strict validation pass
+/// decodes under it, and the published schema derives its
+/// `additionalProperties: false` from it — the same typo surfaces both
+/// ways.
 struct DenyUnknownKeys {
     constexpr static bool deny_unknown_fields = true;
 };
@@ -276,6 +279,11 @@ Config Config::load_from_workspace(llvm::StringRef workspace_root,
 constexpr std::array MACHINE_DERIVED_FIELDS = {"stateless_worker_count",
                                                "max_stateless_worker_count"};
 
+/// The fields finalize() rejects `0` for.
+constexpr std::array ZERO_INVALID_FIELDS = {"stateful_worker_count",
+                                            "stateless_worker_count",
+                                            "worker_memory_limit"};
+
 /// Scrub the machine-derived fields out of a `default` object: sections
 /// carry whole-object defaults, so the values appear below `default`
 /// keys too, not only in the fields' own schemas.
@@ -294,41 +302,54 @@ static void remove_machine_fields(kota::codec::dyn::Value& value) {
     }
 }
 
-/// Drop the `default` annotations whose fresh value depends on the
-/// running machine: a committed schema must be byte-identical on every
-/// host, and the affected fields' descriptions state the derivation
-/// instead.
-static void strip_machine_defaults(kota::codec::dyn::Value& value) {
+/// The schema object of `field` inside a `properties` map, if present.
+static kota::codec::dyn::Object* field_schema(kota::codec::dyn::Object& properties,
+                                              std::string_view field) {
+    if(auto* schema = properties.find(field)) {
+        return schema->get_object();
+    }
+    return nullptr;
+}
+
+/// Patch the field schemas with what the annotations cannot express:
+/// `default`s whose fresh value depends on the running machine are
+/// dropped — a committed schema must be byte-identical on every host, so
+/// the affected fields' descriptions state the derivation instead — and
+/// the zero-invalid fields carry the lower bound finalize() enforces.
+static void patch_field_schemas(kota::codec::dyn::Value& value) {
     if(auto* object = value.get_object()) {
         for(auto& [key, child]: *object) {
             if(key == "properties") {
                 if(auto* properties = child.get_object()) {
                     for(auto field: MACHINE_DERIVED_FIELDS) {
-                        if(auto* schema = properties->find(field)) {
-                            if(auto* field_object = schema->get_object()) {
-                                field_object->remove("default");
-                            }
+                        if(auto* schema = field_schema(*properties, field)) {
+                            schema->remove("default");
+                        }
+                    }
+                    for(auto field: ZERO_INVALID_FIELDS) {
+                        if(auto* schema = field_schema(*properties, field)) {
+                            schema->assign("minimum", std::uint64_t{1});
                         }
                     }
                 }
             } else if(key == "default") {
                 remove_machine_fields(child);
             }
-            strip_machine_defaults(child);
+            patch_field_schemas(child);
         }
     } else if(auto* array = value.get_array()) {
         for(auto& child: *array) {
-            strip_machine_defaults(child);
+            patch_field_schemas(child);
         }
     }
 }
 
 std::expected<std::string, std::string> Config::json_schema() {
-    auto schema = kota::codec::json::schema<Config>();
+    auto schema = kota::codec::json::schema<Config, DenyUnknownKeys>();
     if(!schema) {
         return std::unexpected(schema.error().message);
     }
-    strip_machine_defaults(*schema);
+    patch_field_schemas(*schema);
 
     auto compact = kota::codec::json::to_string(std::move(*schema));
     if(!compact) {

--- a/src/server/state/config.cpp
+++ b/src/server/state/config.cpp
@@ -102,6 +102,9 @@ void Config::finalize(llvm::StringRef workspace_root) {
     reject_zero(p.stateless_worker_count,
                 defaults.stateless_worker_count,
                 "stateless_worker_count");
+    reject_zero(p.min_stateless_worker_count,
+                defaults.min_stateless_worker_count,
+                "min_stateless_worker_count");
     reject_zero(p.worker_memory_limit, defaults.worker_memory_limit, "worker_memory_limit");
 
     if(p.cache_dir.empty() && !workspace_root.empty()) {
@@ -282,6 +285,7 @@ constexpr std::array MACHINE_DERIVED_FIELDS = {"stateless_worker_count",
 /// The fields finalize() rejects `0` for.
 constexpr std::array ZERO_INVALID_FIELDS = {"stateful_worker_count",
                                             "stateless_worker_count",
+                                            "min_stateless_worker_count",
                                             "worker_memory_limit"};
 
 /// Scrub the machine-derived fields out of a `default` object: sections
@@ -314,8 +318,10 @@ static kota::codec::dyn::Object* field_schema(kota::codec::dyn::Object& properti
 /// Patch the field schemas with what the annotations cannot express:
 /// `default`s whose fresh value depends on the running machine are
 /// dropped — a committed schema must be byte-identical on every host, so
-/// the affected fields' descriptions state the derivation instead — and
-/// the zero-invalid fields carry the lower bound finalize() enforces.
+/// the affected fields' descriptions state the derivation instead — the
+/// zero-invalid fields carry the lower bound finalize() enforces, and
+/// `index_db` names the backends open_database() accepts, so editors
+/// flag a typo that would silently fall back to LMDB.
 static void patch_field_schemas(kota::codec::dyn::Value& value) {
     if(auto* object = value.get_object()) {
         for(auto& [key, child]: *object) {
@@ -330,6 +336,9 @@ static void patch_field_schemas(kota::codec::dyn::Value& value) {
                         if(auto* schema = field_schema(*properties, field)) {
                             schema->assign("minimum", std::uint64_t{1});
                         }
+                    }
+                    if(auto* schema = field_schema(*properties, "index_db")) {
+                        schema->assign("enum", kota::codec::dyn::Array{"lmdb", "files"});
                     }
                 }
             } else if(key == "default") {

--- a/src/server/state/config.h
+++ b/src/server/state/config.h
@@ -27,10 +27,10 @@ struct ConfigRule {
     KOTATSU_ANNOTATE(defaulted = true,
                      description =
                          "Glob patterns selecting the files this rule applies "
-                         "to: `*` matches within a path segment, `?` a single "
-                         "character, `**` any number of segments, `{a,b}` "
-                         "alternatives, `[0-9]` a character range, `[!...]` a "
-                         "negated range.")
+                         "to: `*` matches within a path segment (a pattern of "
+                         "just `*` matches any path), `?` a single character, "
+                         "`**` any number of segments, `{a,b}` alternatives, "
+                         "`[0-9]` a character range, `[!...]` a negated range.")
     <std::vector<std::string>> patterns;
 
     KOTATSU_ANNOTATE(defaulted = true,
@@ -77,9 +77,9 @@ struct ProjectConfig {
     KOTATSU_ANNOTATE(defaulted = true,
                      description =
                          "Paths searched for compile_commands.json — file paths, "
-                         "or directories to look inside. Empty searches the "
-                         "workspace root and then each of its immediate "
-                         "subdirectories, first hit wins.")
+                         "or directories to look inside. When these all miss — or "
+                         "the list is empty — the workspace root and then each of "
+                         "its immediate subdirectories are searched.")
     <std::vector<std::string>> compile_commands_paths;
 
     KOTATSU_ANNOTATE(defaulted = true,
@@ -96,8 +96,8 @@ struct ProjectConfig {
 
     KOTATSU_ANNOTATE(defaulted = true,
                      description =
-                         "Idle delay in milliseconds after the last edit before "
-                         "background indexing starts.")
+                         "Idle delay in milliseconds before background indexing "
+                         "starts.")
     <int> idle_timeout_ms = 3000;
 
     /// The hooks can generate load on demand (log floods).
@@ -110,7 +110,8 @@ struct ProjectConfig {
     KOTATSU_ANNOTATE(defaulted = true,
                      description =
                          "Number of stateful workers — they hold ASTs in memory "
-                         "and serve queries (hover, semantic tokens, ...).")
+                         "and serve queries (hover, semantic tokens, ...); `0` is "
+                         "invalid and falls back to the default.")
     <std::uint32_t> stateful_worker_count = 2;
 
     KOTATSU_ANNOTATE(defaulted = true,
@@ -118,7 +119,7 @@ struct ProjectConfig {
                          "Initial number of stateless workers — they handle "
                          "ephemeral tasks (PCH/PCM builds, completion, signature "
                          "help); defaults to half the machine's parallelism, at "
-                         "least 2.")
+                         "least 2. `0` is invalid and falls back to that default.")
     <std::uint32_t> stateless_worker_count = default_stateless_worker_count();
 
     /// See WorkerPoolOptions.
@@ -134,7 +135,8 @@ struct ProjectConfig {
 
     KOTATSU_ANNOTATE(defaulted = true,
                      description =
-                         "Per-stateful-worker memory limit in bytes. Not yet "
+                         "Per-stateful-worker memory limit in bytes; `0` is "
+                         "invalid and falls back to the default. Not yet "
                          "enforced: parsed, but memory-based eviction is not "
                          "implemented.")
     <std::uint64_t> worker_memory_limit = 4ULL * 1024 * 1024 * 1024;

--- a/src/server/state/config.h
+++ b/src/server/state/config.h
@@ -264,7 +264,9 @@ struct Config {
     /// The configuration's JSON schema (draft 2020-12), pretty-printed.
     /// Fields whose defaults derive from the running machine (the worker
     /// counts follow the CPU count) carry no `default` annotation, so the
-    /// schema is byte-identical on every host.
+    /// schema is byte-identical on every host. Unknown properties are
+    /// rejected — the schema-side face of the strict decode pass's typo
+    /// warnings.
     static std::expected<std::string, std::string> json_schema();
 };
 

--- a/src/server/state/config.h
+++ b/src/server/state/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <expected>
 #include <optional>
 #include <string>
 #include <vector>
@@ -85,7 +86,10 @@ struct ProjectConfig {
     KOTATSU_ANNOTATE(defaulted = true, description = "Number of stateful workers.")
     <std::uint32_t> stateful_worker_count = 2;
 
-    KOTATSU_ANNOTATE(defaulted = true, description = "Initial number of stateless workers.")
+    KOTATSU_ANNOTATE(defaulted = true,
+                     description =
+                         "Initial number of stateless workers; defaults to half "
+                         "the machine's parallelism, at least 2.")
     <std::uint32_t> stateless_worker_count = default_stateless_worker_count();
 
     /// See WorkerPoolOptions.
@@ -94,7 +98,9 @@ struct ProjectConfig {
     <std::uint32_t> min_stateless_worker_count = 1;
 
     KOTATSU_ANNOTATE(defaulted = true,
-                     description = "Upper bound for dynamic stateless-worker scaling.")
+                     description =
+                         "Upper bound for dynamic stateless-worker scaling; "
+                         "defaults to the machine's parallelism.")
     <std::uint32_t> max_stateless_worker_count = default_max_stateless_worker_count();
 
     KOTATSU_ANNOTATE(defaulted = true, description = "Per-stateful-worker memory limit in bytes.")
@@ -219,6 +225,12 @@ struct Config {
                                       std::vector<ConfigIssue>* issues = nullptr,
                                       std::string* loaded_path = nullptr,
                                       bool finalized = true);
+
+    /// The configuration's JSON schema (draft 2020-12), pretty-printed.
+    /// Fields whose defaults derive from the running machine (the worker
+    /// counts follow the CPU count) carry no `default` annotation, so the
+    /// schema is byte-identical on every host.
+    static std::expected<std::string, std::string> json_schema();
 };
 
 }  // namespace clice

--- a/src/server/state/config.h
+++ b/src/server/state/config.h
@@ -25,15 +25,24 @@ std::uint32_t default_max_stateless_worker_count();
 /// Corresponds to `[[rules]]` in clice.toml.
 struct ConfigRule {
     KOTATSU_ANNOTATE(defaulted = true,
-                     description = "Glob patterns selecting the files this rule applies to.")
+                     description =
+                         "Glob patterns selecting the files this rule applies "
+                         "to: `*` matches within a path segment, `?` a single "
+                         "character, `**` any number of segments, `{a,b}` "
+                         "alternatives, `[0-9]` a character range, `[!...]` a "
+                         "negated range.")
     <std::vector<std::string>> patterns;
 
     KOTATSU_ANNOTATE(defaulted = true,
-                     description = "Compilation flags appended for matching files.")
+                     description =
+                         "Compilation flags appended for matching files, e.g. "
+                         "`[\"-std=c++20\", \"-DNDEBUG\"]`.")
     <std::vector<std::string>> append;
 
     KOTATSU_ANNOTATE(defaulted = true,
-                     description = "Compilation flags removed for matching files.")
+                     description =
+                         "Compilation flags removed for matching files, e.g. "
+                         "`[\"-Wall\"]`.")
     <std::vector<std::string>> remove;
 };
 
@@ -43,25 +52,40 @@ struct ConfigRule {
 /// finalize().
 struct ProjectConfig {
     KOTATSU_ANNOTATE(defaulted = true,
-                     description = "Run clang-tidy alongside compiler diagnostics.")
+                     description =
+                         "Run clang-tidy alongside compiler diagnostics. Not yet "
+                         "wired: the option is parsed but has no effect.")
     <bool> clang_tidy = false;
 
     KOTATSU_ANNOTATE(defaulted = true,
                      description =
-                         "Directory for the index and PCH cache; empty derives it "
-                         "from the workspace root.")
+                         "Directory for the unified on-disk cache (PCH, PCM and "
+                         "index artifacts). Empty derives it from XDG_CACHE_HOME "
+                         "(or `~/.cache`) with a per-workspace subdirectory named "
+                         "after the workspace plus a short hash, falling back to "
+                         "`${workspace}/.clice`; the resolved path is printed at "
+                         "startup.")
     <std::string> cache_dir;
 
     KOTATSU_ANNOTATE(defaulted = true,
                      description =
-                         "Directory for log files; empty derives it from the "
-                         "cache directory.")
+                         "Directory for log files; empty derives `${cache_dir}/logs`. "
+                         "Each server session logs into its own timestamped "
+                         "subdirectory.")
     <std::string> logging_dir;
 
-    KOTATSU_ANNOTATE(defaulted = true, description = "Paths searched for compile_commands.json.")
+    KOTATSU_ANNOTATE(defaulted = true,
+                     description =
+                         "Paths searched for compile_commands.json — file paths, "
+                         "or directories to look inside. Empty searches the "
+                         "workspace root and then each of its immediate "
+                         "subdirectories, first hit wins.")
     <std::vector<std::string>> compile_commands_paths;
 
-    KOTATSU_ANNOTATE(defaulted = true, description = "Build the background index.")
+    KOTATSU_ANNOTATE(defaulted = true,
+                     description =
+                         "Build the background index that serves cross-TU "
+                         "features (find references, workspace symbols, ...).")
     <bool> enable_indexing = true;
 
     KOTATSU_ANNOTATE(defaulted = true,
@@ -72,8 +96,8 @@ struct ProjectConfig {
 
     KOTATSU_ANNOTATE(defaulted = true,
                      description =
-                         "Idle delay in milliseconds before background indexing "
-                         "starts.")
+                         "Idle delay in milliseconds after the last edit before "
+                         "background indexing starts.")
     <int> idle_timeout_ms = 3000;
 
     /// The hooks can generate load on demand (log floods).
@@ -83,13 +107,18 @@ struct ProjectConfig {
                          "harness.")
     <bool> test_hooks = false;
 
-    KOTATSU_ANNOTATE(defaulted = true, description = "Number of stateful workers.")
+    KOTATSU_ANNOTATE(defaulted = true,
+                     description =
+                         "Number of stateful workers — they hold ASTs in memory "
+                         "and serve queries (hover, semantic tokens, ...).")
     <std::uint32_t> stateful_worker_count = 2;
 
     KOTATSU_ANNOTATE(defaulted = true,
                      description =
-                         "Initial number of stateless workers; defaults to half "
-                         "the machine's parallelism, at least 2.")
+                         "Initial number of stateless workers — they handle "
+                         "ephemeral tasks (PCH/PCM builds, completion, signature "
+                         "help); defaults to half the machine's parallelism, at "
+                         "least 2.")
     <std::uint32_t> stateless_worker_count = default_stateless_worker_count();
 
     /// See WorkerPoolOptions.
@@ -103,7 +132,11 @@ struct ProjectConfig {
                          "defaults to the machine's parallelism.")
     <std::uint32_t> max_stateless_worker_count = default_max_stateless_worker_count();
 
-    KOTATSU_ANNOTATE(defaulted = true, description = "Per-stateful-worker memory limit in bytes.")
+    KOTATSU_ANNOTATE(defaulted = true,
+                     description =
+                         "Per-stateful-worker memory limit in bytes. Not yet "
+                         "enforced: parsed, but memory-based eviction is not "
+                         "implemented.")
     <std::uint64_t> worker_memory_limit = 4ULL * 1024 * 1024 * 1024;
 };
 

--- a/src/server/state/config.h
+++ b/src/server/state/config.h
@@ -98,7 +98,7 @@ struct ProjectConfig {
                      description =
                          "Idle delay in milliseconds before background indexing "
                          "starts.")
-    <int> idle_timeout_ms = 3000;
+    <std::uint32_t> idle_timeout_ms = 3000;
 
     /// The hooks can generate load on demand (log floods).
     KOTATSU_ANNOTATE(defaulted = true,
@@ -124,13 +124,16 @@ struct ProjectConfig {
 
     /// See WorkerPoolOptions.
     KOTATSU_ANNOTATE(defaulted = true,
-                     description = "Lower bound for dynamic stateless-worker scaling.")
+                     description =
+                         "Lower bound for dynamic stateless-worker scaling; `0` "
+                         "is invalid and falls back to the default.")
     <std::uint32_t> min_stateless_worker_count = 1;
 
     KOTATSU_ANNOTATE(defaulted = true,
                      description =
-                         "Upper bound for dynamic stateless-worker scaling; "
-                         "defaults to the machine's parallelism.")
+                         "Upper bound for dynamic stateless-worker scaling; `0` "
+                         "means the machine's parallelism, which is also the "
+                         "default.")
     <std::uint32_t> max_stateless_worker_count = default_max_stateless_worker_count();
 
     KOTATSU_ANNOTATE(defaulted = true,

--- a/tests/unit/server/config_tests.cpp
+++ b/tests/unit/server/config_tests.cpp
@@ -90,7 +90,7 @@ TEST_CASE(ParsePartialProject) {
     EXPECT_EQ(std::string_view(result->cache_dir), "/tmp/test");
     EXPECT_EQ(result->clang_tidy.value, false);
     EXPECT_EQ(result->enable_indexing.value, true);
-    EXPECT_EQ(result->idle_timeout_ms.value, 3000);
+    EXPECT_EQ(result->idle_timeout_ms.value, 3000u);
 }
 
 TEST_CASE(ParseConfigRule) {
@@ -214,7 +214,7 @@ TEST_CASE(BornValidDefaults) {
     Config config;
     EXPECT_EQ(config.project.clang_tidy.value, false);
     EXPECT_EQ(config.project.enable_indexing.value, true);
-    EXPECT_EQ(config.project.idle_timeout_ms.value, 3000);
+    EXPECT_EQ(config.project.idle_timeout_ms.value, 3000u);
     EXPECT_EQ(config.project.test_hooks.value, false);
     EXPECT_EQ(config.project.stateful_worker_count.value, 2u);
     EXPECT_GE(config.project.stateless_worker_count.value, 2u);
@@ -373,7 +373,7 @@ TEST_CASE(ConfigPriorityJson) {
     auto from_json =
         Config::load_from_json(R"({ "project": { "idle_timeout_ms": 42 } })", "/workspace");
     EXPECT_TRUE(from_json.has_value());
-    EXPECT_EQ(from_json->project.idle_timeout_ms.value, 42);
+    EXPECT_EQ(from_json->project.idle_timeout_ms.value, 42u);
     // Unset fields still receive defaults.
     EXPECT_EQ(from_json->project.enable_indexing.value, true);
     EXPECT_EQ(from_json->project.stateful_worker_count.value, 2u);
@@ -605,10 +605,12 @@ TEST_CASE(ZeroWorkerCountRejected) {
     Config config;
     config.project.stateful_worker_count = 0;
     config.project.stateless_worker_count = 0;
+    config.project.min_stateless_worker_count = 0;
     config.project.worker_memory_limit = 0;
     config.finalize("");
     EXPECT_EQ(config.project.stateful_worker_count.value, 2u);
     EXPECT_GE(config.project.stateless_worker_count.value, 2u);
+    EXPECT_EQ(config.project.min_stateless_worker_count.value, 1u);
     EXPECT_EQ(config.project.worker_memory_limit.value, 4ULL * 1024 * 1024 * 1024);
 }
 
@@ -697,7 +699,7 @@ append = ["-DFROM_TOML"]
     auto config = Config::load_from_workspace(tmp.root.str());
     EXPECT_EQ(std::string_view(config.project.cache_dir), "/from/toml");
     EXPECT_EQ(config.project.clang_tidy.value, true);
-    EXPECT_EQ(config.project.idle_timeout_ms.value, 16);
+    EXPECT_EQ(config.project.idle_timeout_ms.value, 16u);
     EXPECT_EQ(config.compiled_rules.size(), 1u);
 
     // Overlay only `idle_timeout_ms` via JSON.
@@ -706,7 +708,7 @@ append = ["-DFROM_TOML"]
     config.finalize(tmp.root.str());
 
     // Overridden field.
-    EXPECT_EQ(config.project.idle_timeout_ms.value, 99);
+    EXPECT_EQ(config.project.idle_timeout_ms.value, 99u);
     // Untouched fields stay at TOML values.
     EXPECT_EQ(std::string_view(config.project.cache_dir), "/from/toml");
     EXPECT_EQ(config.project.clang_tidy.value, true);
@@ -806,22 +808,37 @@ TEST_CASE(JsonSchema) {
     // Control: a stable field does appear under the section default.
     EXPECT_TRUE(default_mentions(*doc, "idle_timeout_ms", false));
 
-    // A stable field initializer survives as the schema default.
+    // A stable field initializer survives as the schema default, and the
+    // unsigned field type keeps negative delays out of the schema.
     const auto* idle = find_property(*doc, "idle_timeout_ms");
     ASSERT_TRUE(idle != nullptr);
     EXPECT_TRUE(idle->get_object()->find("default") != nullptr);
+    const auto* idle_minimum = idle->get_object()->find("minimum");
+    ASSERT_TRUE(idle_minimum != nullptr);
+    EXPECT_EQ(idle_minimum->get_uint().value_or(1), 0u);
 
     // skip = true fields stay out of the schema entirely.
     EXPECT_TRUE(find_property(*doc, "compiled_rules") == nullptr);
 
     // The fields finalize() rejects `0` for carry the matching lower bound.
-    for(auto field: {"stateful_worker_count", "stateless_worker_count", "worker_memory_limit"}) {
+    for(auto field: {"stateful_worker_count",
+                     "stateless_worker_count",
+                     "min_stateless_worker_count",
+                     "worker_memory_limit"}) {
         const auto* property = find_property(*doc, field);
         ASSERT_TRUE(property != nullptr);
         const auto* minimum = property->get_object()->find("minimum");
         ASSERT_TRUE(minimum != nullptr);
         EXPECT_EQ(minimum->get_uint().value_or(0), 1u);
     }
+
+    // index_db names the accepted backends, so editors flag a typo that
+    // open_database() would silently turn into LMDB.
+    const auto* index_db = find_property(*doc, "index_db");
+    ASSERT_TRUE(index_db != nullptr);
+    const auto* backends = index_db->get_object()->find("enum");
+    ASSERT_TRUE(backends != nullptr);
+    EXPECT_EQ(*backends, kota::codec::dyn::Value(kota::codec::dyn::Array{"lmdb", "files"}));
 
     // Root and every section body reject unknown properties, so editors
     // flag typos the way the strict decode pass does.

--- a/tests/unit/server/config_tests.cpp
+++ b/tests/unit/server/config_tests.cpp
@@ -5,6 +5,7 @@
 #include "server/state/config.h"
 #include "support/filesystem.h"
 
+#include "kota/codec/dyn/decode.h"
 #include "kota/codec/json/json.h"
 #include "kota/codec/toml/toml.h"
 
@@ -26,6 +27,57 @@ static void unset_env(const char* name) {
 #else
     ::unsetenv(name);
 #endif
+}
+
+/// The schema object of a property named `name`, found anywhere in the
+/// document's nested `properties` maps.
+const static kota::codec::dyn::Value* find_property(const kota::codec::dyn::Value& value,
+                                                    std::string_view name) {
+    if(const auto* object = value.get_object()) {
+        for(const auto& [key, child]: *object) {
+            if(key == "properties") {
+                if(const auto* properties = child.get_object()) {
+                    if(const auto* found = properties->find(name)) {
+                        return found;
+                    }
+                }
+            }
+            if(const auto* found = find_property(child, name)) {
+                return found;
+            }
+        }
+    } else if(const auto* array = value.get_array()) {
+        for(const auto& child: *array) {
+            if(const auto* found = find_property(child, name)) {
+                return found;
+            }
+        }
+    }
+    return nullptr;
+}
+
+/// Whether `name` appears as an object key anywhere below a `default`
+/// annotation in the schema document.
+static bool default_mentions(const kota::codec::dyn::Value& value,
+                             std::string_view name,
+                             bool under_default) {
+    if(const auto* object = value.get_object()) {
+        for(const auto& [key, child]: *object) {
+            if(under_default && key == name) {
+                return true;
+            }
+            if(default_mentions(child, name, under_default || key == "default")) {
+                return true;
+            }
+        }
+    } else if(const auto* array = value.get_array()) {
+        for(const auto& child: *array) {
+            if(default_mentions(child, name, under_default)) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 TEST_SUITE(Config) {
@@ -730,6 +782,37 @@ append = ["-DTOML_ONLY"]
     config.match_rules("/src/x.cc", append, remove);
     EXPECT_EQ(append.size(), 1u);
     EXPECT_EQ(append[0], "-DFROM_JSON");
+}
+
+TEST_CASE(JsonSchema) {
+    auto schema = Config::json_schema();
+    ASSERT_TRUE(schema.has_value());
+    auto doc = kota::codec::json::from_string<kota::codec::dyn::Value>(*schema);
+    ASSERT_TRUE(doc.has_value());
+
+    // Machine-derived worker counts describe their derivation but carry no
+    // default value anywhere — neither in their own schema nor inside a
+    // section's whole-object default — so the schema stays byte-identical
+    // across hosts.
+    for(auto field: {"stateless_worker_count", "max_stateless_worker_count"}) {
+        const auto* worker = find_property(*doc, field);
+        ASSERT_TRUE(worker != nullptr);
+        const auto* object = worker->get_object();
+        ASSERT_TRUE(object != nullptr);
+        EXPECT_TRUE(object->find("description") != nullptr);
+        EXPECT_TRUE(object->find("default") == nullptr);
+        EXPECT_TRUE(!default_mentions(*doc, field, false));
+    }
+    // Control: a stable field does appear under the section default.
+    EXPECT_TRUE(default_mentions(*doc, "idle_timeout_ms", false));
+
+    // A stable field initializer survives as the schema default.
+    const auto* idle = find_property(*doc, "idle_timeout_ms");
+    ASSERT_TRUE(idle != nullptr);
+    EXPECT_TRUE(idle->get_object()->find("default") != nullptr);
+
+    // skip = true fields stay out of the schema entirely.
+    EXPECT_TRUE(find_property(*doc, "compiled_rules") == nullptr);
 }
 
 };  // TEST_SUITE(Config)

--- a/tests/unit/server/config_tests.cpp
+++ b/tests/unit/server/config_tests.cpp
@@ -813,6 +813,28 @@ TEST_CASE(JsonSchema) {
 
     // skip = true fields stay out of the schema entirely.
     EXPECT_TRUE(find_property(*doc, "compiled_rules") == nullptr);
+
+    // The fields finalize() rejects `0` for carry the matching lower bound.
+    for(auto field: {"stateful_worker_count", "stateless_worker_count", "worker_memory_limit"}) {
+        const auto* property = find_property(*doc, field);
+        ASSERT_TRUE(property != nullptr);
+        const auto* minimum = property->get_object()->find("minimum");
+        ASSERT_TRUE(minimum != nullptr);
+        EXPECT_EQ(minimum->get_uint().value_or(0), 1u);
+    }
+
+    // Root and every section body reject unknown properties, so editors
+    // flag typos the way the strict decode pass does.
+    auto denies_unknown = [](const kota::codec::dyn::Value& body) {
+        const auto* additional = body.get_object()->find("additionalProperties");
+        return additional != nullptr && additional->get_bool() == false;
+    };
+    EXPECT_TRUE(denies_unknown(*doc));
+    const auto* defs = doc->get_object()->find("$defs");
+    ASSERT_TRUE(defs != nullptr);
+    for(const auto& [name, body]: *defs->get_object()) {
+        EXPECT_TRUE(denies_unknown(body));
+    }
 }
 
 };  // TEST_SUITE(Config)

--- a/tools/config_docs.ts
+++ b/tools/config_docs.ts
@@ -68,16 +68,27 @@ function renderType(field: FieldSchema): string {
         case "string":
             return "`string`";
         case "integer": {
-            if (field.minimum === 0 && field.maximum !== undefined) {
-                return field.maximum > 2 ** 53 ? "`uint64`" : "`uint32`";
+            // Exact bounds only: a width this table does not know must
+            // fail loudly rather than render a wrong type name.
+            if (field.minimum === 0 && field.maximum === 4294967295) {
+                return "`uint32`";
             }
-            return "`int`";
+            if (field.minimum === 0 && field.maximum !== undefined && field.maximum > 2 ** 53) {
+                return "`uint64`";
+            }
+            if (field.minimum === -2147483648 && field.maximum === 2147483647) {
+                return "`int`";
+            }
+            throw new Error(`unhandled integer bounds [${field.minimum}, ${field.maximum}]`);
         }
         case "array": {
             if (field.items?.type === "string") {
                 return "`array of string`";
             }
-            return "`array of table`";
+            if (field.items?.$ref !== undefined) {
+                return "`array of table`";
+            }
+            throw new Error(`unhandled array item schema '${JSON.stringify(field.items)}'`);
         }
         default:
             throw new Error(`unhandled schema type '${field.type}'`);

--- a/tools/config_docs.ts
+++ b/tools/config_docs.ts
@@ -68,12 +68,17 @@ function renderType(field: FieldSchema): string {
         case "string":
             return "`string`";
         case "integer": {
-            // Exact bounds only: a width this table does not know must
-            // fail loudly rather than render a wrong type name.
-            if (field.minimum === 0 && field.maximum === 4294967295) {
+            // The exact maximum decides the width — a maximum this table
+            // does not know must fail loudly rather than render a wrong
+            // type name. The minimum may sit above the width's floor when
+            // the field carries a validity bound (zero-invalid fields).
+            if (field.minimum === undefined || field.maximum === undefined) {
+                throw new Error(`missing integer bounds [${field.minimum}, ${field.maximum}]`);
+            }
+            if (field.minimum >= 0 && field.maximum === 4294967295) {
                 return "`uint32`";
             }
-            if (field.minimum === 0 && field.maximum !== undefined && field.maximum > 2 ** 53) {
+            if (field.minimum >= 0 && field.maximum > 2 ** 53) {
                 return "`uint64`";
             }
             if (field.minimum === -2147483648 && field.maximum === 2147483647) {

--- a/tools/config_docs.ts
+++ b/tools/config_docs.ts
@@ -81,9 +81,6 @@ function renderType(field: FieldSchema): string {
             if (field.minimum >= 0 && field.maximum > 2 ** 53) {
                 return "`uint64`";
             }
-            if (field.minimum === -2147483648 && field.maximum === 2147483647) {
-                return "`int`";
-            }
             throw new Error(`unhandled integer bounds [${field.minimum}, ${field.maximum}]`);
         }
         case "array": {

--- a/tools/config_docs.ts
+++ b/tools/config_docs.ts
@@ -1,0 +1,228 @@
+/// Render the configuration reference from the committed JSON schema.
+///
+/// The schema (docs/public/clice-config.schema.json) is dumped by
+/// `clice inspect --config-schema` from the annotated config structs —
+/// the single source of truth for option names, types, defaults and
+/// descriptions. This script rewrites the generated regions of
+/// docs/en/guide/configuration.md from it:
+///
+///     <!-- BEGIN GENERATED CONFIG: project -->
+///     <!-- END GENERATED CONFIG -->
+///
+/// Section intros, the file-location/precedence preamble, variable
+/// substitution and the example stay handwritten. CI runs `check`; a
+/// separate binary-backed step keeps the committed schema itself fresh.
+///
+/// Usage:
+///     node tools/config_docs.ts update   # rewrite generated regions
+///     node tools/config_docs.ts check    # fail if regions are stale
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { REPO_ROOT } from "./compile_commands.ts";
+
+const SCHEMA_PATH = "docs/public/clice-config.schema.json";
+const DOC_PATH = "docs/en/guide/configuration.md";
+
+const BEGIN_RE = /^<!-- BEGIN GENERATED CONFIG: (.+?) -->$/;
+const END_MARKER = "<!-- END GENERATED CONFIG -->";
+
+interface FieldSchema {
+    type?: string;
+    items?: FieldSchema;
+    minimum?: number;
+    maximum?: number;
+    description?: string;
+    default?: unknown;
+    $ref?: string;
+}
+
+interface StructSchema {
+    properties?: Record<string, FieldSchema>;
+    $defs?: Record<string, StructSchema>;
+}
+
+function resolveRef(root: StructSchema, schema: FieldSchema): StructSchema {
+    const ref = schema.$ref;
+    if (ref === undefined) {
+        return schema as StructSchema;
+    }
+    const prefix = "#/$defs/";
+    if (!ref.startsWith(prefix)) {
+        throw new Error(`unsupported $ref '${ref}'`);
+    }
+    const target = root.$defs?.[ref.slice(prefix.length)];
+    if (!target) {
+        throw new Error(`dangling $ref '${ref}'`);
+    }
+    return target;
+}
+
+/// The doc spelling of a field's type, mirroring the C++ declaration
+/// (`uint32`/`uint64` from the integer bounds, since JSON schema has no
+/// width of its own).
+function renderType(field: FieldSchema): string {
+    switch (field.type) {
+        case "boolean":
+            return "`bool`";
+        case "string":
+            return "`string`";
+        case "integer": {
+            if (field.minimum === 0 && field.maximum !== undefined) {
+                return field.maximum > 2 ** 53 ? "`uint64`" : "`uint32`";
+            }
+            return "`int`";
+        }
+        case "array": {
+            if (field.items?.type === "string") {
+                return "`array of string`";
+            }
+            return "`array of table`";
+        }
+        default:
+            throw new Error(`unhandled schema type '${field.type}'`);
+    }
+}
+
+/// The Default cell. A field without a `default` annotation derives its
+/// value from the running machine — the description states how — so the
+/// cell shows a dash rather than any one host's number.
+function renderDefault(field: FieldSchema): string {
+    if (!("default" in field)) {
+        return "—";
+    }
+    return `\`${JSON.stringify(field.default)}\``;
+}
+
+/// Prettier pads table columns to equal width; match it so `pixi run
+/// format` leaves the generated regions untouched.
+function renderTable(rows: string[][]): string[] {
+    const widths = rows[0]?.map((_, column) => {
+        return Math.max(...rows.map((row) => (row[column] ?? "").length));
+    });
+    const line = (row: string[]): string => {
+        return `| ${row.map((cell, i) => cell.padEnd(widths?.[i] ?? 0)).join(" | ")} |`;
+    };
+    const separator = (widths ?? []).map((width) => "-".repeat(width));
+    return [line(rows[0] ?? []), line(separator), ...rows.slice(1).map(line)];
+}
+
+/// One option: a `### section.name` heading, the type/default table, and
+/// the description paragraph from the annotation.
+function renderField(heading: string, field: FieldSchema): string[] {
+    const out: string[] = [];
+    out.push(`### \`${heading}\``);
+    out.push("");
+    out.push(
+        ...renderTable([
+            ["Type", "Default"],
+            [renderType(field), renderDefault(field)],
+        ]),
+    );
+    if (field.description !== undefined) {
+        out.push("");
+        out.push(field.description);
+    }
+    return out;
+}
+
+/// A section region's body: every option of the section's struct, in
+/// declaration order. `rules` is the one array-of-table section; its
+/// entries render as `[rules].field`.
+function renderSection(root: StructSchema, section: string): string {
+    const top = root.properties?.[section];
+    if (!top) {
+        throw new Error(`schema has no top-level section '${section}'`);
+    }
+    const isArray = top.type === "array";
+    const struct = resolveRef(root, isArray ? (top.items ?? {}) : top);
+    const properties = struct.properties ?? {};
+    const parts: string[] = [];
+    for (const [name, field] of Object.entries(properties)) {
+        const heading = isArray ? `[${section}].${name}` : `${section}.${name}`;
+        parts.push(renderField(heading, field).join("\n"));
+    }
+    return parts.join("\n\n");
+}
+
+function rewriteDoc(docText: string, root: StructSchema, problems: string[]): string {
+    const lines = docText.split("\n");
+    const out: string[] = [];
+    const seen = new Set<string>();
+
+    let idx = 0;
+    while (idx < lines.length) {
+        const line = lines[idx] ?? "";
+        const match = BEGIN_RE.exec(line);
+        if (!match) {
+            out.push(line);
+            idx += 1;
+            continue;
+        }
+        const section = (match[1] ?? "").trim();
+        if (seen.has(section)) {
+            problems.push(`${DOC_PATH}: duplicate region '${section}'`);
+        }
+        seen.add(section);
+        let end = idx + 1;
+        while (end < lines.length && lines[end] !== END_MARKER) {
+            end += 1;
+        }
+        if (end >= lines.length) {
+            problems.push(`${DOC_PATH}: region '${section}' has no closing marker`);
+            for (let k = idx; k < lines.length; k++) {
+                out.push(lines[k] ?? "");
+            }
+            return out.join("\n");
+        }
+        out.push(line);
+        out.push("");
+        out.push(renderSection(root, section));
+        out.push("");
+        out.push(lines[end] ?? "");
+        idx = end + 1;
+    }
+
+    for (const section of Object.keys(root.properties ?? {})) {
+        if (!seen.has(section)) {
+            problems.push(`${DOC_PATH}: config section '${section}' has no marker region`);
+        }
+    }
+    return out.join("\n");
+}
+
+function main(argv: string[]): number {
+    const mode = argv[0];
+    if (mode !== "update" && mode !== "check") {
+        console.error("usage: config_docs.ts update|check");
+        return 2;
+    }
+
+    const problems: string[] = [];
+    const root = JSON.parse(
+        fs.readFileSync(path.join(REPO_ROOT, SCHEMA_PATH), "utf8"),
+    ) as StructSchema;
+    const docPath = path.join(REPO_ROOT, DOC_PATH);
+    const current = fs.readFileSync(docPath, "utf8").replaceAll("\r\n", "\n");
+    const updated = rewriteDoc(current, root, problems);
+
+    if (problems.length > 0) {
+        console.error("config_docs: problems found:");
+        for (const problem of problems) {
+            console.error(`  - ${problem}`);
+        }
+        return 1;
+    }
+    if (current === updated) {
+        return 0;
+    }
+    if (mode === "update") {
+        fs.writeFileSync(docPath, updated, "utf8");
+        console.log(`updated ${DOC_PATH}`);
+        return 0;
+    }
+    console.error(`config_docs: ${DOC_PATH} is stale; run 'config_docs.ts update'`);
+    return 1;
+}
+
+process.exit(main(process.argv.slice(2)));


### PR DESCRIPTION
## What changed

Replaces the handwritten configuration reference with one generated from the config structs themselves, closing the third leg of the docs-from-source plan (#632/#633/#634 covered the feature pages).

- **`clice inspect --config-schema`** prints a JSON Schema (draft 2020-12) of the whole configuration, generated by kotatsu's schema emitter from the annotated config structs — names, types, integer bounds, defaults and descriptions all come from the declarations. Defaults that derive from the running machine (the stateless-worker counts follow the CPU count) are scrubbed at every level — their own schema and the sections' whole-object defaults — so the dump is byte-identical on every host; their descriptions state the derivation instead. A unit test pins both the scrub and that `skip` fields stay out.
- The schema is committed at **`docs/public/clice-config.schema.json`**, so the docs site publishes it at a stable URL — editors that validate TOML/JSON against a schema can point at it.
- **`tools/config_docs.ts`** (update/check, mirroring `feature_docs.ts`) renders `docs/en/guide/configuration.md` from the committed schema: per-option heading, type/default table (`uint32`/`uint64` recovered from the integer bounds; machine-derived defaults show a dash), and the annotation's description. Section intros, the precedence preamble, variable substitution and the example stay handwritten.
- **Doc prose migrated into the annotations** — the descriptions in `config.h`/`feature.h` are now the single source of truth. The richer handwritten text (cache_dir's XDG derivation, glob syntax for rule patterns, the "not yet wired/enforced" caveats on `clang_tidy` and `worker_memory_limit`, inlay-hint examples) moved into `KOTATSU_ANNOTATE` descriptions.
- The regeneration fixed real drift in the old handwritten page: `min_stateless_worker_count` documented as "`0` (auto)" while the code defaults to `1`, `max_stateless_worker_count` likewise; `project.index_db`, `project.test_hooks` and the entire `[code_completion]` section were missing.
- **CI now enforces the generated docs** on the ubuntu RelWithDebInfo leg: the committed schema must match a fresh dump from the just-built binary, and both `feature_docs.ts check` and `config_docs.ts check` must be clean. (The feature-docs check from the earlier PRs had no CI enforcement until now — local discipline was the only gate.)

## Tests

All four suites pass locally: unit 1320 (new `Config.JsonSchema` case), integration 357, smoke 3/3, snap 626. `npm run check`, `node tools/config_docs.ts check`, `node tools/feature_docs.ts check` and `pixi run format` are green; format is idempotent over the generated regions.
