### PR TITLE
fix(command): honor the CDB working directory in toolchain queries

### DIFF
--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -87,6 +87,11 @@ object_ptr<CompilationInfo>
                                                llvm::ArrayRef<const char*> arguments) {
     assert(!arguments.empty() && "arguments must contain at least the driver");
 
+    /// Every use below — nvcc's absolutization, the -I patch joins, the interned
+    /// identity field — must see one spelling of the working directory.
+    auto normalized_directory = path::normalize_directory(directory);
+    directory = normalized_directory;
+
     /// clang's option table cannot parse nvcc's own spellings, and the loop
     /// below discards what it cannot parse — rewrite them first so the
     /// regular classification applies.
@@ -299,7 +304,9 @@ std::optional<std::size_t> CompilationDatabase::load(llvm::StringRef path) {
             continue;
         }
 
-        llvm::StringRef dir_ref(dir_sv.data(), dir_sv.size());
+        auto dir_normalized =
+            path::normalize_directory(llvm::StringRef(dir_sv.data(), dir_sv.size()));
+        llvm::StringRef dir_ref(dir_normalized);
         llvm::StringRef file_ref(file_sv.data(), file_sv.size());
 
         // Skip non-C-family files (e.g. .rc, .asm, .def) that some build

--- a/src/command/toolchain.cpp
+++ b/src/command/toolchain.cpp
@@ -643,6 +643,7 @@ struct PendingQuery {
 }  // namespace
 
 Toolchain::Toolchain() :
+    query_concurrency(kota::sys::parallelism()),
     allocator(std::make_unique<llvm::BumpPtrAllocator>()), strings(allocator.get()) {}
 
 Toolchain::~Toolchain() = default;
@@ -925,23 +926,34 @@ void Toolchain::warm(llvm::ArrayRef<CompileCommand> commands) {
         std::expected<std::vector<std::string>, std::string> result;
     };
 
-    // The query is moved into the coroutine frame as a parameter, so the
-    // argument references stay valid for the coroutine's whole lifetime.
-    auto make_task = [](PendingQuery q) -> kota::task<QueryOutcome> {
-        auto result = co_await query_one(q.query_args, q.file, q.directory);
-        co_return QueryOutcome{std::move(q.key), std::move(result)};
-    };
+    // Pullers rather than a semaphore around each query: kota::semaphore bounds
+    // the probes in flight just as well, but it would have to sit inside a
+    // when_all, which materializes every query's coroutine frame up front and
+    // holds it for the whole batch. A puller reuses one frame across the queue.
+    //
+    // The loop is single-threaded and a puller suspends only inside query_one(),
+    // so the shared cursor and result vector need no synchronization.
+    std::vector<QueryOutcome> outcomes;
+    outcomes.reserve(pending.size());
+    std::size_t next = 0;
 
-    kota::small_vector<QueryOutcome> outcomes;
+    auto puller = [&]() -> kota::task<> {
+        while(next < pending.size()) {
+            auto& q = pending[next++];
+            auto result = co_await query_one(q.query_args, q.file, q.directory);
+            outcomes.push_back({std::move(q.key), std::move(result)});
+        }
+    };
 
     kota::event_loop loop;
     auto run = [&]() -> kota::task<> {
-        std::vector<kota::task<QueryOutcome>> tasks;
-        tasks.reserve(pending.size());
-        for(auto& q: pending)
-            tasks.push_back(make_task(std::move(q)));
+        auto count = std::min<std::size_t>(std::max(query_concurrency, 1u), pending.size());
+        std::vector<kota::task<>> pullers;
+        pullers.reserve(count);
+        for(std::size_t i = 0; i != count; ++i)
+            pullers.push_back(puller());
 
-        outcomes = co_await kota::when_all(std::move(tasks));
+        co_await kota::when_all(std::move(pullers));
     };
     loop.schedule(run());
     loop.run();

--- a/src/command/toolchain.cpp
+++ b/src/command/toolchain.cpp
@@ -262,6 +262,15 @@ kota::task<std::expected<GCCToolchainFlags, std::string>>
     };
 }
 
+/// The directory a probe will actually run in. A CDB outlives the build
+/// directory it names, and spawning in one that is gone fails, so an unusable
+/// directory degrades to the clice process cwd — what every query used before.
+llvm::StringRef usable_directory(llvm::StringRef directory) {
+    if(directory.empty() || fs::is_directory(directory))
+        return directory;
+    return {};
+}
+
 kota::task<std::expected<std::vector<std::string>, std::string>>
     query_one(llvm::ArrayRef<const char*> arguments,
               llvm::StringRef file,
@@ -269,12 +278,9 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
     if(arguments.empty())
         co_return std::unexpected(std::string("Empty arguments"));
 
-    /// A CDB outlives the build directory it names. Spawning there fails, and
-    /// warm() would keep that failure for the session, so an unusable directory
-    /// degrades to the clice process cwd — what every query used before.
-    if(!directory.empty() && !fs::is_directory(directory)) {
+    if(auto usable = usable_directory(directory); usable.empty() && !directory.empty()) {
         LOG_WARN("Working directory {} is unusable; querying from the process cwd", directory);
-        directory = {};
+        directory = usable;
     }
 
     llvm::StringRef driver = arguments[0];
@@ -325,6 +331,12 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
         if(auto e = fs::remove(src_path))
             LOG_ERROR("Fail to remove temporary file: {}", e);
     });
+
+    /// TMPDIR is taken verbatim, so a relative one yields a relative probe path
+    /// — which the driver, spawned in `directory`, would resolve there instead of
+    /// where the file was created.
+    if(auto e = fs::make_absolute(src_path))
+        co_return std::unexpected(std::format("Failed to resolve temp file: {}", e.message()));
 
     /// .cuh is not a clang-known extension: without a language override the
     /// probe counts as linker input and the driver builds no compile job.
@@ -443,6 +455,11 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
                 if(auto e = fs::remove(nvcc_probe))
                     LOG_ERROR("Fail to remove temporary file: {}", e);
             });
+
+            /// Absolute for the same reason `src_path` is.
+            if(auto e = fs::make_absolute(nvcc_probe))
+                co_return std::unexpected(
+                    std::format("Failed to resolve temp file: {}", e.message()));
 
             std::vector<std::string> dryrun_args = {driver.str(),
                                                     "--dryrun",
@@ -746,7 +763,12 @@ Toolchain::ToolchainExtract Toolchain::extract_flags(llvm::StringRef file,
     /// The probe subprocess runs in `directory`, so its result only holds there.
     /// Keyed unconditionally rather than detected: a wrong detection silently
     /// shares one entry between directories that need different flags.
-    result.key += directory;
+    ///
+    /// Keyed on the directory the probe will really use: an unusable one degrades
+    /// to the process cwd, and nothing clears this cache within a session, so
+    /// keying the request would keep serving that degraded result once the
+    /// directory reappears.
+    result.key += usable_directory(directory);
     result.key += '\0';
     result.key += arguments[0];
     result.key += '\0';

--- a/src/command/toolchain.cpp
+++ b/src/command/toolchain.cpp
@@ -279,9 +279,25 @@ kota::task<std::expected<GCCToolchainFlags, std::string>>
 /// deciding twice lets a directory that appears or vanishes in between store a
 /// probe's result under a key describing the other case.
 llvm::StringRef usable_directory(llvm::StringRef directory) {
-    if(directory.empty() || fs::is_directory(directory))
+    if(directory.empty())
         return directory;
-    return {};
+    if(!fs::is_directory(directory))
+        return {};
+#ifndef _WIN32
+    /// Existing is not enough: the child chdirs into it, which needs search
+    /// permission, while `is_directory` only stats it. A mode that denies search
+    /// would otherwise surface as a spawn failure that the negative cache keeps
+    /// for the session, unrecoverable even once the mode is fixed.
+    ///
+    /// `access` directly rather than `fs::can_execute`, which answers a different
+    /// question — it reports false for anything that is not a regular file, so
+    /// every directory would look unusable. Windows traverse rights are not
+    /// expressible this way, so there the spawn failure stays the only signal.
+    llvm::SmallString<128> terminated(directory);
+    if(::access(terminated.c_str(), X_OK) != 0)
+        return {};
+#endif
+    return directory;
 }
 
 /// Announce a degraded directory where a probe is about to run, so the warning

--- a/src/command/toolchain.cpp
+++ b/src/command/toolchain.cpp
@@ -82,6 +82,15 @@ kota::task<std::expected<std::string, std::string>>
     opts.cwd = directory.str();
 #ifndef _WIN32
     opts.env = process_env();
+    /// getcwd() in the child is `directory`, but an inherited PWD still names
+    /// clice's launch directory. A shell re-derives PWD at startup, so only a
+    /// wrapper that reads it without being one — a script in another language, a
+    /// compiled shim — sees the stale value, and it would resolve its relative
+    /// paths where the recorded build never ran.
+    if(!directory.empty()) {
+        std::erase_if(opts.env, [](llvm::StringRef entry) { return entry.starts_with("PWD="); });
+        opts.env.emplace_back("PWD=" + directory.str());
+    }
 #endif
     opts.streams = {
         kota::process::stdio::ignore(),
@@ -265,23 +274,30 @@ kota::task<std::expected<GCCToolchainFlags, std::string>>
 /// The directory a probe will actually run in. A CDB outlives the build
 /// directory it names, and spawning in one that is gone fails, so an unusable
 /// directory degrades to the clice process cwd — what every query used before.
+///
+/// Callers decide once and pass the result to both the cache key and the probe:
+/// deciding twice lets a directory that appears or vanishes in between store a
+/// probe's result under a key describing the other case.
 llvm::StringRef usable_directory(llvm::StringRef directory) {
     if(directory.empty() || fs::is_directory(directory))
         return directory;
     return {};
 }
 
+/// Announce a degraded directory where a probe is about to run, so the warning
+/// stays one per probe rather than one per command resolved.
+void warn_if_degraded(llvm::StringRef requested, llvm::StringRef effective) {
+    if(effective.empty() && !requested.empty())
+        LOG_WARN("Working directory {} is unusable; querying from the process cwd", requested);
+}
+
+/// `directory` is already vetted by `usable_directory`.
 kota::task<std::expected<std::vector<std::string>, std::string>>
     query_one(llvm::ArrayRef<const char*> arguments,
               llvm::StringRef file,
               llvm::StringRef directory) {
     if(arguments.empty())
         co_return std::unexpected(std::string("Empty arguments"));
-
-    if(auto usable = usable_directory(directory); usable.empty() && !directory.empty()) {
-        LOG_WARN("Working directory {} is unusable; querying from the process cwd", directory);
-        directory = usable;
-    }
 
     llvm::StringRef driver = arguments[0];
 
@@ -706,10 +722,12 @@ CompilerFamily Toolchain::driver_family(llvm::StringRef driver) {
     return try_get(name);
 }
 
-std::expected<std::vector<std::string>, std::string>
-    Toolchain::query(llvm::ArrayRef<const char*> arguments,
-                     llvm::StringRef file,
-                     llvm::StringRef directory) {
+/// Run one query to completion on a private loop. `directory` must already be
+/// vetted; the public entry point below is what vets it.
+static std::expected<std::vector<std::string>, std::string>
+    run_query_one(llvm::ArrayRef<const char*> arguments,
+                  llvm::StringRef file,
+                  llvm::StringRef directory) {
     std::expected<std::vector<std::string>, std::string> result;
     kota::event_loop loop;
     auto task = [&]() -> kota::task<> {
@@ -718,6 +736,15 @@ std::expected<std::vector<std::string>, std::string>
     loop.schedule(task());
     loop.run();
     return result;
+}
+
+std::expected<std::vector<std::string>, std::string>
+    Toolchain::query(llvm::ArrayRef<const char*> arguments,
+                     llvm::StringRef file,
+                     llvm::StringRef directory) {
+    auto usable = usable_directory(directory);
+    warn_if_degraded(directory, usable);
+    return run_query_one(arguments, file, usable);
 }
 
 /// Whether the command targets windows-gnu: an explicit target flag wins
@@ -764,11 +791,9 @@ Toolchain::ToolchainExtract Toolchain::extract_flags(llvm::StringRef file,
     /// Keyed unconditionally rather than detected: a wrong detection silently
     /// shares one entry between directories that need different flags.
     ///
-    /// Keyed on the directory the probe will really use: an unusable one degrades
-    /// to the process cwd, and nothing clears this cache within a session, so
-    /// keying the request would keep serving that degraded result once the
-    /// directory reappears.
-    result.key += usable_directory(directory);
+    /// Callers pass the directory already vetted by `usable_directory`, so the
+    /// key describes where the probe will really run.
+    result.key += directory;
     result.key += '\0';
     result.key += arguments[0];
     result.key += '\0';
@@ -818,12 +843,25 @@ Toolchain::ToolchainExtract Toolchain::extract_flags(llvm::StringRef file,
     return result;
 }
 
+#ifdef CLICE_ENABLE_TEST
+
+std::string Toolchain::cache_key(llvm::StringRef file,
+                                 llvm::ArrayRef<const char*> arguments,
+                                 llvm::StringRef directory) {
+    return extract_flags(file, arguments, usable_directory(directory)).key;
+}
+
+#endif
+
 std::expected<void, std::string> Toolchain::resolve(CompileCommand& cmd) {
     if(cmd.resolved.flags.empty())
         return std::unexpected("empty flags");
 
+    /// Decided once: the key and the probe must name the same directory.
+    auto directory = usable_directory(cmd.resolved.directory);
+
     auto [key, query_args, preserve_external_resource] =
-        extract_flags(cmd.source_file, cmd.resolved.flags, cmd.resolved.directory);
+        extract_flags(cmd.source_file, cmd.resolved.flags, directory);
 
     auto it = cache.find(key);
     if(it == cache.end()) {
@@ -831,8 +869,9 @@ std::expected<void, std::string> Toolchain::resolve(CompileCommand& cmd) {
             return std::unexpected(failed_it->second);
 
         LOG_WARN("Toolchain cache miss: file={}", cmd.source_file);
+        warn_if_degraded(cmd.resolved.directory, directory);
 
-        auto result = query(query_args, cmd.source_file, cmd.resolved.directory);
+        auto result = run_query_one(query_args, cmd.source_file, directory);
         if(!result) {
             failed.try_emplace(key, result.error());
             return std::unexpected(std::move(result.error()));
@@ -924,15 +963,23 @@ void Toolchain::warm(llvm::ArrayRef<CompileCommand> commands) {
         if(cmd.resolved.flags.empty())
             continue;
 
-        auto extract = extract_flags(cmd.source_file, cmd.resolved.flags, cmd.resolved.directory);
+        /// Decided once, then carried to the probe: a bounded warm() can queue
+        /// this entry for a while, and re-deciding inside the puller would let a
+        /// directory that appeared or vanished meanwhile store its result under a
+        /// key describing the other case.
+        auto directory = usable_directory(cmd.resolved.directory);
+
+        auto extract = extract_flags(cmd.source_file, cmd.resolved.flags, directory);
         auto& key = extract.key;
         if(cache.count(key) || failed.count(key) || !seen.try_emplace(key, true).second)
             continue;
 
+        warn_if_degraded(cmd.resolved.directory, directory);
+
         pending.push_back({.key = std::move(key),
                            .query_args = std::move(extract.query_args),
                            .file = cmd.source_file,
-                           .directory = cmd.resolved.directory});
+                           .directory = directory});
     }
 
     if(pending.empty())

--- a/src/command/toolchain.cpp
+++ b/src/command/toolchain.cpp
@@ -73,10 +73,13 @@ kota::task<std::string> drain_pipe(kota::pipe p) {
 }
 
 kota::task<std::expected<std::string, std::string>>
-    execute_async(std::vector<std::string> arguments, bool capture_stdout = false) {
+    execute_async(std::vector<std::string> arguments,
+                  llvm::StringRef directory,
+                  bool capture_stdout = false) {
     kota::process::options opts;
     opts.file = arguments[0];
     opts.args = std::move(arguments);
+    opts.cwd = directory.str();
 #ifndef _WIN32
     opts.env = process_env();
 #endif
@@ -232,12 +235,13 @@ struct GCCToolchainFlags {
     std::string install_dir;
 };
 
-kota::task<std::expected<GCCToolchainFlags, std::string>> query_gcc_flags(std::string driver) {
-    auto target = co_await execute_async({driver, "-dumpmachine"}, true);
+kota::task<std::expected<GCCToolchainFlags, std::string>>
+    query_gcc_flags(std::string driver, llvm::StringRef directory) {
+    auto target = co_await execute_async({driver, "-dumpmachine"}, directory, true);
     if(!target)
         co_return std::unexpected(std::move(target.error()));
 
-    auto search_dirs = co_await execute_async({driver, "-print-search-dirs"}, true);
+    auto search_dirs = co_await execute_async({driver, "-print-search-dirs"}, directory, true);
     if(!search_dirs)
         co_return std::unexpected(std::move(search_dirs.error()));
 
@@ -259,9 +263,19 @@ kota::task<std::expected<GCCToolchainFlags, std::string>> query_gcc_flags(std::s
 }
 
 kota::task<std::expected<std::vector<std::string>, std::string>>
-    query_one(llvm::ArrayRef<const char*> arguments, llvm::StringRef file) {
+    query_one(llvm::ArrayRef<const char*> arguments,
+              llvm::StringRef file,
+              llvm::StringRef directory) {
     if(arguments.empty())
         co_return std::unexpected(std::string("Empty arguments"));
+
+    /// A CDB outlives the build directory it names. Spawning there fails, and
+    /// warm() would keep that failure for the session, so an unusable directory
+    /// degrades to the clice process cwd — what every query used before.
+    if(!directory.empty() && !fs::is_directory(directory)) {
+        LOG_WARN("Working directory {} is unusable; querying from the process cwd", directory);
+        directory = {};
+    }
 
     llvm::StringRef driver = arguments[0];
 
@@ -272,18 +286,28 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
     /// Therefore, never use `realpath` on the initial `driver` name, as that
     /// would lose the context needed for the driver to behave correctly (and break caching).
     llvm::SmallString<128> resolved_path;
-    if(!path::is_absolute(driver)) {
-        /// If the path is not absolute path like g++, find it in the env vars.
+    if(path::has_parent_path(driver)) {
+        /// A path-bearing driver is relative to the working directory; with none,
+        /// it stays relative and `fs::make_absolute` anchors it to the clice cwd.
+        resolved_path = driver;
+        path::make_absolute(directory, resolved_path);
+        if(auto error = fs::make_absolute(resolved_path))
+            co_return std::unexpected(
+                std::format("Failed to resolve driver {}: {}", driver.str(), error.message()));
+    } else {
         auto program = llvm::sys::findProgramByName(driver);
         if(!program)
             co_return std::unexpected(std::format("Cannot find driver: {}", driver.str()));
         resolved_path = *program;
-        driver = resolved_path.c_str();
     }
 
-    if(!fs::exists(driver) || !fs::can_execute(driver))
+    if(!fs::exists(resolved_path) || !fs::can_execute(resolved_path))
         co_return std::unexpected(
-            std::format("Driver {} not found or not executable", driver.str()));
+            std::format("Driver {} not found or not executable", resolved_path.str()));
+
+    /// `args` below stores `driver.data()` as a NUL-terminated `const char*`, so
+    /// `resolved_path` must outlive it and must not be mutated from here on.
+    driver = resolved_path.c_str();
 
     llvm::SmallVector<const char*, 256> args;
     args.emplace_back(driver.data());
@@ -316,7 +340,7 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
         // Query g++ or mingw toolchain info. We detect the target and corresponding
         // gcc toolchain install path as default behavior.
         case CompilerFamily::GCC: {
-            auto gcc = co_await query_gcc_flags(driver.str());
+            auto gcc = co_await query_gcc_flags(driver.str(), directory);
             if(!gcc)
                 co_return std::unexpected(std::move(gcc.error()));
 
@@ -360,7 +384,7 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
             for(auto arg: remaining)
                 exec_args.emplace_back(arg);
 
-            auto content = co_await execute_async(std::move(exec_args));
+            auto content = co_await execute_async(std::move(exec_args), directory);
             if(!content)
                 co_return std::unexpected(std::move(content.error()));
 
@@ -429,7 +453,7 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
                     dryrun_args.push_back(arg.str());
             }
 
-            auto dryrun = co_await execute_async(std::move(dryrun_args));
+            auto dryrun = co_await execute_async(std::move(dryrun_args), directory);
             if(!dryrun)
                 co_return std::unexpected(std::move(dryrun.error()));
 
@@ -470,7 +494,7 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
 
             switch(Toolchain::driver_family(host)) {
                 case CompilerFamily::GCC: {
-                    auto gcc = co_await query_gcc_flags(host);
+                    auto gcc = co_await query_gcc_flags(host, directory);
                     if(!gcc)
                         co_return std::unexpected(std::move(gcc.error()));
                     cuda_args.push_back(std::move(gcc->target));
@@ -610,9 +634,10 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
 struct PendingQuery {
     std::string key;
     std::vector<const char*> query_args;
-    /// Points to interned, pointer-stable storage in CompileCommand::source_file;
+    /// Both point to interned, pointer-stable storage in the CompileCommand;
     /// valid for the whole warm() call.
     llvm::StringRef file;
+    llvm::StringRef directory;
 };
 
 }  // namespace
@@ -664,11 +689,13 @@ CompilerFamily Toolchain::driver_family(llvm::StringRef driver) {
 }
 
 std::expected<std::vector<std::string>, std::string>
-    Toolchain::query(llvm::ArrayRef<const char*> arguments, llvm::StringRef file) {
+    Toolchain::query(llvm::ArrayRef<const char*> arguments,
+                     llvm::StringRef file,
+                     llvm::StringRef directory) {
     std::expected<std::vector<std::string>, std::string> result;
     kota::event_loop loop;
     auto task = [&]() -> kota::task<> {
-        result = co_await query_one(arguments, file);
+        result = co_await query_one(arguments, file, directory);
     };
     loop.schedule(task());
     loop.run();
@@ -704,7 +731,8 @@ static bool uses_windows_gnu_target(llvm::ArrayRef<const char*> arguments) {
 }
 
 Toolchain::ToolchainExtract Toolchain::extract_flags(llvm::StringRef file,
-                                                     llvm::ArrayRef<const char*> arguments) {
+                                                     llvm::ArrayRef<const char*> arguments,
+                                                     llvm::StringRef directory) {
     ToolchainExtract result;
 
     // LLVM-MinGW's resource headers and libc++ are a matched installation.
@@ -714,9 +742,13 @@ Toolchain::ToolchainExtract Toolchain::extract_flags(llvm::StringRef file,
     // and builtin headers stay version-matched.
     result.preserve_external_resource = uses_windows_gnu_target(arguments);
 
+    /// The probe subprocess runs in `directory`, so its result only holds there.
+    /// Keyed unconditionally rather than detected: a wrong detection silently
+    /// shares one entry between directories that need different flags.
+    result.key += directory;
+    result.key += '\0';
     result.key += arguments[0];
     result.key += '\0';
-
     result.key += path::extension(file);
     result.key += '\0';
 
@@ -768,7 +800,7 @@ std::expected<void, std::string> Toolchain::resolve(CompileCommand& cmd) {
         return std::unexpected("empty flags");
 
     auto [key, query_args, preserve_external_resource] =
-        extract_flags(cmd.source_file, cmd.resolved.flags);
+        extract_flags(cmd.source_file, cmd.resolved.flags, cmd.resolved.directory);
 
     auto it = cache.find(key);
     if(it == cache.end()) {
@@ -777,7 +809,7 @@ std::expected<void, std::string> Toolchain::resolve(CompileCommand& cmd) {
 
         LOG_WARN("Toolchain cache miss: file={}", cmd.source_file);
 
-        auto result = query(query_args, cmd.source_file);
+        auto result = query(query_args, cmd.source_file, cmd.resolved.directory);
         if(!result) {
             failed.try_emplace(key, result.error());
             return std::unexpected(std::move(result.error()));
@@ -869,12 +901,15 @@ void Toolchain::warm(llvm::ArrayRef<CompileCommand> commands) {
         if(cmd.resolved.flags.empty())
             continue;
 
-        auto extract = extract_flags(cmd.source_file, cmd.resolved.flags);
+        auto extract = extract_flags(cmd.source_file, cmd.resolved.flags, cmd.resolved.directory);
         auto& key = extract.key;
         if(cache.count(key) || failed.count(key) || !seen.try_emplace(key, true).second)
             continue;
 
-        pending.push_back({std::move(key), std::move(extract.query_args), cmd.source_file});
+        pending.push_back({.key = std::move(key),
+                           .query_args = std::move(extract.query_args),
+                           .file = cmd.source_file,
+                           .directory = cmd.resolved.directory});
     }
 
     if(pending.empty())
@@ -893,7 +928,7 @@ void Toolchain::warm(llvm::ArrayRef<CompileCommand> commands) {
     // The query is moved into the coroutine frame as a parameter, so the
     // argument references stay valid for the coroutine's whole lifetime.
     auto make_task = [](PendingQuery q) -> kota::task<QueryOutcome> {
-        auto result = co_await query_one(q.query_args, q.file);
+        auto result = co_await query_one(q.query_args, q.file, q.directory);
         co_return QueryOutcome{std::move(q.key), std::move(result)};
     };
 

--- a/src/command/toolchain.h
+++ b/src/command/toolchain.h
@@ -68,6 +68,11 @@ public:
     /// TODO: the GCC/MSVC/NVCC families synthesize their final cc1 through an
     /// in-process clang driver running in clice's cwd, so relative paths in their
     /// remaining flags escape `directory` — give that driver `directory` too.
+    /// A bare `arguments[0]` is looked up through PATH before the child changes
+    /// cwd, so a relative PATH entry anchors to clice's cwd where POSIX would
+    /// anchor it to `directory`. Left as is on purpose: anchoring it means
+    /// hand-rolling platform PATH lookup, for a spelling that is a security
+    /// hazard and effectively unused by build systems.
     /// Unlike resolve(), this is uncached and forwards `arguments` as-is; prefer
     /// resolve() for CDB commands so results are cached and per-file user-content
     /// flags are re-appended.

--- a/src/command/toolchain.h
+++ b/src/command/toolchain.h
@@ -44,6 +44,14 @@ public:
     /// parallel internally. Blocks until all queries complete.
     void warm(llvm::ArrayRef<CompileCommand> commands);
 
+    /// How many probe subprocesses warm() may run at once. Defaults to the CPU
+    /// parallelism and follows the configured worker-process ceiling when the
+    /// server sets one. The bound matters beyond throughput: a probe forks a
+    /// compiler driver and holds two pipes, and a failed spawn caches its key as
+    /// permanently failed, so exhausting fds over a many-directory CDB would
+    /// leave those commands without flags for the rest of the session.
+    unsigned query_concurrency;
+
     /// Resolve a driver-level command to cc1 level by querying the toolchain.
     /// Modifies the command in-place.
     [[nodiscard]] std::expected<void, std::string> resolve(CompileCommand& cmd);

--- a/src/command/toolchain.h
+++ b/src/command/toolchain.h
@@ -28,9 +28,10 @@ enum class CompilerFamily {
 };
 
 /// Patches raw CDB commands into clang-acceptable cc1 arguments by querying
-/// the compiler driver. Results are cached by (driver, file extension,
-/// non-user-content flags); user-content flags (-I, -D, ...) don't affect
-/// the query and are re-appended from the original command after resolution.
+/// the compiler driver. Results are cached by (working directory, driver, file
+/// extension, non-user-content flags); user-content flags (-I, -D, ...) don't
+/// affect the query and are re-appended from the original command after
+/// resolution.
 class Toolchain {
 public:
     Toolchain();
@@ -52,11 +53,20 @@ public:
 
     /// Single synchronous toolchain query. Returns cc1 arguments as owned strings.
     /// `file` is used for temp file extension detection (optional if -x is set).
+    /// `directory` is the driver's working directory: probe subprocesses (gcc
+    /// -dumpmachine/-print-search-dirs, clang -###, nvcc --dryrun) run in it and a
+    /// path-bearing relative `arguments[0]` resolves against it; when empty the
+    /// driver inherits clice's own cwd.
+    /// TODO: the GCC/MSVC/NVCC families synthesize their final cc1 through an
+    /// in-process clang driver running in clice's cwd, so relative paths in their
+    /// remaining flags escape `directory` — give that driver `directory` too.
     /// Unlike resolve(), this is uncached and forwards `arguments` as-is; prefer
     /// resolve() for CDB commands so results are cached and per-file user-content
     /// flags are re-appended.
     static std::expected<std::vector<std::string>, std::string>
-        query(llvm::ArrayRef<const char*> arguments, llvm::StringRef file = {});
+        query(llvm::ArrayRef<const char*> arguments,
+              llvm::StringRef file = {},
+              llvm::StringRef directory = {});
 
     bool has_cache() const;
 
@@ -65,8 +75,10 @@ public:
 #ifdef CLICE_ENABLE_TEST
 
     /// Compute the cache key for the given file and driver-level arguments.
-    std::string cache_key(llvm::StringRef file, llvm::ArrayRef<const char*> arguments) {
-        return extract_flags(file, arguments).key;
+    std::string cache_key(llvm::StringRef file,
+                          llvm::ArrayRef<const char*> arguments,
+                          llvm::StringRef directory = {}) {
+        return extract_flags(file, arguments, directory).key;
     }
 
     /// Number of cached toolchain query results.
@@ -96,7 +108,9 @@ private:
         bool preserve_external_resource = false;
     };
 
-    ToolchainExtract extract_flags(llvm::StringRef file, llvm::ArrayRef<const char*> arguments);
+    ToolchainExtract extract_flags(llvm::StringRef file,
+                                   llvm::ArrayRef<const char*> arguments,
+                                   llvm::StringRef directory);
 
     std::unique_ptr<llvm::BumpPtrAllocator> allocator;
     StringSet strings;

--- a/src/command/toolchain.h
+++ b/src/command/toolchain.h
@@ -87,12 +87,11 @@ public:
 
 #ifdef CLICE_ENABLE_TEST
 
-    /// Compute the cache key for the given file and driver-level arguments.
+    /// Compute the cache key for the given file and driver-level arguments,
+    /// vetting `directory` the way resolve() does.
     std::string cache_key(llvm::StringRef file,
                           llvm::ArrayRef<const char*> arguments,
-                          llvm::StringRef directory = {}) {
-        return extract_flags(file, arguments, directory).key;
-    }
+                          llvm::StringRef directory = {});
 
     /// Number of cached toolchain query results.
     std::size_t cache_size() const {

--- a/src/driver/inspect.cc
+++ b/src/driver/inspect.cc
@@ -439,9 +439,9 @@ std::optional<FileCommand> file_command(FileEntry& entry,
             // TU semantics instead of a precompiled-header job.
             driver_args.insert(driver_args.end(), {"-x", "c++"});
         }
-        // The toolchain query spawns the driver from the process cwd, and the
-        // driver reads @response-files itself — resolve them against the
-        // input directory so they don't depend on where inspect was launched.
+        // The driver expands @response-files itself, so resolve them against the
+        // input directory rather than letting them depend on where inspect was
+        // launched.
         std::vector<std::string> resolved_flags(flags.begin(), flags.end());
         for(auto& flag: resolved_flags) {
             llvm::StringRef rest(flag);
@@ -455,7 +455,7 @@ std::optional<FileCommand> file_command(FileEntry& entry,
             driver_args.push_back(flag.c_str());
         }
         driver_args.insert(driver_args.end(), {"-fsyntax-only", file.c_str()});
-        auto cc1 = Toolchain::query(driver_args, file);
+        auto cc1 = Toolchain::query(driver_args, file, flags_directory);
         if(!cc1) {
             entry.error = "toolchain_error";
             entry.diagnostics = {std::move(cc1.error())};
@@ -534,7 +534,7 @@ std::optional<FileCommand> file_command(FileEntry& entry,
         } else {
             driver_args = {"clang", "-fsyntax-only", file.c_str()};
         }
-        auto cc1 = Toolchain::query(driver_args, file);
+        auto cc1 = Toolchain::query(driver_args, file, path::parent_path(file));
         if(!cc1) {
             entry.error = "toolchain_error";
             entry.diagnostics = {std::move(cc1.error())};

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -504,6 +504,12 @@ void MasterServer::load_workspace() {
 
     auto& cfg = workspace.config.project;
 
+    // Driver probes and stateless workers are both compiler-weight processes
+    // competing for the same machine, so the configured worker ceiling bounds
+    // the probe fan-out too. 0 means auto there, which is the default already.
+    if(cfg.max_stateless_worker_count != 0)
+        workspace.toolchain.query_concurrency = cfg.max_stateless_worker_count;
+
     open_cache_store();
 
     auto cdb_path = discover_compile_commands(workspace.config, workspace_root);

--- a/src/support/filesystem.h
+++ b/src/support/filesystem.h
@@ -75,6 +75,32 @@ inline void canonicalize([[maybe_unused]] std::string& p) {
 #endif
 }
 
+/// Identity spelling of a directory: canonical per the rule above, with "."
+/// components and duplicate or trailing separators collapsed.
+///
+/// ".." is left as written — collapsing it lexically merges distinct
+/// directories whenever the skipped component is a symlink — and the real path
+/// is never resolved, which would change the path handed to a spawned compiler
+/// and is not stable across mounts.
+inline std::string normalize_directory(llvm::StringRef directory) {
+    std::string result = directory.str();
+    canonicalize(result);
+
+    /// The style is pinned rather than native: on Windows the canonical spelling
+    /// is forward-slashed, which native (windows) style would reassemble with
+    /// backslashes and whose `c:/` root posix style would eat; on POSIX windows
+    /// style would take '\' in a legal filename for a separator.
+#ifdef _WIN32
+    constexpr auto style = Style::windows_slash;
+#else
+    constexpr auto style = Style::posix;
+#endif
+
+    llvm::SmallString<128> buf(result);
+    remove_dots(buf, /*remove_dot_dot=*/false, style);
+    return std::string(buf);
+}
+
 }  // namespace path
 
 namespace fs {

--- a/tests/integration/agentic/rpc.ts
+++ b/tests/integration/agentic/rpc.ts
@@ -220,8 +220,13 @@ export function runCli(
     return runQuery(executable, args);
 }
 
-/// Forward-slash form of a path; the agentic side channel speaks POSIX
-/// paths on every platform.
+/// Canonical spelling of a path for the agentic side channel: forward slashes
+/// on every platform, plus the lowercase drive letter that is Windows path
+/// identity for the server (`path::needs_canonical`). The compile database's
+/// `directory` is normalized to that form at load, so an expectation built from
+/// the raw OS spelling would differ from what the server reports by drive case
+/// alone.
 export function posix(p: string): string {
-    return p.split(path.sep).join("/");
+    const slashed = p.split(path.sep).join("/");
+    return /^[A-Z]:/.test(slashed) ? slashed[0].toLowerCase() + slashed.slice(1) : slashed;
 }

--- a/tests/integration/agentic/rpc.ts
+++ b/tests/integration/agentic/rpc.ts
@@ -228,5 +228,5 @@ export function runCli(
 /// alone.
 export function posix(p: string): string {
     const slashed = p.split(path.sep).join("/");
-    return /^[A-Z]:/.test(slashed) ? slashed[0].toLowerCase() + slashed.slice(1) : slashed;
+    return slashed.replace(/^[A-Z](?=:)/, (drive) => drive.toLowerCase());
 }

--- a/tests/unit/command/command_tests.cpp
+++ b/tests/unit/command/command_tests.cpp
@@ -276,6 +276,27 @@ TEST_CASE(UniqueConfigsMultiFile) {
     }
 };
 
+TEST_CASE(DirectorySpellingNormalized) {
+    CompilationDatabase database;
+    database.add_command("/fake/build", "main.cpp", "clang++ -std=c++20 main.cpp"sv);
+    database.add_command("/fake/build/", "main.cpp", "clang++ -std=c++20 main.cpp"sv);
+    database.add_command("/fake/build/./", "main.cpp", "clang++ -std=c++20 main.cpp"sv);
+
+    // One directory in three spellings: the working directory is identity (it
+    // keys the toolchain cache), so they must not split into three configs.
+    EXPECT_EQ(database.unique_configs(quiet_options()).size(), 1U);
+};
+
+TEST_CASE(DirectoryDotDotKept) {
+    CompilationDatabase database;
+    database.add_command("/fake/build", "main.cpp", "clang++ -std=c++20 main.cpp"sv);
+    database.add_command("/fake/x/../build", "main.cpp", "clang++ -std=c++20 main.cpp"sv);
+
+    // ".." is left alone on purpose: collapsing it lexically merges distinct
+    // directories whenever the skipped component is a symlink.
+    EXPECT_EQ(database.unique_configs(quiet_options()).size(), 2U);
+};
+
 TEST_CASE(GroupCommandRebuild) {
     CompilationDatabase database;
     database.add_command("fake", "main.cpp", "clang++ -std=c++17 main.cpp"sv);

--- a/tests/unit/command/toolchain_tests.cpp
+++ b/tests/unit/command/toolchain_tests.cpp
@@ -341,6 +341,24 @@ TEST_CASE(KeyTracksWorkingDirectory) {
               tc.cache_key("/tmp/a.cpp", args));
 }
 
+TEST_CASE(KeyIgnoresUnenterableDirectory, skip = Windows) {
+    Toolchain tc;
+    std::vector<const char*> args = {"clang++", "-std=c++23"};
+
+    TempDir temp;
+    temp.mkdir("sealed");
+    auto sealed = temp.path("sealed");
+
+    // Denying search permission makes the child's chdir fail while stat still
+    // succeeds, so `is_directory` alone would accept it and the spawn failure
+    // would be cached for the session.
+    ASSERT_TRUE(!llvm::sys::fs::setPermissions(sealed, llvm::sys::fs::perms::no_perms));
+    auto restore = llvm::make_scope_exit(
+        [&] { llvm::sys::fs::setPermissions(sealed, llvm::sys::fs::perms::all_all); });
+
+    EXPECT_EQ(tc.cache_key("/tmp/a.cpp", args, sealed), tc.cache_key("/tmp/a.cpp", args));
+}
+
 TEST_CASE(ResolveEmptyFlags) {
     Toolchain tc;
     CompileCommand cmd;

--- a/tests/unit/command/toolchain_tests.cpp
+++ b/tests/unit/command/toolchain_tests.cpp
@@ -502,6 +502,52 @@ TEST_CASE(WarmPartialFailure, skip = Windows) {
     EXPECT_EQ(tc.failed_size(), std::size_t(1));
 }
 
+TEST_CASE(WarmBoundsConcurrency, skip = Windows) {
+    auto log = fs::createTemporaryFile("clice-probe", "log");
+    ASSERT_TRUE(log.has_value());
+    auto log_cleanup = llvm::make_scope_exit([&] { fs::remove(*log); });
+
+    // Each probe brackets a sleep with an append, so the log records real-time
+    // overlap: a prefix sum over it is the number of probes alive at that point.
+    auto prelude = "printf '%s' + >> " + *log + "\nsleep 0.3\nprintf '%s' - >> " + *log + "\n";
+
+    llvm::SmallVector<std::string> drivers;
+    llvm::SmallVector<CompileCommand> cmds;
+    for(int i = 0; i != 5; ++i) {
+        auto driver = create_fake_clang(fake_cc1_line, prelude);
+        ASSERT_TRUE(driver.has_value());
+        drivers.push_back(*driver);
+    }
+    auto driver_cleanup = llvm::make_scope_exit([&] {
+        for(auto& driver: drivers)
+            fs::remove(driver);
+    });
+
+    // Distinct drivers, so none of the five collapses into one key.
+    for(std::size_t i = 0; i != drivers.size(); ++i) {
+        CompileCommand cmd;
+        cmd.resolved.flags = {drivers[i].c_str()};
+        cmd.source_file = "/tmp/a.cpp";
+        cmds.push_back(cmd);
+    }
+
+    Toolchain tc;
+    tc.query_concurrency = 2;
+    tc.warm(cmds);
+    EXPECT_EQ(tc.cache_size(), drivers.size());
+
+    auto content = fs::read(*log);
+    ASSERT_TRUE(content.has_value());
+
+    int alive = 0;
+    int peak = 0;
+    for(char c: *content) {
+        alive += c == '+' ? 1 : -1;
+        peak = std::max(peak, alive);
+    }
+    EXPECT_EQ(peak, 2);
+}
+
 TEST_CASE(ResolveFailNegativeCache, skip = Windows) {
     // A fake driver whose -### output contains no cc1 line, so the query fails.
     auto driver = create_fake_clang("this is not a cc1 line");

--- a/tests/unit/command/toolchain_tests.cpp
+++ b/tests/unit/command/toolchain_tests.cpp
@@ -8,6 +8,8 @@
 #include "compile/compilation.h"
 #include "support/logging.h"
 
+#include "llvm/ADT/ScopeExit.h"
+
 namespace clice::testing {
 namespace {
 
@@ -303,6 +305,27 @@ TEST_CASE(KeyTracksSemantics) {
     EXPECT_NE(key, tc.cache_key("/tmp/a.cpp", semantic));
 }
 
+TEST_CASE(KeyTracksWorkingDirectory) {
+    Toolchain tc;
+    std::vector<const char*> args = {"clang++", "-std=c++23"};
+
+    // The driver runs in the working directory, so its query result belongs to
+    // that directory — two directories never share a cache entry, however
+    // cwd-independent the command looks.
+    EXPECT_NE(tc.cache_key("/tmp/a.cpp", args, "/tmp/project-a"),
+              tc.cache_key("/tmp/a.cpp", args, "/tmp/project-b"));
+
+    // The directory is a separate key field, not a prefix glued onto the driver
+    // spelling: these two contrived pairs concatenate to the same bytes, so a
+    // missing field separator would merge them.
+    EXPECT_NE(tc.cache_key("/tmp/a.cpp", {"b/clang++", "-std=c++23"}, "/tmp/a"),
+              tc.cache_key("/tmp/a.cpp", {"/clang++", "-std=c++23"}, "/tmp/ab"));
+
+    // An absent directory (query() runs the driver in clice's own cwd) is one
+    // more distinct case, not an alias of any real directory.
+    EXPECT_NE(tc.cache_key("/tmp/a.cpp", args), tc.cache_key("/tmp/a.cpp", args, "/tmp/project-a"));
+}
+
 TEST_CASE(ResolveEmptyFlags) {
     Toolchain tc;
     CompileCommand cmd;
@@ -367,15 +390,23 @@ TEST_CASE(ParseCC1DropsCodegen) {
 constexpr static llvm::StringRef fake_cc1_line =
     R"( "/usr/bin/clang-22" "-cc1" "-triple" "x86_64-unknown-linux-gnu" "-fmodules-reduced-bmi" "-fmodule-output=/tmp/probe.pcm" "-clice-future-flag" "val" "-std=c++23")";
 
+/// The cc1 args query() should produce from `fake_cc1_line`: unknown future flag
+/// and its value dropped, BMI emission flags stripped, known flags kept.
+std::vector<std::string> fake_cc1_expected() {
+    return {"/usr/bin/clang-22", "-cc1", "-triple", "x86_64-unknown-linux-gnu", "-std=c++23"};
+}
+
 /// Create an executable shell script named `*.clang` (detected as the Clang
 /// family) that prints a canned `-###` line to stderr, standing in for a
-/// real external driver.
-std::optional<std::string> create_fake_clang(llvm::StringRef cc1_line) {
+/// real external driver. `prelude` is injected before the echo, letting a
+/// test make the script assert something about how it was invoked.
+std::optional<std::string> create_fake_clang(llvm::StringRef cc1_line,
+                                             llvm::StringRef prelude = {}) {
     auto file = fs::createTemporaryFile("clice-fake", "clang");
     if(!file)
         return std::nullopt;
 
-    auto script = "#!/bin/sh\necho '" + cc1_line.str() + "' >&2\n";
+    auto script = "#!/bin/sh\n" + prelude.str() + "echo '" + cc1_line.str() + "' >&2\n";
     if(!fs::write(*file, script))
         return std::nullopt;
 
@@ -393,12 +424,55 @@ TEST_CASE(QueryFakeDriver, skip = Windows) {
     ASSERT_TRUE(result.has_value());
 
     // Unknown flag + value dropped, BMI emission flags stripped, known kept.
-    std::vector<std::string> expected = {"/usr/bin/clang-22",
-                                         "-cc1",
-                                         "-triple",
-                                         "x86_64-unknown-linux-gnu",
-                                         "-std=c++23"};
-    EXPECT_EQ(*result, expected);
+    EXPECT_EQ(*result, fake_cc1_expected());
+}
+
+TEST_CASE(QueryRelativeDriver, skip = Windows) {
+    auto marker = fs::createTemporaryFile("clice-cwd", "marker");
+    ASSERT_TRUE(marker.has_value());
+    auto marker_cleanup = llvm::make_scope_exit([&] { fs::remove(*marker); });
+
+    /// The fake driver only emits its cc1 line if it finds the marker through a
+    /// bare relative name, which requires it to be spawned in `directory`.
+    auto prelude = "test -f " + path::filename(*marker).str() + " || exit 1\n";
+    auto driver = create_fake_clang(fake_cc1_line, prelude);
+    ASSERT_TRUE(driver.has_value());
+    auto driver_cleanup = llvm::make_scope_exit([&] { fs::remove(*driver); });
+
+    auto directory = path::parent_path(*driver).str();
+    auto relative_driver = "./" + path::filename(*driver).str();
+
+    /// Otherwise the marker check could succeed via the runner's own cwd.
+    llvm::SmallString<128> cwd;
+    ASSERT_TRUE(!fs::current_path(cwd));
+    ASSERT_NE(cwd.str(), llvm::StringRef(directory));
+    ASSERT_EQ(path::parent_path(*marker), llvm::StringRef(directory));
+
+    CompileCommand command;
+    command.resolved.directory = directory;
+    command.resolved.flags = {relative_driver.c_str()};
+    command.source_file = "/tmp/a.cpp";
+
+    Toolchain tc;
+    ASSERT_TRUE(tc.resolve(command).has_value());
+    EXPECT_TRUE(command.resolved.is_cc1);
+
+    std::vector<std::string> actual(command.resolved.flags.begin(), command.resolved.flags.end());
+    EXPECT_EQ(actual, fake_cc1_expected());
+}
+
+TEST_CASE(QueryVanishedDirectory, skip = Windows) {
+    auto driver = create_fake_clang(fake_cc1_line);
+    ASSERT_TRUE(driver.has_value());
+    auto driver_cleanup = llvm::make_scope_exit([&] { fs::remove(*driver); });
+
+    // A CDB outlives the build directory it names. Spawning the probe there
+    // would fail, and warm() caches a failure for the whole session, so an
+    // unusable directory falls back to clice's cwd.
+    auto result =
+        Toolchain::query({driver->c_str()}, "/tmp/a.cpp", "/tmp/clice-vanished-directory");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, fake_cc1_expected());
 }
 
 TEST_CASE(WarmPartialFailure, skip = Windows) {

--- a/tests/unit/command/toolchain_tests.cpp
+++ b/tests/unit/command/toolchain_tests.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <optional>
 
+#include "test/temp_dir.h"
 #include "test/test.h"
 #include "command/argument_parser.h"
 #include "command/command.h"
@@ -309,21 +310,35 @@ TEST_CASE(KeyTracksWorkingDirectory) {
     Toolchain tc;
     std::vector<const char*> args = {"clang++", "-std=c++23"};
 
+    TempDir temp;
+    temp.mkdir("project-a");
+    temp.mkdir("project-b");
+    auto project_a = temp.path("project-a");
+    auto project_b = temp.path("project-b");
+
     // The driver runs in the working directory, so its query result belongs to
     // that directory — two directories never share a cache entry, however
     // cwd-independent the command looks.
-    EXPECT_NE(tc.cache_key("/tmp/a.cpp", args, "/tmp/project-a"),
-              tc.cache_key("/tmp/a.cpp", args, "/tmp/project-b"));
+    EXPECT_NE(tc.cache_key("/tmp/a.cpp", args, project_a),
+              tc.cache_key("/tmp/a.cpp", args, project_b));
 
     // The directory is a separate key field, not a prefix glued onto the driver
     // spelling: these two contrived pairs concatenate to the same bytes, so a
     // missing field separator would merge them.
-    EXPECT_NE(tc.cache_key("/tmp/a.cpp", {"b/clang++", "-std=c++23"}, "/tmp/a"),
-              tc.cache_key("/tmp/a.cpp", {"/clang++", "-std=c++23"}, "/tmp/ab"));
+    temp.mkdir("a");
+    temp.mkdir("ab");
+    EXPECT_NE(tc.cache_key("/tmp/a.cpp", {"b/clang++", "-std=c++23"}, temp.path("a")),
+              tc.cache_key("/tmp/a.cpp", {"/clang++", "-std=c++23"}, temp.path("ab")));
 
     // An absent directory (query() runs the driver in clice's own cwd) is one
     // more distinct case, not an alias of any real directory.
-    EXPECT_NE(tc.cache_key("/tmp/a.cpp", args), tc.cache_key("/tmp/a.cpp", args, "/tmp/project-a"));
+    EXPECT_NE(tc.cache_key("/tmp/a.cpp", args), tc.cache_key("/tmp/a.cpp", args, project_a));
+
+    // A directory that is gone is not a case of its own: the probe degrades to
+    // the process cwd, and keying that result under the requested path would
+    // keep serving it once the build directory reappears.
+    EXPECT_EQ(tc.cache_key("/tmp/a.cpp", args, temp.path("vanished")),
+              tc.cache_key("/tmp/a.cpp", args));
 }
 
 TEST_CASE(ResolveEmptyFlags) {

--- a/tests/unit/support/filesystem_tests.cpp
+++ b/tests/unit/support/filesystem_tests.cpp
@@ -1,0 +1,74 @@
+#include "test/test.h"
+#include "support/filesystem.h"
+
+namespace clice::testing {
+
+namespace {
+
+TEST_SUITE(Filesystem) {
+
+TEST_CASE(CanonicalSpelling) {
+    // The rewrite itself is platform-independent and testable anywhere;
+    // only its application is Windows-gated.
+    auto canon = [](std::string s) {
+        path::make_canonical(llvm::MutableArrayRef(s.data(), s.size()));
+        return s;
+    };
+    EXPECT_EQ(canon(R"(D:\ws\x.h)"), "d:/ws/x.h");
+    EXPECT_EQ(canon("d:/ws/x.h"), "d:/ws/x.h");
+    EXPECT_EQ(canon("/usr/X.h"), "/usr/X.h");
+
+    EXPECT_TRUE(path::needs_canonical(R"(a\b)"));
+    EXPECT_TRUE(path::needs_canonical("C:/x.h"));
+    EXPECT_FALSE(path::needs_canonical("c:/x.h"));
+    EXPECT_FALSE(path::needs_canonical("/usr/x.h"));
+}
+
+TEST_CASE(NormalizeDirectoryEquivalence) {
+    // The working directory is an identity field: it keys the toolchain query
+    // cache, joins the command hash and takes part in CompilationInfo dedup, so
+    // every spelling of one directory must normalize to one string.
+    auto norm = [](llvm::StringRef p) {
+        return path::normalize_directory(p);
+    };
+
+    auto base = norm("/a/b");
+    EXPECT_EQ(norm("/a/b/"), base);
+    EXPECT_EQ(norm("/a/./b"), base);
+    EXPECT_EQ(norm("/a/b/."), base);
+    EXPECT_EQ(norm("/a/b/./"), base);
+    EXPECT_EQ(norm("/a//b"), base);
+    EXPECT_EQ(norm("/a/b//"), base);
+
+    // Relative spellings normalize too; nothing here resolves against a cwd.
+    EXPECT_EQ(norm("a/b/"), norm("a/./b"));
+}
+
+TEST_CASE(NormalizeDirectoryKeepsDotDot) {
+    // ".." is left as written: collapsing it lexically merges distinct
+    // directories whenever the skipped component is a symlink. The inequality
+    // alone would also hold for a realpath-resolving implementation, so pin the
+    // component itself.
+    EXPECT_TRUE(llvm::StringRef(path::normalize_directory("/a/x/../b")).contains(".."));
+}
+
+TEST_CASE(NormalizeDirectoryEdges) {
+    // Stripping the trailing separator must stop at the root, which would
+    // otherwise normalize to the empty string and alias "no directory".
+    EXPECT_EQ(path::normalize_directory("/"), "/");
+    EXPECT_EQ(path::normalize_directory("//"), "/");
+    EXPECT_EQ(path::normalize_directory(""), "");
+
+    // A bare "." collapses to the empty spelling, which is the same directory
+    // it denotes: empty tells the driver probe to inherit clice's cwd, and an
+    // unresolved "." resolves there too. A compile database is specified to
+    // carry absolute directories, so this only arises for a degenerate one.
+    EXPECT_EQ(path::normalize_directory("."), "");
+    EXPECT_EQ(path::normalize_directory("./"), "");
+}
+
+};  // TEST_SUITE(Filesystem)
+
+}  // namespace
+
+}  // namespace clice::testing

--- a/tests/unit/support/path_pool_tests.cpp
+++ b/tests/unit/support/path_pool_tests.cpp
@@ -1,5 +1,4 @@
 #include "test/test.h"
-#include "support/filesystem.h"
 #include "support/path_pool.h"
 
 namespace clice::testing {
@@ -7,23 +6,6 @@ namespace clice::testing {
 namespace {
 
 TEST_SUITE(PathPool) {
-
-TEST_CASE(CanonicalSpelling) {
-    // The rewrite itself is platform-independent and testable anywhere;
-    // only its application is Windows-gated.
-    auto canon = [](std::string s) {
-        path::make_canonical(llvm::MutableArrayRef(s.data(), s.size()));
-        return s;
-    };
-    EXPECT_EQ(canon(R"(D:\ws\x.h)"), "d:/ws/x.h");
-    EXPECT_EQ(canon("d:/ws/x.h"), "d:/ws/x.h");
-    EXPECT_EQ(canon("/usr/X.h"), "/usr/X.h");
-
-    EXPECT_TRUE(path::needs_canonical(R"(a\b)"));
-    EXPECT_TRUE(path::needs_canonical("C:/x.h"));
-    EXPECT_FALSE(path::needs_canonical("c:/x.h"));
-    EXPECT_FALSE(path::needs_canonical("/usr/x.h"));
-}
 
 #ifdef _WIN32
 TEST_CASE(WindowsSpellingsCollapse) {


### PR DESCRIPTION
## Related issue

Fixes #638

## What changed

Three commits, the first two for the probe cwd and the third for the spelling.

**`fix(toolchain): run driver query in the CDB working directory`**

The working directory is threaded from `CompileCommand::resolved.directory` down
to `query_one` and set as the spawned probe's cwd, so every probe subprocess —
`gcc -dumpmachine`, `gcc -print-search-dirs`, `clang -###`, `nvcc --dryrun` —
runs where the build ran.

Driver resolution now splits on whether the spelling carries a path rather than
on whether it is absolute. A path-bearing driver (`./bin/clang++`) is anchored to
the working directory via `path::make_absolute`; a bare name (`g++`) still goes
through PATH lookup, which is what the CDB means by it.

A CDB outlives the build directory it names, and spawning in a directory that no
longer exists fails. Since `warm()` records a failed key in the negative cache
for the whole session, an unusable directory degrades to the process cwd with a
warning instead — the behavior every query had before this change.

The directory became a leading field of the toolchain cache key, unconditionally.
A probe's result is only valid for the directory it ran in. Keying on it only for
queries that *look* cwd-dependent (relative driver, unrecognized compiler,
relative `--sysroot`) was considered and rejected: a wrong detection silently
shares one entry between directories that need different flags, while the cost of
always keying — extra probes for a CDB that varies `directory` — is bounded and
paid once per directory.

A `TODO` is left on `Toolchain::query`: the GCC/MSVC/NVCC families synthesize
their final cc1 line through an *in-process* clang driver, which still runs in
clice's cwd, so relative paths among their remaining flags can still escape
`directory`. That driver needs the same treatment and is out of scope here.

**`perf(toolchain): bound the driver probe fan-out in warm()`**

Making `directory` part of the key turns one probe per unique flag set into one
probe per directory, and `warm()` handed every unique query to `when_all` at
once. Each probe forks a compiler driver and holds two pipes, so a CDB with
thousands of build directories would put thousands of drivers in flight. The
failure mode is not slowness: a spawn that dies on the fd limit is recorded in
the negative cache, and those commands then serve unresolved flags until the
server restarts.

Queries are now drawn through a fixed set of puller coroutines, so at most
`query_concurrency` probes exist at once. The server sets that from
`max_stateless_worker_count` — probes and stateless workers are both
compiler-weight processes competing for one machine, so the configured worker
ceiling is the process budget the user already expressed. It defaults to the CPU
parallelism.

Pullers rather than a semaphore around each query: `kota::semaphore` bounds the
probes in flight just as well, but it has to sit inside a `when_all`, which
materializes every query's coroutine frame up front and holds it for the whole
batch. A puller reuses one frame across the queue.

**`fix(command): normalize the CDB working directory at load`**

`path::normalize_directory` is applied once before the directory is interned, so
the toolchain cache key, the command hash and `CompilationInfo` dedup all see one
spelling. It applies the repo's existing Windows spelling rule via
`path::canonicalize` (separators and drive-letter case), collapses `.` components
and duplicate separators through `remove_dots`, and strips a trailing separator
while keeping the root. The JSON loader normalizes before resolving relative
`file` paths, so the `PathPool` spelling and the interned directory agree.

`..` is deliberately left as written and the real path is never resolved.
Collapsing `..` lexically merges distinct directories whenever the skipped
component is a symlink, and `realpath` would change the very path handed to a
spawned compiler while not being stable across mounts.

## Tests

New unit tests:

- `toolchain_tests`: `KeyTracksWorkingDirectory` (the key separates two
  directories), `QueryRelativeDriver` (a path-bearing relative driver resolves
  against `directory`, verified through a marker the fake driver writes),
  `QueryVanishedDirectory` (a deleted directory degrades instead of failing),
  `WarmBoundsConcurrency` (a fake driver logs its own overlap; peak concurrency
  never exceeds the bound)
- `command_tests`: `DirectorySpellingNormalized`, `DirectoryDotDotKept`
- `filesystem_tests`: a new `Filesystem` suite over `canonicalize` and
  `normalize_directory` — equivalence classes, `..` preservation, and the edge
  cases (root, empty, repeated separators)

All four suites pass locally, plus `pixi run format`.

Beyond the suites, each reproduction from #638 was run against a build of this
branch and against a clean build of `main` at 70106e45, using `clice inspect` and
`clice index` as probes:

- relative driver — `main`: `Toolchain resolve failed ... Driver
  toolchain/bin/clang++ not found or not executable`; this branch: resolves, no
  warning
- recorded probe cwd — `main`: clice's own cwd; this branch: the entry's
  `directory`
- re-spelled directory (trailing separator, and a `.` component) — `main`:
  `Compile command changed since the last session; reindexing ...` on the next
  run; this branch: no change detected
