### PR TITLE
feat(server): introduce readonly mode

### DIFF
--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -66,13 +66,13 @@ Build the background index that serves cross-TU features (find references, works
 
 Index persistence backend: "lmdb" (single database file) or "files" (one file per blob).
 
-### `project.pch_build`
+### `project.readonly`
 
-| Type     | Default     |
-| -------- | ----------- |
-| `string` | `"on_edit"` |
+| Type     | Default |
+| -------- | ------- |
+| `string` | `"off"` |
 
-What triggers PCH/AST builds for an open file: "on_open" compiles eagerly on didOpen, "on_edit" serves reads from the index and compiles only when an edit-intent trigger fires (edit, completion, signature help, context switch), "never" never builds them — reads serve from the index alone, while completion and signature help still compile on demand without a preamble. Feature routing always answers from the best source currently available; this option only decides when the expensive sources get built.
+Read-only serving for open files: "off" targets a full AST for every open file — builds are pulled by the first request that needs them, with the index answering in the meantime; "on" never builds a PCH — reads serve from the index alone (a cold file jumps the indexing queue), while completion and signature help still compile on demand without a preamble; "auto" starts every file as "on" and switches it to "off" at the first edit intent (edit, completion, signature help, context switch). Feature routing always answers from the best source currently available.
 
 ### `project.idle_timeout_ms`
 

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -72,7 +72,7 @@ Index persistence backend: "lmdb" (single database file) or "files" (one file pe
 | -------- | ----------- |
 | `string` | `"on_edit"` |
 
-What triggers PCH/AST builds for an open file: "on_open" compiles eagerly on didOpen, "on_edit" serves reads from the index and compiles only when an edit-intent trigger fires (edit, completion, signature help, context switch), "never" serves purely from the index. Feature routing always answers from the best source currently available; this option only decides when the expensive sources get built.
+What triggers PCH/AST builds for an open file: "on_open" compiles eagerly on didOpen, "on_edit" serves reads from the index and compiles only when an edit-intent trigger fires (edit, completion, signature help, context switch), "never" never builds them — reads serve from the index alone, while completion and signature help still compile on demand without a preamble. Feature routing always answers from the best source currently available; this option only decides when the expensive sources get built.
 
 ### `project.idle_timeout_ms`
 

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -70,7 +70,7 @@ Index persistence backend: "lmdb" (single database file) or "files" (one file pe
 
 | Type     | Default     |
 | -------- | ----------- |
-| `string` | `"on_open"` |
+| `string` | `"on_edit"` |
 
 What triggers PCH/AST builds for an open file: "on_open" compiles eagerly on didOpen, "on_edit" serves reads from the index and compiles only when an edit-intent trigger fires (edit, completion, signature help, context switch), "never" serves purely from the index. Feature routing always answers from the best source currently available; this option only decides when the expensive sources get built.
 

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -66,6 +66,14 @@ Build the background index that serves cross-TU features (find references, works
 
 Index persistence backend: "lmdb" (single database file) or "files" (one file per blob).
 
+### `project.pch_build`
+
+| Type     | Default     |
+| -------- | ----------- |
+| `string` | `"on_open"` |
+
+What triggers PCH/AST builds for an open file: "on_open" compiles eagerly on didOpen, "on_edit" serves reads from the index and compiles only when an edit-intent trigger fires (edit, completion, signature help, context switch), "never" serves purely from the index. Feature routing always answers from the best source currently available; this option only decides when the expensive sources get built.
+
 ### `project.idle_timeout_ms`
 
 | Type     | Default |

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -72,7 +72,7 @@ Index persistence backend: "lmdb" (single database file) or "files" (one file pe
 | -------- | ------- |
 | `string` | `"off"` |
 
-Read-only serving for open files: "off" targets a full AST for every open file — builds are pulled by the first request that needs them, with the index answering in the meantime; "on" never builds a PCH — reads serve from the index alone (a cold file jumps the indexing queue), while completion and signature help still compile on demand without a preamble; "auto" starts every file as "on" and switches it to "off" at the first edit intent (edit, completion, signature help, context switch). Feature routing always answers from the best source currently available.
+Read-only serving for open files: "off" targets a full AST for every open file — builds are pulled by the first request that needs them, with the index answering in the meantime; "on" never builds a PCH — reads serve from the index alone (a cold file jumps the indexing queue), while completion and signature help still compile on demand without a preamble; "auto" starts every file as "on", switches it to "off" at the first edit intent (edit, completion, signature help, context switch), and falls back to "off" for a file the index cannot serve. Feature routing always answers from the best source currently available.
 
 ### `project.idle_timeout_ms`
 

--- a/docs/public/clice-config.schema.json
+++ b/docs/public/clice-config.schema.json
@@ -12,7 +12,7 @@
                 "compile_commands_paths": [],
                 "enable_indexing": true,
                 "index_db": "lmdb",
-                "pch_build": "on_edit",
+                "readonly": "off",
                 "idle_timeout_ms": 3000,
                 "test_hooks": false,
                 "stateful_worker_count": 2,
@@ -112,14 +112,14 @@
                         "files"
                     ]
                 },
-                "pch_build": {
+                "readonly": {
                     "type": "string",
-                    "description": "What triggers PCH/AST builds for an open file: \"on_open\" compiles eagerly on didOpen, \"on_edit\" serves reads from the index and compiles only when an edit-intent trigger fires (edit, completion, signature help, context switch), \"never\" never builds them — reads serve from the index alone, while completion and signature help still compile on demand without a preamble. Feature routing always answers from the best source currently available; this option only decides when the expensive sources get built.",
-                    "default": "on_edit",
+                    "description": "Read-only serving for open files: \"off\" targets a full AST for every open file — builds are pulled by the first request that needs them, with the index answering in the meantime; \"on\" never builds a PCH — reads serve from the index alone (a cold file jumps the indexing queue), while completion and signature help still compile on demand without a preamble; \"auto\" starts every file as \"on\" and switches it to \"off\" at the first edit intent (edit, completion, signature help, context switch). Feature routing always answers from the best source currently available.",
+                    "default": "off",
                     "enum": [
-                        "on_open",
-                        "on_edit",
-                        "never"
+                        "off",
+                        "on",
+                        "auto"
                     ]
                 },
                 "idle_timeout_ms": {

--- a/docs/public/clice-config.schema.json
+++ b/docs/public/clice-config.schema.json
@@ -114,7 +114,7 @@
                 },
                 "pch_build": {
                     "type": "string",
-                    "description": "What triggers PCH/AST builds for an open file: \"on_open\" compiles eagerly on didOpen, \"on_edit\" serves reads from the index and compiles only when an edit-intent trigger fires (edit, completion, signature help, context switch), \"never\" serves purely from the index. Feature routing always answers from the best source currently available; this option only decides when the expensive sources get built.",
+                    "description": "What triggers PCH/AST builds for an open file: \"on_open\" compiles eagerly on didOpen, \"on_edit\" serves reads from the index and compiles only when an edit-intent trigger fires (edit, completion, signature help, context switch), \"never\" never builds them — reads serve from the index alone, while completion and signature help still compile on demand without a preamble. Feature routing always answers from the best source currently available; this option only decides when the expensive sources get built.",
                     "default": "on_edit",
                     "enum": [
                         "on_open",

--- a/docs/public/clice-config.schema.json
+++ b/docs/public/clice-config.schema.json
@@ -12,6 +12,7 @@
                 "compile_commands_paths": [],
                 "enable_indexing": true,
                 "index_db": "lmdb",
+                "pch_build": "on_open",
                 "idle_timeout_ms": 3000,
                 "test_hooks": false,
                 "stateful_worker_count": 2,
@@ -109,6 +110,16 @@
                     "enum": [
                         "lmdb",
                         "files"
+                    ]
+                },
+                "pch_build": {
+                    "type": "string",
+                    "description": "What triggers PCH/AST builds for an open file: \"on_open\" compiles eagerly on didOpen, \"on_edit\" serves reads from the index and compiles only when an edit-intent trigger fires (edit, completion, signature help, context switch), \"never\" serves purely from the index. Feature routing always answers from the best source currently available; this option only decides when the expensive sources get built.",
+                    "default": "on_open",
+                    "enum": [
+                        "on_open",
+                        "on_edit",
+                        "never"
                     ]
                 },
                 "idle_timeout_ms": {

--- a/docs/public/clice-config.schema.json
+++ b/docs/public/clice-config.schema.json
@@ -114,7 +114,7 @@
                 },
                 "readonly": {
                     "type": "string",
-                    "description": "Read-only serving for open files: \"off\" targets a full AST for every open file — builds are pulled by the first request that needs them, with the index answering in the meantime; \"on\" never builds a PCH — reads serve from the index alone (a cold file jumps the indexing queue), while completion and signature help still compile on demand without a preamble; \"auto\" starts every file as \"on\" and switches it to \"off\" at the first edit intent (edit, completion, signature help, context switch). Feature routing always answers from the best source currently available.",
+                    "description": "Read-only serving for open files: \"off\" targets a full AST for every open file — builds are pulled by the first request that needs them, with the index answering in the meantime; \"on\" never builds a PCH — reads serve from the index alone (a cold file jumps the indexing queue), while completion and signature help still compile on demand without a preamble; \"auto\" starts every file as \"on\", switches it to \"off\" at the first edit intent (edit, completion, signature help, context switch), and falls back to \"off\" for a file the index cannot serve. Feature routing always answers from the best source currently available.",
                     "default": "off",
                     "enum": [
                         "off",

--- a/docs/public/clice-config.schema.json
+++ b/docs/public/clice-config.schema.json
@@ -12,7 +12,7 @@
                 "compile_commands_paths": [],
                 "enable_indexing": true,
                 "index_db": "lmdb",
-                "pch_build": "on_open",
+                "pch_build": "on_edit",
                 "idle_timeout_ms": 3000,
                 "test_hooks": false,
                 "stateful_worker_count": 2,
@@ -115,7 +115,7 @@
                 "pch_build": {
                     "type": "string",
                     "description": "What triggers PCH/AST builds for an open file: \"on_open\" compiles eagerly on didOpen, \"on_edit\" serves reads from the index and compiles only when an edit-intent trigger fires (edit, completion, signature help, context switch), \"never\" serves purely from the index. Feature routing always answers from the best source currently available; this option only decides when the expensive sources get built.",
-                    "default": "on_open",
+                    "default": "on_edit",
                     "enum": [
                         "on_open",
                         "on_edit",

--- a/src/feature/document_symbols.cpp
+++ b/src/feature/document_symbols.cpp
@@ -372,19 +372,31 @@ auto document_symbols(CompilationUnitRef unit) -> std::vector<DocumentSymbol> {
 
 auto document_symbols(CompilationUnitRef unit, PositionEncoding encoding)
     -> std::vector<protocol::DocumentSymbol> {
-    auto internal = document_symbols(unit);
-    LineMap map(unit.interested_content(), unit.line_starts(), encoding);
+    return document_symbols_to_protocol(document_symbols(unit),
+                                        unit.interested_content(),
+                                        unit.line_starts(),
+                                        encoding);
+}
 
-    std::vector<protocol::DocumentSymbol> symbols;
-    symbols.reserve(internal.size());
+auto document_symbols_to_protocol(llvm::ArrayRef<DocumentSymbol> symbols,
+                                  llvm::StringRef content,
+                                  llvm::ArrayRef<std::uint32_t> line_starts,
+                                  PositionEncoding encoding)
+    -> std::vector<protocol::DocumentSymbol> {
+    LineMap map(content,
+                std::span<const std::uint32_t>(line_starts.data(), line_starts.size()),
+                encoding);
 
-    for(const auto& symbol: internal) {
+    std::vector<protocol::DocumentSymbol> result;
+    result.reserve(symbols.size());
+
+    for(const auto& symbol: symbols) {
         if(auto converted = to_protocol_symbol(symbol, map)) {
-            symbols.push_back(std::move(*converted));
+            result.push_back(std::move(*converted));
         }
     }
 
-    return symbols;
+    return result;
 }
 
 }  // namespace clice::feature

--- a/src/feature/feature.h
+++ b/src/feature/feature.h
@@ -482,9 +482,10 @@ using IndexSymbolResolver = llvm::function_ref<std::optional<IndexSymbolInfo>(in
 /// parses only, C++ otherwise. A default-constructed LangOptions is C89
 /// — `class` would lex as an identifier. `standard` is the serving
 /// command's -std value when known: the rows were classified under it,
-/// and the latest standard's extra keywords (`concept` in C++17 code)
-/// would conflict with them. Unknown or contradicting values fall back
-/// to the language's latest.
+/// and a newer standard's extra keywords (`concept` in C++17 code)
+/// would shadow them. Absent, unknown or contradicting values fall back
+/// to the driver's default standard — the dialect a -std-less command
+/// was indexed under.
 auto index_lang_options(llvm::StringRef path, bool c_rows, llvm::StringRef standard = {})
     -> const clang::LangOptions&;
 

--- a/src/feature/feature.h
+++ b/src/feature/feature.h
@@ -477,10 +477,11 @@ struct IndexSymbolInfo {
 
 using IndexSymbolResolver = llvm::function_ref<std::optional<IndexSymbolInfo>(index::SymbolHash)>;
 
-/// Language options for raw-lexing `path` without a compile command:
-/// C for .c files, C++ (latest) otherwise. A default-constructed
+/// Language options for raw-lexing `path` without a compile command: C
+/// for .c files and when `c_rows` says the served rows were built by C
+/// parses only, C++ (latest) otherwise. A default-constructed
 /// LangOptions is C89 — `class` would lex as an identifier.
-auto index_lang_options(llvm::StringRef path) -> const clang::LangOptions&;
+auto index_lang_options(llvm::StringRef path, bool c_rows) -> const clang::LangOptions&;
 
 /// Lexical layer (keywords, literals, comments, directives) from a raw lex
 /// of `content`, semantic kinds from `occurrences` resolved through

--- a/src/feature/feature.h
+++ b/src/feature/feature.h
@@ -479,9 +479,14 @@ using IndexSymbolResolver = llvm::function_ref<std::optional<IndexSymbolInfo>(in
 
 /// Language options for raw-lexing `path` without a compile command: C
 /// for .c files and when `c_rows` says the served rows were built by C
-/// parses only, C++ (latest) otherwise. A default-constructed
-/// LangOptions is C89 — `class` would lex as an identifier.
-auto index_lang_options(llvm::StringRef path, bool c_rows) -> const clang::LangOptions&;
+/// parses only, C++ otherwise. A default-constructed LangOptions is C89
+/// — `class` would lex as an identifier. `standard` is the serving
+/// command's -std value when known: the rows were classified under it,
+/// and the latest standard's extra keywords (`concept` in C++17 code)
+/// would conflict with them. Unknown or contradicting values fall back
+/// to the language's latest.
+auto index_lang_options(llvm::StringRef path, bool c_rows, llvm::StringRef standard = {})
+    -> const clang::LangOptions&;
 
 /// Lexical layer (keywords, literals, comments, directives) from a raw lex
 /// of `content`, semantic kinds from `occurrences` resolved through

--- a/src/feature/feature.h
+++ b/src/feature/feature.h
@@ -349,12 +349,31 @@ auto semantic_tokens(CompilationUnitRef unit) -> std::vector<SemanticToken>;
 auto semantic_tokens(CompilationUnitRef unit, PositionEncoding encoding)
     -> protocol::SemanticTokens;
 
+/// Wire encoding of computed tokens against the text they describe — one
+/// encoder for the worker's AST results and the master's index
+/// projections, so both paths emit byte-identical replies.
+auto semantic_tokens_to_protocol(llvm::ArrayRef<SemanticToken> tokens,
+                                 llvm::StringRef content,
+                                 llvm::ArrayRef<std::uint32_t> line_starts,
+                                 PositionEncoding encoding) -> protocol::SemanticTokens;
+
 auto folding_ranges(CompilationUnitRef unit) -> std::vector<FoldingRange>;
 auto folding_ranges(CompilationUnitRef unit, PositionEncoding encoding)
     -> std::vector<protocol::FoldingRange>;
 
+auto folding_ranges_to_protocol(llvm::ArrayRef<FoldingRange> ranges,
+                                llvm::StringRef content,
+                                llvm::ArrayRef<std::uint32_t> line_starts,
+                                PositionEncoding encoding) -> std::vector<protocol::FoldingRange>;
+
 auto document_symbols(CompilationUnitRef unit) -> std::vector<DocumentSymbol>;
 auto document_symbols(CompilationUnitRef unit, PositionEncoding encoding)
+    -> std::vector<protocol::DocumentSymbol>;
+
+auto document_symbols_to_protocol(llvm::ArrayRef<DocumentSymbol> symbols,
+                                  llvm::StringRef content,
+                                  llvm::ArrayRef<std::uint32_t> line_starts,
+                                  PositionEncoding encoding)
     -> std::vector<protocol::DocumentSymbol>;
 
 auto inlay_hints(CompilationUnitRef unit,
@@ -456,8 +475,7 @@ struct IndexSymbolInfo {
     SymbolKind kind = SymbolKind::Invalid;
 };
 
-using IndexSymbolResolver =
-    llvm::function_ref<std::optional<IndexSymbolInfo>(index::SymbolHash)>;
+using IndexSymbolResolver = llvm::function_ref<std::optional<IndexSymbolInfo>(index::SymbolHash)>;
 
 /// Language options for raw-lexing `path` without a compile command:
 /// C for .c files, C++ (latest) otherwise. A default-constructed
@@ -477,8 +495,8 @@ auto index_semantic_tokens(llvm::StringRef content,
 /// Outline tree built from declaration extents by range containment;
 /// extents that merely overlap (macro-generated siblings collapse onto one
 /// invocation range) become siblings in source order. `detail` stays empty.
-auto index_document_symbols(llvm::ArrayRef<IndexDeclRow> decls,
-                            IndexSymbolResolver resolve) -> std::vector<DocumentSymbol>;
+auto index_document_symbols(llvm::ArrayRef<IndexDeclRow> decls, IndexSymbolResolver resolve)
+    -> std::vector<DocumentSymbol>;
 
 /// Declaration folds: each definition extent folds its last balanced brace
 /// group (brace matching over a raw lex, so braces in strings and comments

--- a/src/feature/feature.h
+++ b/src/feature/feature.h
@@ -7,6 +7,7 @@
 
 #include "compile/compilation.h"
 #include "compile/compilation_unit.h"
+#include "index/types.h"
 #include "semantic/display.h"
 #include "semantic/symbol.h"
 #include "support/anomaly.h"
@@ -423,5 +424,90 @@ auto document_format(llvm::StringRef file,
                      std::optional<LocalSourceRange> range,
                      PositionEncoding encoding = PositionEncoding::UTF16)
     -> std::vector<protocol::TextEdit>;
+
+/// Index projections: whole-document features computed from index rows plus
+/// the document text, serving open files that have no AST yet (see
+/// FeatureRouter's routing rules). Inputs are index vocabulary types and
+/// narrow resolvers, never index storage — the caller extracts rows from
+/// shard/ProjectIndex and hands them over. Each projection's output is an
+/// honest subset of its AST twin's: missing pieces (Sema modifiers, outline
+/// detail, statement folds, ...) are pinned by the read-only test corpus.
+
+/// One Decl/Def relation row of the document: the name-token anchor, the
+/// declaration's full extent (invalid when the index recorded none — a
+/// cross-file or invalid source range) and the symbol it belongs to.
+struct IndexDeclRow {
+    LocalSourceRange range;
+    LocalSourceRange extent;
+    index::SymbolHash symbol = 0;
+    bool definition = false;
+};
+
+/// An include edge of the document, from the TU manifest: the 1-based
+/// directive line and the resolved target's absolute path.
+struct IndexIncludeEdge {
+    std::uint32_t line = 0;
+    std::string target;
+};
+
+/// A row symbol's identity as the resolver hands it back.
+struct IndexSymbolInfo {
+    std::string name;
+    SymbolKind kind = SymbolKind::Invalid;
+};
+
+using IndexSymbolResolver =
+    llvm::function_ref<std::optional<IndexSymbolInfo>(index::SymbolHash)>;
+
+/// Language options for raw-lexing `path` without a compile command:
+/// C for .c files, C++ (latest) otherwise. A default-constructed
+/// LangOptions is C89 — `class` would lex as an identifier.
+auto index_lang_options(llvm::StringRef path) -> const clang::LangOptions&;
+
+/// Lexical layer (keywords, literals, comments, directives) from a raw lex
+/// of `content`, semantic kinds from `occurrences` resolved through
+/// `resolve`, Declaration/Definition modifiers from `decls`. Both row
+/// arrays must be sorted by range, as shard readers hand them out.
+auto index_semantic_tokens(llvm::StringRef content,
+                           const clang::LangOptions& lang_opts,
+                           llvm::ArrayRef<index::Occurrence> occurrences,
+                           llvm::ArrayRef<IndexDeclRow> decls,
+                           IndexSymbolResolver resolve) -> std::vector<SemanticToken>;
+
+/// Outline tree built from declaration extents by range containment;
+/// extents that merely overlap (macro-generated siblings collapse onto one
+/// invocation range) become siblings in source order. `detail` stays empty.
+auto index_document_symbols(llvm::ArrayRef<IndexDeclRow> decls,
+                            IndexSymbolResolver resolve) -> std::vector<DocumentSymbol>;
+
+/// Declaration folds: each definition extent folds its last balanced brace
+/// group (brace matching over a raw lex, so braces in strings and comments
+/// do not count), keeping the name and signature visible like the AST
+/// folds do.
+auto index_folding_ranges(llvm::StringRef content,
+                          const clang::LangOptions& lang_opts,
+                          llvm::ArrayRef<IndexDeclRow> decls,
+                          IndexSymbolResolver resolve) -> std::vector<FoldingRange>;
+
+/// Document links from manifest include edges: each edge's argument span is
+/// located with find_directive_argument on its directive line. Lines the
+/// manifest has no edge for (guard-skipped includes, __has_include, #embed)
+/// produce no link.
+auto index_document_links(llvm::StringRef content,
+                          const clang::LangOptions& lang_opts,
+                          llvm::ArrayRef<IndexIncludeEdge> edges) -> std::vector<DocumentLink>;
+
+/// The comment block immediately preceding the line containing `offset`:
+/// contiguous //- or /*-style lines directly above it, comment markers
+/// stripped. Empty when a blank line or code intervenes. An approximation
+/// of clang's comment attachment, pinned as such by the read-only corpus.
+auto preceding_comment(llvm::StringRef content, std::uint32_t offset) -> std::string;
+
+/// Assemble the read-only hover card: name, kind and what the index can
+/// prove from stored text — no Sema products (type, value, size, aka) and
+/// no qualified scope (the index stores unqualified names).
+auto index_hover(const IndexSymbolInfo& info,
+                 llvm::StringRef definition_text,
+                 llvm::StringRef comment) -> HoverInfo;
 
 }  // namespace clice::feature

--- a/src/feature/feature.h
+++ b/src/feature/feature.h
@@ -500,9 +500,11 @@ auto index_document_symbols(llvm::ArrayRef<IndexDeclRow> decls, IndexSymbolResol
     -> std::vector<DocumentSymbol>;
 
 /// Declaration folds: each definition extent folds its last balanced brace
-/// group (brace matching over a raw lex, so braces in strings and comments
-/// do not count), keeping the name and signature visible like the AST
-/// folds do.
+/// group (brace matching over a raw lex, so braces in strings, comments
+/// and directive lines do not count), keeping the name and signature
+/// visible like the AST folds do. Extents touching a conditional whose
+/// branches unbalance braces produce no fold — a raw pairing there is
+/// wrong for some preprocessing variant.
 auto index_folding_ranges(llvm::StringRef content,
                           const clang::LangOptions& lang_opts,
                           llvm::ArrayRef<IndexDeclRow> decls,

--- a/src/feature/folding_ranges.cpp
+++ b/src/feature/folding_ranges.cpp
@@ -369,13 +369,24 @@ auto folding_ranges(CompilationUnitRef unit) -> std::vector<FoldingRange> {
 
 auto folding_ranges(CompilationUnitRef unit, PositionEncoding encoding)
     -> std::vector<protocol::FoldingRange> {
-    auto collected = folding_ranges(unit);
-    LineMap map(unit.interested_content(), unit.line_starts(), encoding);
+    return folding_ranges_to_protocol(folding_ranges(unit),
+                                      unit.interested_content(),
+                                      unit.line_starts(),
+                                      encoding);
+}
+
+auto folding_ranges_to_protocol(llvm::ArrayRef<FoldingRange> ranges,
+                                llvm::StringRef content,
+                                llvm::ArrayRef<std::uint32_t> line_starts,
+                                PositionEncoding encoding) -> std::vector<protocol::FoldingRange> {
+    LineMap map(content,
+                std::span<const std::uint32_t>(line_starts.data(), line_starts.size()),
+                encoding);
 
     std::vector<protocol::FoldingRange> result;
-    result.reserve(collected.size());
+    result.reserve(ranges.size());
 
-    for(const auto& item: collected) {
+    for(const auto& item: ranges) {
         auto start = to_position(map, item.range.begin);
         auto end = to_position(map, item.range.end);
         if(!start || !end)

--- a/src/feature/index_projection.cpp
+++ b/src/feature/index_projection.cpp
@@ -1,0 +1,520 @@
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "feature/feature.h"
+#include "feature/lexical_classify.h"
+#include "syntax/lexer.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/TargetParser/Triple.h"
+#include "clang/Basic/IdentifierTable.h"
+#include "clang/Basic/LangStandard.h"
+
+namespace clice::feature {
+
+namespace {
+
+/// Lang options plus the matching keyword table; both outlive every call
+/// (projections run on the master's single thread).
+struct LangProfile {
+    clang::LangOptions opts;
+    clang::IdentifierTable keywords;
+
+    explicit LangProfile(clang::Language lang, clang::LangStandard::Kind std) :
+        keywords((set_defaults(opts, lang, std), opts)) {}
+
+private:
+    static void set_defaults(clang::LangOptions& opts,
+                             clang::Language lang,
+                             clang::LangStandard::Kind std) {
+        std::vector<std::string> includes;
+        clang::LangOptions::setLangDefaults(opts, lang, llvm::Triple(), includes, std);
+        opts.LineComment = true;
+    }
+};
+
+LangProfile& cpp_profile() {
+    static LangProfile profile(clang::Language::CXX, clang::LangStandard::lang_cxx23);
+    return profile;
+}
+
+LangProfile& c_profile() {
+    static LangProfile profile(clang::Language::C, clang::LangStandard::lang_c23);
+    return profile;
+}
+
+LangProfile& profile_for(const clang::LangOptions& lang_opts) {
+    return lang_opts.CPlusPlus ? cpp_profile() : c_profile();
+}
+
+/// Line start offsets of `content`, the plain scan (no encoding concerns:
+/// callers index with byte offsets).
+std::vector<std::uint32_t> scan_line_starts(llvm::StringRef content) {
+    std::vector<std::uint32_t> starts{0};
+    for(std::uint32_t i = 0; i < content.size(); i += 1) {
+        if(content[i] == '\n') {
+            starts.push_back(i + 1);
+        }
+    }
+    return starts;
+}
+
+bool outline_kind(SymbolKind kind) {
+    switch(kind) {
+        case SymbolKind::Namespace:
+        case SymbolKind::Class:
+        case SymbolKind::Struct:
+        case SymbolKind::Union:
+        case SymbolKind::Enum:
+        case SymbolKind::Type:
+        case SymbolKind::Concept:
+        case SymbolKind::Field:
+        case SymbolKind::EnumMember:
+        case SymbolKind::Function:
+        case SymbolKind::Method:
+        case SymbolKind::Operator:
+        case SymbolKind::Variable: return true;
+        default: return false;
+    }
+}
+
+}  // namespace
+
+auto index_lang_options(llvm::StringRef path) -> const clang::LangOptions& {
+    return path.ends_with(".c") ? c_profile().opts : cpp_profile().opts;
+}
+
+auto index_semantic_tokens(llvm::StringRef content,
+                           const clang::LangOptions& lang_opts,
+                           llvm::ArrayRef<index::Occurrence> occurrences,
+                           llvm::ArrayRef<IndexDeclRow> decls,
+                           IndexSymbolResolver resolve) -> std::vector<SemanticToken> {
+    auto& profile = profile_for(lang_opts);
+
+    // Rows arrive in shard order (occurrences by range, relations grouped
+    // by symbol); token matching needs both sorted by anchor begin.
+    std::vector<index::Occurrence> occs(occurrences.begin(), occurrences.end());
+    std::ranges::sort(occs, {}, [](const index::Occurrence& o) { return o.range.begin; });
+    std::vector<IndexDeclRow> decl_rows(decls.begin(), decls.end());
+    std::ranges::sort(decl_rows, {}, [](const IndexDeclRow& r) { return r.range.begin; });
+
+    // The semantic classification of the token anchored at `begin`: decl
+    // rows carry their Declaration/Definition modifier; occurrences of
+    // symbols without a decl row here contribute the bare kind. Multiple
+    // rows on one anchor (merged shard variants) combine — kind
+    // disagreement is a Conflict, like instantiation disagreement on the
+    // AST path.
+    auto semantic_at = [&](std::uint32_t begin) {
+        Classified semantic;
+        llvm::SmallVector<index::SymbolHash, 4> covered;
+
+        auto decl_it = std::ranges::lower_bound(decl_rows, begin, {}, [](const IndexDeclRow& r) {
+            return r.range.begin;
+        });
+        for(; decl_it != decl_rows.end() && decl_it->range.begin == begin; ++decl_it) {
+            auto info = resolve(decl_it->symbol);
+            if(!info) {
+                continue;
+            }
+            auto modifier = decl_it->definition ? SymbolModifiers::Definition
+                                                : SymbolModifiers::Declaration;
+            combine(semantic, {info->kind, SymbolModifiers::to_mask(modifier)});
+            covered.push_back(decl_it->symbol);
+        }
+
+        auto occ_it = std::ranges::lower_bound(occs, begin, {}, [](const index::Occurrence& o) {
+            return o.range.begin;
+        });
+        for(; occ_it != occs.end() && occ_it->range.begin == begin; ++occ_it) {
+            if(llvm::is_contained(covered, occ_it->target)) {
+                continue;
+            }
+            if(auto info = resolve(occ_it->target)) {
+                combine(semantic, {info->kind, 0});
+            }
+        }
+        return semantic;
+    };
+
+    std::vector<SemanticToken> tokens;
+    auto emit = [&](LocalSourceRange range, SymbolKind kind, std::uint32_t modifiers) {
+        if(!tokens.empty()) {
+            auto& last = tokens.back();
+            if(last.range.end == range.begin && last.kind == kind && last.modifiers == modifiers) {
+                last.range.end = range.end;
+                return;
+            }
+        }
+        tokens.push_back({.range = range, .kind = kind, .modifiers = modifiers});
+    };
+
+    enum class Directive : std::uint8_t {
+        None,
+        AfterHash,
+        AfterDefine,
+        Body,
+    };
+    Directive directive = Directive::None;
+
+    Lexer lexer(content, {.keep_comments = true, .lang_opts = &profile.opts});
+    while(true) {
+        auto token = lexer.advance();
+        if(token.is_eof()) {
+            break;
+        }
+        if(token.is_eod()) {
+            directive = Directive::None;
+            continue;
+        }
+        if(token.kind == clang::tok::comment) {
+            emit(token.range, SymbolKind::Comment, 0);
+            continue;
+        }
+
+        auto spelling = token.text(content);
+
+        // The raw lexer leaves keywords unresolved; the profile's
+        // identifier table maps them to their token kinds, which also
+        // covers alternative operator spellings (and, or, not).
+        auto kind = token.kind;
+        if(token.is_identifier()) {
+            kind = profile.keywords.get(spelling).getTokenID();
+        }
+        auto lexical_class = classify_lexical_kind(kind, spelling);
+        Classified lexical{lexical_class.kind, 0};
+
+        // Directive overlay, driven by the lexer's preprocessor awareness:
+        // the hash and the directive name paint as Directive, a #define's
+        // name as Macro, header-name arguments as Header.
+        switch(directive) {
+            case Directive::None: {
+                if(token.is_directive_hash()) {
+                    directive = Directive::AfterHash;
+                    lexical = {SymbolKind::Directive, 0};
+                }
+                break;
+            }
+            case Directive::AfterHash: {
+                if(lexical_class.identifier_like) {
+                    lexical = {SymbolKind::Directive, 0};
+                }
+                directive = spelling == "define" ? Directive::AfterDefine : Directive::Body;
+                break;
+            }
+            case Directive::AfterDefine: {
+                if(lexical_class.identifier_like) {
+                    lexical = {SymbolKind::Macro, 0};
+                }
+                directive = Directive::Body;
+                break;
+            }
+            case Directive::Body: break;
+        }
+        if(token.is_header_name()) {
+            lexical = {SymbolKind::Header, 0};
+        }
+
+        // Only tokens that can spell a name take semantic classification —
+        // mirroring the AST path, which anchors declaration names at
+        // identifiers and a destructor's `~` only.
+        Classified semantic;
+        if(lexical_class.identifier_like || kind == clang::tok::tilde) {
+            semantic = semantic_at(token.range.begin);
+        }
+
+        // Semantic classification beats the lexical directive kinds; any
+        // other disagreement is a Conflict, matching the AST path's rule.
+        Classified result = semantic;
+        if(result.kind == SymbolKind::Invalid) {
+            result = lexical;
+        } else if(lexical.kind != SymbolKind::Invalid && lexical.kind != SymbolKind::Directive &&
+                  lexical.kind != SymbolKind::Header && lexical.kind != result.kind) {
+            result.kind = SymbolKind::Conflict;
+        }
+
+        if(result.kind != SymbolKind::Invalid) {
+            emit(token.range, result.kind, result.modifiers);
+        }
+    }
+
+    return tokens;
+}
+
+auto index_document_symbols(llvm::ArrayRef<IndexDeclRow> decls,
+                            IndexSymbolResolver resolve) -> std::vector<DocumentSymbol> {
+    struct Entry {
+        DocumentSymbol symbol;
+        LocalSourceRange extent;
+    };
+
+    std::vector<Entry> entries;
+    for(const auto& row: decls) {
+        if(!row.extent.valid() || row.extent.begin >= row.extent.end) {
+            continue;
+        }
+        auto info = resolve(row.symbol);
+        if(!info || info->name.empty() || !outline_kind(info->kind)) {
+            continue;
+        }
+        auto selection = row.range;
+        if(selection.begin < row.extent.begin || selection.end > row.extent.end) {
+            selection = row.extent;
+        }
+        entries.push_back({{.name = std::move(info->name),
+                            .kind = info->kind,
+                            .range = row.extent,
+                            .selection_range = selection},
+                           row.extent});
+    }
+
+    // Merged shard rows can duplicate an anchor (a symbol's Declaration
+    // and Definition rows of an inline definition share it, and so do
+    // context variants); one outline entry per (site, symbol identity).
+    // Descending end puts a strict container before everything inside it.
+    std::ranges::sort(entries, [](const Entry& lhs, const Entry& rhs) {
+        if(lhs.extent.begin != rhs.extent.begin) {
+            return lhs.extent.begin < rhs.extent.begin;
+        }
+        if(lhs.extent.end != rhs.extent.end) {
+            return lhs.extent.end > rhs.extent.end;
+        }
+        if(lhs.symbol.selection_range.begin != rhs.symbol.selection_range.begin) {
+            return lhs.symbol.selection_range.begin < rhs.symbol.selection_range.begin;
+        }
+        return lhs.symbol.name < rhs.symbol.name;
+    });
+    auto duplicates = std::ranges::unique(entries, [](const Entry& lhs, const Entry& rhs) {
+        return lhs.extent == rhs.extent &&
+               lhs.symbol.selection_range == rhs.symbol.selection_range &&
+               lhs.symbol.name == rhs.symbol.name && lhs.symbol.kind == rhs.symbol.kind;
+    });
+    entries.erase(duplicates.begin(), duplicates.end());
+
+    // Entries are sorted by (begin asc, end desc): a strict container
+    // precedes everything it contains, so a stack builds the tree; equal
+    // or merely overlapping extents fail the containment test and become
+    // siblings in source order.
+    std::vector<DocumentSymbol> roots;
+    auto contains = [](const LocalSourceRange& outer, const LocalSourceRange& inner) {
+        return outer.begin <= inner.begin && inner.end <= outer.end && outer != inner;
+    };
+    std::vector<std::pair<Entry*, std::vector<DocumentSymbol>>> pending;
+
+    auto close_top = [&] {
+        auto [entry, children] = std::move(pending.back());
+        pending.pop_back();
+        entry->symbol.children = std::move(children);
+        auto& into = pending.empty() ? roots : pending.back().second;
+        into.push_back(std::move(entry->symbol));
+    };
+
+    for(auto& entry: entries) {
+        while(!pending.empty() && !contains(pending.back().first->extent, entry.extent)) {
+            close_top();
+        }
+        pending.emplace_back(&entry, std::vector<DocumentSymbol>{});
+    }
+    while(!pending.empty()) {
+        close_top();
+    }
+
+    // Sibling order matches the AST outline's final sort: position
+    // ascending, shorter range first.
+    auto order = [](auto& self, std::vector<DocumentSymbol>& symbols) -> void {
+        std::ranges::sort(symbols, [](const DocumentSymbol& lhs, const DocumentSymbol& rhs) {
+            if(lhs.range.begin != rhs.range.begin) {
+                return lhs.range.begin < rhs.range.begin;
+            }
+            return lhs.range.end < rhs.range.end;
+        });
+        for(auto& symbol: symbols) {
+            self(self, symbol.children);
+        }
+    };
+    order(order, roots);
+
+    return roots;
+}
+
+auto index_folding_ranges(llvm::StringRef content,
+                          const clang::LangOptions& lang_opts,
+                          llvm::ArrayRef<IndexDeclRow> decls,
+                          IndexSymbolResolver resolve) -> std::vector<FoldingRange> {
+    // One raw lex collects every brace outside comments and literals.
+    struct Brace {
+        LocalSourceRange range;
+        bool open;
+    };
+    std::vector<Brace> braces;
+    {
+        Lexer lexer(content, {.lang_opts = &profile_for(lang_opts).opts});
+        while(true) {
+            auto token = lexer.advance();
+            if(token.is_eof()) {
+                break;
+            }
+            if(token.kind == clang::tok::l_brace || token.kind == clang::tok::r_brace) {
+                braces.push_back({token.range, token.kind == clang::tok::l_brace});
+            }
+        }
+    }
+
+    std::vector<FoldingRange> ranges;
+    for(const auto& row: decls) {
+        if(!row.definition || !row.extent.valid() || row.extent.begin >= row.extent.end) {
+            continue;
+        }
+
+        // The last balanced top-level brace group inside the extent: a
+        // function's body rather than a member-initializer's braces, a
+        // tag's brace range, a namespace's block — keeping the name and
+        // signature visible like the AST folds do.
+        auto begin = std::ranges::lower_bound(braces, row.extent.begin, {}, [](const Brace& b) {
+            return b.range.begin;
+        });
+        std::optional<LocalSourceRange> group;
+        std::int32_t depth = 0;
+        std::uint32_t open_begin = 0;
+        for(auto it = begin; it != braces.end() && it->range.end <= row.extent.end; ++it) {
+            if(it->open) {
+                if(depth == 0) {
+                    open_begin = it->range.begin;
+                }
+                depth += 1;
+            } else if(depth > 0) {
+                depth -= 1;
+                if(depth == 0) {
+                    group = LocalSourceRange{open_begin, it->range.end};
+                }
+            }
+        }
+        if(!group) {
+            continue;
+        }
+
+        // Fold kinds mirror the AST collector's strings; a symbol the
+        // resolver cannot name still folds, just without a kind.
+        std::optional<protocol::FoldingRangeKind> kind;
+        if(auto info = resolve(row.symbol)) {
+            switch(info->kind) {
+                case SymbolKind::Namespace: kind = "namespace"; break;
+                case SymbolKind::Class: kind = "class"; break;
+                case SymbolKind::Struct: kind = "struct"; break;
+                case SymbolKind::Union: kind = "union"; break;
+                case SymbolKind::Enum: kind = "enum"; break;
+                case SymbolKind::Function:
+                case SymbolKind::Method:
+                case SymbolKind::Operator: kind = "functionBody"; break;
+                default: break;
+            }
+        }
+
+        ranges.push_back({.range = *group, .kind = kind, .collapsed_text = "{...}"});
+    }
+
+    std::ranges::sort(ranges, [](const FoldingRange& lhs, const FoldingRange& rhs) {
+        return std::tie(lhs.range.begin, lhs.range.end) < std::tie(rhs.range.begin, rhs.range.end);
+    });
+    auto duplicates = std::ranges::unique(ranges, [](const FoldingRange& lhs,
+                                                     const FoldingRange& rhs) {
+        return lhs.range == rhs.range;
+    });
+    ranges.erase(duplicates.begin(), duplicates.end());
+
+    return ranges;
+}
+
+auto index_document_links(llvm::StringRef content,
+                          const clang::LangOptions& lang_opts,
+                          llvm::ArrayRef<IndexIncludeEdge> edges) -> std::vector<DocumentLink> {
+    auto line_starts = scan_line_starts(content);
+
+    std::vector<DocumentLink> links;
+    for(const auto& edge: edges) {
+        if(edge.line == 0 || edge.line > line_starts.size()) {
+            continue;
+        }
+        auto offset = line_starts[edge.line - 1];
+        auto range = find_directive_argument(content, offset, &lang_opts);
+        if(!range) {
+            continue;
+        }
+        links.push_back({.range = *range, .target = edge.target});
+    }
+
+    std::ranges::sort(links, [](const DocumentLink& lhs, const DocumentLink& rhs) {
+        return std::tie(lhs.range.begin, lhs.target) < std::tie(rhs.range.begin, rhs.target);
+    });
+    auto duplicates = std::ranges::unique(links, [](const DocumentLink& lhs,
+                                                    const DocumentLink& rhs) {
+        return lhs.range == rhs.range && lhs.target == rhs.target;
+    });
+    links.erase(duplicates.begin(), duplicates.end());
+
+    return links;
+}
+
+auto preceding_comment(llvm::StringRef content, std::uint32_t offset) -> std::string {
+    if(offset > content.size()) {
+        return {};
+    }
+
+    // Walk to the start of the line containing `offset`, then collect the
+    // contiguous run of comment-looking lines directly above it.
+    auto line_begin = [&](std::uint32_t pos) {
+        auto nl = content.rfind('\n', pos);
+        return nl == llvm::StringRef::npos ? 0 : static_cast<std::uint32_t>(nl) + 1;
+    };
+
+    auto begin = line_begin(offset);
+    llvm::SmallVector<llvm::StringRef, 8> lines;
+    while(begin > 0) {
+        auto prev_begin = line_begin(begin - 1);
+        auto line = content.substr(prev_begin, begin - prev_begin).rtrim("\r\n").trim();
+        bool comment_like = line.starts_with("//") || line.starts_with("/*") ||
+                            line.starts_with("*") || line.ends_with("*/");
+        if(!comment_like || line.empty()) {
+            break;
+        }
+        lines.push_back(line);
+        begin = prev_begin;
+    }
+
+    std::string result;
+    for(auto& line: llvm::reverse(lines)) {
+        auto text = line;
+        for(llvm::StringRef marker: {"///<", "///", "//!", "//", "/**", "/*", "*/"}) {
+            if(text.starts_with(marker)) {
+                text = text.drop_front(marker.size());
+                break;
+            }
+        }
+        if(text.starts_with("*")) {
+            text = text.drop_front(1);
+        }
+        text = text.rtrim("*/").trim();
+        if(!result.empty()) {
+            result += '\n';
+        }
+        result += text.str();
+    }
+    return llvm::StringRef(result).trim().str();
+}
+
+auto index_hover(const IndexSymbolInfo& info,
+                 llvm::StringRef definition_text,
+                 llvm::StringRef comment) -> HoverInfo {
+    HoverInfo hover;
+    hover.name = info.name;
+    hover.kind = info.kind;
+    hover.definition = definition_text.str();
+    hover.documentation = comment.str();
+    return hover;
+}
+
+}  // namespace clice::feature

--- a/src/feature/index_projection.cpp
+++ b/src/feature/index_projection.cpp
@@ -10,6 +10,7 @@
 #include "syntax/lexer.h"
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/TargetParser/Triple.h"
 #include "clang/Basic/IdentifierTable.h"
@@ -142,6 +143,17 @@ auto index_semantic_tokens(llvm::StringRef content,
         return semantic;
     };
 
+    // A module occurrence spans the whole written name (`demo.core`,
+    // `foo:part` — the index stores one row over all components), while
+    // the raw lex sees one token per component; collect the spans so the
+    // components past the first classify too, as on the AST path.
+    std::vector<LocalSourceRange> module_spans;
+    for(const auto& occ: occs) {
+        if(auto info = resolve(occ.target); info && info->kind == SymbolKind::Module) {
+            module_spans.push_back(occ.range);
+        }
+    }
+
     std::vector<SemanticToken> tokens;
     auto emit = [&](LocalSourceRange range, SymbolKind kind, std::uint32_t modifiers) {
         if(!tokens.empty()) {
@@ -226,6 +238,16 @@ auto index_semantic_tokens(llvm::StringRef content,
         Classified semantic;
         if(lexical_class.identifier_like || kind == clang::tok::tilde) {
             semantic = semantic_at(token.range.begin);
+        }
+        if(semantic.kind == SymbolKind::Invalid && lexical_class.identifier_like &&
+           !module_spans.empty()) {
+            auto covering = std::ranges::upper_bound(module_spans,
+                                                     token.range.begin,
+                                                     {},
+                                                     &LocalSourceRange::begin);
+            if(covering != module_spans.begin() && token.range.end <= (covering - 1)->end) {
+                semantic = {SymbolKind::Module, 0};
+            }
         }
 
         // Semantic classification beats the lexical directive kinds; any
@@ -352,22 +374,75 @@ auto index_folding_ranges(llvm::StringRef content,
                           const clang::LangOptions& lang_opts,
                           llvm::ArrayRef<IndexDeclRow> decls,
                           IndexSymbolResolver resolve) -> std::vector<FoldingRange> {
-    // One raw lex collects every brace outside comments and literals.
+    // One raw lex collects every brace outside comments, literals and
+    // directive lines (a #define body's brace pairs nothing in the file's
+    // own text). Conditional levels are tracked alongside: a branch switch
+    // or #endif observing a brace depth other than its #if's means the
+    // branches unbalance braces — any raw pairing is then wrong for some
+    // variant, and folds touching the region are suppressed below.
     struct Brace {
         LocalSourceRange range;
         bool open;
     };
 
+    struct CondLevel {
+        std::uint32_t begin;
+        std::int32_t depth;
+    };
+
     std::vector<Brace> braces;
+    std::vector<LocalSourceRange> ambiguous;
     {
+        std::vector<CondLevel> levels;
+        std::int32_t depth = 0;
+        std::uint32_t hash_begin = 0;
+        bool after_hash = false;
+        bool in_directive = false;
         Lexer lexer(content, {.lang_opts = &profile_for(lang_opts).opts});
         while(true) {
             auto token = lexer.advance();
             if(token.is_eof()) {
                 break;
             }
+            if(token.is_eod()) {
+                after_hash = false;
+                in_directive = false;
+                continue;
+            }
+            if(token.is_directive_hash()) {
+                hash_begin = token.range.begin;
+                after_hash = true;
+                in_directive = true;
+                continue;
+            }
+            if(after_hash) {
+                after_hash = false;
+                auto spelling = token.text(content);
+                if(spelling == "if" || spelling == "ifdef" || spelling == "ifndef") {
+                    levels.push_back({hash_begin, depth});
+                } else if(spelling == "elif" || spelling == "elifdef" || spelling == "elifndef" ||
+                          spelling == "else" || spelling == "endif") {
+                    if(!levels.empty() && depth != levels.back().depth) {
+                        ambiguous.push_back({levels.back().begin, token.range.end});
+                        levels.back().depth = depth;
+                    }
+                    if(spelling == "endif" && !levels.empty()) {
+                        levels.pop_back();
+                    }
+                }
+                continue;
+            }
+            if(in_directive) {
+                continue;
+            }
             if(token.kind == clang::tok::l_brace || token.kind == clang::tok::r_brace) {
                 braces.push_back({token.range, token.kind == clang::tok::l_brace});
+                depth += token.kind == clang::tok::l_brace ? 1 : -1;
+            }
+        }
+        for(const auto& level: levels) {
+            if(depth != level.depth) {
+                ambiguous.push_back({level.begin, static_cast<std::uint32_t>(content.size())});
             }
         }
     }
@@ -375,6 +450,11 @@ auto index_folding_ranges(llvm::StringRef content,
     std::vector<FoldingRange> ranges;
     for(const auto& row: decls) {
         if(!row.definition || !row.extent.valid() || row.extent.begin >= row.extent.end) {
+            continue;
+        }
+        if(llvm::any_of(ambiguous, [&](const LocalSourceRange& region) {
+               return region.begin < row.extent.end && row.extent.begin < region.end;
+           })) {
             continue;
         }
 

--- a/src/feature/index_projection.cpp
+++ b/src/feature/index_projection.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <cstdint>
+#include <map>
 #include <optional>
 #include <string>
 #include <utility>
@@ -39,18 +40,15 @@ private:
     }
 };
 
-LangProfile& cpp_profile() {
-    static LangProfile profile(clang::Language::CXX, clang::LangStandard::lang_cxx23);
-    return profile;
-}
-
-LangProfile& c_profile() {
-    static LangProfile profile(clang::Language::C, clang::LangStandard::lang_c23);
-    return profile;
+LangProfile& profile_for(clang::Language lang, clang::LangStandard::Kind std) {
+    // Stable addresses: callers hold the profile's opts by reference.
+    static std::map<std::pair<clang::Language, clang::LangStandard::Kind>, LangProfile> profiles;
+    return profiles.try_emplace({lang, std}, lang, std).first->second;
 }
 
 LangProfile& profile_for(const clang::LangOptions& lang_opts) {
-    return lang_opts.CPlusPlus ? cpp_profile() : c_profile();
+    return profile_for(lang_opts.CPlusPlus ? clang::Language::CXX : clang::Language::C,
+                       lang_opts.LangStd);
 }
 
 /// Line start offsets of `content`, the plain scan (no encoding concerns:
@@ -87,8 +85,21 @@ bool outline_kind(SymbolKind kind) {
 
 }  // namespace
 
-auto index_lang_options(llvm::StringRef path, bool c_rows) -> const clang::LangOptions& {
-    return c_rows || path.ends_with(".c") ? c_profile().opts : cpp_profile().opts;
+auto index_lang_options(llvm::StringRef path, bool c_rows, llvm::StringRef standard)
+    -> const clang::LangOptions& {
+    bool c = c_rows || path.ends_with(".c");
+    auto lang = c ? clang::Language::C : clang::Language::CXX;
+    auto kind = c ? clang::LangStandard::lang_c23 : clang::LangStandard::lang_cxx23;
+    if(!standard.empty()) {
+        auto parsed = clang::LangStandard::getLangKind(standard);
+        // A standard of the other language contradicts the resolved rows'
+        // language; keep the language's latest rather than obeying it.
+        if(parsed != clang::LangStandard::lang_unspecified &&
+           clang::LangStandard::getLangStandardForKind(parsed).getLanguage() == lang) {
+            kind = parsed;
+        }
+    }
+    return profile_for(lang, kind).opts;
 }
 
 auto index_semantic_tokens(llvm::StringRef content,
@@ -567,19 +578,45 @@ auto preceding_comment(llvm::StringRef content, std::uint32_t offset) -> std::st
 
     auto begin = line_begin(offset);
     llvm::SmallVector<llvm::StringRef, 8> lines;
+    // Between a closing */ and its opener the scan is inside a block
+    // comment: interior lines need no marker of their own (`/*` above bare
+    // text above `*/`). `block_start` remembers where the block began in
+    // `lines` so one whose opener never surfaces can be dropped.
+    bool in_block = false;
+    std::size_t block_start = 0;
     while(begin > 0) {
         auto prev_begin = line_begin(begin - 1);
         auto line = content.substr(prev_begin, begin - prev_begin).rtrim("\r\n").trim();
-        // A trailing */ only marks a comment line when the opener is on an
-        // earlier line: `int a; /* note */` closes a comment it opened
-        // itself, and everything before the marker is code.
-        bool comment_like = line.starts_with("//") || line.starts_with("/*") ||
-                            line.starts_with("*") || (line.ends_with("*/") && !line.contains("/*"));
-        if(!comment_like || line.empty()) {
-            break;
+        if(in_block) {
+            // An opener sharing its line with code marks a comment trailing
+            // that code, not documentation of the decl below.
+            if(line.contains("/*") && !line.starts_with("/*")) {
+                break;
+            }
+            lines.push_back(line);
+            if(line.starts_with("/*")) {
+                in_block = false;
+            }
+        } else {
+            // A trailing */ only marks a comment line when the opener is on
+            // an earlier line: `int a; /* note */` closes a comment it
+            // opened itself, and everything before the marker is code.
+            bool closes_block = line.ends_with("*/") && !line.contains("/*");
+            bool comment_like = line.starts_with("//") || line.starts_with("/*") ||
+                                line.starts_with("*") || closes_block;
+            if(!comment_like || line.empty()) {
+                break;
+            }
+            if(closes_block) {
+                in_block = true;
+                block_start = lines.size();
+            }
+            lines.push_back(line);
         }
-        lines.push_back(line);
         begin = prev_begin;
+    }
+    if(in_block) {
+        lines.truncate(block_start);
     }
 
     std::string result;

--- a/src/feature/index_projection.cpp
+++ b/src/feature/index_projection.cpp
@@ -121,8 +121,8 @@ auto index_semantic_tokens(llvm::StringRef content,
             if(!info) {
                 continue;
             }
-            auto modifier = decl_it->definition ? SymbolModifiers::Definition
-                                                : SymbolModifiers::Declaration;
+            auto modifier =
+                decl_it->definition ? SymbolModifiers::Definition : SymbolModifiers::Declaration;
             combine(semantic, {info->kind, SymbolModifiers::to_mask(modifier)});
             covered.push_back(decl_it->symbol);
         }
@@ -245,8 +245,8 @@ auto index_semantic_tokens(llvm::StringRef content,
     return tokens;
 }
 
-auto index_document_symbols(llvm::ArrayRef<IndexDeclRow> decls,
-                            IndexSymbolResolver resolve) -> std::vector<DocumentSymbol> {
+auto index_document_symbols(llvm::ArrayRef<IndexDeclRow> decls, IndexSymbolResolver resolve)
+    -> std::vector<DocumentSymbol> {
     struct Entry {
         DocumentSymbol symbol;
         LocalSourceRange extent;
@@ -265,11 +265,13 @@ auto index_document_symbols(llvm::ArrayRef<IndexDeclRow> decls,
         if(selection.begin < row.extent.begin || selection.end > row.extent.end) {
             selection = row.extent;
         }
-        entries.push_back({{.name = std::move(info->name),
-                            .kind = info->kind,
-                            .range = row.extent,
-                            .selection_range = selection},
-                           row.extent});
+        entries.push_back({
+            {.name = std::move(info->name),
+             .kind = info->kind,
+             .range = row.extent,
+             .selection_range = selection},
+            row.extent
+        });
     }
 
     // Merged shard rows can duplicate an anchor (a symbol's Declaration
@@ -350,6 +352,7 @@ auto index_folding_ranges(llvm::StringRef content,
         LocalSourceRange range;
         bool open;
     };
+
     std::vector<Brace> braces;
     {
         Lexer lexer(content, {.lang_opts = &profile_for(lang_opts).opts});
@@ -420,10 +423,10 @@ auto index_folding_ranges(llvm::StringRef content,
     std::ranges::sort(ranges, [](const FoldingRange& lhs, const FoldingRange& rhs) {
         return std::tie(lhs.range.begin, lhs.range.end) < std::tie(rhs.range.begin, rhs.range.end);
     });
-    auto duplicates = std::ranges::unique(ranges, [](const FoldingRange& lhs,
-                                                     const FoldingRange& rhs) {
-        return lhs.range == rhs.range;
-    });
+    auto duplicates =
+        std::ranges::unique(ranges, [](const FoldingRange& lhs, const FoldingRange& rhs) {
+            return lhs.range == rhs.range;
+        });
     ranges.erase(duplicates.begin(), duplicates.end());
 
     return ranges;
@@ -450,10 +453,10 @@ auto index_document_links(llvm::StringRef content,
     std::ranges::sort(links, [](const DocumentLink& lhs, const DocumentLink& rhs) {
         return std::tie(lhs.range.begin, lhs.target) < std::tie(rhs.range.begin, rhs.target);
     });
-    auto duplicates = std::ranges::unique(links, [](const DocumentLink& lhs,
-                                                    const DocumentLink& rhs) {
-        return lhs.range == rhs.range && lhs.target == rhs.target;
-    });
+    auto duplicates =
+        std::ranges::unique(links, [](const DocumentLink& lhs, const DocumentLink& rhs) {
+            return lhs.range == rhs.range && lhs.target == rhs.target;
+        });
     links.erase(duplicates.begin(), duplicates.end());
 
     return links;

--- a/src/feature/index_projection.cpp
+++ b/src/feature/index_projection.cpp
@@ -405,6 +405,12 @@ auto index_folding_ranges(llvm::StringRef content,
             continue;
         }
 
+        // Single-line ranges are not worth folding — and the AST collector
+        // drops them too, so the projection stays a subset.
+        if(!content.substr(group->begin, group->length()).contains('\n')) {
+            continue;
+        }
+
         // Fold kinds mirror the AST collector's strings; a symbol the
         // resolver cannot name still folds, just without a kind.
         std::optional<protocol::FoldingRangeKind> kind;
@@ -484,8 +490,11 @@ auto preceding_comment(llvm::StringRef content, std::uint32_t offset) -> std::st
     while(begin > 0) {
         auto prev_begin = line_begin(begin - 1);
         auto line = content.substr(prev_begin, begin - prev_begin).rtrim("\r\n").trim();
+        // A trailing */ only marks a comment line when the opener is on an
+        // earlier line: `int a; /* note */` closes a comment it opened
+        // itself, and everything before the marker is code.
         bool comment_like = line.starts_with("//") || line.starts_with("/*") ||
-                            line.starts_with("*") || line.ends_with("*/");
+                            line.starts_with("*") || (line.ends_with("*/") && !line.contains("/*"));
         if(!comment_like || line.empty()) {
             break;
         }

--- a/src/feature/index_projection.cpp
+++ b/src/feature/index_projection.cpp
@@ -86,8 +86,8 @@ bool outline_kind(SymbolKind kind) {
 
 }  // namespace
 
-auto index_lang_options(llvm::StringRef path) -> const clang::LangOptions& {
-    return path.ends_with(".c") ? c_profile().opts : cpp_profile().opts;
+auto index_lang_options(llvm::StringRef path, bool c_rows) -> const clang::LangOptions& {
+    return c_rows || path.ends_with(".c") ? c_profile().opts : cpp_profile().opts;
 }
 
 auto index_semantic_tokens(llvm::StringRef content,

--- a/src/feature/index_projection.cpp
+++ b/src/feature/index_projection.cpp
@@ -89,11 +89,13 @@ auto index_lang_options(llvm::StringRef path, bool c_rows, llvm::StringRef stand
     -> const clang::LangOptions& {
     bool c = c_rows || path.ends_with(".c");
     auto lang = c ? clang::Language::C : clang::Language::CXX;
-    auto kind = c ? clang::LangStandard::lang_c23 : clang::LangStandard::lang_cxx23;
+    // A command without -std parses under the driver's default dialect;
+    // the same default keeps the keyword table aligned with the rows.
+    auto kind = clang::getDefaultLanguageStandard(lang, llvm::Triple());
     if(!standard.empty()) {
         auto parsed = clang::LangStandard::getLangKind(standard);
         // A standard of the other language contradicts the resolved rows'
-        // language; keep the language's latest rather than obeying it.
+        // language; keep the language's default rather than obeying it.
         if(parsed != clang::LangStandard::lang_unspecified &&
            clang::LangStandard::getLangStandardForKind(parsed).getLanguage() == lang) {
             kind = parsed;
@@ -245,9 +247,10 @@ auto index_semantic_tokens(llvm::StringRef content,
 
         // Only tokens that can spell a name take semantic classification —
         // mirroring the AST path, which anchors declaration names at
-        // identifiers and a destructor's `~` only.
+        // identifiers and a destructor's `~` only. Keywords stay lexical:
+        // a row anchored on `operator` names nothing written there.
         Classified semantic;
-        if(lexical_class.identifier_like || kind == clang::tok::tilde) {
+        if(kind == clang::tok::identifier || kind == clang::tok::tilde) {
             semantic = semantic_at(token.range.begin);
         }
         if(semantic.kind == SymbolKind::Invalid && lexical_class.identifier_like &&

--- a/src/feature/index_projection.cpp
+++ b/src/feature/index_projection.cpp
@@ -66,6 +66,7 @@ std::vector<std::uint32_t> scan_line_starts(llvm::StringRef content) {
 
 bool outline_kind(SymbolKind kind) {
     switch(kind) {
+        case SymbolKind::Macro:
         case SymbolKind::Namespace:
         case SymbolKind::Class:
         case SymbolKind::Struct:
@@ -250,6 +251,7 @@ auto index_document_symbols(llvm::ArrayRef<IndexDeclRow> decls, IndexSymbolResol
     struct Entry {
         DocumentSymbol symbol;
         LocalSourceRange extent;
+        index::SymbolHash hash = 0;
     };
 
     std::vector<Entry> entries;
@@ -270,7 +272,8 @@ auto index_document_symbols(llvm::ArrayRef<IndexDeclRow> decls, IndexSymbolResol
              .kind = info->kind,
              .range = row.extent,
              .selection_range = selection},
-            row.extent
+            row.extent,
+            row.symbol,
         });
     }
 
@@ -288,12 +291,14 @@ auto index_document_symbols(llvm::ArrayRef<IndexDeclRow> decls, IndexSymbolResol
         if(lhs.symbol.selection_range.begin != rhs.symbol.selection_range.begin) {
             return lhs.symbol.selection_range.begin < rhs.symbol.selection_range.begin;
         }
-        return lhs.symbol.name < rhs.symbol.name;
+        if(lhs.symbol.name != rhs.symbol.name) {
+            return lhs.symbol.name < rhs.symbol.name;
+        }
+        return lhs.hash < rhs.hash;
     });
     auto duplicates = std::ranges::unique(entries, [](const Entry& lhs, const Entry& rhs) {
-        return lhs.extent == rhs.extent &&
-               lhs.symbol.selection_range == rhs.symbol.selection_range &&
-               lhs.symbol.name == rhs.symbol.name && lhs.symbol.kind == rhs.symbol.kind;
+        return lhs.hash == rhs.hash && lhs.extent == rhs.extent &&
+               lhs.symbol.selection_range == rhs.symbol.selection_range;
     });
     entries.erase(duplicates.begin(), duplicates.end());
 

--- a/src/feature/lexical_classify.h
+++ b/src/feature/lexical_classify.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include "semantic/symbol.h"
+
+#include "llvm/ADT/StringRef.h"
+#include "clang/Basic/TokenKinds.h"
+
+namespace clice::feature {
+
+/// The classification of one token: a kind and its modifiers.
+struct Classified {
+    SymbolKind kind = SymbolKind::Invalid;
+    std::uint32_t modifiers = 0;
+};
+
+/// Merge a candidate into the running classification: differing kinds
+/// collapse to Conflict, and only the modifiers every candidate agrees on
+/// survive — a token combining resolutions from several instantiations
+/// must not depend on the order the instantiations were written in.
+inline void combine(Classified& result, Classified candidate) {
+    if(candidate.kind == SymbolKind::Invalid) {
+        return;
+    }
+    if(result.kind == SymbolKind::Invalid) {
+        result = candidate;
+        return;
+    }
+    result.modifiers &= candidate.modifiers;
+    if(result.kind != candidate.kind) {
+        result.kind = SymbolKind::Conflict;
+    }
+}
+
+/// Lexical classification of one token, shared by the AST semantic-token
+/// collector (resolved spelled tokens) and the index projection (raw lex
+/// plus identifier-table keyword resolution): both must color a keyword or
+/// literal identically for the index output to stay a subset of the AST
+/// output.
+struct LexicalClass {
+    SymbolKind kind = SymbolKind::Invalid;
+
+    /// Whether the token reads as a word (identifier or keyword) — the
+    /// directive state machines classify e.g. the name after `#` or
+    /// `#define` only for word-like tokens.
+    bool identifier_like = false;
+};
+
+/// Classify a token from its resolved kind and written spelling. `kind`
+/// must have keywords resolved (a raw_identifier never classifies as a
+/// keyword here — resolve it through an IdentifierTable first).
+inline LexicalClass classify_lexical_kind(clang::tok::TokenKind kind, llvm::StringRef spelling) {
+    LexicalClass result;
+    result.identifier_like = clang::tok::isAnyIdentifier(kind);
+
+    switch(kind) {
+        case clang::tok::numeric_constant: result.kind = SymbolKind::Number; break;
+
+        /// Character literals
+        case clang::tok::char_constant:
+        case clang::tok::wide_char_constant:
+        case clang::tok::utf8_char_constant:
+        case clang::tok::utf16_char_constant:
+        case clang::tok::utf32_char_constant: result.kind = SymbolKind::Character; break;
+
+        /// String literals
+        case clang::tok::string_literal:
+        case clang::tok::wide_string_literal:
+        case clang::tok::utf8_string_literal:
+        case clang::tok::utf16_string_literal:
+        case clang::tok::utf32_string_literal: result.kind = SymbolKind::String; break;
+
+        /// Fundamental and Clang/GNU builtin types; `__fp16` lexes as
+        /// `kw_half`.
+        case clang::tok::kw_bool:
+        case clang::tok::kw_char:
+        case clang::tok::kw_wchar_t:
+        case clang::tok::kw_char8_t:
+        case clang::tok::kw_char16_t:
+        case clang::tok::kw_char32_t:
+        case clang::tok::kw_double:
+        case clang::tok::kw_float:
+        case clang::tok::kw_int:
+        case clang::tok::kw_long:
+        case clang::tok::kw_short:
+        case clang::tok::kw_signed:
+        case clang::tok::kw_unsigned:
+        case clang::tok::kw_void:
+        case clang::tok::kw_half:
+        case clang::tok::kw__BitInt:
+        case clang::tok::kw__Bool:
+        case clang::tok::kw__Complex:
+        case clang::tok::kw__Decimal128:
+        case clang::tok::kw__Decimal32:
+        case clang::tok::kw__Decimal64:
+        case clang::tok::kw__ExtInt:
+        case clang::tok::kw__Float16:
+        case clang::tok::kw__Imaginary:
+        case clang::tok::kw___bf16:
+        case clang::tok::kw___float128:
+        case clang::tok::kw___ibm128:
+        case clang::tok::kw___int64:
+        case clang::tok::kw___int128: {
+            result.kind = SymbolKind::Primitive;
+            result.identifier_like = true;
+            break;
+        }
+
+        /// PP directive hash
+        case clang::tok::hash: break;
+
+        default: {
+            if(clang::tok::getKeywordSpelling(kind)) {
+                result.kind = SymbolKind::Keyword;
+                result.identifier_like = true;
+                break;
+            } else if(auto* punctuator = clang::tok::getPunctuatorSpelling(kind)) {
+                /// Alternative operator spellings (and, or, not, ...) lex
+                /// as their punctuator kinds but are written as words.
+                if(!spelling.empty() && llvm::isAlpha(spelling.front()) &&
+                   spelling != punctuator) {
+                    result.kind = SymbolKind::Keyword;
+                }
+            }
+            break;
+        }
+    }
+
+    return result;
+}
+
+}  // namespace clice::feature

--- a/src/feature/lexical_classify.h
+++ b/src/feature/lexical_classify.h
@@ -116,8 +116,7 @@ inline LexicalClass classify_lexical_kind(clang::tok::TokenKind kind, llvm::Stri
             } else if(auto* punctuator = clang::tok::getPunctuatorSpelling(kind)) {
                 /// Alternative operator spellings (and, or, not, ...) lex
                 /// as their punctuator kinds but are written as words.
-                if(!spelling.empty() && llvm::isAlpha(spelling.front()) &&
-                   spelling != punctuator) {
+                if(!spelling.empty() && llvm::isAlpha(spelling.front()) && spelling != punctuator) {
                     result.kind = SymbolKind::Keyword;
                 }
             }

--- a/src/feature/semantic_tokens.cpp
+++ b/src/feature/semantic_tokens.cpp
@@ -6,6 +6,7 @@
 
 #include "compile/compilation_unit.h"
 #include "feature/feature.h"
+#include "feature/lexical_classify.h"
 #include "semantic/decls.h"
 #include "semantic/semantics.h"
 #include "semantic/symbol.h"
@@ -19,30 +20,6 @@
 namespace clice::feature {
 
 namespace {
-
-/// The classification of one token: a kind and its modifiers.
-struct Classified {
-    SymbolKind kind = SymbolKind::Invalid;
-    std::uint32_t modifiers = 0;
-};
-
-/// Merge a candidate into the running classification: differing kinds
-/// collapse to Conflict, and only the modifiers every candidate agrees on
-/// survive — a token combining resolutions from several instantiations
-/// must not depend on the order the instantiations were written in.
-void combine(Classified& result, Classified candidate) {
-    if(candidate.kind == SymbolKind::Invalid) {
-        return;
-    }
-    if(result.kind == SymbolKind::Invalid) {
-        result = candidate;
-        return;
-    }
-    result.modifiers &= candidate.modifiers;
-    if(result.kind != candidate.kind) {
-        result.kind = SymbolKind::Conflict;
-    }
-}
 
 /// Whether a declaration name is backed by source text that should be highlighted.
 bool can_highlight_name(clang::DeclarationName name) {
@@ -322,82 +299,10 @@ private:
     /// produced by a real lexer, so keywords are already resolved), plus a
     /// small state machine for preprocessor directive context.
     Classified classify_lexical(const clang::syntax::Token& token, std::uint32_t offset) {
-        Classified lexical;
-        bool is_identifier_like = clang::tok::isAnyIdentifier(token.kind());
-
-        switch(token.kind()) {
-            case clang::tok::numeric_constant: lexical.kind = SymbolKind::Number; break;
-
-            /// Character literals
-            case clang::tok::char_constant:
-            case clang::tok::wide_char_constant:
-            case clang::tok::utf8_char_constant:
-            case clang::tok::utf16_char_constant:
-            case clang::tok::utf32_char_constant: lexical.kind = SymbolKind::Character; break;
-
-            /// String literals
-            case clang::tok::string_literal:
-            case clang::tok::wide_string_literal:
-            case clang::tok::utf8_string_literal:
-            case clang::tok::utf16_string_literal:
-            case clang::tok::utf32_string_literal: lexical.kind = SymbolKind::String; break;
-
-            /// Fundamental and Clang/GNU builtin types; `__fp16` lexes as
-            /// `kw_half`.
-            case clang::tok::kw_bool:
-            case clang::tok::kw_char:
-            case clang::tok::kw_wchar_t:
-            case clang::tok::kw_char8_t:
-            case clang::tok::kw_char16_t:
-            case clang::tok::kw_char32_t:
-            case clang::tok::kw_double:
-            case clang::tok::kw_float:
-            case clang::tok::kw_int:
-            case clang::tok::kw_long:
-            case clang::tok::kw_short:
-            case clang::tok::kw_signed:
-            case clang::tok::kw_unsigned:
-            case clang::tok::kw_void:
-            case clang::tok::kw_half:
-            case clang::tok::kw__BitInt:
-            case clang::tok::kw__Bool:
-            case clang::tok::kw__Complex:
-            case clang::tok::kw__Decimal128:
-            case clang::tok::kw__Decimal32:
-            case clang::tok::kw__Decimal64:
-            case clang::tok::kw__ExtInt:
-            case clang::tok::kw__Float16:
-            case clang::tok::kw__Imaginary:
-            case clang::tok::kw___bf16:
-            case clang::tok::kw___float128:
-            case clang::tok::kw___ibm128:
-            case clang::tok::kw___int64:
-            case clang::tok::kw___int128: {
-                lexical.kind = SymbolKind::Primitive;
-                is_identifier_like = true;
-                break;
-            }
-
-            /// PP directive hash
-            case clang::tok::hash: break;
-
-            default: {
-                if(clang::tok::getKeywordSpelling(token.kind())) {
-                    lexical.kind = SymbolKind::Keyword;
-                    is_identifier_like = true;
-                    break;
-                } else if(auto* punctuator = clang::tok::getPunctuatorSpelling(token.kind())) {
-                    /// Alternative operator spellings (and, or, not, ...) lex
-                    /// as their punctuator kinds but are written as words.
-                    auto spelling = content.substr(offset, token.length());
-                    if(!spelling.empty() && llvm::isAlpha(spelling.front()) &&
-                       spelling != punctuator) {
-                        lexical.kind = SymbolKind::Keyword;
-                    }
-                }
-                break;
-            }
-        }
+        auto lexical_class =
+            classify_lexical_kind(token.kind(), content.substr(offset, token.length()));
+        Classified lexical{lexical_class.kind, 0};
+        bool is_identifier_like = lexical_class.identifier_like;
 
         /// Move the directive state machine to classify tokens in a PP directive.
         switch(directive_context) {

--- a/src/feature/semantic_tokens.cpp
+++ b/src/feature/semantic_tokens.cpp
@@ -636,11 +636,14 @@ private:
 
 class SemanticTokenEncoder {
 public:
-    SemanticTokenEncoder(CompilationUnitRef unit,
+    SemanticTokenEncoder(llvm::StringRef content,
+                         llvm::ArrayRef<std::uint32_t> line_starts,
                          PositionEncoding encoding,
                          protocol::SemanticTokens& output) :
-        map(unit.interested_content(), unit.line_starts(), encoding), encoding(encoding),
-        output(output) {}
+        map(content,
+            std::span<const std::uint32_t>(line_starts.data(), line_starts.size()),
+            encoding),
+        encoding(encoding), output(output) {}
 
     void append(const SemanticToken& token) {
         auto content = map.content();
@@ -736,12 +739,20 @@ auto semantic_tokens(CompilationUnitRef unit) -> std::vector<SemanticToken> {
 
 auto semantic_tokens(CompilationUnitRef unit, PositionEncoding encoding)
     -> protocol::SemanticTokens {
-    auto tokens = semantic_tokens(unit);
+    return semantic_tokens_to_protocol(semantic_tokens(unit),
+                                       unit.interested_content(),
+                                       unit.line_starts(),
+                                       encoding);
+}
 
+auto semantic_tokens_to_protocol(llvm::ArrayRef<SemanticToken> tokens,
+                                 llvm::StringRef content,
+                                 llvm::ArrayRef<std::uint32_t> line_starts,
+                                 PositionEncoding encoding) -> protocol::SemanticTokens {
     protocol::SemanticTokens result;
     result.data.reserve(tokens.size() * 5);
 
-    SemanticTokenEncoder encoder(unit, encoding, result);
+    SemanticTokenEncoder encoder(content, line_starts, encoding, result);
     for(const auto& token: tokens) {
         encoder.append(token);
     }

--- a/src/index/include_graph.cpp
+++ b/src/index/include_graph.cpp
@@ -39,11 +39,12 @@ static std::uint32_t addIncludeChain(CompilationUnitRef unit,
         }
         locations[index].path_id = iter->second;
 
-        uint32_t include = -1;
-        if(presumed.getIncludeLoc().isValid()) {
-            include =
-                addIncludeChain(unit, unit.file_id(presumed.getIncludeLoc()), graph, path_table);
-        }
+        // The location of the file CONTAINING the directive — the parent
+        // consumers pair `line` with. Recursing on the directive's own fid
+        // (not the presumed include loc, which names the containing
+        // file's includer and sat one level off) bottoms out at -1 for
+        // directives written in the interested file.
+        auto include = addIncludeChain(unit, unit.file_id(include_loc), graph, path_table);
         locations[index].include = include;
     }
 

--- a/src/index/serialization.h
+++ b/src/index/serialization.h
@@ -103,8 +103,10 @@ namespace clice::index {
 /// Bump it whenever a persisted type's reflected layout changes, when
 /// symbol-hash semantics change (stored rows keyed by old hashes would
 /// silently stop matching newly computed ones), or when the meaning of
-/// stored data changes (v9: preamble document links are document-ordered).
-constexpr inline std::uint32_t index_format_version = 9;
+/// stored data changes (v9: preamble document links are document-ordered;
+/// v10: an include location's `include` names the directive's containing
+/// file, not that file's includer).
+constexpr inline std::uint32_t index_format_version = 10;
 
 /// Serialize a reflected index blob to `os` as a verified-readable
 /// flatbuffer. Encoding only fails on structural impossibilities (e.g. more

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -819,13 +819,17 @@ kota::task<bool> Compiler::ensure_deps(Session& session,
         co_return false;
     }
 
-    // Build or reuse PCH.
-    auto pch_ok =
-        co_await ensure_pch(session, launch_generation, launch_epoch, directory, arguments);
-    if(pch_ok && session.pch_key.has_value()) {
-        if(auto pch_it = workspace.pch_cache.find(*session.pch_key);
-           pch_it != workspace.pch_cache.end()) {
-            pch = {pch_it->second.path, pch_it->second.bound};
+    // Build or reuse PCH. Under pch_build = "never" the build compiles
+    // without a preamble instead — completion and signature help pay full
+    // parses, the profile's stated trade.
+    if(workspace.pch_build != PchBuild::Never) {
+        auto pch_ok =
+            co_await ensure_pch(session, launch_generation, launch_epoch, directory, arguments);
+        if(pch_ok && session.pch_key.has_value()) {
+            if(auto pch_it = workspace.pch_cache.find(*session.pch_key);
+               pch_it != workspace.pch_cache.end()) {
+                pch = {pch_it->second.path, pch_it->second.bound};
+            }
         }
     }
 
@@ -1229,6 +1233,9 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
             .inactive_regions = std::move(inactive),
         };
         on_output.emit(session);
+        // The push above told clients to re-pull what the fresh AST now
+        // answers better; one refresh per landing.
+        session->index_served = false;
         if(on_indexing_needed)
             on_indexing_needed();
         co_return;
@@ -1258,6 +1265,26 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
 /// Compiler's task_group; subsequent ones wait on the shared event.
 /// The spawned task is not cancelled by LSP $/cancelRequest, preventing
 /// the race where cancellation wakes all waiters and they all start compiles.
+void Compiler::escalate(std::shared_ptr<Session> session) {
+    if(session->serving != ServingMode::IndexOnly) {
+        return;
+    }
+    if(workspace.pch_build == PchBuild::Never) {
+        return;
+    }
+    session->serving = ServingMode::Escalated;
+    request_compile(std::move(session));
+}
+
+void Compiler::request_compile(std::shared_ptr<Session> session) {
+    auto kick = [](Compiler& self, std::shared_ptr<Session> session) -> kota::task<> {
+        co_await self.ensure_compiled(std::move(session));
+    };
+    if(!compile_tasks.spawn(kick(*this, std::move(session)))) {
+        LOG_WARN("request_compile: task group stopped, dropping kick");
+    }
+}
+
 kota::task<bool> Compiler::ensure_compiled(std::shared_ptr<Session> session) {
     auto path_id = session->path_id;
     auto gen = session->generation;

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -819,10 +819,10 @@ kota::task<bool> Compiler::ensure_deps(Session& session,
         co_return false;
     }
 
-    // Build or reuse PCH. Under pch_build = "never" the build compiles
+    // Build or reuse PCH. Under readonly = "on" the build compiles
     // without a preamble instead — completion and signature help pay full
     // parses, the profile's stated trade.
-    if(workspace.pch_build != PchBuild::Never) {
+    if(workspace.readonly != ReadonlyMode::On) {
         auto pch_ok =
             co_await ensure_pch(session, launch_generation, launch_epoch, directory, arguments);
         if(pch_ok && session.pch_key.has_value()) {
@@ -1242,6 +1242,25 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
     }
 }
 
+void Compiler::escalate(Session& session) {
+    if(session.serving != ServingMode::IndexOnly) {
+        return;
+    }
+    if(workspace.readonly == ReadonlyMode::On) {
+        return;
+    }
+    session.serving = ServingMode::Escalated;
+}
+
+void Compiler::request_compile(std::shared_ptr<Session> session) {
+    auto kick = [](Compiler& self, std::shared_ptr<Session> session) -> kota::task<> {
+        co_await self.ensure_compiled(std::move(session));
+    };
+    if(!compile_tasks.spawn(kick(*this, std::move(session)))) {
+        LOG_WARN("request_compile: task group stopped, dropping kick");
+    }
+}
+
 /// AST and diagnostics have been published to the client.
 ///
 /// Lifecycle overview (pull-based model):
@@ -1265,26 +1284,6 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
 /// Compiler's task_group; subsequent ones wait on the shared event.
 /// The spawned task is not cancelled by LSP $/cancelRequest, preventing
 /// the race where cancellation wakes all waiters and they all start compiles.
-void Compiler::escalate(std::shared_ptr<Session> session) {
-    if(session->serving != ServingMode::IndexOnly) {
-        return;
-    }
-    if(workspace.pch_build == PchBuild::Never) {
-        return;
-    }
-    session->serving = ServingMode::Escalated;
-    request_compile(std::move(session));
-}
-
-void Compiler::request_compile(std::shared_ptr<Session> session) {
-    auto kick = [](Compiler& self, std::shared_ptr<Session> session) -> kota::task<> {
-        co_await self.ensure_compiled(std::move(session));
-    };
-    if(!compile_tasks.spawn(kick(*this, std::move(session)))) {
-        LOG_WARN("request_compile: task group stopped, dropping kick");
-    }
-}
-
 kota::task<bool> Compiler::ensure_compiled(std::shared_ptr<Session> session) {
     auto path_id = session->path_id;
     auto gen = session->generation;

--- a/src/server/compiler/compiler.h
+++ b/src/server/compiler/compiler.h
@@ -69,10 +69,11 @@ public:
     kota::task<bool> ensure_compiled(std::shared_ptr<Session> session);
 
     /// The escalation triggers' single write point: flip an index-only
-    /// session to Escalated and start its compile without awaiting it.
-    /// A no-op for already-escalated sessions and under pch_build =
-    /// "never" (there is nothing to escalate to).
-    void escalate(std::shared_ptr<Session> session);
+    /// session to Escalated. The build stays pull-driven — the next
+    /// request that needs the AST starts it. A no-op for
+    /// already-escalated sessions and under readonly = "on" (the mode
+    /// transition is disabled).
+    void escalate(Session& session);
 
     /// Start (or join) the session's compile detached — the caller keeps
     /// serving from the index while it lands. ensure_compiled's pending

--- a/src/server/compiler/compiler.h
+++ b/src/server/compiler/compiler.h
@@ -68,6 +68,17 @@ public:
     /// file_index, pch_key, ast_deps, and publishes diagnostics.
     kota::task<bool> ensure_compiled(std::shared_ptr<Session> session);
 
+    /// The escalation triggers' single write point: flip an index-only
+    /// session to Escalated and start its compile without awaiting it.
+    /// A no-op for already-escalated sessions and under pch_build =
+    /// "never" (there is nothing to escalate to).
+    void escalate(std::shared_ptr<Session> session);
+
+    /// Start (or join) the session's compile detached — the caller keeps
+    /// serving from the index while it lands. ensure_compiled's pending
+    /// state dedupes concurrent kicks.
+    void request_compile(std::shared_ptr<Session> session);
+
     /// Interrupt the in-flight compile if the buffer moved past it
     /// (generation mismatch): the worker abandons the stale parse at the
     /// next declaration, while the request still runs to its reply — crash

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -379,15 +379,19 @@ bool Indexer::merge(const void* tu_index_data, std::size_t size) {
     // Sessions without a current file index serve these very rows
     // (freshness clause 4); index_served says the client pulled some of
     // them. Tell subscribers so those results get re-pulled.
-    auto serves_session = [&](std::uint32_t path_id) {
-        auto session = sessions.find(path_id);
-        return session && !session->index_current() && session->index_served;
+    auto serves = [this](std::uint32_t path_id) {
+        return serves_session_rows(path_id);
     };
-    if(llvm::any_of(llvm::make_first_range(replacements), serves_session) ||
-       llvm::any_of(affected, serves_session)) {
+    if(llvm::any_of(llvm::make_first_range(replacements), serves) ||
+       llvm::any_of(affected, serves)) {
         on_serving_rows_changed.emit();
     }
     return true;
+}
+
+bool Indexer::serves_session_rows(std::uint32_t path_id) const {
+    auto session = sessions.find(path_id);
+    return session && !session->index_current() && session->index_served;
 }
 
 void Indexer::drop_index(std::uint32_t tu_path_id) {
@@ -395,14 +399,22 @@ void Indexer::drop_index(std::uint32_t tu_path_id) {
     if(!project.manifests.contains(tu_path_id)) {
         return;
     }
+    // Dropped rows change index-served answers exactly like merged rows
+    // do; without the refresh the client keeps them forever, since no
+    // later merge or compile is owed.
+    bool served = false;
     for(auto path_id: project.remove_manifest(tu_path_id)) {
         auto it = workspace.shards.find(path_id);
         if(it != workspace.shards.end()) {
             it->second.set_live(project.live_variants(path_id));
         }
+        served = served || serves_session_rows(path_id);
     }
     dirty_manifests.insert(tu_path_id);
     global_dirty = true;
+    if(served) {
+        on_serving_rows_changed.emit();
+    }
 }
 
 kota::task<> Indexer::save() {

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -375,6 +375,18 @@ bool Indexer::merge(const void* tu_index_data, std::size_t size) {
         appended,
         rebuilt_ids.size(),
         workspace.shards.size());
+
+    // Sessions without a current file index serve these very rows
+    // (freshness clause 4); index_served says the client pulled some of
+    // them. Tell subscribers so those results get re-pulled.
+    auto serves_session = [&](std::uint32_t path_id) {
+        auto session = sessions.find(path_id);
+        return session && !session->index_current() && session->index_served;
+    };
+    if(llvm::any_of(llvm::make_first_range(replacements), serves_session) ||
+       llvm::any_of(affected, serves_session)) {
+        on_serving_rows_changed.emit();
+    }
     return true;
 }
 

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -1267,28 +1267,42 @@ void Indexer::enqueue(std::uint32_t server_path_id, ReindexReason reason) {
 }
 
 kota::task<> Indexer::await_attempt(std::uint32_t server_path_id) {
-    if(!reindex_reasons.contains(server_path_id)) {
+    auto pending = reindex_reasons.find(server_path_id);
+    if(pending == reindex_reasons.end()) {
         co_return;
     }
-    auto [it, inserted] = attempt_waits.try_emplace(server_path_id);
-    if(inserted) {
-        it->second = std::make_shared<kota::event>();
+    auto ticket = pending->second.ticket;
+    auto& waits = attempt_waits[server_path_id];
+    auto it = llvm::find_if(waits, [&](const AttemptWait& wait) { return wait.ticket == ticket; });
+    if(it == waits.end()) {
+        waits.push_back({ticket, std::make_shared<kota::event>()});
+        it = waits.end() - 1;
     }
     // Hold the shared_ptr across the await: the settle moves the event out
     // of the map before setting it, and a fresh wait after that parks on a
     // new instance.
-    auto event = it->second;
+    auto event = it->event;
     co_await event->wait();
 }
 
-void Indexer::settle_attempt_waits(std::uint32_t server_path_id) {
+void Indexer::settle_attempt_waits(std::uint32_t server_path_id, std::uint64_t ticket) {
     auto it = attempt_waits.find(server_path_id);
     if(it == attempt_waits.end()) {
         return;
     }
-    auto event = std::move(it->second);
-    attempt_waits.erase(it);
-    event->set();
+    llvm::SmallVector<std::shared_ptr<kota::event>, 2> settled;
+    for(auto& wait: it->second) {
+        if(wait.ticket <= ticket) {
+            settled.push_back(std::move(wait.event));
+        }
+    }
+    llvm::erase_if(it->second, [&](const AttemptWait& wait) { return wait.ticket <= ticket; });
+    if(it->second.empty()) {
+        attempt_waits.erase(it);
+    }
+    for(auto& event: settled) {
+        event->set();
+    }
 }
 
 void Indexer::pause_indexing() {
@@ -1313,8 +1327,10 @@ kota::task<> Indexer::stop() {
     co_await bg_tasks.join();
     // Cancelled tasks unwind before their settle bookkeeping; release any
     // parked feature request rather than stranding it past shutdown.
-    for(auto& event: llvm::make_second_range(attempt_waits)) {
-        event->set();
+    for(auto& waits: llvm::make_second_range(attempt_waits)) {
+        for(auto& wait: waits) {
+            wait.event->set();
+        }
     }
     attempt_waits.clear();
 }
@@ -1678,13 +1694,12 @@ kota::task<> Indexer::run_index_task(std::uint32_t server_path_id,
             }
         }
     }
-    // Wake await_attempt waiters after the unservable escalation above, so
-    // they re-derive their route against the settled state. A requeue kept
-    // the entry alive under a fresh ticket — the waiters stay parked for
-    // that newer attempt.
-    if(!reindex_reasons.contains(server_path_id)) {
-        settle_attempt_waits(server_path_id);
-    }
+    // Wake the waiters parked on this attempt (and older tickets it
+    // covers) after the unservable escalation above, so they re-derive
+    // their route against the settled state. Waiters of a requeue made
+    // during the flight bound the fresh ticket and stay parked for that
+    // newer attempt.
+    settle_attempt_waits(server_path_id, ticket);
     round.completed += 1;
     round.inflight -= 1;
     round.task_done.set();

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -1323,11 +1323,20 @@ kota::task<> Indexer::index_one(std::uint32_t server_path_id,
     // the live buffer. Skipping loses no debt: BufferClosed re-checks the
     // shard against the disk on close. An index-only session is the
     // opposite case — its shard IS what the LSP serves (freshness clause
-    // 4), so it indexes like a closed file.
-    if(!index_open_files) {
-        if(auto session = sessions.find(server_path_id);
-           session && session->serving != ServingMode::IndexOnly)
+    // 4), so it indexes like a closed file, but only while its buffer
+    // matches the disk this index would read: rows from a diverged disk
+    // fail clause 4's content gate and would replace the one shard the
+    // session can serve from, blanking its features until an escalation.
+    // Keep the last matching rows instead — the close-time re-check
+    // covers the debt here too.
+    if(auto session = sessions.find(server_path_id)) {
+        if(session->serving != ServingMode::IndexOnly) {
+            if(!index_open_files) {
+                co_return;
+            }
+        } else if(auto disk = fs::read(file_path); !disk || *disk != session->text) {
             co_return;
+        }
     }
 
     // The engine's own observation is authoritative for content changes:

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -1266,6 +1266,31 @@ void Indexer::enqueue(std::uint32_t server_path_id, ReindexReason reason) {
     index_queue.push_back(server_path_id);
 }
 
+kota::task<> Indexer::await_attempt(std::uint32_t server_path_id) {
+    if(!reindex_reasons.contains(server_path_id)) {
+        co_return;
+    }
+    auto [it, inserted] = attempt_waits.try_emplace(server_path_id);
+    if(inserted) {
+        it->second = std::make_shared<kota::event>();
+    }
+    // Hold the shared_ptr across the await: the settle moves the event out
+    // of the map before setting it, and a fresh wait after that parks on a
+    // new instance.
+    auto event = it->second;
+    co_await event->wait();
+}
+
+void Indexer::settle_attempt_waits(std::uint32_t server_path_id) {
+    auto it = attempt_waits.find(server_path_id);
+    if(it == attempt_waits.end()) {
+        return;
+    }
+    auto event = std::move(it->second);
+    attempt_waits.erase(it);
+    event->set();
+}
+
 void Indexer::pause_indexing() {
     ++pause_depth;
     if(pause_depth == 1) {
@@ -1286,6 +1311,12 @@ void Indexer::resume_indexing() {
 kota::task<> Indexer::stop() {
     bg_tasks.cancel();
     co_await bg_tasks.join();
+    // Cancelled tasks unwind before their settle bookkeeping; release any
+    // parked feature request rather than stranding it past shutdown.
+    for(auto& event: llvm::make_second_range(attempt_waits)) {
+        event->set();
+    }
+    attempt_waits.clear();
 }
 
 void Indexer::schedule(bool immediate) {
@@ -1646,6 +1677,13 @@ kota::task<> Indexer::run_index_task(std::uint32_t server_path_id,
                 on_session_unservable(server_path_id);
             }
         }
+    }
+    // Wake await_attempt waiters after the unservable escalation above, so
+    // they re-derive their route against the settled state. A requeue kept
+    // the entry alive under a fresh ticket — the waiters stay parked for
+    // that newer attempt.
+    if(!reindex_reasons.contains(server_path_id)) {
+        settle_attempt_waits(server_path_id);
     }
     round.completed += 1;
     round.inflight -= 1;

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -1635,6 +1635,18 @@ kota::task<> Indexer::run_index_task(std::uint32_t server_path_id,
        it != reindex_reasons.end() && it->second.ticket == ticket) {
         reindex_reasons.erase(it);
     }
+    // The attempt settled with no retry pending; an open session still
+    // waiting on the index with nothing servable will never be served by
+    // it (see on_session_unservable).
+    if(on_session_unservable && !reindex_reasons.contains(server_path_id)) {
+        if(auto session = sessions.find(server_path_id);
+           session && session->serving == ServingMode::IndexOnly) {
+            auto it = workspace.shards.find(server_path_id);
+            if(it == workspace.shards.end() || !it->second.matches_content(session->text)) {
+                on_session_unservable(server_path_id);
+            }
+        }
+    }
     round.completed += 1;
     round.inflight -= 1;
     round.task_done.set();

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -1202,6 +1202,20 @@ bool Indexer::need_update(llvm::StringRef file_path) {
     return false;
 }
 
+void Indexer::boost(std::uint32_t server_path_id) {
+    enqueue(server_path_id, ReindexReason::DepsOnly);
+    // Front of the un-consumed tail: the file someone is reading beats
+    // the bulk backlog. A running round is not disturbed (its snapshot
+    // semantics stay, see run_background_indexing); the slot then leads
+    // the next round.
+    auto begin = index_queue.begin() + index_queue_pos;
+    auto it = std::find(begin, index_queue.end(), server_path_id);
+    if(it != index_queue.end()) {
+        std::rotate(begin, it, it + 1);
+    }
+    schedule(/*immediate=*/true);
+}
+
 void Indexer::enqueue(std::uint32_t server_path_id, ReindexReason reason) {
     // A fresh slot means any prior slot was already consumed (or none
     // existed); a queued-and-unconsumed slot makes this call a duplicate.
@@ -1290,13 +1304,19 @@ kota::task<> Indexer::index_one(std::uint32_t server_path_id,
                                 std::size_t total) {
     auto file_path = std::string(workspace.path_pool.resolve(server_path_id));
 
-    // Open files are skipped until an agent shows up: the LSP side never
-    // reads their shards (sessions serve them), so indexing them is pure
-    // waste — but agents read disk truth and need the shards, snapshot
-    // taken from disk regardless of the live buffer. Skipping loses no
-    // debt: BufferClosed re-checks the shard against the disk on close.
-    if(!index_open_files && sessions.find(server_path_id) != nullptr)
-        co_return;
+    // Open files whose session invests in an AST are skipped until an
+    // agent shows up: the LSP side never reads their shards (the session
+    // serves them), so indexing them is pure waste — but agents read disk
+    // truth and need the shards, snapshot taken from disk regardless of
+    // the live buffer. Skipping loses no debt: BufferClosed re-checks the
+    // shard against the disk on close. An index-only session is the
+    // opposite case — its shard IS what the LSP serves (freshness clause
+    // 4), so it indexes like a closed file.
+    if(!index_open_files) {
+        if(auto session = sessions.find(server_path_id);
+           session && session->serving != ServingMode::IndexOnly)
+            co_return;
+    }
 
     // The engine's own observation is authoritative for content changes:
     // it saw the event. The dep-hash check below cannot be trusted to see

--- a/src/server/compiler/indexer.h
+++ b/src/server/compiler/indexer.h
@@ -117,10 +117,12 @@ public:
     /// undisturbed; the file then leads the next one.
     void boost(std::uint32_t server_path_id);
 
-    /// Wait until the file's pending (re)index state ends — the merge
-    /// landed, the attempt gave up, or the entry was cleared — and return
-    /// immediately when nothing is pending. For replies clients cache with
-    /// no refresh request (outline, links): answered while the didOpen
+    /// Wait until the pending (re)index attempt observed at call time
+    /// settles — the merge landed, the attempt gave up, or the entry was
+    /// cleared — and return immediately when nothing is pending. One
+    /// attempt, not a settled file: a requeue landing during the flight
+    /// does not extend the wait. For replies clients cache with no
+    /// refresh request (outline, links): answered while the didOpen
     /// boost is still running, the empty result would freeze until the
     /// next edit.
     kota::task<> await_attempt(std::uint32_t server_path_id);
@@ -423,15 +425,26 @@ private:
     /// the verdicts above are cleared when a round starts, never here.
     bool need_update(llvm::StringRef file_path);
 
-    /// Wake every await_attempt waiter of the file and drop their event.
-    void settle_attempt_waits(std::uint32_t server_path_id);
+    /// Wake the file's await_attempt waiters whose observed ticket the
+    /// settled attempt covers (`ticket` and older) and drop their events.
+    /// The default wakes every waiter — for the paths where no further
+    /// attempt will come (entry cleared, shutdown).
+    void settle_attempt_waits(std::uint32_t server_path_id, std::uint64_t ticket = -1);
 
     llvm::DenseMap<std::uint32_t, PendingReindex> reindex_reasons;
     llvm::DenseSet<std::uint32_t> failed_ids;
 
-    /// One shared event per file some await_attempt is parked on, fired
-    /// when its pending window ends (or wholesale at stop()).
-    llvm::DenseMap<std::uint32_t, std::shared_ptr<kota::event>> attempt_waits;
+    struct AttemptWait {
+        std::uint64_t ticket;
+        std::shared_ptr<kota::event> event;
+    };
+
+    /// The events await_attempt waiters park on, per file and per pending
+    /// ticket observed at wait time; each fires when an attempt covering
+    /// its ticket settles (or wholesale at stop()). Keyed by ticket so a
+    /// requeue during an attempt's flight cannot extend earlier waits —
+    /// await_attempt promises one attempt, not a settled file.
+    llvm::DenseMap<std::uint32_t, llvm::SmallVector<AttemptWait, 2>> attempt_waits;
     std::uint64_t reindex_ticket = 0;
     bool indexing_active = false;
     bool indexing_scheduled = false;

--- a/src/server/compiler/indexer.h
+++ b/src/server/compiler/indexer.h
@@ -272,6 +272,11 @@ public:
     std::function<void(std::uint32_t path_id)> on_session_unservable;
 
 private:
+    /// Whether an open session serves this file's project rows (freshness
+    /// clause 4) and a client already pulled some of them — the emit
+    /// condition of on_serving_rows_changed.
+    bool serves_session_rows(std::uint32_t path_id) const;
+
     kota::event_loop& loop;
     kota::task_group<> bg_tasks;
     Workspace& workspace;

--- a/src/server/compiler/indexer.h
+++ b/src/server/compiler/indexer.h
@@ -244,6 +244,13 @@ public:
     /// file completes, round ends). A subscriber reads progress() on wake.
     Signal<> on_progress_changed;
 
+    /// Emitted when a merge replaced (or re-masked) rows that an open
+    /// index-served session is serving: results the client already pulled
+    /// describe the old rows, and only a refresh request makes it re-pull
+    /// them — index-only sessions never compile, so the compile-driven
+    /// refresh in the output push path cannot cover them.
+    Signal<> on_serving_rows_changed;
+
 private:
     kota::event_loop& loop;
     kota::task_group<> bg_tasks;

--- a/src/server/compiler/indexer.h
+++ b/src/server/compiler/indexer.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -250,6 +251,14 @@ public:
     /// them — index-only sessions never compile, so the compile-driven
     /// refresh in the output push path cannot cover them.
     Signal<> on_serving_rows_changed;
+
+    /// Invoked when an index attempt for a file with an open
+    /// ServingMode::IndexOnly session settled — no retry pending — without
+    /// a shard that can serve the session's buffer: the file is missing or
+    /// diverged on disk, has no real compile command, or failed to index.
+    /// No later round changes that on its own, so the owner escalates the
+    /// session instead of letting it answer empty forever.
+    std::function<void(std::uint32_t path_id)> on_session_unservable;
 
 private:
     kota::event_loop& loop;

--- a/src/server/compiler/indexer.h
+++ b/src/server/compiler/indexer.h
@@ -117,6 +117,14 @@ public:
     /// undisturbed; the file then leads the next one.
     void boost(std::uint32_t server_path_id);
 
+    /// Wait until the file's pending (re)index state ends — the merge
+    /// landed, the attempt gave up, or the entry was cleared — and return
+    /// immediately when nothing is pending. For replies clients cache with
+    /// no refresh request (outline, links): answered while the didOpen
+    /// boost is still running, the empty result would freeze until the
+    /// next edit.
+    kota::task<> await_attempt(std::uint32_t server_path_id);
+
     /// Why the file awaits re-indexing (queued or currently being indexed),
     /// or nullopt when its index is not pending an update. O(1), no I/O —
     /// the query path calls this per candidate file.
@@ -137,6 +145,7 @@ public:
     void clear_pending(std::uint32_t server_path_id) {
         reindex_reasons.erase(server_path_id);
         pending_ids.erase(server_path_id);
+        settle_attempt_waits(server_path_id);
     }
 
     /// Schedule background indexing (respects idle timeout and dedup).
@@ -414,8 +423,15 @@ private:
     /// the verdicts above are cleared when a round starts, never here.
     bool need_update(llvm::StringRef file_path);
 
+    /// Wake every await_attempt waiter of the file and drop their event.
+    void settle_attempt_waits(std::uint32_t server_path_id);
+
     llvm::DenseMap<std::uint32_t, PendingReindex> reindex_reasons;
     llvm::DenseSet<std::uint32_t> failed_ids;
+
+    /// One shared event per file some await_attempt is parked on, fired
+    /// when its pending window ends (or wholesale at stop()).
+    llvm::DenseMap<std::uint32_t, std::shared_ptr<kota::event>> attempt_waits;
     std::uint64_t reindex_ticket = 0;
     bool indexing_active = false;
     bool indexing_scheduled = false;

--- a/src/server/compiler/indexer.h
+++ b/src/server/compiler/indexer.h
@@ -110,6 +110,12 @@ public:
     /// as stale as the edit makes it).
     void enqueue(std::uint32_t server_path_id, ReindexReason reason);
 
+    /// Someone is reading `server_path_id` through the index and nothing
+    /// serves it yet: enqueue it at the front of the un-consumed queue and
+    /// start a round without the idle delay. A running round finishes
+    /// undisturbed; the file then leads the next one.
+    void boost(std::uint32_t server_path_id);
+
     /// Why the file awaits re-indexing (queued or currently being indexed),
     /// or nullopt when its index is not pending an update. O(1), no I/O —
     /// the query path calls this per candidate file.

--- a/src/server/service/feature_router.cpp
+++ b/src/server/service/feature_router.cpp
@@ -232,13 +232,21 @@ kota::task<std::vector<protocol::DocumentLink>, kota::ipc::Error>
             // Manifest edges cover the whole document (the background
             // index has no preamble split); guard-skipped lines and
             // __has_include/#embed have no edge and produce no link.
-            auto path = workspace.path_pool.resolve(session->path_id);
-            auto raw = feature::index_document_links(session->text,
-                                                     feature::index_lang_options(path),
-                                                     index_query.include_edges(*session));
-            session->index_served = true;
+            // Unlike the rows the other projections serve, the edges are
+            // disk truth: the quarantine fallback (own index current,
+            // buffer edited) must not project them onto a buffer the
+            // manifest never described — an edited directive would get
+            // the old target, confidently wrong.
             std::vector<protocol::DocumentLink> links;
-            convert(raw, links);
+            auto it = workspace.shards.find(session->path_id);
+            if(it != workspace.shards.end() && it->second.matches_content(session->text)) {
+                auto path = workspace.path_pool.resolve(session->path_id);
+                auto raw = feature::index_document_links(session->text,
+                                                         feature::index_lang_options(path),
+                                                         index_query.include_edges(*session));
+                convert(raw, links);
+            }
+            session->index_served = true;
             co_return links;
         }
         case Route::Empty: co_return std::vector<protocol::DocumentLink>{};
@@ -289,12 +297,16 @@ kota::task<kota::codec::RawValue, kota::ipc::Error>
         co_return kota::outcome_error(document_not_open());
 
     // An index-only session never owes the compile the worker forward
-    // implies. What the worker leg covers — include directives, which
-    // have no symbol occurrence — the manifest edges answer instead,
-    // under the same content gate as every index answer: manifest lines
-    // are meaningless against a diverged buffer.
-    if(session->serving == ServingMode::IndexOnly) {
-        if(!index_query.open_session_shard(*session)) {
+    // implies — and a session served under freshness clause 4 (escalated,
+    // compile still in flight) already routed to the index, so waiting on
+    // the worker here would break nav_gate's no-compile-owed contract.
+    // What the worker leg covers — include directives, which have no
+    // symbol occurrence — the manifest edges answer instead, under the
+    // same content gate as every index answer: manifest lines are
+    // meaningless against a diverged buffer.
+    auto* shard = index_query.open_session_shard(*session);
+    if(session->serving == ServingMode::IndexOnly || shard) {
+        if(!shard) {
             co_return serde_raw{"[]"};
         }
         if(auto offset = session->line_map().to_offset(pos)) {

--- a/src/server/service/feature_router.cpp
+++ b/src/server/service/feature_router.cpp
@@ -52,7 +52,8 @@ const static index::Shard* index_rows_source(const IndexQuery& query, const Sess
     return query.open_session_shard(session);
 }
 
-kota::task<FeatureRouter::Route> FeatureRouter::pick_route(std::shared_ptr<Session> session) {
+kota::task<FeatureRouter::Route> FeatureRouter::pick_route(std::shared_ptr<Session> session,
+                                                           bool full_lex) {
     // This handler is resumed eagerly: drain the transport pipe before
     // reading any buffer state, so a queued didChange or cancel lands
     // first (the same discipline as completion's yield).
@@ -64,10 +65,12 @@ kota::task<FeatureRouter::Route> FeatureRouter::pick_route(std::shared_ptr<Sessi
     if(ast_answerable(*session)) {
         co_return Route::Ast;
     }
-    // An oversized buffer is not worth a synchronous main-thread lex; it
-    // follows the investment policy instead of the index slice.
-    constexpr std::size_t index_projection_cap = 8 * 1024 * 1024;
-    if(session->text.size() <= index_projection_cap && index_rows_source(index_query, *session)) {
+    // An oversized buffer is not worth a synchronous main-thread lex; the
+    // full-lex projections follow the investment policy instead of the
+    // index slice. Row-backed answers serve at any size.
+    constexpr std::size_t full_lex_cap = 8 * 1024 * 1024;
+    bool capped = full_lex && session->text.size() > full_lex_cap;
+    if(!capped && index_rows_source(index_query, *session)) {
         // The index answering must never strand the investment the policy
         // asked for: keep the escalated session's compile moving.
         if(session->serving == ServingMode::Escalated && session->ast_dirty) {
@@ -191,7 +194,7 @@ std::optional<feature::IndexSymbolInfo> FeatureRouter::resolve_symbol_info(index
 }
 
 kota::task<bool> FeatureRouter::nav_gate(std::shared_ptr<Session> session) {
-    switch(co_await pick_route(session)) {
+    switch(co_await pick_route(session, /*full_lex=*/false)) {
         case Route::Superseded: co_return false;
         // The index sources resolve the cursor under clauses 1/4 — or
         // reject it, which the query layers answer as empty. Either way
@@ -312,7 +315,7 @@ kota::task<std::vector<protocol::DocumentLink>, kota::ipc::Error>
     };
 
     for(bool waited = false;;) {
-        switch(co_await pick_route(session)) {
+        switch(co_await pick_route(session, /*full_lex=*/false)) {
             case Route::Superseded: co_return std::vector<protocol::DocumentLink>{};
             case Route::Index: {
                 // Manifest edges cover the whole document (the background
@@ -469,7 +472,7 @@ FeatureRouter::RawResult FeatureRouter::hover(std::shared_ptr<Session> session,
         return std::nullopt;
     };
 
-    switch(co_await pick_route(session)) {
+    switch(co_await pick_route(session, /*full_lex=*/false)) {
         case Route::Superseded: co_return serde_raw{"null"};
         case Route::Index: {
             if(auto card = index_card()) {
@@ -522,7 +525,7 @@ FeatureRouter::RawResult
     FeatureRouter::semantic_tokens(std::shared_ptr<Session> session,
                                    std::optional<kota::cancellation_token> token) {
     if(session) {
-        switch(co_await pick_route(session)) {
+        switch(co_await pick_route(session, /*full_lex=*/true)) {
             case Route::Superseded: co_return serde_raw{"null"};
             case Route::Index: {
                 auto* source = index_rows_source(index_query, *session);
@@ -581,7 +584,7 @@ FeatureRouter::RawResult
     FeatureRouter::folding_range(std::shared_ptr<Session> session,
                                  std::optional<kota::cancellation_token> token) {
     if(session) {
-        switch(co_await pick_route(session)) {
+        switch(co_await pick_route(session, /*full_lex=*/true)) {
             case Route::Superseded: co_return serde_raw{"null"};
             case Route::Index: {
                 auto* source = index_rows_source(index_query, *session);
@@ -621,7 +624,7 @@ FeatureRouter::RawResult
                                    std::optional<kota::cancellation_token> token) {
     if(session) {
         for(bool waited = false;;) {
-            switch(co_await pick_route(session)) {
+            switch(co_await pick_route(session, /*full_lex=*/false)) {
                 case Route::Superseded: co_return serde_raw{"null"};
                 case Route::Index: {
                     auto* source = index_rows_source(index_query, *session);

--- a/src/server/service/feature_router.cpp
+++ b/src/server/service/feature_router.cpp
@@ -98,14 +98,69 @@ FeatureRouter::IndexRows FeatureRouter::extract_rows(const index::Shard& shard) 
     return rows;
 }
 
+/// The language the last -x of the file's own CDB entry forces, if any:
+/// the driver override beats every suffix heuristic. Rules applied, like
+/// the resolve path's effective command.
+static std::optional<bool> command_forces_c(Workspace& workspace, llvm::StringRef path) {
+    if(!workspace.cdb.has_entry(path)) {
+        return std::nullopt;
+    }
+    std::vector<std::string> append, remove;
+    workspace.config.match_rules(path, append, remove);
+    auto commands = workspace.cdb.lookup(path, {.remove = remove, .append = append});
+
+    std::optional<bool> forces_c;
+    auto& flags = commands.front().resolved.flags;
+    for(std::size_t i = 0; i < flags.size(); i += 1) {
+        llvm::StringRef flag = flags[i];
+        llvm::StringRef language;
+        if(flag == "-x") {
+            if(i + 1 < flags.size()) {
+                language = flags[i + 1];
+            }
+        } else if(flag.starts_with("-x")) {
+            language = flag.drop_front(2);
+        } else {
+            continue;
+        }
+        if(!language.empty()) {
+            forces_c = language == "c" || language == "c-header";
+        }
+    }
+    return forces_c;
+}
+
 const clang::LangOptions& FeatureRouter::index_lang_options(const Session& session) {
+    auto path = workspace.path_pool.resolve(session.path_id);
+    if(auto forces_c = command_forces_c(workspace, path)) {
+        return feature::index_lang_options("", *forces_c);
+    }
+
+    // A header's active context (the user's persisted choice, else the
+    // resolved host) names the view being read; its language beats the
+    // contributor union the way it does for the AST after an escalation.
+    auto host = no_path_id;
+    if(auto it = contexts.saved_contexts.find(session.path_id);
+       it != contexts.saved_contexts.end()) {
+        host = it->second.host_path_id;
+    }
+    if(host == no_path_id) {
+        if(const auto* context = contexts.header_context(session.path_id)) {
+            host = context->host_path_id;
+        }
+    }
+    if(host != no_path_id) {
+        bool c_host = workspace.path_pool.resolve(host).ends_with(".c");
+        return feature::index_lang_options(path, c_host);
+    }
+
     auto& contributions = workspace.project_index.contributions;
     auto it = contributions.find(session.path_id);
     bool c_rows = it != contributions.end() && !it->second.empty() &&
                   llvm::all_of(llvm::make_first_range(it->second), [&](std::uint32_t tu) {
                       return workspace.path_pool.resolve(tu).ends_with(".c");
                   });
-    return feature::index_lang_options(workspace.path_pool.resolve(session.path_id), c_rows);
+    return feature::index_lang_options(path, c_rows);
 }
 
 std::optional<feature::IndexSymbolInfo> FeatureRouter::resolve_symbol_info(index::SymbolHash hash) {
@@ -237,30 +292,47 @@ kota::task<std::vector<protocol::DocumentLink>, kota::ipc::Error>
         }
     };
 
-    switch(co_await pick_route(session)) {
-        case Route::Superseded: co_return std::vector<protocol::DocumentLink>{};
-        case Route::Index: {
-            // Manifest edges cover the whole document (the background
-            // index has no preamble split); guard-skipped lines and
-            // __has_include/#embed have no edge and produce no link.
-            // Unlike the rows the other projections serve, the edges are
-            // disk truth: the quarantine fallback (own index current,
-            // buffer edited) must not project them onto a buffer the
-            // manifest never described — an edited directive would get
-            // the old target, confidently wrong.
-            std::vector<protocol::DocumentLink> links;
-            auto it = workspace.shards.find(session->path_id);
-            if(it != workspace.shards.end() && it->second.matches_content(session->text)) {
-                auto raw = feature::index_document_links(session->text,
-                                                         index_lang_options(*session),
-                                                         index_query.include_edges(*session));
-                convert(raw, links);
+    for(bool waited = false;;) {
+        switch(co_await pick_route(session)) {
+            case Route::Superseded: co_return std::vector<protocol::DocumentLink>{};
+            case Route::Index: {
+                // Manifest edges cover the whole document (the background
+                // index has no preamble split); guard-skipped lines and
+                // __has_include/#embed have no edge and produce no link.
+                // Unlike the rows the other projections serve, the edges are
+                // disk truth: the quarantine fallback (own index current,
+                // buffer edited) must not project them onto a buffer the
+                // manifest never described — an edited directive would get
+                // the old target, confidently wrong.
+                std::vector<protocol::DocumentLink> links;
+                auto it = workspace.shards.find(session->path_id);
+                if(it != workspace.shards.end() && it->second.matches_content(session->text)) {
+                    auto raw = feature::index_document_links(session->text,
+                                                             index_lang_options(*session),
+                                                             index_query.include_edges(*session));
+                    convert(raw, links);
+                }
+                session->index_served = true;
+                co_return links;
             }
-            session->index_served = true;
-            co_return links;
+            case Route::Empty: {
+                // Like the outline, links have no refresh request; a cold
+                // document's empty reply would outlive the boost that is
+                // about to make them real. Await it once, then answer
+                // from the settled state.
+                if(!waited) {
+                    waited = true;
+                    auto gen = session->generation;
+                    co_await indexer.await_attempt(session->path_id);
+                    if(session->generation == gen) {
+                        continue;
+                    }
+                }
+                co_return std::vector<protocol::DocumentLink>{};
+            }
+            case Route::Ast: break;
         }
-        case Route::Empty: co_return std::vector<protocol::DocumentLink>{};
-        case Route::Ast: break;
+        break;
     }
 
     auto result = co_await compiler.forward_document_links(session, std::move(token));
@@ -529,24 +601,45 @@ FeatureRouter::RawResult
     FeatureRouter::document_symbol(std::shared_ptr<Session> session,
                                    std::optional<kota::cancellation_token> token) {
     if(session) {
-        switch(co_await pick_route(session)) {
-            case Route::Superseded: co_return serde_raw{"null"};
-            case Route::Index: {
-                auto* source = index_rows_source(index_query, *session);
-                auto rows = extract_rows(*source);
-                auto symbols =
-                    feature::index_document_symbols(rows.decls, [&](index::SymbolHash hash) {
-                        return resolve_symbol_info(hash);
-                    });
-                session->index_served = true;
-                co_return to_raw(
-                    feature::document_symbols_to_protocol(symbols,
-                                                          session->text,
-                                                          session->line_starts,
-                                                          feature::PositionEncoding::UTF16));
+        for(bool waited = false;;) {
+            switch(co_await pick_route(session)) {
+                case Route::Superseded: co_return serde_raw{"null"};
+                case Route::Index: {
+                    auto* source = index_rows_source(index_query, *session);
+                    auto rows = extract_rows(*source);
+                    auto symbols =
+                        feature::index_document_symbols(rows.decls, [&](index::SymbolHash hash) {
+                            return resolve_symbol_info(hash);
+                        });
+                    session->index_served = true;
+                    co_return to_raw(
+                        feature::document_symbols_to_protocol(symbols,
+                                                              session->text,
+                                                              session->line_starts,
+                                                              feature::PositionEncoding::UTF16));
+                }
+                case Route::Empty: {
+                    // The outline has no workspace refresh request: an
+                    // empty reply to a cold document would be cached by
+                    // the client for good — no signal ever makes it
+                    // re-pull. Await the didOpen boost instead (bounded
+                    // by one index attempt) and answer from whatever
+                    // source that settles: the shard, the escalated
+                    // compile, or honestly empty under `never`.
+                    if(!waited) {
+                        waited = true;
+                        auto gen = session->generation;
+                        co_await indexer.await_attempt(session->path_id);
+                        if(session->generation == gen) {
+                            continue;
+                        }
+                        co_return serde_raw{"null"};
+                    }
+                    co_return serde_raw{"[]"};
+                }
+                case Route::Ast: break;
             }
-            case Route::Empty: co_return serde_raw{"[]"};
-            case Route::Ast: break;
+            break;
         }
     }
     co_return co_await compiler.forward_query(worker::QueryKind::DocumentSymbol,

--- a/src/server/service/feature_router.cpp
+++ b/src/server/service/feature_router.cpp
@@ -440,7 +440,15 @@ FeatureRouter::RawResult
                                                          session->line_starts,
                                                          feature::PositionEncoding::UTF16));
             }
-            case Route::Empty: co_return serde_raw{"null"};
+            case Route::Empty: {
+                // The client caches this null, and only a semanticTokens
+                // refresh makes it re-pull once the cold document's shard
+                // lands — the merge signals refreshes for sessions with
+                // this flag, so an empty pull registers the same interest
+                // as a served one.
+                session->index_served = true;
+                co_return serde_raw{"null"};
+            }
             case Route::Ast: break;
         }
     }

--- a/src/server/service/feature_router.cpp
+++ b/src/server/service/feature_router.cpp
@@ -36,6 +36,97 @@ static kota::ipc::Error item_not_resolved(llvm::StringRef kind) {
                             std::format("Failed to resolve {} item", kind)};
 }
 
+bool FeatureRouter::ast_answerable(const Session& session) {
+    return session.index_current() && !session.quarantine.blocked();
+}
+
+/// The rows that may serve the session's document from the index: its own
+/// file index when current (the quarantine fallback — the worker cannot
+/// be asked, the rows are still true), else the disk shard admitted by
+/// freshness clause 4. Content is the buffer either way.
+const static index::Shard* index_rows_source(const IndexQuery& query, const Session& session) {
+    if(session.index_current()) {
+        return &session.file_rows();
+    }
+    return query.open_session_shard(session);
+}
+
+kota::task<FeatureRouter::Route> FeatureRouter::pick_route(std::shared_ptr<Session> session) {
+    // This handler is resumed eagerly: drain the transport pipe before
+    // reading any buffer state, so a queued didChange or cancel lands
+    // first (the same discipline as completion's yield).
+    auto gen = session->generation;
+    co_await kota::yield();
+    if(session->generation != gen) {
+        co_return Route::Superseded;
+    }
+    if(ast_answerable(*session)) {
+        co_return Route::Ast;
+    }
+    // An oversized buffer is not worth a synchronous main-thread lex; it
+    // follows the investment policy instead of the index slice.
+    constexpr std::size_t index_projection_cap = 8 * 1024 * 1024;
+    if(session->text.size() <= index_projection_cap && index_rows_source(index_query, *session)) {
+        // The index answering must never strand the investment the policy
+        // asked for: keep the escalated session's compile moving.
+        if(session->serving == ServingMode::Escalated && session->ast_dirty) {
+            compiler.request_compile(session);
+        }
+        co_return Route::Index;
+    }
+    co_return session->serving == ServingMode::Escalated ? Route::Ast : Route::Empty;
+}
+
+FeatureRouter::IndexRows FeatureRouter::extract_rows(const index::Shard& shard) {
+    IndexRows rows;
+    shard.for_each_occurrence([&](const index::Occurrence& occurrence) {
+        rows.occurrences.push_back(occurrence);
+        return true;
+    });
+    shard.for_each_relation([&](index::SymbolHash hash, const index::Relation& relation) {
+        RelationKind kind(relation.kind);
+        if(kind.isDeclOrDef()) {
+            auto copy = relation;
+            rows.decls.push_back({.range = relation.range,
+                                  .extent = copy.definition_range(),
+                                  .symbol = hash,
+                                  .definition = kind.is_one_of(RelationKind::Definition)});
+        }
+        return true;
+    });
+    return rows;
+}
+
+std::optional<feature::IndexSymbolInfo> FeatureRouter::resolve_symbol_info(index::SymbolHash hash) {
+    feature::IndexSymbolInfo info;
+    if(index_query.find_symbol_info(hash, info.name, info.kind)) {
+        return info;
+    }
+    return std::nullopt;
+}
+
+kota::task<bool> FeatureRouter::nav_gate(std::shared_ptr<Session> session) {
+    switch(co_await pick_route(session)) {
+        case Route::Superseded: co_return false;
+        // The index sources resolve the cursor under clauses 1/4 — or
+        // reject it, which the query layers answer as empty. Either way
+        // no compile is owed.
+        case Route::Index:
+        case Route::Empty: co_return true;
+        case Route::Ast: break;
+    }
+    // Same posture as every AST-backed request: the session's file index
+    // is produced by the very compile awaited here, so once this settles
+    // the index describes the buffer. A failed or superseded compile
+    // (buffer changed while awaiting) yields null rather than a lookup
+    // against positions the buffer no longer has.
+    auto gen = session->generation;
+    if(!co_await compiler.ensure_compiled(session) || session->generation != gen) {
+        co_return false;
+    }
+    co_return true;
+}
+
 std::vector<feature::DocumentLink> FeatureRouter::find_preamble_links(const Session& session) {
     if(!session.pch_key)
         return {};
@@ -120,26 +211,49 @@ std::optional<protocol::Hover>
 kota::task<std::vector<protocol::DocumentLink>, kota::ipc::Error>
     FeatureRouter::document_links(std::shared_ptr<Session> session,
                                   std::optional<kota::cancellation_token> token) {
+    // Links carry byte offsets; this reply edge converts them.
+    auto convert = [&](llvm::ArrayRef<feature::DocumentLink> raw_links,
+                       std::vector<protocol::DocumentLink>& links) {
+        auto map = session->line_map();
+        for(const auto& link: raw_links) {
+            auto range = map.to_range(link.range.begin, link.range.end);
+            if(!range)
+                continue;
+            protocol::DocumentLink out{.range = *range};
+            out.target = feature::to_uri(link.target);
+            out.tooltip = link.target;
+            links.push_back(std::move(out));
+        }
+    };
+
+    switch(co_await pick_route(session)) {
+        case Route::Superseded: co_return std::vector<protocol::DocumentLink>{};
+        case Route::Index: {
+            // Manifest edges cover the whole document (the background
+            // index has no preamble split); guard-skipped lines and
+            // __has_include/#embed have no edge and produce no link.
+            auto path = workspace.path_pool.resolve(session->path_id);
+            auto raw = feature::index_document_links(session->text,
+                                                     feature::index_lang_options(path),
+                                                     index_query.include_edges(*session));
+            session->index_served = true;
+            std::vector<protocol::DocumentLink> links;
+            convert(raw, links);
+            co_return links;
+        }
+        case Route::Empty: co_return std::vector<protocol::DocumentLink>{};
+        case Route::Ast: break;
+    }
+
     auto result = co_await compiler.forward_document_links(session, std::move(token));
     if(!result.has_value())
         co_return kota::outcome_error(std::move(result.error()));
 
     // The preamble is compiled into the PCH, so the worker's AST only
     // covers the rest of the file — merge the preamble's links in front.
-    // Links carry byte offsets; this reply edge converts them.
     std::vector<protocol::DocumentLink> links;
-    auto map = session->line_map();
-    auto append = [&](const feature::DocumentLink& link) {
-        auto range = map.to_range(link.range.begin, link.range.end);
-        if(!range)
-            return;
-        protocol::DocumentLink out{.range = *range};
-        out.target = feature::to_uri(link.target);
-        out.tooltip = link.target;
-        links.push_back(std::move(out));
-    };
-    std::ranges::for_each(find_preamble_links(*session), append);
-    std::ranges::for_each(result.value(), append);
+    convert(find_preamble_links(*session), links);
+    convert(result.value(), links);
     co_return links;
 }
 
@@ -148,16 +262,8 @@ kota::task<kota::codec::RawValue, kota::ipc::Error>
                               llvm::StringRef path,
                               const protocol::Position& pos,
                               std::optional<kota::cancellation_token> token) {
-    // Same posture as every AST-backed request: the session's file index
-    // is produced by the very compile awaited here, so once this settles
-    // the index describes the buffer. A failed or superseded compile
-    // (buffer changed while awaiting) yields null rather than a lookup
-    // against positions the buffer no longer has.
-    if(session) {
-        auto gen = session->generation;
-        if(!co_await compiler.ensure_compiled(session) || session->generation != gen) {
-            co_return serde_raw{"null"};
-        }
+    if(session && !co_await nav_gate(session)) {
+        co_return serde_raw{"null"};
     }
 
     // Preamble include lines first: they have no symbol occurrence in
@@ -172,18 +278,39 @@ kota::task<kota::codec::RawValue, kota::ipc::Error>
         }
     }
 
-    // Dirty sessions also skip the eager index query: resolve_cursor
-    // would fall back to the stale merged shard and could return a
-    // non-empty hit for pre-edit content, bypassing the compile below.
-    if(!session || !session->ast_dirty) {
-        auto result = index_query.query_definition(path, pos, session.get());
-        if(!result.empty()) {
-            co_return to_raw(result);
-        }
+    // The eager index query is safe for dirty sessions too: freshness
+    // clause 4 serves their shard only while the buffer is byte-identical,
+    // and rejects the mixed-view lookup otherwise.
+    if(auto result = index_query.query_definition(path, pos, session.get()); !result.empty()) {
+        co_return to_raw(result);
     }
 
     if(!session)
         co_return kota::outcome_error(document_not_open());
+
+    // An index-only session never owes the compile the worker forward
+    // implies. What the worker leg covers — include directives, which
+    // have no symbol occurrence — the manifest edges answer instead.
+    if(session->serving == ServingMode::IndexOnly) {
+        if(auto offset = session->line_map().to_offset(pos)) {
+            auto links = feature::index_document_links(session->text,
+                                                       feature::index_lang_options(path),
+                                                       index_query.include_edges(*session));
+            for(const auto& link: links) {
+                if(*offset >= link.range.begin && *offset < link.range.end) {
+                    std::vector<protocol::Location> locations{
+                        protocol::Location{
+                                           .uri = feature::to_uri(link.target),
+                                           .range = protocol::Range{},
+                                           }
+                    };
+                    co_return to_raw(locations);
+                }
+            }
+        }
+        co_return serde_raw{"[]"};
+    }
+
     auto raw = co_await compiler.forward_query(worker::QueryKind::GoToDefinition,
                                                session,
                                                pos,
@@ -215,6 +342,28 @@ FeatureRouter::RawResult FeatureRouter::hover(std::shared_ptr<Session> session,
         co_return kota::outcome_error(document_not_open());
     }
 
+    auto path = workspace.path_pool.resolve(session->path_id);
+    auto index_card = [&]() -> std::optional<serde_raw> {
+        if(auto info = index_query.hover_card(path, position, session.get())) {
+            return to_raw(
+                feature::to_protocol_hover(*info, workspace.config.hover, session->line_map()));
+        }
+        return std::nullopt;
+    };
+
+    switch(co_await pick_route(session)) {
+        case Route::Superseded: co_return serde_raw{"null"};
+        case Route::Index: {
+            if(auto card = index_card()) {
+                session->index_served = true;
+                co_return std::move(*card);
+            }
+            co_return serde_raw{"null"};
+        }
+        case Route::Empty: co_return serde_raw{"null"};
+        case Route::Ast: break;
+    }
+
     /// Like document_links, the preamble and the worker's AST are disjoint, so merge the two
     /// sources.
     auto gen = session->generation;
@@ -230,6 +379,23 @@ FeatureRouter::RawResult FeatureRouter::hover(std::shared_ptr<Session> session,
         if(auto hover = resolve_preamble_hover(*session, position)) {
             co_return to_raw(*hover);
         }
+        // The preamble region is the one place a null from the AST is not
+        // authoritative — it is compiled into the PCH and invisible to
+        // the worker (a `#define` there has no node). The index card
+        // fills that gap, and only that gap: past the bound the AST saw
+        // the code and declined on purpose (a lambda's auto parameter
+        // must not hover, and the index would happily name it `auto:1`).
+        if(session->pch_key) {
+            if(auto it = workspace.pch_cache.find(*session->pch_key);
+               it != workspace.pch_cache.end()) {
+                auto offset = session->line_map().to_offset(position);
+                if(offset && *offset < it->second.bound) {
+                    if(auto card = index_card()) {
+                        co_return std::move(*card);
+                    }
+                }
+            }
+        }
     }
     co_return std::move(raw);
 }
@@ -237,6 +403,30 @@ FeatureRouter::RawResult FeatureRouter::hover(std::shared_ptr<Session> session,
 FeatureRouter::RawResult
     FeatureRouter::semantic_tokens(std::shared_ptr<Session> session,
                                    std::optional<kota::cancellation_token> token) {
+    if(session) {
+        switch(co_await pick_route(session)) {
+            case Route::Superseded: co_return serde_raw{"null"};
+            case Route::Index: {
+                auto* source = index_rows_source(index_query, *session);
+                auto rows = extract_rows(*source);
+                auto path = workspace.path_pool.resolve(session->path_id);
+                auto tokens = feature::index_semantic_tokens(
+                    session->text,
+                    feature::index_lang_options(path),
+                    rows.occurrences,
+                    rows.decls,
+                    [&](index::SymbolHash hash) { return resolve_symbol_info(hash); });
+                session->index_served = true;
+                co_return to_raw(
+                    feature::semantic_tokens_to_protocol(tokens,
+                                                         session->text,
+                                                         session->line_starts,
+                                                         feature::PositionEncoding::UTF16));
+            }
+            case Route::Empty: co_return serde_raw{"null"};
+            case Route::Ast: break;
+        }
+    }
     co_return co_await compiler.forward_query(worker::QueryKind::SemanticTokens,
                                               session,
                                               {},
@@ -247,6 +437,13 @@ FeatureRouter::RawResult
 FeatureRouter::RawResult FeatureRouter::inlay_hints(std::shared_ptr<Session> session,
                                                     const protocol::Range& range,
                                                     std::optional<kota::cancellation_token> token) {
+    // Inlay hints are Sema products the index cannot project; a session
+    // the policy keeps un-compiled answers honestly empty. The compile
+    // that follows an escalation pushes an inlayHint refresh, so clients
+    // re-pull once real hints exist.
+    if(session && session->serving == ServingMode::IndexOnly) {
+        co_return serde_raw{"[]"};
+    }
     co_return co_await compiler.forward_query(worker::QueryKind::InlayHints,
                                               session,
                                               {},
@@ -257,6 +454,29 @@ FeatureRouter::RawResult FeatureRouter::inlay_hints(std::shared_ptr<Session> ses
 FeatureRouter::RawResult
     FeatureRouter::folding_range(std::shared_ptr<Session> session,
                                  std::optional<kota::cancellation_token> token) {
+    if(session) {
+        switch(co_await pick_route(session)) {
+            case Route::Superseded: co_return serde_raw{"null"};
+            case Route::Index: {
+                auto* source = index_rows_source(index_query, *session);
+                auto rows = extract_rows(*source);
+                auto path = workspace.path_pool.resolve(session->path_id);
+                auto folds = feature::index_folding_ranges(
+                    session->text,
+                    feature::index_lang_options(path),
+                    rows.decls,
+                    [&](index::SymbolHash hash) { return resolve_symbol_info(hash); });
+                session->index_served = true;
+                co_return to_raw(
+                    feature::folding_ranges_to_protocol(folds,
+                                                        session->text,
+                                                        session->line_starts,
+                                                        feature::PositionEncoding::UTF16));
+            }
+            case Route::Empty: co_return serde_raw{"[]"};
+            case Route::Ast: break;
+        }
+    }
     co_return co_await compiler.forward_query(worker::QueryKind::FoldingRange,
                                               session,
                                               {},
@@ -267,6 +487,27 @@ FeatureRouter::RawResult
 FeatureRouter::RawResult
     FeatureRouter::document_symbol(std::shared_ptr<Session> session,
                                    std::optional<kota::cancellation_token> token) {
+    if(session) {
+        switch(co_await pick_route(session)) {
+            case Route::Superseded: co_return serde_raw{"null"};
+            case Route::Index: {
+                auto* source = index_rows_source(index_query, *session);
+                auto rows = extract_rows(*source);
+                auto symbols =
+                    feature::index_document_symbols(rows.decls, [&](index::SymbolHash hash) {
+                        return resolve_symbol_info(hash);
+                    });
+                session->index_served = true;
+                co_return to_raw(
+                    feature::document_symbols_to_protocol(symbols,
+                                                          session->text,
+                                                          session->line_starts,
+                                                          feature::PositionEncoding::UTF16));
+            }
+            case Route::Empty: co_return serde_raw{"[]"};
+            case Route::Ast: break;
+        }
+    }
     co_return co_await compiler.forward_query(worker::QueryKind::DocumentSymbol,
                                               session,
                                               {},
@@ -276,6 +517,12 @@ FeatureRouter::RawResult
 
 FeatureRouter::RawResult FeatureRouter::code_action(std::shared_ptr<Session> session,
                                                     std::optional<kota::cancellation_token> token) {
+    // Code actions are AST products with no index projection; a session
+    // the policy keeps un-compiled answers honestly empty rather than
+    // forcing the compile the policy declined.
+    if(session && !ast_answerable(*session) && session->serving == ServingMode::IndexOnly) {
+        co_return serde_raw{"[]"};
+    }
     co_return co_await compiler.forward_query(worker::QueryKind::CodeAction,
                                               session,
                                               {},
@@ -363,6 +610,10 @@ FeatureRouter::RawResult FeatureRouter::completion(std::shared_ptr<Session> sess
         }
     }
 
+    // Asking for code completion is edit intent: escalate the session so
+    // the PCH/AST investment starts (a no-op when already escalated or
+    // under pch_build = "never").
+    compiler.escalate(session);
     co_return co_await compiler.forward_build(worker::BuildKind::Completion,
                                               position,
                                               std::move(session),
@@ -374,6 +625,7 @@ FeatureRouter::RawResult
                                   const protocol::Position& position,
                                   std::optional<kota::cancellation_token> token) {
     auto pause = indexer.scoped_pause();
+    compiler.escalate(session);
     co_return co_await compiler.forward_build(worker::BuildKind::SignatureHelp,
                                               position,
                                               session,
@@ -398,16 +650,8 @@ FeatureRouter::RawResult FeatureRouter::references(std::shared_ptr<Session> sess
                                                    llvm::StringRef path,
                                                    const protocol::Position& position,
                                                    bool include_declaration) {
-    // Same posture as every AST-backed request: the session's file index
-    // is produced by the very compile awaited here, so once this settles
-    // the index describes the buffer. A failed or superseded compile
-    // (buffer changed while awaiting) yields null rather than a lookup
-    // against positions the buffer no longer has.
-    if(session) {
-        auto gen = session->generation;
-        if(!co_await compiler.ensure_compiled(session) || session->generation != gen) {
-            co_return serde_raw{"null"};
-        }
+    if(session && !co_await nav_gate(session)) {
+        co_return serde_raw{"null"};
     }
 
     co_return to_raw(
@@ -417,16 +661,8 @@ FeatureRouter::RawResult FeatureRouter::references(std::shared_ptr<Session> sess
 FeatureRouter::RawResult FeatureRouter::declaration(std::shared_ptr<Session> session,
                                                     llvm::StringRef path,
                                                     const protocol::Position& position) {
-    // Same posture as every AST-backed request: the session's file index
-    // is produced by the very compile awaited here, so once this settles
-    // the index describes the buffer. A failed or superseded compile
-    // (buffer changed while awaiting) yields null rather than a lookup
-    // against positions the buffer no longer has.
-    if(session) {
-        auto gen = session->generation;
-        if(!co_await compiler.ensure_compiled(session) || session->generation != gen) {
-            co_return serde_raw{"null"};
-        }
+    if(session && !co_await nav_gate(session)) {
+        co_return serde_raw{"null"};
     }
 
     co_return to_raw(index_query.query_declaration(path, position, session.get()));
@@ -435,16 +671,8 @@ FeatureRouter::RawResult FeatureRouter::declaration(std::shared_ptr<Session> ses
 FeatureRouter::RawResult FeatureRouter::type_definition(std::shared_ptr<Session> session,
                                                         llvm::StringRef path,
                                                         const protocol::Position& position) {
-    // Same posture as every AST-backed request: the session's file index
-    // is produced by the very compile awaited here, so once this settles
-    // the index describes the buffer. A failed or superseded compile
-    // (buffer changed while awaiting) yields null rather than a lookup
-    // against positions the buffer no longer has.
-    if(session) {
-        auto gen = session->generation;
-        if(!co_await compiler.ensure_compiled(session) || session->generation != gen) {
-            co_return serde_raw{"null"};
-        }
+    if(session && !co_await nav_gate(session)) {
+        co_return serde_raw{"null"};
     }
 
     co_return to_raw(index_query.query_symbol_targets(path,
@@ -456,16 +684,8 @@ FeatureRouter::RawResult FeatureRouter::type_definition(std::shared_ptr<Session>
 FeatureRouter::RawResult FeatureRouter::implementation(std::shared_ptr<Session> session,
                                                        llvm::StringRef path,
                                                        const protocol::Position& position) {
-    // Same posture as every AST-backed request: the session's file index
-    // is produced by the very compile awaited here, so once this settles
-    // the index describes the buffer. A failed or superseded compile
-    // (buffer changed while awaiting) yields null rather than a lookup
-    // against positions the buffer no longer has.
-    if(session) {
-        auto gen = session->generation;
-        if(!co_await compiler.ensure_compiled(session) || session->generation != gen) {
-            co_return serde_raw{"null"};
-        }
+    if(session && !co_await nav_gate(session)) {
+        co_return serde_raw{"null"};
     }
 
     co_return to_raw(index_query.query_implementation(path, position, session.get()));
@@ -475,16 +695,8 @@ FeatureRouter::RawResult FeatureRouter::call_hierarchy_prepare(std::shared_ptr<S
                                                                const std::string& uri,
                                                                llvm::StringRef path,
                                                                const protocol::Position& position) {
-    // Same posture as every AST-backed request: the session's file index
-    // is produced by the very compile awaited here, so once this settles
-    // the index describes the buffer. A failed or superseded compile
-    // (buffer changed while awaiting) yields null rather than a lookup
-    // against positions the buffer no longer has.
-    if(session) {
-        auto gen = session->generation;
-        if(!co_await compiler.ensure_compiled(session) || session->generation != gen) {
-            co_return serde_raw{"null"};
-        }
+    if(session && !co_await nav_gate(session)) {
+        co_return serde_raw{"null"};
     }
 
     auto info = index_query.lookup_symbol(uri, path, position, session.get());
@@ -545,16 +757,8 @@ FeatureRouter::RawResult FeatureRouter::type_hierarchy_prepare(std::shared_ptr<S
                                                                const std::string& uri,
                                                                llvm::StringRef path,
                                                                const protocol::Position& position) {
-    // Same posture as every AST-backed request: the session's file index
-    // is produced by the very compile awaited here, so once this settles
-    // the index describes the buffer. A failed or superseded compile
-    // (buffer changed while awaiting) yields null rather than a lookup
-    // against positions the buffer no longer has.
-    if(session) {
-        auto gen = session->generation;
-        if(!co_await compiler.ensure_compiled(session) || session->generation != gen) {
-            co_return serde_raw{"null"};
-        }
+    if(session && !co_await nav_gate(session)) {
+        co_return serde_raw{"null"};
     }
 
     auto info = index_query.lookup_symbol(uri, path, position, session.get());

--- a/src/server/service/feature_router.cpp
+++ b/src/server/service/feature_router.cpp
@@ -402,16 +402,17 @@ kota::task<kota::codec::RawValue, kota::ipc::Error>
         co_return kota::outcome_error(document_not_open());
 
     // An index-only session never owes the compile the worker forward
-    // implies — and a session served under freshness clause 4 (escalated,
-    // compile still in flight) already routed to the index, so waiting on
-    // the worker here would break nav_gate's no-compile-owed contract.
-    // What the worker leg covers — include directives, which have no
-    // symbol occurrence — the manifest edges answer instead, under the
-    // same content gate as every index answer: manifest lines are
-    // meaningless against a diverged buffer.
-    auto* shard = index_query.open_session_shard(*session);
-    if(session->serving == ServingMode::IndexOnly || shard) {
-        if(!shard) {
+    // implies, a session served under freshness clause 4 (escalated,
+    // compile still in flight) already routed to the index, and a
+    // quarantined session cannot reach a worker at all. What the worker
+    // leg covers — include directives, which have no symbol occurrence —
+    // the manifest edges answer instead, under the same content gate as
+    // the links projection: manifest lines are meaningless against a
+    // buffer the index never described.
+    if(session->serving == ServingMode::IndexOnly || session->quarantine.blocked() ||
+       index_query.open_session_shard(*session)) {
+        auto it = workspace.shards.find(session->path_id);
+        if(it == workspace.shards.end() || !it->second.matches_content(session->text)) {
             co_return serde_raw{"[]"};
         }
         if(auto offset = session->line_map().to_offset(pos)) {
@@ -708,6 +709,14 @@ FeatureRouter::RawResult FeatureRouter::completion(std::shared_ptr<Session> sess
     // context are computed, so the synchronous include scan below never
     // serves candidates or ranges for a buffer that no longer exists.
     co_await kota::yield();
+
+    // The drain may also have replaced the Session object (a didClose,
+    // with or without a reopen). Downstream generation checks snapshot
+    // the dead object after its close already bumped it, so only the
+    // store can tell; the request belongs to the discarded buffer.
+    if(sessions.find(session->path_id) != session) {
+        co_return serde_raw{"null"};
+    }
 
     auto path_id = session->path_id;
     auto path = std::string(workspace.path_pool.resolve(path_id));

--- a/src/server/service/feature_router.cpp
+++ b/src/server/service/feature_router.cpp
@@ -71,8 +71,9 @@ kota::task<FeatureRouter::Route> FeatureRouter::pick_route(std::shared_ptr<Sessi
     constexpr std::size_t full_lex_cap = 8 * 1024 * 1024;
     bool capped = full_lex && session->text.size() > full_lex_cap;
     if(!capped && index_rows_source(index_query, *session)) {
-        // The index answering must never strand the investment the policy
-        // asked for: keep the escalated session's compile moving.
+        // An index answer must not strand an escalated session's pending
+        // build: this request still pulls the compile it would otherwise
+        // have waited on, just without blocking.
         if(session->serving == ServingMode::Escalated && session->ast_dirty) {
             compiler.request_compile(session);
         }
@@ -647,7 +648,7 @@ FeatureRouter::RawResult
                     // re-pull. Await the didOpen boost instead (bounded
                     // by one index attempt) and answer from whatever
                     // source that settles: the shard, the escalated
-                    // compile, or honestly empty under `never`.
+                    // compile, or honestly empty under readonly "on".
                     if(!waited) {
                         waited = true;
                         auto gen = session->generation;
@@ -692,12 +693,12 @@ FeatureRouter::RawResult FeatureRouter::completion(std::shared_ptr<Session> sess
                                                    std::optional<kota::cancellation_token> token) {
     auto pause = indexer.scoped_pause();
 
-    // Asking for code completion is edit intent: escalate the session so
-    // the PCH/AST investment starts (a no-op when already escalated or
-    // under pch_build = "never"). Before the yield below on purpose — a
-    // didClose drained there replaces the Session object, and escalating
-    // the dead one would kick a compile of abandoned text.
-    compiler.escalate(session);
+    // Asking for code completion is edit intent: flip the session out of
+    // index-only serving (a no-op when already escalated or under
+    // readonly = "on"). Before the yield below on purpose: it must tag
+    // the session this request arrived for, not whatever a drained
+    // didClose/didOpen pair put in its place.
+    compiler.escalate(*session);
 
     // This handler is resumed eagerly, so a $/cancelRequest or didChange
     // sitting in the pipe (rapid-fire completions cancel and re-issue as
@@ -784,7 +785,7 @@ FeatureRouter::RawResult
                                   const protocol::Position& position,
                                   std::optional<kota::cancellation_token> token) {
     auto pause = indexer.scoped_pause();
-    compiler.escalate(session);
+    compiler.escalate(*session);
     co_return co_await compiler.forward_build(worker::BuildKind::SignatureHelp,
                                               position,
                                               session,

--- a/src/server/service/feature_router.cpp
+++ b/src/server/service/feature_router.cpp
@@ -98,10 +98,16 @@ FeatureRouter::IndexRows FeatureRouter::extract_rows(const index::Shard& shard) 
     return rows;
 }
 
-/// The language the last -x of the file's own CDB entry forces, if any:
-/// the driver override beats every suffix heuristic. Rules applied, like
-/// the resolve path's effective command.
-static std::optional<bool> command_forces_c(Workspace& workspace, llvm::StringRef path) {
+/// The language selectors of a file's CDB entry: what the last -x forces,
+/// if any (the driver override beats every suffix heuristic), and the
+/// last -std value. Rules applied, like the resolve path's effective
+/// command.
+struct CommandLang {
+    std::optional<bool> forces_c;
+    std::string standard;
+};
+
+static std::optional<CommandLang> command_lang(Workspace& workspace, llvm::StringRef path) {
     if(!workspace.cdb.has_entry(path)) {
         return std::nullopt;
     }
@@ -109,7 +115,7 @@ static std::optional<bool> command_forces_c(Workspace& workspace, llvm::StringRe
     workspace.config.match_rules(path, append, remove);
     auto commands = workspace.cdb.lookup(path, {.remove = remove, .append = append});
 
-    std::optional<bool> forces_c;
+    CommandLang result;
     auto& flags = commands.front().resolved.flags;
     for(std::size_t i = 0; i < flags.size(); i += 1) {
         llvm::StringRef flag = flags[i];
@@ -120,24 +126,28 @@ static std::optional<bool> command_forces_c(Workspace& workspace, llvm::StringRe
             }
         } else if(flag.starts_with("-x")) {
             language = flag.drop_front(2);
+        } else if(flag.consume_front("-std=") || flag.consume_front("--std=")) {
+            result.standard = flag.str();
+            continue;
         } else {
             continue;
         }
         if(!language.empty()) {
-            forces_c = language == "c" || language == "c-header";
+            result.forces_c = language == "c" || language == "c-header";
         }
     }
-    return forces_c;
+    return result;
 }
 
 const clang::LangOptions& FeatureRouter::index_lang_options(const Session& session) {
     auto path = workspace.path_pool.resolve(session.path_id);
-    if(auto forces_c = command_forces_c(workspace, path)) {
-        return feature::index_lang_options("", *forces_c);
+    auto own = command_lang(workspace, path);
+    if(own && own->forces_c) {
+        return feature::index_lang_options("", *own->forces_c, own->standard);
     }
 
     // A header's active context (the user's persisted choice, else the
-    // resolved host) names the view being read; its language beats the
+    // resolved host) names the view being read; its command beats the
     // contributor union the way it does for the AST after an escalation.
     auto host = no_path_id;
     if(auto it = contexts.saved_contexts.find(session.path_id);
@@ -150,8 +160,15 @@ const clang::LangOptions& FeatureRouter::index_lang_options(const Session& sessi
         }
     }
     if(host != no_path_id) {
-        bool c_host = workspace.path_pool.resolve(host).ends_with(".c");
-        return feature::index_lang_options(path, c_host);
+        auto host_path = workspace.path_pool.resolve(host);
+        auto host_lang = command_lang(workspace, host_path);
+        if(host_lang && host_lang->forces_c) {
+            return feature::index_lang_options("", *host_lang->forces_c, host_lang->standard);
+        }
+        return feature::index_lang_options(path,
+                                           host_path.ends_with(".c"),
+                                           host_lang ? llvm::StringRef(host_lang->standard)
+                                                     : llvm::StringRef());
     }
 
     auto& contributions = workspace.project_index.contributions;
@@ -160,7 +177,9 @@ const clang::LangOptions& FeatureRouter::index_lang_options(const Session& sessi
                   llvm::all_of(llvm::make_first_range(it->second), [&](std::uint32_t tu) {
                       return workspace.path_pool.resolve(tu).ends_with(".c");
                   });
-    return feature::index_lang_options(path, c_rows);
+    return feature::index_lang_options(path,
+                                       c_rows,
+                                       own ? llvm::StringRef(own->standard) : llvm::StringRef());
 }
 
 std::optional<feature::IndexSymbolInfo> FeatureRouter::resolve_symbol_info(index::SymbolHash hash) {

--- a/src/server/service/feature_router.cpp
+++ b/src/server/service/feature_router.cpp
@@ -290,8 +290,13 @@ kota::task<kota::codec::RawValue, kota::ipc::Error>
 
     // An index-only session never owes the compile the worker forward
     // implies. What the worker leg covers — include directives, which
-    // have no symbol occurrence — the manifest edges answer instead.
+    // have no symbol occurrence — the manifest edges answer instead,
+    // under the same content gate as every index answer: manifest lines
+    // are meaningless against a diverged buffer.
     if(session->serving == ServingMode::IndexOnly) {
+        if(!index_query.open_session_shard(*session)) {
+            co_return serde_raw{"[]"};
+        }
         if(auto offset = session->line_map().to_offset(pos)) {
             auto links = feature::index_document_links(session->text,
                                                        feature::index_lang_options(path),
@@ -442,6 +447,7 @@ FeatureRouter::RawResult FeatureRouter::inlay_hints(std::shared_ptr<Session> ses
     // that follows an escalation pushes an inlayHint refresh, so clients
     // re-pull once real hints exist.
     if(session && session->serving == ServingMode::IndexOnly) {
+        session->index_served = true;
         co_return serde_raw{"[]"};
     }
     co_return co_await compiler.forward_query(worker::QueryKind::InlayHints,
@@ -536,6 +542,13 @@ FeatureRouter::RawResult FeatureRouter::completion(std::shared_ptr<Session> sess
                                                    std::optional<kota::cancellation_token> token) {
     auto pause = indexer.scoped_pause();
 
+    // Asking for code completion is edit intent: escalate the session so
+    // the PCH/AST investment starts (a no-op when already escalated or
+    // under pch_build = "never"). Before the yield below on purpose — a
+    // didClose drained there replaces the Session object, and escalating
+    // the dead one would kick a compile of abandoned text.
+    compiler.escalate(session);
+
     // This handler is resumed eagerly, so a $/cancelRequest or didChange
     // sitting in the pipe (rapid-fire completions cancel and re-issue as
     // the user types) has not been read yet. Yield once BEFORE reading any
@@ -610,10 +623,6 @@ FeatureRouter::RawResult FeatureRouter::completion(std::shared_ptr<Session> sess
         }
     }
 
-    // Asking for code completion is edit intent: escalate the session so
-    // the PCH/AST investment starts (a no-op when already escalated or
-    // under pch_build = "never").
-    compiler.escalate(session);
     co_return co_await compiler.forward_build(worker::BuildKind::Completion,
                                               position,
                                               std::move(session),

--- a/src/server/service/feature_router.cpp
+++ b/src/server/service/feature_router.cpp
@@ -19,6 +19,7 @@
 #include "syntax/include_resolver.h"
 
 #include "kota/codec/json/json.h"
+#include "llvm/ADT/STLExtras.h"
 
 namespace clice {
 
@@ -95,6 +96,16 @@ FeatureRouter::IndexRows FeatureRouter::extract_rows(const index::Shard& shard) 
         return true;
     });
     return rows;
+}
+
+const clang::LangOptions& FeatureRouter::index_lang_options(const Session& session) {
+    auto& contributions = workspace.project_index.contributions;
+    auto it = contributions.find(session.path_id);
+    bool c_rows = it != contributions.end() && !it->second.empty() &&
+                  llvm::all_of(llvm::make_first_range(it->second), [&](std::uint32_t tu) {
+                      return workspace.path_pool.resolve(tu).ends_with(".c");
+                  });
+    return feature::index_lang_options(workspace.path_pool.resolve(session.path_id), c_rows);
 }
 
 std::optional<feature::IndexSymbolInfo> FeatureRouter::resolve_symbol_info(index::SymbolHash hash) {
@@ -240,9 +251,8 @@ kota::task<std::vector<protocol::DocumentLink>, kota::ipc::Error>
             std::vector<protocol::DocumentLink> links;
             auto it = workspace.shards.find(session->path_id);
             if(it != workspace.shards.end() && it->second.matches_content(session->text)) {
-                auto path = workspace.path_pool.resolve(session->path_id);
                 auto raw = feature::index_document_links(session->text,
-                                                         feature::index_lang_options(path),
+                                                         index_lang_options(*session),
                                                          index_query.include_edges(*session));
                 convert(raw, links);
             }
@@ -311,7 +321,7 @@ kota::task<kota::codec::RawValue, kota::ipc::Error>
         }
         if(auto offset = session->line_map().to_offset(pos)) {
             auto links = feature::index_document_links(session->text,
-                                                       feature::index_lang_options(path),
+                                                       index_lang_options(*session),
                                                        index_query.include_edges(*session));
             for(const auto& link: links) {
                 if(*offset >= link.range.begin && *offset < link.range.end) {
@@ -426,10 +436,9 @@ FeatureRouter::RawResult
             case Route::Index: {
                 auto* source = index_rows_source(index_query, *session);
                 auto rows = extract_rows(*source);
-                auto path = workspace.path_pool.resolve(session->path_id);
                 auto tokens = feature::index_semantic_tokens(
                     session->text,
-                    feature::index_lang_options(path),
+                    index_lang_options(*session),
                     rows.occurrences,
                     rows.decls,
                     [&](index::SymbolHash hash) { return resolve_symbol_info(hash); });
@@ -486,10 +495,9 @@ FeatureRouter::RawResult
             case Route::Index: {
                 auto* source = index_rows_source(index_query, *session);
                 auto rows = extract_rows(*source);
-                auto path = workspace.path_pool.resolve(session->path_id);
                 auto folds = feature::index_folding_ranges(
                     session->text,
-                    feature::index_lang_options(path),
+                    index_lang_options(*session),
                     rows.decls,
                     [&](index::SymbolHash hash) { return resolve_symbol_info(hash); });
                 session->index_served = true;
@@ -499,7 +507,14 @@ FeatureRouter::RawResult
                                                         session->line_starts,
                                                         feature::PositionEncoding::UTF16));
             }
-            case Route::Empty: co_return serde_raw{"[]"};
+            case Route::Empty: {
+                // Same contract as the semantic-tokens Empty route: the
+                // client caches this reply, and only a foldingRange
+                // refresh makes it re-pull once the cold document's
+                // shard lands.
+                session->index_served = true;
+                co_return serde_raw{"[]"};
+            }
             case Route::Ast: break;
         }
     }

--- a/src/server/service/feature_router.h
+++ b/src/server/service/feature_router.h
@@ -6,6 +6,7 @@
 #include "feature/feature.h"
 #include "server/service/query.h"
 #include "server/state/session.h"
+#include "server/state/session_store.h"
 #include "server/state/workspace.h"
 
 #include "kota/async/async.h"
@@ -49,9 +50,10 @@ public:
                   IndexQuery& index_query,
                   Workspace& workspace,
                   ContextResolver& contexts,
-                  Indexer& indexer) :
+                  Indexer& indexer,
+                  SessionStore& sessions) :
         compiler(compiler), index_query(index_query), workspace(workspace), contexts(contexts),
-        indexer(indexer) {}
+        indexer(indexer), sessions(sessions) {}
 
     using RawResult = kota::task<kota::codec::RawValue, kota::ipc::Error>;
 
@@ -237,6 +239,7 @@ private:
     Workspace& workspace;
     ContextResolver& contexts;
     Indexer& indexer;
+    SessionStore& sessions;
 };
 
 }  // namespace clice

--- a/src/server/service/feature_router.h
+++ b/src/server/service/feature_router.h
@@ -162,6 +162,54 @@ public:
     RawResult workspace_symbol(llvm::StringRef query);
 
 private:
+    /// Whether the worker's AST can answer for this session right now:
+    /// compiled, current, and not quarantined (the quarantine gate sits
+    /// before ensure_compiled's clean-AST fast path, so a quarantined
+    /// session's forward returns null even with a clean AST). When false,
+    /// the routing rules try the index before deciding to await a compile.
+    static bool ast_answerable(const Session& session);
+
+    /// The route decision for requests the index may serve: drains the
+    /// transport pipe (the handler resumed eagerly; a didChange or cancel
+    /// may be queued), then re-derives the source from current state.
+    enum class Route : std::uint8_t {
+        /// The request was superseded while draining (didChange, close);
+        /// answer empty — the client re-requests against the new state.
+        Superseded,
+        /// Serve from the index slice (the shard admitted by freshness
+        /// clause 4).
+        Index,
+        /// Fall through to the AST path (forward_query, which compiles
+        /// as needed).
+        Ast,
+        /// No source can serve and none is being invested in (IndexOnly
+        /// with no matching shard): answer honestly empty.
+        Empty,
+    };
+
+    /// See Route. Sets up escalated sessions' compile kick so an index
+    /// answer never strands the AST investment the policy asked for.
+    kota::task<FeatureRouter::Route> pick_route(std::shared_ptr<Session> session);
+
+    /// The compile gate of index-navigation requests: awaits the compile
+    /// exactly when the routing decided the AST is the serving source
+    /// (freshness clause 1 needs the settled file index), and lets
+    /// index-served sessions resolve through clauses 1/4 without forcing
+    /// the build. False means answer null — the compile failed or the
+    /// request was superseded.
+    kota::task<bool> nav_gate(std::shared_ptr<Session> session);
+
+    /// The document's rows extracted for the projections, plus the
+    /// resolver the projections share.
+    struct IndexRows {
+        std::vector<index::Occurrence> occurrences;
+        std::vector<feature::IndexDeclRow> decls;
+    };
+
+    static IndexRows extract_rows(const index::Shard& shard);
+
+    std::optional<feature::IndexSymbolInfo> resolve_symbol_info(index::SymbolHash hash);
+
     /// The preamble include links of a session's active PCH; empty when
     /// there is no PCH or its preamble no longer matches the buffer.
     std::vector<feature::DocumentLink> find_preamble_links(const Session& session);

--- a/src/server/service/feature_router.h
+++ b/src/server/service/feature_router.h
@@ -204,9 +204,11 @@ private:
 
     static IndexRows extract_rows(const index::Shard& shard);
 
-    /// The lexing dialect of a session's index projections: C when the
-    /// file is a C source or every TU contributing its indexed rows is
-    /// one, C++ otherwise (mixed inclusion favors the superset).
+    /// The lexing dialect of a session's index projections. An explicit -x
+    /// in the file's own CDB entry decides outright; a header follows its
+    /// active context's host when one exists; otherwise C when the file is
+    /// a C source or every TU contributing its indexed rows is one, C++
+    /// else (mixed inclusion favors the superset).
     const clang::LangOptions& index_lang_options(const Session& session);
 
     std::optional<feature::IndexSymbolInfo> resolve_symbol_info(index::SymbolHash hash);

--- a/src/server/service/feature_router.h
+++ b/src/server/service/feature_router.h
@@ -204,6 +204,11 @@ private:
 
     static IndexRows extract_rows(const index::Shard& shard);
 
+    /// The lexing dialect of a session's index projections: C when the
+    /// file is a C source or every TU contributing its indexed rows is
+    /// one, C++ otherwise (mixed inclusion favors the superset).
+    const clang::LangOptions& index_lang_options(const Session& session);
+
     std::optional<feature::IndexSymbolInfo> resolve_symbol_info(index::SymbolHash hash);
 
     /// The preamble include links of a session's active PCH; empty when

--- a/src/server/service/feature_router.h
+++ b/src/server/service/feature_router.h
@@ -185,7 +185,11 @@ private:
 
     /// See Route. Sets up escalated sessions' compile kick so an index
     /// answer never strands the AST investment the policy asked for.
-    kota::task<FeatureRouter::Route> pick_route(std::shared_ptr<Session> session);
+    /// `full_lex` marks projections that raw-lex the whole buffer
+    /// (semantic tokens, folds): those follow the investment policy once
+    /// the buffer is oversized, while row- and cursor-backed answers
+    /// serve at any size.
+    kota::task<FeatureRouter::Route> pick_route(std::shared_ptr<Session> session, bool full_lex);
 
     /// The compile gate of index-navigation requests: awaits the compile
     /// exactly when the routing decided the AST is the serving source

--- a/src/server/service/feature_router.h
+++ b/src/server/service/feature_router.h
@@ -31,13 +31,13 @@ namespace protocol = kota::ipc::protocol;
 ///     region;
 ///   - the index: disk-derived shards queried through IndexQuery.
 ///
-/// Features fall into two shapes. Whole-document results (document links,
-/// semantic tokens, folding ranges, ...) have a payload determined entirely
-/// by the document content, so they could in the future be served from a
-/// content-addressed result cache. Position-parameterized queries
-/// (definition, hover, completion) take a cursor and cannot be keyed that
-/// way; for these the index could in the future grow into a complete
-/// provider, serving files that are not open at all.
+/// Routing is derived per request from readiness, never from a mode
+/// flag: a current AST answers as today; otherwise an index source that
+/// is byte-identical to the buffer answers immediately (whole-document
+/// features through the feature::index_* projections, cursor queries
+/// through IndexQuery's freshness clauses); otherwise the request awaits
+/// the compile the policy owes, or answers honestly empty when it owes
+/// none (ServingMode::IndexOnly).
 ///
 /// Discipline: any feature whose answer is assembled from more than one
 /// source belongs here. Transports (LSP/agentic handlers) only translate
@@ -72,16 +72,12 @@ public:
                          const protocol::Position& pos,
                          std::optional<kota::cancellation_token> token = {});
 
-    /// Single-source features routed through the router as a matter of
-    /// discipline, not necessity. Each currently forwards to exactly one
-    /// provider (the worker's AST, a stateless build, or the index), so most
-    /// are one-line delegations. They live here as reserved tenants: the
-    /// router is where a feature's answer is assembled once it draws on more
-    /// than one source, and these are the designated hooks for a future
-    /// read-only provider strategy (e.g. serving closed files from the index).
-    /// They are NOT dead code to be inlined back into the transports.
-    /// Each takes the request's cancellation token and forwards it to the
-    /// worker sends (see Compiler::forward_query).
+    /// Whole-document features and hover, routed by readiness (see
+    /// pick_route): the AST answers when current, the index projections
+    /// answer while it is not, and a session the policy keeps un-compiled
+    /// answers with its pinned degraded surface (empty inlay hints and
+    /// code actions). Each takes the request's cancellation token and
+    /// forwards it to the worker sends (see Compiler::forward_query).
     RawResult hover(std::shared_ptr<Session> session,
                     const protocol::Position& position,
                     std::optional<kota::cancellation_token> token = {});

--- a/src/server/service/query.cpp
+++ b/src/server/service/query.cpp
@@ -909,6 +909,22 @@ static std::string extract_line(llvm::StringRef content, std::uint32_t offset) {
     return content.slice(line_start, line_end).str();
 }
 
+/// A definition's extent within one shard's stored content, or nullopt
+/// when the shard has no in-bounds Definition payload for the symbol.
+static std::optional<LocalSourceRange> definition_extent(const index::Shard& shard,
+                                                         index::SymbolHash hash,
+                                                         llvm::StringRef content) {
+    std::optional<LocalSourceRange> extent;
+    shard.lookup(hash, RelationKind::Definition, [&](const index::Relation& r) {
+        auto def_range = std::bit_cast<LocalSourceRange>(r.target_symbol);
+        if(def_range.begin >= def_range.end || def_range.end > content.size())
+            return true;
+        extent = def_range;
+        return false;
+    });
+    return extent;
+}
+
 std::optional<IndexQuery::DefinitionText> IndexQuery::get_definition_text(index::SymbolHash hash) {
     auto sym_it = workspace.project_index.symbols.find(hash);
     if(sym_it == workspace.project_index.symbols.end())
@@ -927,30 +943,127 @@ std::optional<IndexQuery::DefinitionText> IndexQuery::get_definition_text(index:
         if(!text)
             continue;
         llvm::StringRef content = *text;
-        lsp::LineMap map(content, merged_index.line_starts());
+        auto extent = definition_extent(merged_index, hash, content);
+        if(!extent)
+            continue;
 
-        std::optional<DefinitionText> result;
-        merged_index.lookup(hash, RelationKind::Definition, [&](const index::Relation& r) {
-            auto def_range = std::bit_cast<LocalSourceRange>(r.target_symbol);
-            if(def_range.begin >= def_range.end || def_range.end > content.size())
-                return true;
-            auto range = map.to_range(def_range.begin, def_range.end);
-            if(!range)
-                return true;
-            result = DefinitionText{
-                .file = file_path.str(),
-                .start_line = static_cast<int>(range->start.line) + 1,
-                .end_line = static_cast<int>(range->end.line) + 1,
-                .text =
-                    std::string(content.substr(def_range.begin, def_range.end - def_range.begin)),
-            };
-            return false;
-        });
-        if(result)
-            return result;
+        lsp::LineMap map(content, merged_index.line_starts());
+        auto range = map.to_range(extent->begin, extent->end);
+        if(!range)
+            continue;
+        return DefinitionText{
+            .file = file_path.str(),
+            .start_line = static_cast<int>(range->start.line) + 1,
+            .end_line = static_cast<int>(range->end.line) + 1,
+            .text = std::string(content.substr(extent->begin, extent->length())),
+        };
     }
 
     return std::nullopt;
+}
+
+const index::Shard* IndexQuery::open_session_shard(const Session& session) const {
+    if(session.index_current()) {
+        return nullptr;
+    }
+    auto it = workspace.shards.find(session.path_id);
+    if(it == workspace.shards.end() || !it->second.matches_content(session.text)) {
+        return nullptr;
+    }
+    return &it->second;
+}
+
+std::vector<feature::IndexIncludeEdge> IndexQuery::include_edges(const Session& session) const {
+    auto& project = workspace.project_index;
+    auto manifest_it = project.manifests.find(session.path_id);
+    if(manifest_it == project.manifests.end()) {
+        return {};
+    }
+
+    // Nodes without a parent node sit in the TU's own file — the manifest
+    // edges of the document itself. (Directives inside included headers
+    // hang off the node of the file that contains them.)
+    std::vector<feature::IndexIncludeEdge> edges;
+    for(const auto& node: manifest_it->second.nodes) {
+        if(node.parent != ~0u) {
+            continue;
+        }
+        auto version = project.file_versions.find(node.fv);
+        if(version == project.file_versions.end()) {
+            continue;
+        }
+        edges.push_back({
+            .line = node.line,
+            .target = std::string(workspace.path_pool.resolve(version->second.path_id)),
+        });
+    }
+    return edges;
+}
+
+std::optional<feature::HoverInfo> IndexQuery::hover_card(llvm::StringRef path,
+                                                         const protocol::Position& position,
+                                                         Session* session) {
+    auto hit = resolve_cursor(path, position, session);
+    if(hit.hash == 0) {
+        return std::nullopt;
+    }
+
+    feature::IndexSymbolInfo info;
+    if(!find_symbol_info(hit.hash, info.name, info.kind)) {
+        return std::nullopt;
+    }
+
+    // Definition text and its comment block, preferring the document's own
+    // serving source (buffer-true content); external symbols defined
+    // elsewhere fall back to the defining file's stored content.
+    std::string definition;
+    std::string comment;
+    auto slice_from = [&](const index::Shard& shard, llvm::StringRef content) {
+        auto extent = definition_extent(shard, hit.hash, content);
+        if(!extent) {
+            return false;
+        }
+        definition = std::string(content.substr(extent->begin, extent->length()));
+        comment = feature::preceding_comment(content, extent->begin);
+        return true;
+    };
+
+    bool sliced = false;
+    if(session) {
+        if(session->index_current()) {
+            sliced = slice_from(session->file_rows(), session->text);
+        } else if(auto* shard = open_session_shard(*session)) {
+            sliced = slice_from(*shard, session->text);
+        }
+    }
+    if(!sliced) {
+        if(auto sym_it = workspace.project_index.symbols.find(hit.hash);
+           sym_it != workspace.project_index.symbols.end()) {
+            for(auto file_id: sym_it->second.reference_files) {
+                if(skip_shard(file_id))
+                    continue;
+                auto shard_it = workspace.shards.find(file_id);
+                if(shard_it == workspace.shards.end())
+                    continue;
+                std::unique_ptr<llvm::MemoryBuffer> storage;
+                auto text =
+                    indexed_text(workspace.path_pool.resolve(file_id), shard_it->second, storage);
+                if(text && slice_from(shard_it->second, *text))
+                    break;
+            }
+        }
+    }
+
+    auto hover = feature::index_hover(info, definition, comment);
+    if(session) {
+        auto map = session->line_map();
+        auto begin = map.to_offset(hit.range.start);
+        auto end = map.to_offset(hit.range.end);
+        if(begin && end) {
+            hover.symbol_range = LocalSourceRange{*begin, *end};
+        }
+    }
+    return hover;
 }
 
 std::vector<IndexQuery::ReferenceWithContext> IndexQuery::collect_references(index::SymbolHash hash,

--- a/src/server/service/query.cpp
+++ b/src/server/service/query.cpp
@@ -1040,6 +1040,19 @@ std::optional<feature::HoverInfo> IndexQuery::hover_card(llvm::StringRef path,
         if(auto sym_it = workspace.project_index.symbols.find(hit.hash);
            sym_it != workspace.project_index.symbols.end()) {
             for(auto file_id: sym_it->second.reference_files) {
+                // A defining file that is itself open serves through its
+                // session sources — the very reason skip_shard rejects
+                // its disk shard — so slice from those buffer-true rows
+                // instead of losing the definition text.
+                if(!options.disk_only) {
+                    if(auto other = sessions.find(file_id)) {
+                        if(other->index_current() && slice_from(other->file_rows(), other->text))
+                            break;
+                        if(auto* shard = open_session_shard(*other);
+                           shard && slice_from(*shard, other->text))
+                            break;
+                    }
+                }
                 if(skip_shard(file_id))
                     continue;
                 auto shard_it = workspace.shards.find(file_id);

--- a/src/server/service/query.cpp
+++ b/src/server/service/query.cpp
@@ -40,7 +40,7 @@ void IndexQuery::visit_sessions(SessionVisitor visitor) const {
     sessions.for_each([&](std::uint32_t path_id, const Session& session) -> bool {
         // Freshness contract, clause 3: a dirty session's file index may
         // describe a buffer that no longer exists — skip it.
-        if(session.index.loaded() && !session.ast_dirty) {
+        if(session.index_current()) {
             return visitor(path_id, session);
         }
         return true;
@@ -220,7 +220,25 @@ static void drop_cursor_site(std::vector<protocol::Location>& locations,
 }
 
 bool IndexQuery::skip_shard(std::uint32_t path_id) const {
-    return (!options.disk_only && is_path_open(path_id)) || skip_stale_contribution(path_id);
+    if(options.disk_only) {
+        return skip_stale_contribution(path_id);
+    }
+    auto session = sessions.find(path_id);
+    if(!session) {
+        return skip_stale_contribution(path_id);
+    }
+    if(session->index_current()) {
+        return true;
+    }
+    // Freshness contract, clause 4: an open document without a current
+    // file index is served by its shard as if closed, while the buffer is
+    // byte-identical to the content the rows were built from. The content
+    // gate replaces the stale-contribution check — it compares against
+    // the buffer being served, which is stricter than any disk baseline —
+    // and a diverged buffer (edit in flight, restored unsaved text)
+    // contributes nothing, exactly as before this clause.
+    auto it = workspace.shards.find(path_id);
+    return it == workspace.shards.end() || !it->second.matches_content(session->text);
 }
 
 bool IndexQuery::skip_stale_contribution(std::uint32_t path_id) const {
@@ -284,18 +302,10 @@ bool IndexQuery::find_symbol_info(index::SymbolHash hash,
 IndexQuery::CursorHit IndexQuery::resolve_cursor(llvm::StringRef path,
                                                  const protocol::Position& position,
                                                  Session* session) {
-    // Freshness contract, clause 1: callers awaited the session's compile,
-    // and the file index settles together with it. An open document
-    // resolves against that index or not at all — its shard describes a
-    // disk snapshot, and mapping live buffer offsets onto it is exactly
-    // the mixed-view lookup the contract exists to prevent (the
-    // cross-file visit already skips shards of open files for the same
-    // reason). A dirty-after-await session (failed or superseded compile)
-    // or an index-less one therefore reports no hit.
-    if(session && (!session->index.loaded() || session->ast_dirty)) {
-        return {};
-    }
-    if(session && session->index.loaded() && !session->ast_dirty) {
+    // Freshness contract, clause 1: an open document with a current file
+    // index resolves against it — the compile the caller awaited settled
+    // it together with the buffer.
+    if(session && session->index_current()) {
         auto map = session->line_map();
         auto offset = map.to_offset(position);
         if(!offset)
@@ -328,21 +338,25 @@ IndexQuery::CursorHit IndexQuery::resolve_cursor(llvm::StringRef path,
         return hit;
     }
 
-    // Fallback to the disk shard. Position -> offset uses the session text when
-    // one exists (open but not yet compiled); for closed files the shard's
-    // own stored content provides the mapping.
+    // Fallback to the disk shard. Freshness contract, clause 4: an open
+    // document without a current file index resolves against its shard
+    // while the buffer is byte-identical to the rows' content — the gate
+    // that keeps a diverged buffer (edit in flight, restored unsaved
+    // text) from the mixed-view lookup the contract exists to prevent.
+    // Closed files keep the stale-contribution gate against their disk
+    // baseline instead.
     auto path_id = workspace.path_pool.find(path);
     if(!path_id)
         return {};
-    // A content-changed pending file's rows describe stale text: a cursor
-    // resolved against them would name the wrong symbol.
-    if(skip_stale_contribution(*path_id))
+    if(!session && skip_stale_contribution(*path_id))
         return {};
     auto shard_it = workspace.shards.find(*path_id);
     if(shard_it == workspace.shards.end())
         return {};
 
     auto& merged_index = shard_it->second;
+    if(session && !merged_index.matches_content(session->text))
+        return {};
     IndexedLineMap map(merged_index.content(),
                        merged_index.content_size(),
                        merged_index.line_starts());

--- a/src/server/service/query.cpp
+++ b/src/server/service/query.cpp
@@ -24,6 +24,7 @@
 #include "kota/ipc/lsp/uri.h"
 #include "kota/meta/enum.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
@@ -975,27 +976,72 @@ const index::Shard* IndexQuery::open_session_shard(const Session& session) const
 
 std::vector<feature::IndexIncludeEdge> IndexQuery::include_edges(const Session& session) const {
     auto& project = workspace.project_index;
-    auto manifest_it = project.manifests.find(session.path_id);
-    if(manifest_it == project.manifests.end()) {
+
+    // Every consumer projects the edges onto content the serving shard
+    // matches, so a manifest contributes only where the version it entered
+    // for this document carries that same content generation — a TU that
+    // indexed an older revision would place its lines in text that moved.
+    auto shard_it = workspace.shards.find(session.path_id);
+    if(shard_it == workspace.shards.end()) {
         return {};
     }
+    auto generation = shard_it->second.content_hash();
 
-    // Nodes without a parent node sit in the TU's own file — the manifest
-    // edges of the document itself. (Directives inside included headers
-    // hang off the node of the file that contains them.)
+    auto version_of = [&](std::uint32_t fv) -> const index::FileVersionRecord* {
+        auto it = project.file_versions.find(fv);
+        return it == project.file_versions.end() ? nullptr : &it->second;
+    };
+    auto is_document = [&](std::uint32_t fv) {
+        const auto* version = version_of(fv);
+        return version && version->path_id == session.path_id &&
+               version->content_hash == generation;
+    };
+
+    // A directive line of the document is a node whose parent node entered
+    // this file: the TU root (parent == ~0u) when the document is the TU
+    // itself, or any node of the document's own file version otherwise
+    // (directives inside included headers hang off the node of the file
+    // that contains them).
     std::vector<feature::IndexIncludeEdge> edges;
-    for(const auto& node: manifest_it->second.nodes) {
-        if(node.parent != ~0u) {
-            continue;
+    auto append = [&](const index::TUManifest& manifest) {
+        bool root_is_document = is_document(manifest.tu_fv);
+        llvm::SmallVector<bool> document_nodes(manifest.nodes.size());
+        for(auto [i, node]: llvm::enumerate(manifest.nodes)) {
+            document_nodes[i] = is_document(node.fv);
         }
-        auto version = project.file_versions.find(node.fv);
-        if(version == project.file_versions.end()) {
-            continue;
+        for(const auto& node: manifest.nodes) {
+            if(node.parent == ~0u ? !root_is_document : !document_nodes[node.parent]) {
+                continue;
+            }
+            const auto* target = version_of(node.fv);
+            if(!target) {
+                continue;
+            }
+            edges.push_back({
+                .line = node.line,
+                .target = std::string(workspace.path_pool.resolve(target->path_id)),
+            });
         }
-        edges.push_back({
-            .line = node.line,
-            .target = std::string(workspace.path_pool.resolve(version->second.path_id)),
-        });
+    };
+
+    // The document's own manifest is its own context and answers alone; a
+    // header reached only through source TUs has none, and its directives
+    // live in the contributing TUs' manifests instead. The generation gate
+    // above dedups divergent revisions; agreeing TUs collapse in the
+    // projection's dedup.
+    if(auto manifest_it = project.manifests.find(session.path_id);
+       manifest_it != project.manifests.end()) {
+        append(manifest_it->second);
+        return edges;
+    }
+    if(auto contribution_it = project.contributions.find(session.path_id);
+       contribution_it != project.contributions.end()) {
+        for(auto tu: llvm::make_first_range(contribution_it->second)) {
+            if(auto manifest_it = project.manifests.find(tu);
+               manifest_it != project.manifests.end()) {
+                append(manifest_it->second);
+            }
+        }
     }
     return edges;
 }

--- a/src/server/service/query.h
+++ b/src/server/service/query.h
@@ -78,6 +78,14 @@ struct ResolvedSymbol {
 ///      entirely (see visit_sessions): their buffer may have diverged from
 ///      the last file index, and unlike closed files their reindex is the
 ///      next compile, which the current file's request already awaits.
+///   4. An open session without a current file index is served by the
+///      file's shard under closed-file rules — but only while the buffer
+///      is byte-identical to the content the rows were built from
+///      (Shard::matches_content). This is what serves documents opened
+///      for reading before any compile is invested in them; the moment
+///      the buffer diverges (an edit, restored unsaved text) the shard
+///      withdraws and clauses 1-3 govern again. Arbitration is strict:
+///      a current file index always wins over the shard (never both).
 ///
 ///   Symbol identity lookups (find_symbol_info: hash → name/kind) are not
 ///   gated: a hash identifies one symbol, so even a stale shard answers

--- a/src/server/service/query.h
+++ b/src/server/service/query.h
@@ -260,10 +260,13 @@ public:
     /// would double-serve.
     const index::Shard* open_session_shard(const Session& session) const;
 
-    /// The include edges of the session's document from its TU manifest:
-    /// the input of the document-link projection. Empty when the file has
-    /// no manifest (never indexed, or a header only reached through other
-    /// TUs).
+    /// The include edges of the session's document, the input of the
+    /// document-link projection: from its own TU manifest when it has one,
+    /// else from the contributing TUs' manifests (a header reached only
+    /// through source TUs — its directives are nodes hanging off the
+    /// header's own node there). Only manifests that entered the document
+    /// at the serving shard's content generation contribute; empty when
+    /// the file was never indexed.
     std::vector<feature::IndexIncludeEdge> include_edges(const Session& session) const;
 
     /// The read-only hover card for the symbol under the cursor: name and

--- a/src/server/service/query.h
+++ b/src/server/service/query.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "feature/feature.h"
 #include "semantic/symbol.h"
 #include "server/protocol/agentic.h"
 #include "server/state/workspace.h"
@@ -251,6 +252,27 @@ public:
     /// changed and awaits reindexing (clause 2), or — unless disk_only —
     /// the file is open and its session serves it instead.
     bool skip_shard(std::uint32_t path_id) const;
+
+    /// The shard that may serve `session`'s document as if closed
+    /// (freshness clause 4): the session has no current file index and
+    /// the buffer is byte-identical to the rows' content. Nullptr
+    /// otherwise — including when the session's own index is current and
+    /// would double-serve.
+    const index::Shard* open_session_shard(const Session& session) const;
+
+    /// The include edges of the session's document from its TU manifest:
+    /// the input of the document-link projection. Empty when the file has
+    /// no manifest (never indexed, or a header only reached through other
+    /// TUs).
+    std::vector<feature::IndexIncludeEdge> include_edges(const Session& session) const;
+
+    /// The read-only hover card for the symbol under the cursor: name and
+    /// kind from the symbol tables, definition text sliced from stored
+    /// content, the comment block above the definition. No Sema products
+    /// — see feature::index_hover.
+    std::optional<feature::HoverInfo> hover_card(llvm::StringRef path,
+                                                 const protocol::Position& position,
+                                                 Session* session);
 
     /// Iterate all open Sessions with valid, up-to-date file indices.
     void visit_sessions(SessionVisitor visitor) const;

--- a/src/server/state/config.cpp
+++ b/src/server/state/config.cpp
@@ -340,6 +340,10 @@ static void patch_field_schemas(kota::codec::dyn::Value& value) {
                     if(auto* schema = field_schema(*properties, "index_db")) {
                         schema->assign("enum", kota::codec::dyn::Array{"lmdb", "files"});
                     }
+                    if(auto* schema = field_schema(*properties, "pch_build")) {
+                        schema->assign("enum",
+                                       kota::codec::dyn::Array{"on_open", "on_edit", "never"});
+                    }
                 }
             } else if(key == "default") {
                 remove_machine_fields(child);

--- a/src/server/state/config.cpp
+++ b/src/server/state/config.cpp
@@ -340,9 +340,8 @@ static void patch_field_schemas(kota::codec::dyn::Value& value) {
                     if(auto* schema = field_schema(*properties, "index_db")) {
                         schema->assign("enum", kota::codec::dyn::Array{"lmdb", "files"});
                     }
-                    if(auto* schema = field_schema(*properties, "pch_build")) {
-                        schema->assign("enum",
-                                       kota::codec::dyn::Array{"on_open", "on_edit", "never"});
+                    if(auto* schema = field_schema(*properties, "readonly")) {
+                        schema->assign("enum", kota::codec::dyn::Array{"off", "on", "auto"});
                     }
                 }
             } else if(key == "default") {

--- a/src/server/state/config.h
+++ b/src/server/state/config.h
@@ -100,11 +100,13 @@ struct ProjectConfig {
                          "\"on_open\" compiles eagerly on didOpen, \"on_edit\" "
                          "serves reads from the index and compiles only when "
                          "an edit-intent trigger fires (edit, completion, "
-                         "signature help, context switch), \"never\" serves "
-                         "purely from the index. Feature routing always "
-                         "answers from the best source currently available; "
-                         "this option only decides when the expensive sources "
-                         "get built.")
+                         "signature help, context switch), \"never\" never "
+                         "builds them — reads serve from the index alone, "
+                         "while completion and signature help still compile "
+                         "on demand without a preamble. Feature routing "
+                         "always answers from the best source currently "
+                         "available; this option only decides when the "
+                         "expensive sources get built.")
     <std::string> pch_build = "on_edit";
 
     KOTATSU_ANNOTATE(defaulted = true,

--- a/src/server/state/config.h
+++ b/src/server/state/config.h
@@ -96,6 +96,19 @@ struct ProjectConfig {
 
     KOTATSU_ANNOTATE(defaulted = true,
                      description =
+                         "What triggers PCH/AST builds for an open file: "
+                         "\"on_open\" compiles eagerly on didOpen, \"on_edit\" "
+                         "serves reads from the index and compiles only when "
+                         "an edit-intent trigger fires (edit, completion, "
+                         "signature help, context switch), \"never\" serves "
+                         "purely from the index. Feature routing always "
+                         "answers from the best source currently available; "
+                         "this option only decides when the expensive sources "
+                         "get built.")
+    <std::string> pch_build = "on_open";
+
+    KOTATSU_ANNOTATE(defaulted = true,
+                     description =
                          "Idle delay in milliseconds before background indexing "
                          "starts.")
     <std::uint32_t> idle_timeout_ms = 3000;

--- a/src/server/state/config.h
+++ b/src/server/state/config.h
@@ -96,18 +96,19 @@ struct ProjectConfig {
 
     KOTATSU_ANNOTATE(defaulted = true,
                      description =
-                         "What triggers PCH/AST builds for an open file: "
-                         "\"on_open\" compiles eagerly on didOpen, \"on_edit\" "
-                         "serves reads from the index and compiles only when "
-                         "an edit-intent trigger fires (edit, completion, "
-                         "signature help, context switch), \"never\" never "
-                         "builds them — reads serve from the index alone, "
-                         "while completion and signature help still compile "
-                         "on demand without a preamble. Feature routing "
-                         "always answers from the best source currently "
-                         "available; this option only decides when the "
-                         "expensive sources get built.")
-    <std::string> pch_build = "on_edit";
+                         "Read-only serving for open files: \"off\" targets a "
+                         "full AST for every open file — builds are pulled by "
+                         "the first request that needs them, with the index "
+                         "answering in the meantime; \"on\" never builds a "
+                         "PCH — reads serve from the index alone (a cold file "
+                         "jumps the indexing queue), while completion and "
+                         "signature help still compile on demand without a "
+                         "preamble; \"auto\" starts every file as \"on\" and "
+                         "switches it to \"off\" at the first edit intent "
+                         "(edit, completion, signature help, context switch). "
+                         "Feature routing always answers from the best source "
+                         "currently available.")
+    <std::string> readonly = "off";
 
     KOTATSU_ANNOTATE(defaulted = true,
                      description =

--- a/src/server/state/config.h
+++ b/src/server/state/config.h
@@ -105,7 +105,7 @@ struct ProjectConfig {
                          "answers from the best source currently available; "
                          "this option only decides when the expensive sources "
                          "get built.")
-    <std::string> pch_build = "on_open";
+    <std::string> pch_build = "on_edit";
 
     KOTATSU_ANNOTATE(defaulted = true,
                      description =

--- a/src/server/state/config.h
+++ b/src/server/state/config.h
@@ -103,11 +103,12 @@ struct ProjectConfig {
                          "PCH — reads serve from the index alone (a cold file "
                          "jumps the indexing queue), while completion and "
                          "signature help still compile on demand without a "
-                         "preamble; \"auto\" starts every file as \"on\" and "
+                         "preamble; \"auto\" starts every file as \"on\", "
                          "switches it to \"off\" at the first edit intent "
-                         "(edit, completion, signature help, context switch). "
-                         "Feature routing always answers from the best source "
-                         "currently available.")
+                         "(edit, completion, signature help, context switch), "
+                         "and falls back to \"off\" for a file the index "
+                         "cannot serve. Feature routing always answers from "
+                         "the best source currently available.")
     <std::string> readonly = "off";
 
     KOTATSU_ANNOTATE(defaulted = true,

--- a/src/server/state/invalidator.cpp
+++ b/src/server/state/invalidator.cpp
@@ -105,8 +105,10 @@ void Invalidator::cascade_disk_content_change(std::uint32_t path_id, DirtySet& d
         // Contexts outlive their sessions: a closed header's shard rows
         // were indexed under the old chain and only a background reindex
         // can refresh them. The header's own content did not change, so
-        // its rows keep serving meanwhile.
-        if(!store.find(header_id)) {
+        // its rows keep serving meanwhile. An open index-only session is
+        // in the same boat — its shard is what the LSP serves.
+        auto session = store.find(header_id);
+        if(!session || session->serving == ServingMode::IndexOnly) {
             dirty.add_reindex_deps_only(header_id);
         }
     }

--- a/src/server/state/invalidator.cpp
+++ b/src/server/state/invalidator.cpp
@@ -30,6 +30,21 @@ static void dedup(llvm::SmallVector<std::uint32_t>& ids) {
     ids.erase(llvm::unique(ids), ids.end());
 }
 
+/// An invalidated dependent recompiles when its session invests in an
+/// AST, reindexes when closed — and does both for an index-only session
+/// (freshness clause 4): the buffer is the compile truth, but the serving
+/// rows are the shard's, and only a reindex refreshes those.
+void Invalidator::mark_dependent(std::uint32_t path_id, DirtySet& dirty) {
+    if(auto session = store.find(path_id)) {
+        dirty.mark_ast_dirty.push_back(path_id);
+        if(session->serving == ServingMode::IndexOnly) {
+            dirty.add_reindex_deps_only(path_id);
+        }
+    } else {
+        dirty.add_reindex_deps_only(path_id);
+    }
+}
+
 void Invalidator::cascade_compile_graph(std::uint32_t path_id, DirtySet& dirty) {
     if(!workspace.compile_graph || !workspace.compile_graph->has_unit(path_id)) {
         return;
@@ -37,11 +52,7 @@ void Invalidator::cascade_compile_graph(std::uint32_t path_id, DirtySet& dirty) 
     for(auto dirty_id: workspace.compile_graph->update(path_id)) {
         workspace.pcm_paths.erase(dirty_id);
         workspace.pcm_cache.erase(dirty_id);
-        if(store.find(dirty_id)) {
-            dirty.mark_ast_dirty.push_back(dirty_id);
-        } else {
-            dirty.add_reindex_deps_only(dirty_id);
-        }
+        mark_dependent(dirty_id, dirty);
     }
 }
 
@@ -63,11 +74,7 @@ void Invalidator::cascade_disk_content_change(std::uint32_t path_id, DirtySet& d
     // products went stale.
     auto dirtied = workspace.rescan_after_save(path_id);
     for(auto dirty_id: dirtied) {
-        if(store.find(dirty_id)) {
-            dirty.mark_ast_dirty.push_back(dirty_id);
-        } else {
-            dirty.add_reindex_deps_only(dirty_id);
-        }
+        mark_dependent(dirty_id, dirty);
     }
 
     // The new content is a compile input of every TU that transitively
@@ -79,11 +86,7 @@ void Invalidator::cascade_disk_content_change(std::uint32_t path_id, DirtySet& d
     // TODO: observe on large projects before adding debouncing.
     auto split_dependents = [&](llvm::ArrayRef<std::uint32_t> roots) {
         for(auto root: roots) {
-            if(store.find(root)) {
-                dirty.mark_ast_dirty.push_back(root);
-            } else {
-                dirty.add_reindex_deps_only(root);
-            }
+            mark_dependent(root, dirty);
         }
     };
     split_dependents(old_dependents);
@@ -229,11 +232,7 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                 // closed ones reindex — nothing else would ever queue them.
                 // Snapshot before the scrub below rewrites the graph.
                 for(auto root: workspace.dep_graph.find_host_sources(path_id)) {
-                    if(store.find(root)) {
-                        dirty.mark_ast_dirty.push_back(root);
-                    } else {
-                        dirty.add_reindex_deps_only(root);
-                    }
+                    mark_dependent(root, dirty);
                 }
                 // A removed module unit takes its PCM with it: importers'
                 // build products went stale, and it stops providing its
@@ -348,8 +347,14 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                         // command too; its manifest is as stale as the
                         // host's (no-op for headers indexed only via TUs).
                         dirty.drop_index.push_back(header_id);
-                        if(store.find(header_id)) {
+                        if(auto session = store.find(header_id)) {
                             dirty.mark_ast_dirty.push_back(header_id);
+                            // An index-only session just lost its serving
+                            // rows with the drop; only a reindex under the
+                            // new command brings them back.
+                            if(session->serving == ServingMode::IndexOnly) {
+                                dirty.add_reindex_content_changed(header_id);
+                            }
                         } else {
                             dirty.add_reindex_content_changed(header_id);
                         }

--- a/src/server/state/invalidator.h
+++ b/src/server/state/invalidator.h
@@ -275,6 +275,10 @@ private:
     /// dependent module units), splitting dirtied units open/closed.
     void cascade_compile_graph(std::uint32_t path_id, DirtySet& dirty);
 
+    /// See the definition: the open/closed/index-only split of a
+    /// dependency invalidation.
+    void mark_dependent(std::uint32_t path_id, DirtySet& dirty);
+
     Workspace& workspace;
     const SessionStore& store;
     const ContextResolver& contexts;

--- a/src/server/state/session.h
+++ b/src/server/state/session.h
@@ -156,6 +156,13 @@ struct Session {
     /// background indexing.
     index::TUIndex index;
 
+    /// Whether `index` describes the current buffer: the last compile
+    /// landed and no invalidation arrived since. The arbitration key of
+    /// the index freshness contract (IndexQuery clauses 3-4).
+    bool index_current() const {
+        return index.loaded() && !ast_dirty;
+    }
+
     /// The interested file's rows within `index` (an empty shard when the
     /// compile produced none).
     const index::Shard& file_rows() const {

--- a/src/server/state/session.h
+++ b/src/server/state/session.h
@@ -21,6 +21,18 @@ namespace clice {
 /// the compile command came from; Session only stores the verdict.
 enum class CommandSource : std::uint8_t;
 
+/// A session's resource-investment state. Written at exactly two points:
+/// session creation (from the policy) and Compiler::escalate (the
+/// triggers). Everything else derives routing from readiness, not from
+/// this flag.
+enum class ServingMode : std::uint8_t {
+    /// No PCH/AST investment: the session is served from the index.
+    IndexOnly,
+    /// PCH/AST investment is on; the index still answers while a compile
+    /// is in flight.
+    Escalated,
+};
+
 /// The publishable products of the most recent compilation (materialized
 /// whole-document feature results). The data lives here; the compiler's
 /// on_output signal only wakes the push path up — a missed signal is
@@ -84,6 +96,16 @@ struct Session {
     /// the cut one document burns slot after slot until the whole pool is
     /// dead. All transitions go through the type; see quarantine.h.
     Quarantine quarantine;
+
+    /// See ServingMode for the write discipline. Escalated is the
+    /// default so a session constructed outside the didOpen path (tests,
+    /// fixtures) behaves like the pre-policy server.
+    ServingMode serving = ServingMode::Escalated;
+
+    /// Set when an index projection answered a request for this session;
+    /// the compile-output push path reads it to tell clients to re-pull
+    /// what the AST now answers better (semantic tokens, inlay hints).
+    bool index_served = false;
 
     /// Whether the AST needs to be rebuilt before serving queries.
     bool ast_dirty = true;

--- a/src/server/state/session.h
+++ b/src/server/state/session.h
@@ -22,7 +22,7 @@ namespace clice {
 enum class CommandSource : std::uint8_t;
 
 /// A session's resource-investment state. Written at exactly two points:
-/// session creation (from the policy) and Compiler::escalate (the
+/// session creation (from the readonly mode) and Compiler::escalate (the
 /// triggers). Everything else derives routing from readiness, not from
 /// this flag.
 enum class ServingMode : std::uint8_t {

--- a/src/server/state/workspace.h
+++ b/src/server/state/workspace.h
@@ -196,8 +196,9 @@ enum class PchBuild : std::uint8_t {
     /// context switch, a restored buffer that diverged from the index)
     /// starts investing; unedited documents serve from the index alone.
     OnEdit,
-    /// Never build a PCH: pure index serving, completion compiles without
-    /// a preamble. The agent / low-resource profile.
+    /// Never build a PCH: reads serve from the index alone, while
+    /// completion and signature help still compile on demand — without a
+    /// preamble. The agent / low-resource profile.
     Never,
 };
 

--- a/src/server/state/workspace.h
+++ b/src/server/state/workspace.h
@@ -184,22 +184,25 @@ struct PCMState {
     DepsSnapshot deps;
 };
 
-/// What event triggers PCH/AST investment in an open file — the parsed
-/// form of the `pch_build` config option. Routing is not governed by
-/// this: every request is answered by the best source available at that
-/// moment (see FeatureRouter); the policy only decides when the expensive
-/// sources get built.
-enum class PchBuild : std::uint8_t {
-    /// didOpen compiles eagerly; the index serves until the AST lands.
-    OnOpen,
-    /// Only an escalation trigger (edit, completion, signature help, a
-    /// context switch, a restored buffer that diverged from the index)
-    /// starts investing; unedited documents serve from the index alone.
-    OnEdit,
-    /// Never build a PCH: reads serve from the index alone, while
-    /// completion and signature help still compile on demand — without a
-    /// preamble. The agent / low-resource profile.
-    Never,
+/// How open files are served — the parsed form of the `readonly` config
+/// option. Routing is not governed by this: every request is answered by
+/// the best source available at that moment (see FeatureRouter); the mode
+/// only decides whether PCH/AST builds are a goal at all. Builds are
+/// always pull-driven — no lifecycle event starts one, the first request
+/// that needs the AST does.
+enum class ReadonlyMode : std::uint8_t {
+    /// Every open file targets a full AST; the index answers while the
+    /// pulled compile is in flight.
+    Off,
+    /// Never build a PCH: reads serve from the index alone (a cold file
+    /// jumps the indexing queue), while completion and signature help
+    /// still compile on demand — without a preamble. The agent /
+    /// low-resource profile.
+    On,
+    /// Files start as On and switch to Off at the first edit intent
+    /// (edit, completion, signature help, a context switch, a restored
+    /// buffer that diverged from the index).
+    Auto,
 };
 
 /// All persistent, project-wide state derived from files on disk.
@@ -231,12 +234,9 @@ struct Workspace {
     CompilationDatabase cdb;
     Toolchain toolchain;
 
-    /// Parsed form of config.project.pch_build, resolved once at server
-    /// initialization; an unknown value warns and falls back to on_open.
-    /// Directly-built Workspaces (unit tests, tools) keep the pre-policy
-    /// behavior through Session's Escalated default, not through this
-    /// field.
-    PchBuild pch_build = PchBuild::OnEdit;
+    /// Parsed form of config.project.readonly, resolved once at server
+    /// initialization; an unknown value warns and falls back to off.
+    ReadonlyMode readonly = ReadonlyMode::Off;
 
     PathPool path_pool;
 

--- a/src/server/state/workspace.h
+++ b/src/server/state/workspace.h
@@ -231,10 +231,11 @@ struct Workspace {
     Toolchain toolchain;
 
     /// Parsed form of config.project.pch_build, resolved once at server
-    /// initialization (an unknown value warns and falls back here). The
-    /// initializer keeps directly-built Workspaces (unit tests, tools) on
-    /// the pre-policy behavior.
-    PchBuild pch_build = PchBuild::OnOpen;
+    /// initialization; an unknown value warns and falls back to on_open.
+    /// Directly-built Workspaces (unit tests, tools) keep the pre-policy
+    /// behavior through Session's Escalated default, not through this
+    /// field.
+    PchBuild pch_build = PchBuild::OnEdit;
 
     PathPool path_pool;
 

--- a/src/server/state/workspace.h
+++ b/src/server/state/workspace.h
@@ -201,7 +201,10 @@ enum class ReadonlyMode : std::uint8_t {
     On,
     /// Files start as On and switch to Off at the first edit intent
     /// (edit, completion, signature help, a context switch, a restored
-    /// buffer that diverged from the index).
+    /// buffer that diverged from the index). A file the index can never
+    /// serve — indexing disabled, or its boost attempt settled without a
+    /// servable shard — falls back to Off rather than answering empty
+    /// forever.
     Auto,
 };
 

--- a/src/server/state/workspace.h
+++ b/src/server/state/workspace.h
@@ -203,6 +203,23 @@ struct PCMState {
 ///   - Initialization  (load_workspace at startup)
 ///   - didSave         (rescan_after_save: rescan disk, cascade invalidation)
 ///   - Background index (merge TUIndex results from stateless workers)
+/// What event triggers PCH/AST investment in an open file — the parsed
+/// form of the `pch_build` config option. Routing is not governed by
+/// this: every request is answered by the best source available at that
+/// moment (see FeatureRouter); the policy only decides when the expensive
+/// sources get built.
+enum class PchBuild : std::uint8_t {
+    /// didOpen compiles eagerly; the index serves until the AST lands.
+    OnOpen,
+    /// Only an escalation trigger (edit, completion, signature help, a
+    /// context switch, a restored buffer that diverged from the index)
+    /// starts investing; unedited documents serve from the index alone.
+    OnEdit,
+    /// Never build a PCH: pure index serving, completion compiles without
+    /// a preamble. The agent / low-resource profile.
+    Never,
+};
+
 struct Workspace {
     /// A default-constructed Config is born valid (every option holds its
     /// real default), so a directly-built Workspace (unit tests, tools)
@@ -212,6 +229,12 @@ struct Workspace {
     Config config;
     CompilationDatabase cdb;
     Toolchain toolchain;
+
+    /// Parsed form of config.project.pch_build, resolved once at server
+    /// initialization (an unknown value warns and falls back here). The
+    /// initializer keeps directly-built Workspaces (unit tests, tools) on
+    /// the pre-policy behavior.
+    PchBuild pch_build = PchBuild::OnOpen;
 
     PathPool path_pool;
 

--- a/src/server/state/workspace.h
+++ b/src/server/state/workspace.h
@@ -184,6 +184,23 @@ struct PCMState {
     DepsSnapshot deps;
 };
 
+/// What event triggers PCH/AST investment in an open file — the parsed
+/// form of the `pch_build` config option. Routing is not governed by
+/// this: every request is answered by the best source available at that
+/// moment (see FeatureRouter); the policy only decides when the expensive
+/// sources get built.
+enum class PchBuild : std::uint8_t {
+    /// didOpen compiles eagerly; the index serves until the AST lands.
+    OnOpen,
+    /// Only an escalation trigger (edit, completion, signature help, a
+    /// context switch, a restored buffer that diverged from the index)
+    /// starts investing; unedited documents serve from the index alone.
+    OnEdit,
+    /// Never build a PCH: pure index serving, completion compiles without
+    /// a preamble. The agent / low-resource profile.
+    Never,
+};
+
 /// All persistent, project-wide state derived from files on disk.
 ///
 /// Design principle: open files are never depended upon by other files.
@@ -203,23 +220,6 @@ struct PCMState {
 ///   - Initialization  (load_workspace at startup)
 ///   - didSave         (rescan_after_save: rescan disk, cascade invalidation)
 ///   - Background index (merge TUIndex results from stateless workers)
-/// What event triggers PCH/AST investment in an open file — the parsed
-/// form of the `pch_build` config option. Routing is not governed by
-/// this: every request is answered by the best source available at that
-/// moment (see FeatureRouter); the policy only decides when the expensive
-/// sources get built.
-enum class PchBuild : std::uint8_t {
-    /// didOpen compiles eagerly; the index serves until the AST lands.
-    OnOpen,
-    /// Only an escalation trigger (edit, completion, signature help, a
-    /// context switch, a restored buffer that diverged from the index)
-    /// starts investing; unedited documents serve from the index alone.
-    OnEdit,
-    /// Never build a PCH: pure index serving, completion compiles without
-    /// a preamble. The agent / low-resource profile.
-    Never,
-};
-
 struct Workspace {
     /// A default-constructed Config is born valid (every option holds its
     /// real default), so a directly-built Workspace (unit tests, tools)

--- a/src/server/transport/lsp_client.cpp
+++ b/src/server/transport/lsp_client.cpp
@@ -53,6 +53,8 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         [this](const std::shared_ptr<Session>& session) { push_output(*session); });
     progress_conn =
         server.indexer.on_progress_changed.connect([this]() { report_index_progress(); });
+    serving_conn =
+        server.indexer.on_serving_rows_changed.connect([this]() { refresh_index_served(); });
 
     // Guidance/anomaly messages travel as window/logMessage, which the LSP
     // spec allows before the initialize handshake — drain what a headless
@@ -820,6 +822,18 @@ void LSPClient::push_output(const Session& session) {
             fire(protocol::InlayHintRefreshParams{});
         }
     }
+}
+
+void LSPClient::refresh_index_served() {
+    if(!client_ready || !semantic_tokens_refresh) {
+        return;
+    }
+    // Same peer lifetime discipline as push_output's fire: the peer
+    // outlives this client, and teardown fails pending requests.
+    server.loop.schedule([](kota::ipc::JsonPeer* peer) -> kota::task<> {
+        co_await peer->send_request(protocol::SemanticTokensRefreshParams{},
+                                    {.timeout = std::chrono::milliseconds(3000)});
+    }(&peer));
 }
 
 void LSPClient::report_index_progress() {

--- a/src/server/transport/lsp_client.cpp
+++ b/src/server/transport/lsp_client.cpp
@@ -620,8 +620,9 @@ void LSPClient::register_extensions() {
                                                                context_path_id,
                                                                params);
             // A context choice asks for the context-pure AST view; the
-            // merged index cannot give it (union rows).
-            if(session) {
+            // merged index cannot give it (union rows). A rejected switch
+            // (stale epoch, bad host) changed no context and owes none.
+            if(result.success) {
                 this->server.compiler.escalate(session);
             }
             co_return to_raw(result);

--- a/src/server/transport/lsp_client.cpp
+++ b/src/server/transport/lsp_client.cpp
@@ -48,6 +48,18 @@ static bool past_shutdown(ServerLifecycle lifecycle) {
     return lifecycle == ServerLifecycle::ShuttingDown || lifecycle == ServerLifecycle::Exited;
 }
 
+/// Fire a workspace refresh request without awaiting the reply. Peer
+/// lifetime discipline as in the progress handshake: the peer outlives the
+/// client, and teardown fails pending requests before run() returns. A
+/// captureless coroutine lambda invoked immediately: parameters are copied
+/// into the frame, captures would dangle.
+template <typename Params>
+static void fire_refresh(kota::event_loop& loop, kota::ipc::JsonPeer& peer, Params params) {
+    loop.schedule([](kota::ipc::JsonPeer* peer, Params request) -> kota::task<> {
+        co_await peer->send_request(request, {.timeout = std::chrono::milliseconds(3000)});
+    }(&peer, std::move(params)));
+}
+
 LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(server), peer(peer) {
     output_conn = server.compiler.on_output.connect(
         [this](const std::shared_ptr<Session>& session) { push_output(*session); });
@@ -112,6 +124,8 @@ void LSPClient::register_lifecycle() {
                 ws_caps.semantic_tokens.has_value() && ws_caps.semantic_tokens->refresh_support;
             inlay_hint_refresh =
                 ws_caps.inlay_hint.has_value() && ws_caps.inlay_hint->refresh_support;
+            folding_range_refresh =
+                ws_caps.folding_range.has_value() && ws_caps.folding_range->refresh_support;
         }
 
         if(init.initialization_options.has_value()) {
@@ -803,38 +817,33 @@ void LSPClient::push_output(const Session& session) {
 
     // The session served index projections while this compile was
     // pending: whole-document results the client already pulled (tokens,
-    // inlay hints) just got better, and only a refresh request makes it
-    // re-pull them. Peer lifetime discipline as in the progress
-    // handshake: the peer outlives this client, and teardown fails
-    // pending requests before run() returns.
+    // folds, inlay hints) just got better, and only a refresh request
+    // makes it re-pull them.
     if(session.index_served && output.version.has_value()) {
-        auto fire = [this](auto params) {
-            // Captureless coroutine lambda invoked immediately: parameters
-            // are copied into the frame, captures would dangle.
-            server.loop.schedule([](kota::ipc::JsonPeer* peer,
-                                    decltype(params) request) -> kota::task<> {
-                co_await peer->send_request(request, {.timeout = std::chrono::milliseconds(3000)});
-            }(&peer, params));
-        };
         if(semantic_tokens_refresh) {
-            fire(protocol::SemanticTokensRefreshParams{});
+            fire_refresh(server.loop, peer, protocol::SemanticTokensRefreshParams{});
         }
         if(inlay_hint_refresh) {
-            fire(protocol::InlayHintRefreshParams{});
+            fire_refresh(server.loop, peer, protocol::InlayHintRefreshParams{});
+        }
+        if(folding_range_refresh) {
+            fire_refresh(server.loop, peer, protocol::FoldingRangeRefreshParams{});
         }
     }
 }
 
 void LSPClient::refresh_index_served() {
-    if(!client_ready || !semantic_tokens_refresh) {
+    if(!client_ready) {
         return;
     }
-    // Same peer lifetime discipline as push_output's fire: the peer
-    // outlives this client, and teardown fails pending requests.
-    server.loop.schedule([](kota::ipc::JsonPeer* peer) -> kota::task<> {
-        co_await peer->send_request(protocol::SemanticTokensRefreshParams{},
-                                    {.timeout = std::chrono::milliseconds(3000)});
-    }(&peer));
+    // Inlay hints stay out: index projections never produce them, so a
+    // background merge cannot have changed what the client holds.
+    if(semantic_tokens_refresh) {
+        fire_refresh(server.loop, peer, protocol::SemanticTokensRefreshParams{});
+    }
+    if(folding_range_refresh) {
+        fire_refresh(server.loop, peer, protocol::FoldingRangeRefreshParams{});
+    }
 }
 
 void LSPClient::report_index_progress() {

--- a/src/server/transport/lsp_client.cpp
+++ b/src/server/transport/lsp_client.cpp
@@ -104,6 +104,14 @@ void LSPClient::register_lifecycle() {
             path::canonicalize(srv.workspace_root);
         }
 
+        if(init.capabilities.workspace.has_value()) {
+            auto& ws_caps = *init.capabilities.workspace;
+            semantic_tokens_refresh =
+                ws_caps.semantic_tokens.has_value() && ws_caps.semantic_tokens->refresh_support;
+            inlay_hint_refresh =
+                ws_caps.inlay_hint.has_value() && ws_caps.inlay_hint->refresh_support;
+        }
+
         if(init.initialization_options.has_value()) {
             auto json =
                 kota::codec::json::to_string<kota::ipc::lsp_config>(*init.initialization_options);
@@ -258,6 +266,7 @@ void LSPClient::register_document_sync() {
         srv.contexts.validate_saved_context(*session);
 
         srv.dispatch(FileEvent::buffer_opened(path_id));
+        srv.settle_open_serving(session);
 
         LOG_DEBUG("didOpen: {} (v{})", path, params.text_document.version);
     });
@@ -290,6 +299,10 @@ void LSPClient::register_document_sync() {
         // the supersede: with no follow-up request the stale parse (or its
         // dependency prep) would run to completion and hold up its waiters.
         srv.compiler.abandon_superseded(*session);
+
+        // Editing is the canonical escalation trigger: from here on the
+        // session invests in PCH/AST.
+        srv.compiler.escalate(session);
 
         srv.dispatch(FileEvent::buffer_edited(path_id));
 
@@ -604,6 +617,11 @@ void LSPClient::register_extensions() {
                                                                context_path,
                                                                context_path_id,
                                                                params);
+            // A context choice asks for the context-pure AST view; the
+            // merged index cannot give it (union rows).
+            if(session) {
+                this->server.compiler.escalate(session);
+            }
             co_return to_raw(result);
         });
 
@@ -778,6 +796,29 @@ void LSPClient::push_output(const Session& session) {
         regions.uri = uri_str;
         regions.regions = format_inactive_regions(session, output);
         peer.send_notification("clice/inactiveRegions", regions);
+    }
+
+    // The session served index projections while this compile was
+    // pending: whole-document results the client already pulled (tokens,
+    // inlay hints) just got better, and only a refresh request makes it
+    // re-pull them. Peer lifetime discipline as in the progress
+    // handshake: the peer outlives this client, and teardown fails
+    // pending requests before run() returns.
+    if(session.index_served && output.version.has_value()) {
+        auto fire = [this](auto params) {
+            // Captureless coroutine lambda invoked immediately: parameters
+            // are copied into the frame, captures would dangle.
+            server.loop.schedule([](kota::ipc::JsonPeer* peer,
+                                    decltype(params) request) -> kota::task<> {
+                co_await peer->send_request(request, {.timeout = std::chrono::milliseconds(3000)});
+            }(&peer, params));
+        };
+        if(semantic_tokens_refresh) {
+            fire(protocol::SemanticTokensRefreshParams{});
+        }
+        if(inlay_hint_refresh) {
+            fire(protocol::InlayHintRefreshParams{});
+        }
     }
 }
 

--- a/src/server/transport/lsp_client.cpp
+++ b/src/server/transport/lsp_client.cpp
@@ -318,7 +318,7 @@ void LSPClient::register_document_sync() {
 
         // Editing is the canonical escalation trigger: from here on the
         // session invests in PCH/AST.
-        srv.compiler.escalate(session);
+        srv.compiler.escalate(*session);
 
         srv.dispatch(FileEvent::buffer_edited(path_id));
 
@@ -637,7 +637,7 @@ void LSPClient::register_extensions() {
             // merged index cannot give it (union rows). A rejected switch
             // (stale epoch, bad host) changed no context and owes none.
             if(result.success) {
-                this->server.compiler.escalate(session);
+                this->server.compiler.escalate(*session);
             }
             co_return to_raw(result);
         });

--- a/src/server/transport/lsp_client.h
+++ b/src/server/transport/lsp_client.h
@@ -58,9 +58,10 @@ private:
     /// background indexer's on_progress_changed signal.
     void report_index_progress();
 
-    /// Ask the client to re-pull semantic tokens after a background merge
-    /// replaced rows an index-served session was serving. Invoked by the
-    /// indexer's on_serving_rows_changed signal; capability-gated.
+    /// Ask the client to re-pull semantic tokens and folding ranges after
+    /// a background merge replaced rows an index-served session was
+    /// serving. Invoked by the indexer's on_serving_rows_changed signal;
+    /// capability-gated.
     void refresh_index_served();
 
     /// Send every not-yet-forwarded notify-log message as
@@ -79,11 +80,13 @@ private:
     /// initialized handler from the sessions' materialized output state.
     bool client_ready = false;
 
-    /// Whether the client accepts workspace/semanticTokens/refresh and
-    /// workspace/inlayHint/refresh — the upgrade signal after an
-    /// index-served session's compile lands (see push_output).
+    /// Whether the client accepts workspace/semanticTokens/refresh,
+    /// workspace/inlayHint/refresh and workspace/foldingRange/refresh —
+    /// the upgrade signal after an index-served session's compile lands
+    /// (see push_output).
     bool semantic_tokens_refresh = false;
     bool inlay_hint_refresh = false;
+    bool folding_range_refresh = false;
 
     /// Subscription to compile outputs; disconnects on destruction.
     Signal<std::shared_ptr<Session>>::Connection output_conn;

--- a/src/server/transport/lsp_client.h
+++ b/src/server/transport/lsp_client.h
@@ -58,6 +58,11 @@ private:
     /// background indexer's on_progress_changed signal.
     void report_index_progress();
 
+    /// Ask the client to re-pull semantic tokens after a background merge
+    /// replaced rows an index-served session was serving. Invoked by the
+    /// indexer's on_serving_rows_changed signal; capability-gated.
+    void refresh_index_served();
+
     /// Send every not-yet-forwarded notify-log message as
     /// window/logMessage, advancing notify_cursor. Invoked once from the
     /// constructor (a headless server may have accumulated messages) and
@@ -85,6 +90,10 @@ private:
 
     /// Subscription to background-index progress; disconnects on destruction.
     Signal<>::Connection progress_conn;
+
+    /// Subscription to serving-row replacements by background merges;
+    /// disconnects on destruction.
+    Signal<>::Connection serving_conn;
 
     /// Subscription to guidance/anomaly message wake-ups; disconnects on
     /// destruction.

--- a/src/server/transport/lsp_client.h
+++ b/src/server/transport/lsp_client.h
@@ -74,6 +74,12 @@ private:
     /// initialized handler from the sessions' materialized output state.
     bool client_ready = false;
 
+    /// Whether the client accepts workspace/semanticTokens/refresh and
+    /// workspace/inlayHint/refresh — the upgrade signal after an
+    /// index-served session's compile lands (see push_output).
+    bool semantic_tokens_refresh = false;
+    bool inlay_hint_refresh = false;
+
     /// Subscription to compile outputs; disconnects on destruction.
     Signal<std::shared_ptr<Session>>::Connection output_conn;
 

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -107,22 +107,6 @@ void MasterServer::initialize() {
         workspace.pch_build = PchBuild::OnOpen;
     }
 
-    // A didOpen racing ahead of the handshake created its session under
-    // the default policy; the configured one governs from here. Re-derive
-    // and settle those sessions now (a compile kicked before workers are
-    // up degrades to a dirty session the first request recompiles).
-    llvm::SmallVector<std::uint32_t> early_sessions;
-    sessions.for_each([&](std::uint32_t path_id, const Session&) {
-        early_sessions.push_back(path_id);
-        return true;
-    });
-    for(auto path_id: early_sessions) {
-        auto session = sessions.find(path_id);
-        session->serving = workspace.pch_build == PchBuild::OnOpen ? ServingMode::Escalated
-                                                                   : ServingMode::IndexOnly;
-        settle_open_serving(std::move(session));
-    }
-
     if(!cfg.logging_dir.empty()) {
         auto now = std::chrono::system_clock::now();
         auto pid = llvm::sys::Process::getProcessId();
@@ -179,11 +163,19 @@ void MasterServer::initialize() {
     load_workspace();
 
     // Documents opened before the server became ready were validated
-    // against an empty resolver; re-check their persisted context choices
-    // now that the workspace cache is loaded.
+    // against an empty resolver and created under the default policy;
+    // re-check their persisted context choices and re-derive their
+    // serving mode now that the configuration governs. Settlement waits
+    // until here — after load_workspace — so divergence detection sees
+    // the persisted shards it just loaded (a restored unsaved buffer must
+    // escalate, not read as merely unindexed) and any compile it kicks
+    // lands on a started worker pool.
     for(auto& [path_id, session]: sessions.sessions) {
         if(session) {
             contexts.validate_saved_context(*session);
+            session->serving = workspace.pch_build == PchBuild::OnOpen ? ServingMode::Escalated
+                                                                       : ServingMode::IndexOnly;
+            settle_open_serving(session);
         }
     }
 
@@ -303,8 +295,13 @@ void MasterServer::settle_open_serving(std::shared_ptr<Session> session) {
         return;
     }
     // Nothing indexed yet: reading this file is the reason to index it
-    // first.
-    indexer.boost(session->path_id);
+    // first — unless indexing is disabled, in which case no shard will
+    // ever arrive and only an AST can serve the document.
+    if(workspace.config.project.enable_indexing.value) {
+        indexer.boost(session->path_id);
+    } else {
+        compiler.escalate(std::move(session));
+    }
 }
 
 void MasterServer::close_session(std::uint32_t path_id) {

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -96,6 +96,17 @@ void MasterServer::initialize() {
 
     auto& cfg = workspace.config.project;
 
+    if(cfg.pch_build == "on_edit") {
+        workspace.pch_build = PchBuild::OnEdit;
+    } else if(cfg.pch_build == "never") {
+        workspace.pch_build = PchBuild::Never;
+    } else {
+        if(cfg.pch_build != "on_open") {
+            LOG_WARN("Unknown pch_build '{}'; using on_open", std::string(cfg.pch_build));
+        }
+        workspace.pch_build = PchBuild::OnOpen;
+    }
+
     if(!cfg.logging_dir.empty()) {
         auto now = std::chrono::system_clock::now();
         auto pid = llvm::sys::Process::getProcessId();
@@ -250,7 +261,34 @@ std::shared_ptr<Session> MasterServer::find_session(std::uint32_t path_id) {
 }
 
 std::shared_ptr<Session> MasterServer::open_session(std::uint32_t path_id) {
-    return sessions.open(path_id);
+    auto session = sessions.open(path_id);
+    // The serving mode's creation write point; the only other write is
+    // Compiler::escalate.
+    session->serving =
+        workspace.pch_build == PchBuild::OnOpen ? ServingMode::Escalated : ServingMode::IndexOnly;
+    return session;
+}
+
+void MasterServer::settle_open_serving(std::shared_ptr<Session> session) {
+    // on_open invests immediately; the index still answers until the
+    // compile lands.
+    if(session->serving == ServingMode::Escalated) {
+        compiler.request_compile(std::move(session));
+        return;
+    }
+    auto it = workspace.shards.find(session->path_id);
+    if(it != workspace.shards.end()) {
+        // A buffer that already diverges from the indexed content (a
+        // restored unsaved file) can never be served read-only: escalate
+        // now instead of answering empty until the first edit.
+        if(!it->second.matches_content(session->text)) {
+            compiler.escalate(std::move(session));
+        }
+        return;
+    }
+    // Nothing indexed yet: reading this file is the reason to index it
+    // first.
+    indexer.boost(session->path_id);
 }
 
 void MasterServer::close_session(std::uint32_t path_id) {

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -37,7 +37,7 @@ MasterServer::MasterServer(kota::event_loop& loop, std::string self_path) :
     loop(loop), pool(loop), contexts(workspace), compiler(loop, workspace, contexts, pool),
     indexer(loop, workspace, pool, contexts, sessions), index_query(workspace, sessions, indexer),
     agent_query(workspace, sessions, indexer, {.disk_only = true}),
-    features(compiler, index_query, workspace, contexts, indexer),
+    features(compiler, index_query, workspace, contexts, indexer, sessions),
     invalidator(workspace, sessions, contexts), bg_tasks(loop), self_path(std::move(self_path)) {
     // The notify hook is process-wide because the logging layer cannot
     // depend on the server; the composition root owns it for the server's

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -96,15 +96,15 @@ void MasterServer::initialize() {
 
     auto& cfg = workspace.config.project;
 
-    if(cfg.pch_build == "on_edit") {
-        workspace.pch_build = PchBuild::OnEdit;
-    } else if(cfg.pch_build == "never") {
-        workspace.pch_build = PchBuild::Never;
+    if(cfg.readonly == "on") {
+        workspace.readonly = ReadonlyMode::On;
+    } else if(cfg.readonly == "auto") {
+        workspace.readonly = ReadonlyMode::Auto;
     } else {
-        if(cfg.pch_build != "on_open") {
-            LOG_WARN("Unknown pch_build '{}'; using on_open", std::string(cfg.pch_build));
+        if(cfg.readonly != "off") {
+            LOG_WARN("Unknown readonly '{}'; using off", std::string(cfg.readonly));
         }
-        workspace.pch_build = PchBuild::OnOpen;
+        workspace.readonly = ReadonlyMode::Off;
     }
 
     if(!cfg.logging_dir.empty()) {
@@ -163,17 +163,16 @@ void MasterServer::initialize() {
     load_workspace();
 
     // Documents opened before the server became ready were validated
-    // against an empty resolver and created under the default policy;
+    // against an empty resolver and created under the default mode;
     // re-check their persisted context choices and re-derive their
     // serving mode now that the configuration governs. Settlement waits
     // until here — after load_workspace — so divergence detection sees
     // the persisted shards it just loaded (a restored unsaved buffer must
-    // escalate, not read as merely unindexed) and any compile it kicks
-    // lands on a started worker pool.
+    // escalate, not read as merely unindexed).
     for(auto& [path_id, session]: sessions.sessions) {
         if(session) {
             contexts.validate_saved_context(*session);
-            session->serving = workspace.pch_build == PchBuild::OnOpen ? ServingMode::Escalated
+            session->serving = workspace.readonly == ReadonlyMode::Off ? ServingMode::Escalated
                                                                        : ServingMode::IndexOnly;
             settle_open_serving(session);
         }
@@ -264,7 +263,7 @@ void MasterServer::wire() {
     // session answers empty until its first edit.
     indexer.on_session_unservable = [this](std::uint32_t path_id) {
         if(auto session = sessions.find(path_id)) {
-            compiler.escalate(std::move(session));
+            compiler.escalate(*session);
         }
     };
 }
@@ -283,15 +282,15 @@ std::shared_ptr<Session> MasterServer::open_session(std::uint32_t path_id) {
     // The serving mode's creation write point; the only other write is
     // Compiler::escalate.
     session->serving =
-        workspace.pch_build == PchBuild::OnOpen ? ServingMode::Escalated : ServingMode::IndexOnly;
+        workspace.readonly == ReadonlyMode::Off ? ServingMode::Escalated : ServingMode::IndexOnly;
     return session;
 }
 
 void MasterServer::settle_open_serving(std::shared_ptr<Session> session) {
-    // on_open invests immediately; the index still answers until the
-    // compile lands.
+    // An escalated session needs no settlement: builds stay pull-driven,
+    // and boosting its file would enqueue work the indexer skips for
+    // open non-IndexOnly documents.
     if(session->serving == ServingMode::Escalated) {
-        compiler.request_compile(std::move(session));
         return;
     }
     auto it = workspace.shards.find(session->path_id);
@@ -300,7 +299,7 @@ void MasterServer::settle_open_serving(std::shared_ptr<Session> session) {
         // restored unsaved file) can never be served read-only: escalate
         // now instead of answering empty until the first edit.
         if(!it->second.matches_content(session->text)) {
-            compiler.escalate(std::move(session));
+            compiler.escalate(*session);
         }
         return;
     }
@@ -311,7 +310,7 @@ void MasterServer::settle_open_serving(std::shared_ptr<Session> session) {
     if(workspace.config.project.enable_indexing.value) {
         indexer.boost(session->path_id);
     } else {
-        compiler.escalate(std::move(session));
+        compiler.escalate(*session);
     }
 }
 

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -257,6 +257,16 @@ void MasterServer::wire() {
     compiler.on_stale = [this](std::uint32_t path_id) {
         dispatch(FileEvent::disk_changed(path_id));
     };
+
+    // The boost in settle_open_serving promised the index would serve the
+    // cold session; an attempt that settles without a servable shard ends
+    // that promise — escalate like the disabled-indexing branch, or the
+    // session answers empty until its first edit.
+    indexer.on_session_unservable = [this](std::uint32_t path_id) {
+        if(auto session = sessions.find(path_id)) {
+            compiler.escalate(std::move(session));
+        }
+    };
 }
 
 void MasterServer::initialize(llvm::StringRef root) {
@@ -296,7 +306,8 @@ void MasterServer::settle_open_serving(std::shared_ptr<Session> session) {
     }
     // Nothing indexed yet: reading this file is the reason to index it
     // first — unless indexing is disabled, in which case no shard will
-    // ever arrive and only an AST can serve the document.
+    // ever arrive and only an AST can serve the document. A boost the
+    // indexer cannot fulfill escalates through on_session_unservable.
     if(workspace.config.project.enable_indexing.value) {
         indexer.boost(session->path_id);
     } else {

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -107,6 +107,22 @@ void MasterServer::initialize() {
         workspace.pch_build = PchBuild::OnOpen;
     }
 
+    // A didOpen racing ahead of the handshake created its session under
+    // the default policy; the configured one governs from here. Re-derive
+    // and settle those sessions now (a compile kicked before workers are
+    // up degrades to a dirty session the first request recompiles).
+    llvm::SmallVector<std::uint32_t> early_sessions;
+    sessions.for_each([&](std::uint32_t path_id, const Session&) {
+        early_sessions.push_back(path_id);
+        return true;
+    });
+    for(auto path_id: early_sessions) {
+        auto session = sessions.find(path_id);
+        session->serving = workspace.pch_build == PchBuild::OnOpen ? ServingMode::Escalated
+                                                                   : ServingMode::IndexOnly;
+        settle_open_serving(std::move(session));
+    }
+
     if(!cfg.logging_dir.empty()) {
         auto now = std::chrono::system_clock::now();
         auto pid = llvm::sys::Process::getProcessId();

--- a/src/server/transport/master_server.h
+++ b/src/server/transport/master_server.h
@@ -104,6 +104,11 @@ public:
     std::shared_ptr<Session> find_session(std::uint32_t path_id);
     std::shared_ptr<Session> open_session(std::uint32_t path_id);
 
+    /// Apply the serving policy to a freshly opened buffer: kick the
+    /// eager compile (on_open), escalate a diverged restored buffer, or
+    /// boost the file's background indexing when nothing can serve it.
+    void settle_open_serving(std::shared_ptr<Session> session);
+
     /// Close the session. The diagnostics clear travels through the
     /// session's output + on_output signal; a transport whose client has
     /// not completed the handshake drops it (nothing was ever pushed, so

--- a/src/server/transport/master_server.h
+++ b/src/server/transport/master_server.h
@@ -104,9 +104,10 @@ public:
     std::shared_ptr<Session> find_session(std::uint32_t path_id);
     std::shared_ptr<Session> open_session(std::uint32_t path_id);
 
-    /// Apply the serving policy to a freshly opened buffer: kick the
-    /// eager compile (on_open), escalate a diverged restored buffer, or
-    /// boost the file's background indexing when nothing can serve it.
+    /// Settle a freshly opened index-only buffer: escalate one that
+    /// already diverged from its shard, or boost the file's background
+    /// indexing when nothing can serve it. Escalated sessions need no
+    /// settlement — builds are pull-driven.
     void settle_open_serving(std::shared_ptr<Session> session);
 
     /// Close the session. The diagnostics clear travels through the

--- a/tests/integration/features/read_only.test.ts
+++ b/tests/integration/features/read_only.test.ts
@@ -12,7 +12,9 @@ const MAIN = [
     '#include "header.h"',
     "",
     "/// Doubles a value.",
-    "int twice(int x) { return add(x, x); }",
+    "int twice(int x) {",
+    "    return add(x, x);",
+    "}",
     "",
     "int main() { return twice(2); }",
     "",
@@ -57,18 +59,18 @@ test("index serves unedited reads", async ({ session }) => {
     const links = await client.documentLinks(uri);
     expect(links?.some((l) => l.target?.endsWith("header.h"))).toBe(true);
 
-    // `add` in `return add(x, x)` on line 3.
-    const hover = await client.hoverAt(uri, 3, 26);
+    // `add` in `return add(x, x)` on line 4.
+    const hover = await client.hoverAt(uri, 4, 11);
     expect(JSON.stringify(hover?.contents ?? "")).toContain("add");
 
-    const defs = (await client.definitionAt(uri, 3, 26)) as proto.Location[] | null;
+    const defs = (await client.definitionAt(uri, 4, 11)) as proto.Location[] | null;
     expect(defs?.length ?? 0).toBeGreaterThan(0);
     expect(defs![0]!.uri.endsWith("header.h")).toBe(true);
 
     // Pinned degradations of the read-only surface.
     const hints = await client.inlayHints(uri, {
         start: { line: 0, character: 0 },
-        end: { line: 6, character: 0 },
+        end: { line: 8, character: 0 },
     });
     expect(hints ?? []).toEqual([]);
     expect(client.diagnostics.has(uri)).toBe(false);
@@ -129,7 +131,7 @@ test("never builds no pch", async ({ session }) => {
     expect(await client.waitForIndex(uri, "twice")).toBe(true);
 
     // Completion still answers — a full parse without a preamble.
-    const completion = await client.completionAt(uri, 5, 22);
+    const completion = await client.completionAt(uri, 7, 22);
     expect(labelsOf(completion)).toContain("twice");
 
     // The whole point of the profile.
@@ -147,7 +149,7 @@ test("escalation upgrades inlay hints", async ({ session }) => {
 
     const range = {
         start: { line: 0, character: 0 },
-        end: { line: 6, character: 0 },
+        end: { line: 8, character: 0 },
     };
     expect((await client.inlayHints(uri, range)) ?? []).toEqual([]);
 

--- a/tests/integration/features/read_only.test.ts
+++ b/tests/integration/features/read_only.test.ts
@@ -1,0 +1,169 @@
+/// The pch_build policy: reads are answered from the index, PCH/AST
+/// investment follows the configured trigger. Each degraded surface the
+/// design pins (empty inlay hints, no diagnostics push before a trigger)
+/// is asserted explicitly.
+
+import * as proto from "vscode-languageserver-protocol";
+import type { Workspace } from "@clice/tools/workspace";
+import { expect, test } from "../fixtures.ts";
+
+const HEADER = "#pragma once\nint add(int a, int b);\n";
+const MAIN = [
+    '#include "header.h"',
+    "",
+    "/// Doubles a value.",
+    "int twice(int x) { return add(x, x); }",
+    "",
+    "int main() { return twice(2); }",
+    "",
+].join("\n");
+
+function writeProject(session: { tmpdir(): Workspace }): Workspace {
+    const ws = session.tmpdir();
+    ws.write("header.h", HEADER);
+    ws.write("main.cpp", MAIN);
+    ws.writeCDB(["main.cpp"]);
+    ws.pinCacheDir();
+    return ws;
+}
+
+const ON_EDIT = { project: { pch_build: "on_edit" } };
+
+function labelsOf(result: proto.CompletionItem[] | proto.CompletionList | null): string[] {
+    if (result === null) {
+        return [];
+    }
+    const items = Array.isArray(result) ? result : result.items;
+    return items.map((item) => item.label);
+}
+
+test("index serves unedited reads", async ({ session }) => {
+    const ws = writeProject(session);
+    const client = session.spawn(ws);
+    await client.initialize(ws, { initializationOptions: ON_EDIT });
+
+    const [uri] = client.open("main.cpp");
+    expect(await client.waitForIndex(uri, "twice")).toBe(true);
+
+    const tokens = await client.semanticTokensFull(uri);
+    expect(tokens?.data.length ?? 0).toBeGreaterThan(0);
+
+    const symbols = (await client.documentSymbols(uri)) as proto.DocumentSymbol[] | null;
+    expect(symbols?.map((s) => s.name)).toContain("twice");
+
+    const folds = await client.foldingRanges(uri);
+    expect(folds?.length ?? 0).toBeGreaterThan(0);
+
+    const links = await client.documentLinks(uri);
+    expect(links?.some((l) => l.target?.endsWith("header.h"))).toBe(true);
+
+    // `add` in `return add(x, x)` on line 3.
+    const hover = await client.hoverAt(uri, 3, 26);
+    expect(JSON.stringify(hover?.contents ?? "")).toContain("add");
+
+    const defs = (await client.definitionAt(uri, 3, 26)) as proto.Location[] | null;
+    expect(defs?.length ?? 0).toBeGreaterThan(0);
+    expect(defs![0]!.uri.endsWith("header.h")).toBe(true);
+
+    // Pinned degradations of the read-only surface.
+    const hints = await client.inlayHints(uri, {
+        start: { line: 0, character: 0 },
+        end: { line: 6, character: 0 },
+    });
+    expect(hints ?? []).toEqual([]);
+    expect(client.diagnostics.has(uri)).toBe(false);
+
+    // Reading never builds a PCH.
+    expect(ws.pchFiles()).toEqual([]);
+});
+
+test("edit escalates to compile", async ({ session }) => {
+    const ws = writeProject(session);
+    const client = session.spawn(ws);
+    await client.initialize(ws, { initializationOptions: ON_EDIT });
+
+    const [uri] = client.open("main.cpp");
+    expect(await client.waitForIndex(uri, "twice")).toBe(true);
+    expect(client.diagnostics.has(uri)).toBe(false);
+
+    // The edit is the trigger: diagnostics arrive without any feature
+    // request pulling the compile.
+    const arrived = client.armDiagnostics(uri);
+    client.change(uri, 2, MAIN + "// edited\n");
+    await arrived;
+    client.assertNoErrors(uri);
+});
+
+test("diverged open buffer escalates", async ({ session }) => {
+    const ws = writeProject(session);
+
+    // Warm the index, then restart: the second server starts with the
+    // shard on disk and nothing compiled.
+    const first = session.spawn(ws);
+    await first.initialize(ws, { initializationOptions: ON_EDIT });
+    const [warm] = first.open("main.cpp");
+    expect(await first.waitForIndex(warm, "twice")).toBe(true);
+    await first.shutdown();
+
+    const second = session.spawn(ws);
+    await second.initialize(ws, { initializationOptions: ON_EDIT });
+
+    // A restored unsaved buffer diverges from the indexed content: the
+    // open itself escalates, diagnostics arrive with no edit and no
+    // feature request.
+    const uri = ws.uri("main.cpp");
+    const arrived = second.armDiagnostics(uri);
+    second.open("main.cpp", 0, { text: MAIN + "// restored, unsaved\n" });
+    await arrived;
+    second.assertNoErrors(uri);
+});
+
+test("never builds no pch", async ({ session }) => {
+    const ws = writeProject(session);
+    const client = session.spawn(ws);
+    await client.initialize(ws, {
+        initializationOptions: { project: { pch_build: "never" } },
+    });
+
+    const [uri] = client.open("main.cpp");
+    expect(await client.waitForIndex(uri, "twice")).toBe(true);
+
+    // Completion still answers — a full parse without a preamble.
+    const completion = await client.completionAt(uri, 5, 22);
+    expect(labelsOf(completion)).toContain("twice");
+
+    // The whole point of the profile.
+    expect(ws.pchFiles()).toEqual([]);
+    expect(client.diagnostics.has(uri)).toBe(false);
+});
+
+test("on_open compiles eagerly", async ({ session }) => {
+    const ws = writeProject(session);
+    const client = session.spawn(ws);
+    await client.initialize(ws);
+
+    // No feature request at all: didOpen itself starts the compile.
+    const uri = ws.uri("main.cpp");
+    const arrived = client.armDiagnostics(uri);
+    client.open("main.cpp");
+    await arrived;
+    client.assertNoErrors(uri);
+});
+
+test("index answers while eager compile runs", async ({ session }) => {
+    const ws = writeProject(session);
+
+    const first = session.spawn(ws);
+    await first.initialize(ws, { initializationOptions: ON_EDIT });
+    const [warm] = first.open("main.cpp");
+    expect(await first.waitForIndex(warm, "twice")).toBe(true);
+    await first.shutdown();
+
+    // Default on_open: the compile is kicked at didOpen, but the very
+    // first request must not wait for it — the warm shard answers.
+    const second = session.spawn(ws);
+    await second.initialize(ws);
+    const [uri] = second.open("main.cpp");
+    const symbols = (await second.documentSymbols(uri)) as proto.DocumentSymbol[] | null;
+    expect(symbols?.map((s) => s.name)).toContain("twice");
+});

--- a/tests/integration/features/read_only.test.ts
+++ b/tests/integration/features/read_only.test.ts
@@ -137,10 +137,12 @@ test("never builds no pch", async ({ session }) => {
     expect(client.diagnostics.has(uri)).toBe(false);
 });
 
+const ON_OPEN = { project: { pch_build: "on_open" } };
+
 test("on_open compiles eagerly", async ({ session }) => {
     const ws = writeProject(session);
     const client = session.spawn(ws);
-    await client.initialize(ws);
+    await client.initialize(ws, { initializationOptions: ON_OPEN });
 
     // No feature request at all: didOpen itself starts the compile.
     const uri = ws.uri("main.cpp");
@@ -159,10 +161,10 @@ test("index answers while eager compile runs", async ({ session }) => {
     expect(await first.waitForIndex(warm, "twice")).toBe(true);
     await first.shutdown();
 
-    // Default on_open: the compile is kicked at didOpen, but the very
-    // first request must not wait for it — the warm shard answers.
+    // on_open: the compile is kicked at didOpen, but the very first
+    // request must not wait for it — the warm shard answers.
     const second = session.spawn(ws);
-    await second.initialize(ws);
+    await second.initialize(ws, { initializationOptions: ON_OPEN });
     const [uri] = second.open("main.cpp");
     const symbols = (await second.documentSymbols(uri)) as proto.DocumentSymbol[] | null;
     expect(symbols?.map((s) => s.name)).toContain("twice");

--- a/tests/integration/features/read_only.test.ts
+++ b/tests/integration/features/read_only.test.ts
@@ -79,6 +79,24 @@ test("index serves unedited reads", async ({ session }) => {
     expect(ws.pchFiles()).toEqual([]);
 });
 
+test("cold outline awaits the boost", async ({ session }) => {
+    const ws = writeProject(session);
+    const client = session.spawn(ws);
+    await client.initialize(ws, { initializationOptions: ON_EDIT });
+
+    // No waitForIndex: outline and links have no refresh request, so the
+    // replies themselves await the didOpen boost instead of freezing an
+    // empty result in the client's cache.
+    const [uri] = client.open("main.cpp");
+    const [symbolsRaw, links] = await Promise.all([
+        client.documentSymbols(uri),
+        client.documentLinks(uri),
+    ]);
+    const symbols = symbolsRaw as proto.DocumentSymbol[] | null;
+    expect(symbols?.map((s) => s.name)).toContain("twice");
+    expect(links?.some((l) => l.target?.endsWith("header.h"))).toBe(true);
+});
+
 test("edit escalates to compile", async ({ session }) => {
     const ws = writeProject(session);
     const client = session.spawn(ws);
@@ -141,6 +159,25 @@ test("unservable boost escalates", async ({ session }) => {
     client.open("scratch.cpp", 0, { text: "int scratch() { return 2; }\n" });
     await scratchArrived;
     client.assertNoErrors(ws.uri("scratch.cpp"));
+});
+
+test("explicit -x beats the suffix", async ({ session }) => {
+    const ws = session.tmpdir();
+    // C++ code behind a C suffix, forced by the CDB's -x: the index
+    // projection must lex with the forced dialect — under the C keyword
+    // table `class` would go unpainted and the first token would start at
+    // `Widget` instead.
+    ws.write("legacy.c", "class Widget { public: int value; };\n");
+    ws.writeCDB(["legacy.c"], { extraArgs: ["-x", "c++"] });
+    ws.pinCacheDir();
+    const client = session.spawn(ws);
+    await client.initialize(ws, { initializationOptions: ON_EDIT });
+
+    const [uri] = client.open("legacy.c");
+    expect(await client.waitForIndex(uri, "Widget")).toBe(true);
+    const tokens = await client.semanticTokensFull(uri);
+    expect(tokens?.data.slice(0, 2)).toEqual([0, 0]);
+    expect(ws.pchFiles()).toEqual([]);
 });
 
 test("never builds no pch", async ({ session }) => {

--- a/tests/integration/features/read_only.test.ts
+++ b/tests/integration/features/read_only.test.ts
@@ -120,6 +120,29 @@ test("diverged open buffer escalates", async ({ session }) => {
     second.assertNoErrors(uri);
 });
 
+test("unservable boost escalates", async ({ session }) => {
+    const ws = writeProject(session);
+    // orphan.cpp is on disk but outside the CDB with no includer, so
+    // indexing refuses the guessed command; scratch.cpp has a CDB entry
+    // but exists only as the didOpen buffer, and indexing reads disk
+    // truth. Neither boost can deliver a shard: the failed attempt
+    // escalates, and diagnostics arrive with no edit.
+    ws.write("orphan.cpp", "int orphan() { return 1; }\n");
+    ws.writeCDB(["main.cpp", "scratch.cpp"]);
+    const client = session.spawn(ws);
+    await client.initialize(ws, { initializationOptions: ON_EDIT });
+
+    const orphanArrived = client.armDiagnostics(ws.uri("orphan.cpp"));
+    client.open("orphan.cpp");
+    await orphanArrived;
+    client.assertNoErrors(ws.uri("orphan.cpp"));
+
+    const scratchArrived = client.armDiagnostics(ws.uri("scratch.cpp"));
+    client.open("scratch.cpp", 0, { text: "int scratch() { return 2; }\n" });
+    await scratchArrived;
+    client.assertNoErrors(ws.uri("scratch.cpp"));
+});
+
 test("never builds no pch", async ({ session }) => {
     const ws = writeProject(session);
     const client = session.spawn(ws);

--- a/tests/integration/features/read_only.test.ts
+++ b/tests/integration/features/read_only.test.ts
@@ -1,9 +1,10 @@
-/// The pch_build policy: reads are answered from the index, PCH/AST
-/// investment follows the configured trigger. Each degraded surface the
-/// design pins (empty inlay hints, no diagnostics push before a trigger)
-/// is asserted explicitly.
+/// The readonly serving modes: reads are answered from the index while
+/// PCH/AST builds stay pull-driven — the mode only decides whether they
+/// are a goal at all. Each degraded surface the design pins (empty inlay
+/// hints, no diagnostics push before a pull) is asserted explicitly.
 
 import * as proto from "vscode-languageserver-protocol";
+import { SETTLE_TIME, sleep } from "@clice/tools/client";
 import type { Workspace } from "@clice/tools/workspace";
 import { expect, test } from "../fixtures.ts";
 
@@ -29,7 +30,7 @@ function writeProject(session: { tmpdir(): Workspace }): Workspace {
     return ws;
 }
 
-const ON_EDIT = { project: { pch_build: "on_edit" } };
+const AUTO = { project: { readonly: "auto" } };
 
 function labelsOf(result: proto.CompletionItem[] | proto.CompletionList | null): string[] {
     if (result === null) {
@@ -42,7 +43,7 @@ function labelsOf(result: proto.CompletionItem[] | proto.CompletionList | null):
 test("index serves unedited reads", async ({ session }) => {
     const ws = writeProject(session);
     const client = session.spawn(ws);
-    await client.initialize(ws, { initializationOptions: ON_EDIT });
+    await client.initialize(ws, { initializationOptions: AUTO });
 
     const [uri] = client.open("main.cpp");
     expect(await client.waitForIndex(uri, "twice")).toBe(true);
@@ -89,7 +90,7 @@ test("oversized buffer keeps row answers", async ({ session }) => {
     ws.writeCDB(["main.cpp"]);
     ws.pinCacheDir();
     const client = session.spawn(ws);
-    await client.initialize(ws, { initializationOptions: ON_EDIT });
+    await client.initialize(ws, { initializationOptions: AUTO });
 
     const [uri] = client.open("main.cpp");
     expect(await client.waitForIndex(uri, "twice")).toBe(true);
@@ -112,7 +113,7 @@ test("oversized buffer keeps row answers", async ({ session }) => {
 test("cold outline awaits the boost", async ({ session }) => {
     const ws = writeProject(session);
     const client = session.spawn(ws);
-    await client.initialize(ws, { initializationOptions: ON_EDIT });
+    await client.initialize(ws, { initializationOptions: AUTO });
 
     // No waitForIndex: outline and links have no refresh request, so the
     // replies themselves await the didOpen boost instead of freezing an
@@ -130,16 +131,18 @@ test("cold outline awaits the boost", async ({ session }) => {
 test("edit escalates to compile", async ({ session }) => {
     const ws = writeProject(session);
     const client = session.spawn(ws);
-    await client.initialize(ws, { initializationOptions: ON_EDIT });
+    await client.initialize(ws, { initializationOptions: AUTO });
 
     const [uri] = client.open("main.cpp");
     expect(await client.waitForIndex(uri, "twice")).toBe(true);
     expect(client.diagnostics.has(uri)).toBe(false);
 
-    // The edit is the trigger: diagnostics arrive without any feature
-    // request pulling the compile.
+    // The edit flips the mode; the build itself stays pull-driven, so
+    // diagnostics ride the next read instead of the edit.
     const arrived = client.armDiagnostics(uri);
     client.change(uri, 2, MAIN + "// edited\n");
+    const hover = await client.hoverAt(uri, 4, 11);
+    expect(JSON.stringify(hover?.contents ?? "")).toContain("add");
     await arrived;
     client.assertNoErrors(uri);
 });
@@ -150,20 +153,22 @@ test("diverged open buffer escalates", async ({ session }) => {
     // Warm the index, then restart: the second server starts with the
     // shard on disk and nothing compiled.
     const first = session.spawn(ws);
-    await first.initialize(ws, { initializationOptions: ON_EDIT });
+    await first.initialize(ws, { initializationOptions: AUTO });
     const [warm] = first.open("main.cpp");
     expect(await first.waitForIndex(warm, "twice")).toBe(true);
     await first.shutdown();
 
     const second = session.spawn(ws);
-    await second.initialize(ws, { initializationOptions: ON_EDIT });
+    await second.initialize(ws, { initializationOptions: AUTO });
 
     // A restored unsaved buffer diverges from the indexed content: the
-    // open itself escalates, diagnostics arrive with no edit and no
-    // feature request.
+    // open itself escalates, so the first read pulls a compile instead
+    // of answering empty from a withdrawn shard.
     const uri = ws.uri("main.cpp");
     const arrived = second.armDiagnostics(uri);
     second.open("main.cpp", 0, { text: MAIN + "// restored, unsaved\n" });
+    const symbols = (await second.documentSymbols(uri)) as proto.DocumentSymbol[] | null;
+    expect(symbols?.map((s) => s.name)).toContain("twice");
     await arrived;
     second.assertNoErrors(uri);
 });
@@ -174,21 +179,25 @@ test("unservable boost escalates", async ({ session }) => {
     // indexing refuses the guessed command; scratch.cpp has a CDB entry
     // but exists only as the didOpen buffer, and indexing reads disk
     // truth. Neither boost can deliver a shard: the failed attempt
-    // escalates, and diagnostics arrive with no edit.
+    // escalates, and the parked outline re-routes to a pulled compile.
     ws.write("orphan.cpp", "int orphan() { return 1; }\n");
     ws.writeCDB(["main.cpp", "scratch.cpp"]);
     const client = session.spawn(ws);
-    await client.initialize(ws, { initializationOptions: ON_EDIT });
+    await client.initialize(ws, { initializationOptions: AUTO });
 
     const orphanArrived = client.armDiagnostics(ws.uri("orphan.cpp"));
-    client.open("orphan.cpp");
+    const [orphanUri] = client.open("orphan.cpp");
+    const orphan = (await client.documentSymbols(orphanUri)) as proto.DocumentSymbol[] | null;
+    expect(orphan?.map((s) => s.name)).toContain("orphan");
     await orphanArrived;
-    client.assertNoErrors(ws.uri("orphan.cpp"));
+    client.assertNoErrors(orphanUri);
 
     const scratchArrived = client.armDiagnostics(ws.uri("scratch.cpp"));
-    client.open("scratch.cpp", 0, { text: "int scratch() { return 2; }\n" });
+    const [scratchUri] = client.open("scratch.cpp", 0, { text: "int scratch() { return 2; }\n" });
+    const scratch = (await client.documentSymbols(scratchUri)) as proto.DocumentSymbol[] | null;
+    expect(scratch?.map((s) => s.name)).toContain("scratch");
     await scratchArrived;
-    client.assertNoErrors(ws.uri("scratch.cpp"));
+    client.assertNoErrors(scratchUri);
 });
 
 test("explicit -x beats the suffix", async ({ session }) => {
@@ -201,7 +210,7 @@ test("explicit -x beats the suffix", async ({ session }) => {
     ws.writeCDB(["legacy.c"], { extraArgs: ["-x", "c++"] });
     ws.pinCacheDir();
     const client = session.spawn(ws);
-    await client.initialize(ws, { initializationOptions: ON_EDIT });
+    await client.initialize(ws, { initializationOptions: AUTO });
 
     const [uri] = client.open("legacy.c");
     expect(await client.waitForIndex(uri, "Widget")).toBe(true);
@@ -210,11 +219,11 @@ test("explicit -x beats the suffix", async ({ session }) => {
     expect(ws.pchFiles()).toEqual([]);
 });
 
-test("never builds no pch", async ({ session }) => {
+test("readonly on builds no pch", async ({ session }) => {
     const ws = writeProject(session);
     const client = session.spawn(ws);
     await client.initialize(ws, {
-        initializationOptions: { project: { pch_build: "never" } },
+        initializationOptions: { project: { readonly: "on" } },
     });
 
     const [uri] = client.open("main.cpp");
@@ -232,7 +241,7 @@ test("never builds no pch", async ({ session }) => {
 test("escalation upgrades inlay hints", async ({ session }) => {
     const ws = writeProject(session);
     const client = session.spawn(ws);
-    await client.initialize(ws, { initializationOptions: ON_EDIT });
+    await client.initialize(ws, { initializationOptions: AUTO });
 
     const [uri] = client.open("main.cpp");
     expect(await client.waitForIndex(uri, "twice")).toBe(true);
@@ -243,11 +252,9 @@ test("escalation upgrades inlay hints", async ({ session }) => {
     };
     expect((await client.inlayHints(uri, range)) ?? []).toEqual([]);
 
-    // After the edit-triggered compile lands, a re-pull gets real hints
-    // (parameter names at the call sites).
-    const arrived = client.armDiagnostics(uri);
+    // The edit flips the mode: the inlay re-pull rides the pulled
+    // compile and answers from the AST (parameter names at call sites).
     client.change(uri, 2, MAIN + "// edited\n");
-    await arrived;
     const upgraded = await client.inlayHints(uri, range);
     expect(upgraded?.length ?? 0).toBeGreaterThan(0);
 });
@@ -256,16 +263,17 @@ test("diverged buffer serves no links", async ({ session }) => {
     const ws = writeProject(session);
 
     const first = session.spawn(ws);
-    await first.initialize(ws, { initializationOptions: ON_EDIT });
+    await first.initialize(ws, { initializationOptions: AUTO });
     const [warm] = first.open("main.cpp");
     expect(await first.waitForIndex(warm, "twice")).toBe(true);
     await first.shutdown();
 
-    // Under `never` a diverged buffer cannot escalate: every index answer
-    // must withdraw rather than map stale manifest lines onto new text.
+    // Under readonly "on" a diverged buffer cannot escalate: every index
+    // answer must withdraw rather than map stale manifest lines onto new
+    // text.
     const second = session.spawn(ws);
     await second.initialize(ws, {
-        initializationOptions: { project: { pch_build: "never" } },
+        initializationOptions: { project: { readonly: "on" } },
     });
     const [uri] = second.open("main.cpp", 0, {
         text: '#include "renamed.h"\n' + MAIN.split("\n").slice(1).join("\n"),
@@ -275,7 +283,7 @@ test("diverged buffer serves no links", async ({ session }) => {
     expect(defs === null || (Array.isArray(defs) && defs.length === 0)).toBe(true);
 });
 
-const ON_OPEN = { project: { pch_build: "on_open" } };
+const OFF = { project: { readonly: "off" } };
 
 test("preamble define hovers under pch", async ({ session }) => {
     const ws = session.tmpdir();
@@ -284,7 +292,7 @@ test("preamble define hovers under pch", async ({ session }) => {
     ws.writeCDB(["main.cpp"]);
     ws.pinCacheDir();
     const client = session.spawn(ws);
-    await client.initialize(ws, { initializationOptions: ON_OPEN });
+    await client.initialize(ws, { initializationOptions: OFF });
 
     // The define is compiled into the PCH and has no AST node; the null
     // from the worker falls back to the index card for the preamble
@@ -295,32 +303,41 @@ test("preamble define hovers under pch", async ({ session }) => {
     expect(JSON.stringify(hover?.contents ?? "")).toContain("LIMIT");
 });
 
-test("on_open compiles eagerly", async ({ session }) => {
+test("off compiles on demand", async ({ session }) => {
     const ws = writeProject(session);
     const client = session.spawn(ws);
-    await client.initialize(ws, { initializationOptions: ON_OPEN });
+    await client.initialize(ws, { initializationOptions: OFF });
 
-    // No feature request at all: didOpen itself starts the compile.
+    // didOpen alone starts nothing (the pre-readonly contract): the
+    // diagnostics push rides the first read's pulled compile.
     const uri = ws.uri("main.cpp");
-    const arrived = client.armDiagnostics(uri);
+    let published = false;
+    const arrived = client.armDiagnostics(uri).then(() => {
+        published = true;
+    });
     client.open("main.cpp");
+    await sleep(SETTLE_TIME);
+    expect(published).toBe(false);
+
+    const hover = await client.hoverAt(uri, 4, 11);
+    expect(JSON.stringify(hover?.contents ?? "")).toContain("add");
     await arrived;
     client.assertNoErrors(uri);
 });
 
-test("index answers while eager compile runs", async ({ session }) => {
+test("index answers while pull compile runs", async ({ session }) => {
     const ws = writeProject(session);
 
     const first = session.spawn(ws);
-    await first.initialize(ws, { initializationOptions: ON_EDIT });
+    await first.initialize(ws, { initializationOptions: AUTO });
     const [warm] = first.open("main.cpp");
     expect(await first.waitForIndex(warm, "twice")).toBe(true);
     await first.shutdown();
 
-    // on_open: the compile is kicked at didOpen, but the very first
-    // request must not wait for it — the warm shard answers.
+    // off: the first read pulls the compile, but must not block on it —
+    // the warm shard answers instantly.
     const second = session.spawn(ws);
-    await second.initialize(ws, { initializationOptions: ON_OPEN });
+    await second.initialize(ws, { initializationOptions: OFF });
     const [uri] = second.open("main.cpp");
     const symbols = (await second.documentSymbols(uri)) as proto.DocumentSymbol[] | null;
     expect(symbols?.map((s) => s.name)).toContain("twice");

--- a/tests/integration/features/read_only.test.ts
+++ b/tests/integration/features/read_only.test.ts
@@ -137,7 +137,71 @@ test("never builds no pch", async ({ session }) => {
     expect(client.diagnostics.has(uri)).toBe(false);
 });
 
+test("escalation upgrades inlay hints", async ({ session }) => {
+    const ws = writeProject(session);
+    const client = session.spawn(ws);
+    await client.initialize(ws, { initializationOptions: ON_EDIT });
+
+    const [uri] = client.open("main.cpp");
+    expect(await client.waitForIndex(uri, "twice")).toBe(true);
+
+    const range = {
+        start: { line: 0, character: 0 },
+        end: { line: 6, character: 0 },
+    };
+    expect((await client.inlayHints(uri, range)) ?? []).toEqual([]);
+
+    // After the edit-triggered compile lands, a re-pull gets real hints
+    // (parameter names at the call sites).
+    const arrived = client.armDiagnostics(uri);
+    client.change(uri, 2, MAIN + "// edited\n");
+    await arrived;
+    const upgraded = await client.inlayHints(uri, range);
+    expect(upgraded?.length ?? 0).toBeGreaterThan(0);
+});
+
+test("diverged buffer serves no links", async ({ session }) => {
+    const ws = writeProject(session);
+
+    const first = session.spawn(ws);
+    await first.initialize(ws, { initializationOptions: ON_EDIT });
+    const [warm] = first.open("main.cpp");
+    expect(await first.waitForIndex(warm, "twice")).toBe(true);
+    await first.shutdown();
+
+    // Under `never` a diverged buffer cannot escalate: every index answer
+    // must withdraw rather than map stale manifest lines onto new text.
+    const second = session.spawn(ws);
+    await second.initialize(ws, {
+        initializationOptions: { project: { pch_build: "never" } },
+    });
+    const [uri] = second.open("main.cpp", 0, {
+        text: '#include "renamed.h"\n' + MAIN.split("\n").slice(1).join("\n"),
+    });
+    expect((await second.documentLinks(uri)) ?? []).toEqual([]);
+    const defs = await second.definitionAt(uri, 0, 12);
+    expect(defs === null || (Array.isArray(defs) && defs.length === 0)).toBe(true);
+});
+
 const ON_OPEN = { project: { pch_build: "on_open" } };
+
+test("preamble define hovers under pch", async ({ session }) => {
+    const ws = session.tmpdir();
+    ws.write("header.h", HEADER);
+    ws.write("main.cpp", "#define LIMIT 10\n" + MAIN);
+    ws.writeCDB(["main.cpp"]);
+    ws.pinCacheDir();
+    const client = session.spawn(ws);
+    await client.initialize(ws, { initializationOptions: ON_OPEN });
+
+    // The define is compiled into the PCH and has no AST node; the null
+    // from the worker falls back to the index card for the preamble
+    // region (and only there).
+    await client.openAndWait("main.cpp");
+    const uri = ws.uri("main.cpp");
+    const hover = await client.hoverAt(uri, 0, 9);
+    expect(JSON.stringify(hover?.contents ?? "")).toContain("LIMIT");
+});
 
 test("on_open compiles eagerly", async ({ session }) => {
     const ws = writeProject(session);

--- a/tests/integration/features/read_only.test.ts
+++ b/tests/integration/features/read_only.test.ts
@@ -79,6 +79,36 @@ test("index serves unedited reads", async ({ session }) => {
     expect(ws.pchFiles()).toEqual([]);
 });
 
+test("oversized buffer keeps row answers", async ({ session }) => {
+    const ws = session.tmpdir();
+    // Past the 8 MiB full-lex cap only semantic tokens and folds follow
+    // the investment policy; row- and cursor-backed projections still
+    // serve from the shard.
+    ws.write("header.h", HEADER);
+    ws.write("main.cpp", MAIN + "// padding\n".repeat(800_000));
+    ws.writeCDB(["main.cpp"]);
+    ws.pinCacheDir();
+    const client = session.spawn(ws);
+    await client.initialize(ws, { initializationOptions: ON_EDIT });
+
+    const [uri] = client.open("main.cpp");
+    expect(await client.waitForIndex(uri, "twice")).toBe(true);
+
+    const symbols = (await client.documentSymbols(uri)) as proto.DocumentSymbol[] | null;
+    expect(symbols?.map((s) => s.name)).toContain("twice");
+
+    const links = await client.documentLinks(uri);
+    expect(links?.some((l) => l.target?.endsWith("header.h"))).toBe(true);
+
+    // `add` in `return add(x, x)` on line 4.
+    const hover = await client.hoverAt(uri, 4, 11);
+    expect(JSON.stringify(hover?.contents ?? "")).toContain("add");
+
+    expect(await client.semanticTokensFull(uri)).toBeNull();
+    expect(await client.foldingRanges(uri)).toEqual([]);
+    expect(ws.pchFiles()).toEqual([]);
+});
+
 test("cold outline awaits the boost", async ({ session }) => {
     const ws = writeProject(session);
     const client = session.spawn(ws);

--- a/tests/integration/features/read_only.test.ts
+++ b/tests/integration/features/read_only.test.ts
@@ -138,9 +138,15 @@ test("edit escalates to compile", async ({ session }) => {
     expect(client.diagnostics.has(uri)).toBe(false);
 
     // The edit flips the mode; the build itself stays pull-driven, so
-    // diagnostics ride the next read instead of the edit.
-    const arrived = client.armDiagnostics(uri);
+    // nothing lands until the next read pulls it.
+    let published = false;
+    const arrived = client.armDiagnostics(uri).then(() => {
+        published = true;
+    });
     client.change(uri, 2, MAIN + "// edited\n");
+    await sleep(SETTLE_TIME);
+    expect(published).toBe(false);
+
     const hover = await client.hoverAt(uri, 4, 11);
     expect(JSON.stringify(hover?.contents ?? "")).toContain("add");
     await arrived;
@@ -335,10 +341,14 @@ test("index answers while pull compile runs", async ({ session }) => {
     await first.shutdown();
 
     // off: the first read pulls the compile, but must not block on it —
-    // the warm shard answers instantly.
+    // the warm shard answers instantly, and the detached pull still
+    // lands the AST (diagnostics prove it).
     const second = session.spawn(ws);
     await second.initialize(ws, { initializationOptions: OFF });
+    const arrived = second.armDiagnostics(ws.uri("main.cpp"));
     const [uri] = second.open("main.cpp");
     const symbols = (await second.documentSymbols(uri)) as proto.DocumentSymbol[] | null;
     expect(symbols?.map((s) => s.name)).toContain("twice");
+    await arrived;
+    second.assertNoErrors(uri);
 });

--- a/tests/integration/lifecycle/protocol_edges.test.ts
+++ b/tests/integration/lifecycle/protocol_edges.test.ts
@@ -10,7 +10,7 @@ import type { Workspace } from "@clice/tools/workspace";
 import { expect, test, type SessionFactory } from "../fixtures.ts";
 
 const TEST_TOML =
-    '[project]\ncache_dir = "${workspace}/.clice"\nenable_indexing = false\n' +
+    '[project]\ncache_dir = "${workspace}/.clice"\nenable_indexing = false\npch_build = "on_open"\n' +
     "\n[tracker]\ncdb_poll_seconds = 0\nworkspace_poll_seconds = 0\n";
 
 // hello_world's main.cpp, recreated in a temp workspace so the pre-handshake

--- a/tests/integration/lifecycle/protocol_edges.test.ts
+++ b/tests/integration/lifecycle/protocol_edges.test.ts
@@ -10,7 +10,7 @@ import type { Workspace } from "@clice/tools/workspace";
 import { expect, test, type SessionFactory } from "../fixtures.ts";
 
 const TEST_TOML =
-    '[project]\ncache_dir = "${workspace}/.clice"\nenable_indexing = false\npch_build = "on_open"\n' +
+    '[project]\ncache_dir = "${workspace}/.clice"\nenable_indexing = false\n' +
     "\n[tracker]\ncdb_poll_seconds = 0\nworkspace_poll_seconds = 0\n";
 
 // hello_world's main.cpp, recreated in a temp workspace so the pre-handshake

--- a/tests/unit/feature/index_projection_tests.cpp
+++ b/tests/unit/feature/index_projection_tests.cpp
@@ -75,6 +75,7 @@ struct Point {
     int x;
     int y;
     int sum();
+    Point operator+(Point other);
 };
 
 int Point::sum() {
@@ -323,8 +324,8 @@ TEST_CASE(ModuleNameComponents) {
 
 TEST_CASE(CDialectKeywords) {
     // `class` is a valid C identifier: rows built by C parses must lex
-    // under the C keyword table, or the C++ keyword overlay would fight
-    // the row's kind.
+    // under the C keyword table, or the C++ table would take `class` as
+    // a keyword and shadow the row's kind.
     llvm::StringRef content = "int class;\n";
     std::vector<feature::IndexDeclRow> rows = {
         {.range = {4, 9}, .extent = {0, 10}, .symbol = 1, .definition = true},
@@ -347,13 +348,13 @@ TEST_CASE(CDialectKeywords) {
                                                      rows,
                                                      resolve_synthetic);
     ASSERT_EQ(cpp_tokens.size(), std::size_t(2));
-    ASSERT_EQ(cpp_tokens[1].kind.value_of(), SymbolKind(SymbolKind::Conflict).value_of());
+    ASSERT_EQ(cpp_tokens[1].kind.value_of(), SymbolKind(SymbolKind::Keyword).value_of());
 }
 
 TEST_CASE(StandardFromCommand) {
     // `concept` is a plain identifier in C++17: rows built under an older
-    // -std must lex with that standard's keyword table, or the latest
-    // standard's overlay would fight the row's kind.
+    // -std must lex with that standard's keyword table, or a newer
+    // table would take `concept` as a keyword and shadow the row.
     llvm::StringRef content = "int concept;\n";
     std::vector<feature::IndexDeclRow> rows = {
         {.range = {4, 11}, .extent = {0, 12}, .symbol = 1, .definition = true},
@@ -371,14 +372,25 @@ TEST_CASE(StandardFromCommand) {
     ASSERT_EQ(cxx17_tokens.size(), std::size_t(2));
     ASSERT_EQ(cxx17_tokens[1].kind.value_of(), SymbolKind(SymbolKind::Variable).value_of());
 
-    auto latest_tokens =
+    auto cxx20_tokens =
+        feature::index_semantic_tokens(content,
+                                       feature::index_lang_options("main.cpp", false, "c++20"),
+                                       {},
+                                       rows,
+                                       resolve_synthetic);
+    ASSERT_EQ(cxx20_tokens.size(), std::size_t(2));
+    ASSERT_EQ(cxx20_tokens[1].kind.value_of(), SymbolKind(SymbolKind::Keyword).value_of());
+
+    // No -std in the command means the rows were indexed under the
+    // driver's default dialect (C++17 today); the fallback matches it.
+    auto default_tokens =
         feature::index_semantic_tokens(content,
                                        feature::index_lang_options("main.cpp", false),
                                        {},
                                        rows,
                                        resolve_synthetic);
-    ASSERT_EQ(latest_tokens.size(), std::size_t(2));
-    ASSERT_EQ(latest_tokens[1].kind.value_of(), SymbolKind(SymbolKind::Conflict).value_of());
+    ASSERT_EQ(default_tokens.size(), std::size_t(2));
+    ASSERT_EQ(default_tokens[1].kind.value_of(), SymbolKind(SymbolKind::Variable).value_of());
 }
 
 TEST_CASE(LinksFromEdges) {

--- a/tests/unit/feature/index_projection_tests.cpp
+++ b/tests/unit/feature/index_projection_tests.cpp
@@ -1,0 +1,290 @@
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "test/test.h"
+#include "test/tester.h"
+#include "feature/feature.h"
+#include "index/tu_index.h"
+
+namespace clice::testing {
+
+namespace {
+
+TEST_SUITE(index_projection, Tester) {
+
+/// The compiled unit's envelope and the main file's rows, extracted the
+/// way the router's index slice does it in production.
+index::TUIndex tu;
+std::string envelope;
+std::vector<index::Occurrence> occurrences;
+std::vector<feature::IndexDeclRow> decls;
+
+void extract_rows() {
+    envelope = index::build_tu_index(*unit);
+    tu = index::TUIndex::from_bytes(envelope);
+
+    auto main_id = tu.path_count() - 1;
+    auto& shard = tu.shard_of(main_id);
+
+    occurrences.clear();
+    shard.for_each_occurrence([&](const index::Occurrence& occurrence) {
+        occurrences.push_back(occurrence);
+        return true;
+    });
+
+    decls.clear();
+    shard.for_each_relation([&](index::SymbolHash hash, const index::Relation& relation) {
+        RelationKind kind(relation.kind);
+        if(kind.isDeclOrDef()) {
+            auto copy = relation;
+            decls.push_back({.range = relation.range,
+                             .extent = copy.definition_range(),
+                             .symbol = hash,
+                             .definition = kind.is_one_of(RelationKind::Definition)});
+        }
+        return true;
+    });
+}
+
+std::optional<feature::IndexSymbolInfo> resolve(index::SymbolHash hash) {
+    if(auto identity = tu.find_symbol(hash)) {
+        return feature::IndexSymbolInfo{std::string(identity->name), identity->kind};
+    }
+    auto main_id = tu.path_count() - 1;
+    std::string name;
+    SymbolKind kind;
+    if(tu.shard_of(main_id).find_symbol(hash, name, kind)) {
+        return feature::IndexSymbolInfo{std::move(name), kind};
+    }
+    return std::nullopt;
+}
+
+auto resolver() {
+    return [this](index::SymbolHash hash) { return resolve(hash); };
+}
+
+TEST_CASE(TokensMatchAst) {
+    add_main("main.cpp", R"cpp(
+// a line comment
+#define VALUE 1
+
+struct Point {
+    int x;
+    int y;
+    int sum();
+};
+
+int Point::sum() {
+    return x + y + VALUE;
+}
+
+int total(Point point, int base) {
+    const char* label = "sum";
+    char letter = 's';
+    if(base > 0) {
+        return point.sum() + base;
+    }
+    return 0;
+}
+)cpp");
+    ASSERT_TRUE(compile());
+    extract_rows();
+
+    auto ast = feature::semantic_tokens(*unit);
+    auto projected = feature::index_semantic_tokens(unit->interested_content(),
+                                                    feature::index_lang_options("main.cpp"),
+                                                    occurrences,
+                                                    decls,
+                                                    resolver());
+
+    // The index knows Declaration/Definition; every other AST modifier
+    // (Readonly, Static, Virtual, ...) is a pinned degradation.
+    auto pinned = SymbolModifiers::to_mask(SymbolModifiers::Declaration) |
+                  SymbolModifiers::to_mask(SymbolModifiers::Definition);
+
+    ASSERT_EQ(projected.size(), ast.size());
+    for(std::size_t i = 0; i < ast.size(); i += 1) {
+        ASSERT_EQ(projected[i].range.begin, ast[i].range.begin);
+        ASSERT_EQ(projected[i].range.end, ast[i].range.end);
+        ASSERT_EQ(projected[i].kind.value_of(), ast[i].kind.value_of());
+        ASSERT_EQ(projected[i].modifiers, ast[i].modifiers & pinned);
+    }
+}
+
+TEST_CASE(OutlineMatchesAst) {
+    add_main("main.cpp", R"cpp(
+namespace app {
+
+struct Point {
+    int x;
+    int sum();
+};
+
+enum class Color {
+    Red,
+    Blue,
+};
+
+int scale(int value) {
+    return value * 2;
+}
+
+}
+)cpp");
+    ASSERT_TRUE(compile());
+    extract_rows();
+
+    auto ast = feature::document_symbols(*unit);
+    auto projected = feature::index_document_symbols(decls, resolver());
+
+    auto compare = [](auto& self, const std::vector<feature::DocumentSymbol>& lhs,
+                      const std::vector<feature::DocumentSymbol>& rhs) -> void {
+        ASSERT_EQ(lhs.size(), rhs.size());
+        for(std::size_t i = 0; i < lhs.size(); i += 1) {
+            ASSERT_EQ(lhs[i].name, rhs[i].name);
+            ASSERT_EQ(lhs[i].kind.value_of(), rhs[i].kind.value_of());
+            self(self, lhs[i].children, rhs[i].children);
+        }
+    };
+    compare(compare, projected, ast);
+}
+
+TEST_CASE(FoldsSubsetOfAst) {
+    add_main("main.cpp", R"cpp(
+namespace app {
+
+struct Holder {
+    int value;
+
+    Holder() : value{0} {
+        value += 1;
+    }
+};
+
+int compute() {
+    return Holder().value;
+}
+
+}
+)cpp");
+    ASSERT_TRUE(compile());
+    extract_rows();
+
+    auto ast = feature::folding_ranges(*unit);
+    auto projected = feature::index_folding_ranges(unit->interested_content(),
+                                                   feature::index_lang_options("main.cpp"),
+                                                   decls,
+                                                   resolver());
+
+    ASSERT_TRUE(!projected.empty());
+    for(auto& fold: projected) {
+        bool known = std::ranges::any_of(ast, [&](const feature::FoldingRange& twin) {
+            return twin.range == fold.range;
+        });
+        ASSERT_TRUE(known);
+    }
+
+    // The constructor's fold anchors at its body, not the member
+    // initializer's braces.
+    auto body = unit->interested_content().find("{\n        value += 1;");
+    bool anchored = std::ranges::any_of(projected, [&](const feature::FoldingRange& fold) {
+        return fold.range.begin == body;
+    });
+    ASSERT_TRUE(anchored);
+}
+
+TEST_CASE(CollapsedRowsBecomeSiblings) {
+    std::vector<feature::IndexDeclRow> rows = {
+        {.range = {8, 9}, .extent = {0, 100}, .symbol = 1, .definition = true},
+        {.range = {20, 25}, .extent = {20, 50}, .symbol = 2, .definition = true},
+        {.range = {20, 25}, .extent = {20, 50}, .symbol = 3, .definition = true},
+    };
+    auto resolve_synthetic =
+        [](index::SymbolHash hash) -> std::optional<feature::IndexSymbolInfo> {
+        switch(hash) {
+            case 1: return feature::IndexSymbolInfo{"outer", SymbolKind::Struct};
+            case 2: return feature::IndexSymbolInfo{"first", SymbolKind::Field};
+            case 3: return feature::IndexSymbolInfo{"second", SymbolKind::Field};
+            default: return std::nullopt;
+        }
+    };
+
+    auto symbols = feature::index_document_symbols(rows, resolve_synthetic);
+    ASSERT_EQ(symbols.size(), std::size_t(1));
+    ASSERT_EQ(symbols[0].name, "outer");
+    ASSERT_EQ(symbols[0].children.size(), std::size_t(2));
+    ASSERT_EQ(symbols[0].children[0].children.size(), std::size_t(0));
+    ASSERT_EQ(symbols[0].children[1].children.size(), std::size_t(0));
+}
+
+TEST_CASE(MergedKindsConflict) {
+    llvm::StringRef content = "value;\n";
+    std::vector<index::Occurrence> merged = {
+        {.range = {0, 5}, .target = 1},
+        {.range = {0, 5}, .target = 2},
+    };
+    auto resolve_synthetic =
+        [](index::SymbolHash hash) -> std::optional<feature::IndexSymbolInfo> {
+        if(hash == 1) {
+            return feature::IndexSymbolInfo{"value", SymbolKind::Variable};
+        }
+        return feature::IndexSymbolInfo{"value", SymbolKind::Function};
+    };
+
+    auto tokens = feature::index_semantic_tokens(content,
+                                                 feature::index_lang_options("main.cpp"),
+                                                 merged,
+                                                 {},
+                                                 resolve_synthetic);
+    ASSERT_EQ(tokens.size(), std::size_t(1));
+    ASSERT_EQ(tokens[0].kind.value_of(), SymbolKind(SymbolKind::Conflict).value_of());
+}
+
+TEST_CASE(LinksFromEdges) {
+    llvm::StringRef content = R"cpp(#include "first.h"
+#include "skipped.h"
+#include <second>
+)cpp";
+    std::vector<feature::IndexIncludeEdge> edges = {
+        {.line = 1, .target = "/tmp/first.h"},
+        {.line = 3, .target = "/usr/include/second"},
+    };
+
+    auto links = feature::index_document_links(content,
+                                               feature::index_lang_options("main.cpp"),
+                                               edges);
+    ASSERT_EQ(links.size(), std::size_t(2));
+    ASSERT_EQ(content.substr(links[0].range.begin, links[0].range.length()), "\"first.h\"");
+    ASSERT_EQ(links[0].target, "/tmp/first.h");
+    ASSERT_EQ(content.substr(links[1].range.begin, links[1].range.length()), "<second>");
+    ASSERT_EQ(links[1].target, "/usr/include/second");
+}
+
+TEST_CASE(CommentBlockExtraction) {
+    llvm::StringRef content = R"cpp(int unrelated;
+
+/// Adds two numbers.
+/// Returns their sum.
+int add(int a, int b);
+
+// stale note
+
+int gap();
+)cpp";
+
+    auto add_offset = static_cast<std::uint32_t>(content.find("int add"));
+    ASSERT_EQ(feature::preceding_comment(content, add_offset),
+              "Adds two numbers.\nReturns their sum.");
+
+    // A blank line between the comment and the declaration breaks the
+    // attachment.
+    auto gap_offset = static_cast<std::uint32_t>(content.find("int gap"));
+    ASSERT_EQ(feature::preceding_comment(content, gap_offset), "");
+}
+
+};
+
+}  // namespace
+
+}  // namespace clice::testing

--- a/tests/unit/feature/index_projection_tests.cpp
+++ b/tests/unit/feature/index_projection_tests.cpp
@@ -61,7 +61,9 @@ std::optional<feature::IndexSymbolInfo> resolve(index::SymbolHash hash) {
 }
 
 auto resolver() {
-    return [this](index::SymbolHash hash) { return resolve(hash); };
+    return [this](index::SymbolHash hash) {
+        return resolve(hash);
+    };
 }
 
 TEST_CASE(TokensMatchAst) {
@@ -138,7 +140,8 @@ int scale(int value) {
     auto ast = feature::document_symbols(*unit);
     auto projected = feature::index_document_symbols(decls, resolver());
 
-    auto compare = [](auto& self, const std::vector<feature::DocumentSymbol>& lhs,
+    auto compare = [](auto& self,
+                      const std::vector<feature::DocumentSymbol>& lhs,
                       const std::vector<feature::DocumentSymbol>& rhs) -> void {
         ASSERT_EQ(lhs.size(), rhs.size());
         for(std::size_t i = 0; i < lhs.size(); i += 1) {
@@ -196,12 +199,11 @@ int compute() {
 
 TEST_CASE(CollapsedRowsBecomeSiblings) {
     std::vector<feature::IndexDeclRow> rows = {
-        {.range = {8, 9}, .extent = {0, 100}, .symbol = 1, .definition = true},
+        {.range = {8, 9},   .extent = {0, 100}, .symbol = 1, .definition = true},
         {.range = {20, 25}, .extent = {20, 50}, .symbol = 2, .definition = true},
         {.range = {20, 25}, .extent = {20, 50}, .symbol = 3, .definition = true},
     };
-    auto resolve_synthetic =
-        [](index::SymbolHash hash) -> std::optional<feature::IndexSymbolInfo> {
+    auto resolve_synthetic = [](index::SymbolHash hash) -> std::optional<feature::IndexSymbolInfo> {
         switch(hash) {
             case 1: return feature::IndexSymbolInfo{"outer", SymbolKind::Struct};
             case 2: return feature::IndexSymbolInfo{"first", SymbolKind::Field};
@@ -224,8 +226,7 @@ TEST_CASE(MergedKindsConflict) {
         {.range = {0, 5}, .target = 1},
         {.range = {0, 5}, .target = 2},
     };
-    auto resolve_synthetic =
-        [](index::SymbolHash hash) -> std::optional<feature::IndexSymbolInfo> {
+    auto resolve_synthetic = [](index::SymbolHash hash) -> std::optional<feature::IndexSymbolInfo> {
         if(hash == 1) {
             return feature::IndexSymbolInfo{"value", SymbolKind::Variable};
         }
@@ -247,13 +248,12 @@ TEST_CASE(LinksFromEdges) {
 #include <second>
 )cpp";
     std::vector<feature::IndexIncludeEdge> edges = {
-        {.line = 1, .target = "/tmp/first.h"},
+        {.line = 1, .target = "/tmp/first.h"       },
         {.line = 3, .target = "/usr/include/second"},
     };
 
-    auto links = feature::index_document_links(content,
-                                               feature::index_lang_options("main.cpp"),
-                                               edges);
+    auto links =
+        feature::index_document_links(content, feature::index_lang_options("main.cpp"), edges);
     ASSERT_EQ(links.size(), std::size_t(2));
     ASSERT_EQ(content.substr(links[0].range.begin, links[0].range.length()), "\"first.h\"");
     ASSERT_EQ(links[0].target, "/tmp/first.h");
@@ -283,7 +283,7 @@ int gap();
     ASSERT_EQ(feature::preceding_comment(content, gap_offset), "");
 }
 
-};
+};  // TEST_SUITE(index_projection)
 
 }  // namespace
 

--- a/tests/unit/feature/index_projection_tests.cpp
+++ b/tests/unit/feature/index_projection_tests.cpp
@@ -350,6 +350,37 @@ TEST_CASE(CDialectKeywords) {
     ASSERT_EQ(cpp_tokens[1].kind.value_of(), SymbolKind(SymbolKind::Conflict).value_of());
 }
 
+TEST_CASE(StandardFromCommand) {
+    // `concept` is a plain identifier in C++17: rows built under an older
+    // -std must lex with that standard's keyword table, or the latest
+    // standard's overlay would fight the row's kind.
+    llvm::StringRef content = "int concept;\n";
+    std::vector<feature::IndexDeclRow> rows = {
+        {.range = {4, 11}, .extent = {0, 12}, .symbol = 1, .definition = true},
+    };
+    auto resolve_synthetic = [](index::SymbolHash) -> std::optional<feature::IndexSymbolInfo> {
+        return feature::IndexSymbolInfo{"concept", SymbolKind::Variable};
+    };
+
+    auto cxx17_tokens =
+        feature::index_semantic_tokens(content,
+                                       feature::index_lang_options("main.cpp", false, "c++17"),
+                                       {},
+                                       rows,
+                                       resolve_synthetic);
+    ASSERT_EQ(cxx17_tokens.size(), std::size_t(2));
+    ASSERT_EQ(cxx17_tokens[1].kind.value_of(), SymbolKind(SymbolKind::Variable).value_of());
+
+    auto latest_tokens =
+        feature::index_semantic_tokens(content,
+                                       feature::index_lang_options("main.cpp", false),
+                                       {},
+                                       rows,
+                                       resolve_synthetic);
+    ASSERT_EQ(latest_tokens.size(), std::size_t(2));
+    ASSERT_EQ(latest_tokens[1].kind.value_of(), SymbolKind(SymbolKind::Conflict).value_of());
+}
+
 TEST_CASE(LinksFromEdges) {
     llvm::StringRef content = R"cpp(#include "first.h"
 #include "skipped.h"
@@ -387,6 +418,17 @@ int scale(int value);
 
 int base = 1; /* setup */
 int next();
+
+/*
+Frees the buffer.
+Then clears it.
+*/
+int release();
+
+int done(); /* trailing block
+still trailing
+*/
+int after();
 )cpp";
 
     auto add_offset = static_cast<std::uint32_t>(content.find("int add"));
@@ -407,6 +449,16 @@ int next();
     // documentation.
     auto next_offset = static_cast<std::uint32_t>(content.find("int next"));
     ASSERT_EQ(feature::preceding_comment(content, next_offset), "");
+
+    // Interior lines of a block comment need no marker of their own.
+    auto release_offset = static_cast<std::uint32_t>(content.find("int release"));
+    ASSERT_EQ(feature::preceding_comment(content, release_offset),
+              "Frees the buffer.\nThen clears it.");
+
+    // A block comment opened behind code trails that code, even when it
+    // closes directly above the declaration.
+    auto after_offset = static_cast<std::uint32_t>(content.find("int after"));
+    ASSERT_EQ(feature::preceding_comment(content, after_offset), "");
 }
 
 };  // TEST_SUITE(index_projection)

--- a/tests/unit/feature/index_projection_tests.cpp
+++ b/tests/unit/feature/index_projection_tests.cpp
@@ -116,6 +116,8 @@ int total(Point point, int base) {
 
 TEST_CASE(OutlineMatchesAst) {
     add_main("main.cpp", R"cpp(
+#define LIMIT 10
+
 namespace app {
 
 struct Point {

--- a/tests/unit/feature/index_projection_tests.cpp
+++ b/tests/unit/feature/index_projection_tests.cpp
@@ -159,6 +159,8 @@ TEST_CASE(FoldsSubsetOfAst) {
     add_main("main.cpp", R"cpp(
 namespace app {
 
+struct Point { int x; };
+
 struct Holder {
     int value;
 
@@ -273,6 +275,13 @@ int add(int a, int b);
 // stale note
 
 int gap();
+
+/* Scales the
+   given input. */
+int scale(int value);
+
+int base = 1; /* setup */
+int next();
 )cpp";
 
     auto add_offset = static_cast<std::uint32_t>(content.find("int add"));
@@ -283,6 +292,16 @@ int gap();
     // attachment.
     auto gap_offset = static_cast<std::uint32_t>(content.find("int gap"));
     ASSERT_EQ(feature::preceding_comment(content, gap_offset), "");
+
+    // A block comment whose closing line only ends with the marker still
+    // attaches whole.
+    auto scale_offset = static_cast<std::uint32_t>(content.find("int scale"));
+    ASSERT_EQ(feature::preceding_comment(content, scale_offset), "Scales the\ngiven input.");
+
+    // A code line trailing a self-contained block comment is code, not
+    // documentation.
+    auto next_offset = static_cast<std::uint32_t>(content.find("int next"));
+    ASSERT_EQ(feature::preceding_comment(content, next_offset), "");
 }
 
 };  // TEST_SUITE(index_projection)

--- a/tests/unit/feature/index_projection_tests.cpp
+++ b/tests/unit/feature/index_projection_tests.cpp
@@ -201,6 +201,48 @@ int compute() {
     ASSERT_TRUE(anchored);
 }
 
+TEST_CASE(ConditionalBracesSuppressFold) {
+    // f's branches unbalance braces: any raw pairing ends the fold in a
+    // branch the indexed parse never took, so the fold is suppressed. g's
+    // conditional keeps every branch balanced and folds normally.
+    llvm::StringRef content = R"cpp(void f() {
+#if defined(X)
+}
+#else
+}
+#endif
+
+void g() {
+#if defined(Y)
+    int a = 1;
+#else
+    int a = 2;
+#endif
+}
+)cpp";
+    auto f_end = static_cast<std::uint32_t>(content.find("#endif") + 6);
+    auto g_begin = static_cast<std::uint32_t>(content.find("void g"));
+    auto g_end = static_cast<std::uint32_t>(content.rfind('}') + 1);
+    std::vector<feature::IndexDeclRow> rows = {
+        {.range = {5, 6},                     .extent = {0, f_end}, .symbol = 1, .definition = true},
+        {.range = {g_begin + 5, g_begin + 6},
+         .extent = {g_begin, g_end},
+         .symbol = 2,
+         .definition = true                                                                        },
+    };
+    auto resolve_synthetic = [](index::SymbolHash hash) -> std::optional<feature::IndexSymbolInfo> {
+        return feature::IndexSymbolInfo{hash == 1 ? "f" : "g", SymbolKind::Function};
+    };
+
+    auto folds = feature::index_folding_ranges(content,
+                                               feature::index_lang_options("main.cpp", false),
+                                               rows,
+                                               resolve_synthetic);
+    ASSERT_EQ(folds.size(), std::size_t(1));
+    ASSERT_EQ(folds[0].range.begin, static_cast<std::uint32_t>(content.find("{", g_begin)));
+    ASSERT_EQ(folds[0].range.end, g_end);
+}
+
 TEST_CASE(CollapsedRowsBecomeSiblings) {
     std::vector<feature::IndexDeclRow> rows = {
         {.range = {8, 9},   .extent = {0, 100}, .symbol = 1, .definition = true},
@@ -244,6 +286,39 @@ TEST_CASE(MergedKindsConflict) {
                                                  resolve_synthetic);
     ASSERT_EQ(tokens.size(), std::size_t(1));
     ASSERT_EQ(tokens[0].kind.value_of(), SymbolKind(SymbolKind::Conflict).value_of());
+}
+
+TEST_CASE(ModuleNameComponents) {
+    // The index stores one occurrence spanning the whole written module
+    // name; every identifier component must classify, as on the AST path
+    // (separators and the contextual `module`/`import` stay unpainted).
+    llvm::StringRef content = "export module demo.core;\nimport foo:part;\n";
+    std::vector<index::Occurrence> merged = {
+        {.range = {14, 23}, .target = 1},
+        {.range = {32, 40}, .target = 1},
+    };
+    auto resolve_synthetic = [](index::SymbolHash) -> std::optional<feature::IndexSymbolInfo> {
+        return feature::IndexSymbolInfo{"demo.core", SymbolKind::Module};
+    };
+
+    auto tokens = feature::index_semantic_tokens(content,
+                                                 feature::index_lang_options("main.cppm", false),
+                                                 merged,
+                                                 {},
+                                                 resolve_synthetic);
+    std::vector<std::pair<std::uint32_t, std::uint32_t>> modules;
+    for(auto& token: tokens) {
+        if(token.kind == SymbolKind::Module) {
+            modules.emplace_back(token.range.begin, token.range.end);
+        }
+    }
+    std::vector<std::pair<std::uint32_t, std::uint32_t>> expected = {
+        {14, 18},
+        {19, 23},
+        {32, 35},
+        {36, 40},
+    };
+    ASSERT_EQ(modules, expected);
 }
 
 TEST_CASE(CDialectKeywords) {

--- a/tests/unit/feature/index_projection_tests.cpp
+++ b/tests/unit/feature/index_projection_tests.cpp
@@ -95,7 +95,7 @@ int total(Point point, int base) {
 
     auto ast = feature::semantic_tokens(*unit);
     auto projected = feature::index_semantic_tokens(unit->interested_content(),
-                                                    feature::index_lang_options("main.cpp"),
+                                                    feature::index_lang_options("main.cpp", false),
                                                     occurrences,
                                                     decls,
                                                     resolver());
@@ -180,7 +180,7 @@ int compute() {
 
     auto ast = feature::folding_ranges(*unit);
     auto projected = feature::index_folding_ranges(unit->interested_content(),
-                                                   feature::index_lang_options("main.cpp"),
+                                                   feature::index_lang_options("main.cpp", false),
                                                    decls,
                                                    resolver());
 
@@ -238,12 +238,41 @@ TEST_CASE(MergedKindsConflict) {
     };
 
     auto tokens = feature::index_semantic_tokens(content,
-                                                 feature::index_lang_options("main.cpp"),
+                                                 feature::index_lang_options("main.cpp", false),
                                                  merged,
                                                  {},
                                                  resolve_synthetic);
     ASSERT_EQ(tokens.size(), std::size_t(1));
     ASSERT_EQ(tokens[0].kind.value_of(), SymbolKind(SymbolKind::Conflict).value_of());
+}
+
+TEST_CASE(CDialectKeywords) {
+    // `class` is a valid C identifier: rows built by C parses must lex
+    // under the C keyword table, or the C++ keyword overlay would fight
+    // the row's kind.
+    llvm::StringRef content = "int class;\n";
+    std::vector<feature::IndexDeclRow> rows = {
+        {.range = {4, 9}, .extent = {0, 10}, .symbol = 1, .definition = true},
+    };
+    auto resolve_synthetic = [](index::SymbolHash) -> std::optional<feature::IndexSymbolInfo> {
+        return feature::IndexSymbolInfo{"class", SymbolKind::Variable};
+    };
+
+    auto c_tokens = feature::index_semantic_tokens(content,
+                                                   feature::index_lang_options("header.h", true),
+                                                   {},
+                                                   rows,
+                                                   resolve_synthetic);
+    ASSERT_EQ(c_tokens.size(), std::size_t(2));
+    ASSERT_EQ(c_tokens[1].kind.value_of(), SymbolKind(SymbolKind::Variable).value_of());
+
+    auto cpp_tokens = feature::index_semantic_tokens(content,
+                                                     feature::index_lang_options("header.h", false),
+                                                     {},
+                                                     rows,
+                                                     resolve_synthetic);
+    ASSERT_EQ(cpp_tokens.size(), std::size_t(2));
+    ASSERT_EQ(cpp_tokens[1].kind.value_of(), SymbolKind(SymbolKind::Conflict).value_of());
 }
 
 TEST_CASE(LinksFromEdges) {
@@ -256,8 +285,9 @@ TEST_CASE(LinksFromEdges) {
         {.line = 3, .target = "/usr/include/second"},
     };
 
-    auto links =
-        feature::index_document_links(content, feature::index_lang_options("main.cpp"), edges);
+    auto links = feature::index_document_links(content,
+                                               feature::index_lang_options("main.cpp", false),
+                                               edges);
     ASSERT_EQ(links.size(), std::size_t(2));
     ASSERT_EQ(content.substr(links[0].range.begin, links[0].range.length()), "\"first.h\"");
     ASSERT_EQ(links[0].target, "/tmp/first.h");

--- a/tests/unit/index/index_query_tests.cpp
+++ b/tests/unit/index/index_query_tests.cpp
@@ -49,9 +49,10 @@ void merge_into_workspace() {
     ASSERT_TRUE(project.merge(view, file_ids_map));
     main_id = file_ids_map[view.path_count() - 1];
 
-    index::TUManifest manifest;
-    manifest.tu_fv = project.intern_file_version(main_id, view.path_hash(view.path_count() - 1));
-
+    // The consumed-content hash per TU-local path: the section's own
+    // record where rows exist, the wire's hash otherwise — mirroring the
+    // indexer, so FileVersions match the shard generations they pin.
+    llvm::SmallVector<std::uint64_t> consumed(view.path_count(), 0);
     for(std::uint32_t section = 0; section < view.section_count(); section += 1) {
         auto local_id = view.section_path(section);
         auto global_id = file_ids_map[local_id];
@@ -59,12 +60,27 @@ void merge_into_workspace() {
         // bytes verbatim, as the indexer's first-variant path does.
         workspace.shards[global_id] = index::Shard::from_buffer(
             llvm::MemoryBuffer::getMemBufferCopy(view.section_blob(section)));
-
-        auto fv = project.intern_file_version(global_id, view.path_hash(local_id));
-        manifest.contributions.emplace_back(fv, view.section_hash(section));
+        consumed[local_id] = workspace.shards[global_id].content_hash();
         if(llvm::sys::path::filename(view.path(local_id)) == "header.h") {
             header_id = global_id;
         }
+    }
+
+    llvm::SmallVector<std::uint32_t> fv_of;
+    for(std::uint32_t i = 0; i < view.path_count(); i += 1) {
+        auto hash = consumed[i] != 0 ? consumed[i] : view.path_hash(i);
+        fv_of.push_back(project.intern_file_version(file_ids_map[i], hash));
+    }
+
+    index::TUManifest manifest;
+    manifest.tu_fv = fv_of[view.path_count() - 1];
+    for(std::uint32_t i = 0; i < view.location_count(); i += 1) {
+        auto location = view.location(i);
+        manifest.nodes.push_back({fv_of[location.path_id], location.include, location.line});
+    }
+    for(std::uint32_t section = 0; section < view.section_count(); section += 1) {
+        manifest.contributions.emplace_back(fv_of[view.section_path(section)],
+                                            view.section_hash(section));
     }
 
     for(auto path_id: project.apply_manifest(main_id, std::move(manifest))) {
@@ -202,6 +218,37 @@ TEST_CASE(DivergedBufferWithdrawsShard) {
     auto position = feature::to_position(session->line_map(), point("use"));
     ASSERT_TRUE(position.has_value());
     ASSERT_TRUE(query.query_definition(main_path(), *position, session.get()).empty());
+}
+
+TEST_CASE(HeaderEdgesFromHostManifest) {
+    add_file("inner.h", R"(
+        int inner_value();
+    )");
+    add_file("header.h", R"(
+        #include "inner.h"
+        struct Widget { int value; };
+    )");
+    add_main("main.cpp", R"(
+        #include "header.h"
+        Widget instance;
+    )");
+    ASSERT_TRUE(compile());
+    merge_into_workspace();
+
+    // The header has no manifest of its own; its directive is a node of
+    // the host TU's manifest hanging off the header's node.
+    auto session = store.open(header_id);
+    store.apply_open(*session, sources.all_files.lookup("header.h").content, 1);
+    auto edges = query.include_edges(*session);
+    ASSERT_EQ(edges.size(), std::size_t(1));
+    ASSERT_TRUE(llvm::StringRef(edges[0].target).ends_with("inner.h"));
+
+    // The TU's own manifest still answers for the TU itself.
+    auto main_session = store.open(main_id);
+    store.apply_open(*main_session, unit->interested_content().str(), 1);
+    auto main_edges = query.include_edges(*main_session);
+    ASSERT_EQ(main_edges.size(), std::size_t(1));
+    ASSERT_TRUE(llvm::StringRef(main_edges[0].target).ends_with("header.h"));
 }
 
 TEST_CASE(StaleContributionSuppressed) {

--- a/tests/unit/index/index_query_tests.cpp
+++ b/tests/unit/index/index_query_tests.cpp
@@ -3,6 +3,7 @@
 
 #include "test/test.h"
 #include "test/tester.h"
+#include "feature/feature.h"
 #include "index/shard.h"
 #include "index/tu_index.h"
 #include "server/compiler/context_resolver.h"
@@ -158,6 +159,49 @@ TEST_CASE(LocalSymbolName) {
     SymbolKind kind;
     ASSERT_TRUE(query.find_symbol_info(symbol, name, kind));
     ASSERT_EQ(name, "hidden");
+}
+
+TEST_CASE(OpenSessionServedByShard) {
+    add_file("header.h", R"(
+        struct §(def)⟦§(def)Widget⟧ { int value; };
+    )");
+    add_main("main.cpp", R"(
+        #include "header.h"
+        §(use)⟦§(use)Widget⟧ instance;
+    )");
+    ASSERT_TRUE(compile());
+    merge_into_workspace();
+
+    // Open the document with exactly the indexed content and never
+    // compile it: freshness clause 4 serves it from its shard.
+    auto session = store.open(main_id);
+    store.apply_open(*session, unit->interested_content().str(), 1);
+    ASSERT_FALSE(session->index_current());
+
+    auto position = feature::to_position(session->line_map(), point("use"));
+    ASSERT_TRUE(position.has_value());
+    auto locations = query.query_definition(main_path(), *position, session.get());
+    ASSERT_FALSE(locations.empty());
+    ASSERT_TRUE(llvm::StringRef(locations.front().uri).ends_with("header.h"));
+}
+
+TEST_CASE(DivergedBufferWithdrawsShard) {
+    add_main("main.cpp", R"(
+        int stale_fn() { return 1; }
+        int use() { return §(use)⟦§(use)stale_fn⟧(); }
+    )");
+    ASSERT_TRUE(compile());
+    merge_into_workspace();
+
+    auto session = store.open(main_id);
+    auto edited = unit->interested_content().str() + "// edited\n";
+    store.apply_open(*session, edited, 1);
+
+    // The buffer no longer matches the rows' content: the shard withdraws
+    // and the un-compiled session resolves nothing.
+    auto position = feature::to_position(session->line_map(), point("use"));
+    ASSERT_TRUE(position.has_value());
+    ASSERT_TRUE(query.query_definition(main_path(), *position, session.get()).empty());
 }
 
 TEST_CASE(StaleContributionSuppressed) {

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -69,6 +69,18 @@ struct IndexerFixture {
         indexer.pending_ids.erase(id);
     }
 
+    /// Complete an attempt for `ticket` on the loop, as run_index_task's
+    /// tail does — waking waiters requires a running loop.
+    void settle(std::uint32_t id, std::uint64_t ticket) {
+        auto body = [&]() -> kota::task<> {
+            indexer.settle_attempt_waits(id, ticket);
+            co_return;
+        };
+        auto task = body();
+        loop.schedule(task);
+        loop.run();
+    }
+
     /// Start a fresh staleness round: per-round FileVersion verdicts are
     /// cleared by run_background_indexing, which these tests bypass.
     void clear_verdicts() {
@@ -2514,6 +2526,46 @@ TEST_CASE(DroppedWithoutPending) {
     IndexerFixture f;
     auto id = f.workspace.path_pool.intern("/proj/gone.cpp");
     ASSERT_EQ(int(f.fail(id, /*crashed=*/true)), int(IndexerFixture::Verdict::Dropped));
+}
+
+TEST_CASE(AttemptWaitPerTicket) {
+    IndexerFixture f;
+    auto id = f.workspace.path_pool.intern("/proj/waited.cpp");
+    f.indexer.enqueue(id, ReindexReason::ContentChanged);
+    auto launch = f.ticket(id);
+
+    bool first_woke = false;
+    auto first_body = [&]() -> kota::task<> {
+        co_await f.indexer.await_attempt(id);
+        first_woke = true;
+    };
+    auto first = first_body();
+    f.loop.schedule(first);
+    f.loop.run();
+
+    // A requeue lands mid-flight: the entry stays pending under a fresh
+    // ticket, and a new waiter binds to that newer attempt.
+    f.consume(id);
+    f.indexer.enqueue(id, ReindexReason::DepsOnly);
+    bool second_woke = false;
+    auto second_body = [&]() -> kota::task<> {
+        co_await f.indexer.await_attempt(id);
+        second_woke = true;
+    };
+    auto second = second_body();
+    f.loop.schedule(second);
+    f.loop.run();
+
+    // The flight's completion covers the ticket its waiter observed, no
+    // matter the requeue: await_attempt promises one attempt, and holding
+    // the waiter through every follow-up would park a feature request for
+    // as long as edits keep landing.
+    f.settle(id, launch);
+    ASSERT_TRUE(first_woke);
+    ASSERT_FALSE(second_woke);
+
+    f.settle(id, f.ticket(id));
+    ASSERT_TRUE(second_woke);
 }
 
 TEST_CASE(ContentChangeResetsBudget) {

--- a/tools/client/client.ts
+++ b/tools/client/client.ts
@@ -429,11 +429,6 @@ export class CliceClient {
         // counts via initializationOptions.
         project["stateless_worker_count"] ??= 1;
         project["stateful_worker_count"] ??= 1;
-        // The corpus predates the pch_build policy and drives compiles
-        // through feature requests (openAndWait's hover); pin the eager
-        // profile so those semantics hold. Policy behavior itself is
-        // tested by read_only.test.ts, which overrides this.
-        project["pch_build"] ??= "on_open";
         initializationOptions["project"] = project;
         // Disable the stat-polling loops: tests drive ticks deterministically
         // through the clice/internal/poll hook instead.

--- a/tools/client/client.ts
+++ b/tools/client/client.ts
@@ -429,6 +429,11 @@ export class CliceClient {
         // counts via initializationOptions.
         project["stateless_worker_count"] ??= 1;
         project["stateful_worker_count"] ??= 1;
+        // The corpus predates the pch_build policy and drives compiles
+        // through feature requests (openAndWait's hover); pin the eager
+        // profile so those semantics hold. Policy behavior itself is
+        // tested by read_only.test.ts, which overrides this.
+        project["pch_build"] ??= "on_open";
         initializationOptions["project"] = project;
         // Disable the stat-polling loops: tests drive ticks deterministically
         // through the clice/internal/poll hook instead.


### PR DESCRIPTION
## What changed

This PR introduces a `readonly` serving mode for open files — the first of the v1.0 mainlines (read-only / index-first serving). The default is **`"off"`, which keeps existing behavior unchanged**: builds stay pull-driven exactly as today — no lifecycle event starts a compile, the first request that needs the AST does — and the only addition under `off` is that a warm index answers the first requests instantly instead of blocking while that pulled compile lands. The read-only profiles are opt-in.

**`readonly` = `"off" | "on" | "auto"`:**

- `off` (default) — every open file targets a full AST; the index answers while the pulled compile is in flight.
- `on` — never build a PCH/AST: reads serve from the index alone (a cold file jumps the indexing queue), and completion/signature help pay a full preamble-less parse on demand. The agent / low-resource profile.
- `auto` — every file starts as `on` and switches to `off` at the first edit intent: edit, completion, signature help, context switch, or a restored buffer that diverged from the index. The switch has a single write point (`Compiler::escalate`) and only flips serving — it never kicks a compile.

Sessions opened before the initialize handshake are re-derived once the configured mode is known.

**Routing: always answer from the best available source.** `FeatureRouter` derives a route per request from readiness, never from a mode flag: a current AST answers as today; otherwise, if the open document's shard is byte-identical to the buffer (`matches_content`), the index answers immediately; otherwise the request awaits the compile (when one is owed) or answers honestly empty. A quarantined-but-compiled session now falls back to its own file index instead of returning null. Escalated sessions keep serving from the index while their compile is in flight, and a `workspace/semanticTokens/refresh` + `inlayHint/refresh` (capability-gated) tells clients to re-pull once the AST lands.

**Index projections** (`src/feature/index_projection.cpp`): five whole-document features computed from index rows plus the document text, sharing the AST path's wire encoders so replies stay byte-compatible:

- semantic tokens — raw lex (keyword resolution via `IdentifierTable`, per-language profile) + occurrence kinds + Decl/Def modifiers; the lexical classification switch is now shared with the AST collector
- document symbols — outline tree by extent containment, collapsed macro siblings stay siblings
- folding ranges — each definition folds its last balanced brace group (signature stays visible; a ctor's member-init braces don't mis-anchor)
- document links — manifest include edges located with `find_directive_argument`
- hover — name/kind + definition text and preceding comment sliced from stored content, zero new storage

Pinned degradations (asserted by tests, not hidden): no Sema token modifiers, no outline detail, no statement-level folds, no links for guard-skipped/`__has_include` lines, no hover type/value info, empty inlay hints and no diagnostics push while a session is index-only.

**Freshness clause 4** (`IndexQuery`): an open session without a current file index is served by its shard under closed-file rules, strictly while the buffer is byte-identical to the indexed content; a current file index always wins, a diverged buffer withdraws the shard. Cursor resolution, shard skipping, and cross-file assembly all share the one arbitration point.

**Supporting changes:** index-only sessions are no longer skipped by the background indexer (their shard is what the LSP serves) and dependency invalidation re-enqueues them; `didOpen` on an unindexed file boosts it to the front of the indexing queue.

## Tests

- **Unit**: new `index_projection` suite — twin tests compile a fixture and assert the projection output against the AST path's output on the same rows (tokens byte-equal modulo the pinned modifier mask, outline shape-equal, folds a subset with the ctor anchor case pinned), plus pure-row cases for merged-variant conflicts, collapsed siblings, manifest links, and comment extraction. New `IndexQuery` cases pin clause 4 (byte-identical serve, diverged withdraw).
- **Integration**: new `read_only.test.ts` — index-served reads with every pinned degradation asserted, edit escalation riding the next pull, diverged-restored-buffer escalation, `on` completing without a PCH, `off` compiling only on demand, and a warm shard answering before the pulled compile lands.
- All four suites pass locally: unit (1335), integration (370), smoke (3/3), snap (626). The snap suite caught — and now pins — that the hover index fallback must stay inside the preamble region, where an AST null is not authoritative.
