### PR TITLE
chore: large-scale technical debt cleanup

### DIFF
--- a/.claude/skills/write-tests/SKILL.md
+++ b/.claude/skills/write-tests/SKILL.md
@@ -49,8 +49,8 @@ gates: `npm run check` at the repo root (tsc strict + ESLint, zero tolerance).
    ```
 
    Variants: `session("name", opts)` (data workspace, locked + initialized),
-   `session.tmp()` (tmpdir + un-initialized server), `session.bare()` (no
-   workspace). Options: `initializationOptions`, `allowAnomaly` (ONLY for
+   `session.tmp()` (tmpdir + un-initialized server). Options:
+   `initializationOptions`, `allowAnomaly` (ONLY for
    tests that deliberately crash workers — assert on the anomaly
    explicitly), `drainStderr: false` (backpressure tests), `args`,
    `socketPort`.
@@ -112,7 +112,7 @@ be workspace-relative. Requests: `hoverAt` `definitionAt` `referencesAt`
 `save` `close`. Waiting: `armDiagnostics` (arm BEFORE the trigger) /
 `waitDiagnostics` / `waitForRecompile` / `waitForIndex` /
 `waitForReference`. Asserts: `assertNoErrors` `assertHasErrors`
-`assertDiagnosticsCount` `assertCleanCompile` `assertNoAnomaly` `errors`.
+`assertCleanCompile` `assertNoAnomaly` `errors`.
 Lifecycle: `shutdown()` `killServer()` `assertExitedCleanly()`. Custom
 protocol (typed): `queryContext` `currentContext` `switchContext` `poll`
 `stats` `logFlood`; raw wire: `sendRequest(TypeOrMethod, params, token?)`,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,11 +46,9 @@ if(CLICE_USE_LIBCXX)
     string(APPEND CMAKE_SHARED_LINKER_FLAGS " -stdlib=libc++")
 endif()
 
-# Releases deliberately do NOT enable LTO yet: ThinLTO's cross-TU inlining
-# defeats kota's out-of-line workaround for llvm-project#105595 (clang < 21
-# drops coroutine promise policy writes under -O3), which silently breaks
-# cancellation — six cancellation unit tests fail on any ThinLTO build.
-# Re-enable together with the clang 21 toolchain upgrade.
+# Releases deliberately do NOT enable LTO yet. LLVM 22 removed the old
+# toolchain blocker, but enabling remains deferred until the cancellation
+# regression suite has been validated under ThinLTO.
 
 if(CLICE_ENABLE_LTO)
     string(APPEND CMAKE_C_FLAGS " -flto=thin")

--- a/docs/en/dev/test-and-debug.md
+++ b/docs/en/dev/test-and-debug.md
@@ -16,9 +16,7 @@ pixi run unit-test Debug    # debug build
 Equivalent to:
 
 ```bash
-./build/RelWithDebInfo/bin/unit_tests \
-    --test-dir="./tests/data" \
-    --verbose
+./build/RelWithDebInfo/bin/unit_tests --verbose
 ```
 
 ### Integration Tests

--- a/docs/en/features/code-action.md
+++ b/docs/en/features/code-action.md
@@ -1,6 +1,6 @@
 # Code Action
 
-clice advertises `textDocument/codeAction` support but currently returns an empty list. This page tracks the intended scope.
+clice does not advertise `textDocument/codeAction` support yet. Direct requests currently reach the stub handler and return an empty list. This page tracks the intended scope.
 
 ## Quick Fixes
 

--- a/docs/en/features/diagnostics.md
+++ b/docs/en/features/diagnostics.md
@@ -41,10 +41,10 @@
 
 - [x] Push diagnostics on compilation completion
 - [x] Clear diagnostics on file close
-- [x] Per-file diagnostic grouping (interested file + headers)
+- [x] Per-file diagnostic grouping (main file + headers)
 - [x] Diagnostic `code` field with Clang error codes
 - [ ] `codeDescription` with links to Clang documentation
-- [ ] Diagnostic `source` field distinguishing clang vs clang-tidy
+- [x] Diagnostic `source` field distinguishing clang vs clang-tidy
 - [ ] Configurable debounce delay before computing diagnostics ([clangd#1471](https://github.com/clangd/clangd/issues/1471))
 - [ ] Recompute diagnostics in open files when background indexing completes ([clangd#2604](https://github.com/clangd/clangd/issues/2604))
 

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -114,14 +114,6 @@ Lower bound for dynamic stateless-worker scaling; `0` is invalid and falls back 
 
 Upper bound for dynamic stateless-worker scaling; `0` means the machine's parallelism, which is also the default.
 
-### `project.worker_memory_limit`
-
-| Type     | Default      |
-| -------- | ------------ |
-| `uint64` | `4294967296` |
-
-Per-stateful-worker memory limit in bytes; `0` is invalid and falls back to the default. Not yet enforced: parsed, but memory-based eviction is not implemented.
-
 <!-- END GENERATED CONFIG -->
 
 ## Tracker

--- a/docs/public/clice-config.schema.json
+++ b/docs/public/clice-config.schema.json
@@ -15,8 +15,7 @@
                 "idle_timeout_ms": 3000,
                 "test_hooks": false,
                 "stateful_worker_count": 2,
-                "min_stateless_worker_count": 1,
-                "worker_memory_limit": 4294967296
+                "min_stateless_worker_count": 1
             }
         },
         "tracker": {
@@ -153,13 +152,6 @@
                     "minimum": 0,
                     "maximum": 4294967295,
                     "description": "Upper bound for dynamic stateless-worker scaling; `0` means the machine's parallelism, which is also the default."
-                },
-                "worker_memory_limit": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 18446744073709551615,
-                    "description": "Per-stateful-worker memory limit in bytes; `0` is invalid and falls back to the default. Not yet enforced: parsed, but memory-based eviction is not implemented.",
-                    "default": 4294967296
                 }
             },
             "additionalProperties": false

--- a/docs/zh/dev/test-and-debug.md
+++ b/docs/zh/dev/test-and-debug.md
@@ -16,9 +16,7 @@ pixi run unit-test Debug    # debug 构建
 等价于：
 
 ```bash
-./build/RelWithDebInfo/bin/unit_tests \
-    --test-dir="./tests/data" \
-    --verbose
+./build/RelWithDebInfo/bin/unit_tests --verbose
 ```
 
 ### 集成测试

--- a/docs/zh/features/code-action.md
+++ b/docs/zh/features/code-action.md
@@ -1,6 +1,6 @@
 # 代码操作
 
-clice 已注册 `textDocument/codeAction` 支持，但目前始终返回空列表。本页记录预期范围。
+clice 尚未公布 `textDocument/codeAction` 支持。直接发送的请求目前会到达存根处理器并返回空列表。本页记录预期范围。
 
 ## 快速修复
 

--- a/docs/zh/features/diagnostics.md
+++ b/docs/zh/features/diagnostics.md
@@ -41,10 +41,10 @@
 
 - [x] 编译完成时推送诊断
 - [x] 文件关闭时清除诊断
-- [x] 按文件分组诊断（关注的文件 + 头文件）
+- [x] 按文件分组诊断（主文件 + 头文件）
 - [x] 诊断 `code` 字段包含 Clang 错误代码
 - [ ] `codeDescription` 链接到 Clang 文档
-- [ ] 诊断 `source` 字段区分 clang 与 clang-tidy
+- [x] 诊断 `source` 字段区分 clang 与 clang-tidy
 - [ ] 可配置的诊断计算防抖延迟（[clangd#1471](https://github.com/clangd/clangd/issues/1471)）
 - [ ] 后台索引完成后重新计算已打开文件的诊断（[clangd#2604](https://github.com/clangd/clangd/issues/2604)）
 

--- a/docs/zh/guide/configuration.md
+++ b/docs/zh/guide/configuration.md
@@ -24,11 +24,11 @@ clice 从工作区根目录的 `clice.toml` 中读取配置；若该文件不存
 
 ### `project.cache_dir`
 
-| 类型     | 默认值                                                              |
-| -------- | ------------------------------------------------------------------- |
-| `string` | `$XDG_CACHE_HOME/clice/<workspace>-<hash>` 或 `${workspace}/.clice` |
+| 类型     | 默认值 |
+| -------- | ------ |
+| `string` | `""`   |
 
-统一磁盘缓存的存储目录（PCH、PCM 与索引产物都在这里）。默认使用 XDG_CACHE_HOME（或 `~/.cache`）下以工作区目录名加短哈希命名的子目录，例如 `~/.cache/clice/myproject-1a2b3c4d`。如果 XDG 目录无法创建，则回退到 `${workspace}/.clice`。实际解析出的路径会在启动时的有效配置日志中打印（可在编辑器的 clice 输出面板查看）。
+统一磁盘缓存的存储目录（PCH、PCM 与索引产物都在这里）。空值默认使用 `${workspace}/.clice`；clice 会生成 `.gitignore` 和 `CACHEDIR.TAG`，使缓存不进入版本控制并允许备份工具忽略它（`.clice/config.toml` 仍对 Git 可见）。显式配置的目录不会添加这些标记。实际解析出的路径会在启动时打印。
 
 ### `project.logging_dir`
 
@@ -93,14 +93,6 @@ clice 从工作区根目录的 `clice.toml` 中读取配置；若该文件不存
 | `uint32` | `0`（自动） |
 
 无状态工作进程动态扩容的上限。`0` 表示使用 CPU 核心数。
-
-### `project.worker_memory_limit`
-
-| 类型     | 默认值               |
-| -------- | -------------------- |
-| `uint64` | `4294967296`（4 GB） |
-
-每个工作进程的内存限制（字节）。**尚未强制执行**——该选项会被解析，但基于内存的淘汰/重启尚未实现。
 
 ## Tracker
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8557,15 +8557,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/vscode-jsonrpc": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
-      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/vscode-languageclient": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
@@ -9148,7 +9139,6 @@
         "typescript": "~5.5.4",
         "typescript-eslint": "^8.65.0",
         "vitest": "^3.2.0",
-        "vscode-jsonrpc": "^8.2.1",
         "vscode-languageserver-protocol": "^3.17.5",
         "vscode-uri": "^3.1.0"
       }
@@ -9158,7 +9148,6 @@
       "version": "0.0.0",
       "dependencies": {
         "diff": "^9.0.0",
-        "vscode-jsonrpc": "^8.2.1",
         "vscode-languageserver-protocol": "^3.17.5",
         "vscode-uri": "^3.1.0"
       },

--- a/pixi.toml
+++ b/pixi.toml
@@ -186,7 +186,7 @@ cmd = "node tools/feature_docs.ts check"
 
 [feature.test.tasks.unit-test]
 args = [{ arg = "type", default = "RelWithDebInfo" }]
-cmd = './build/{{ type }}/bin/unit_tests --test-dir="./tests/data" --verbose'
+cmd = './build/{{ type }}/bin/unit_tests --verbose'
 depends-on = [{ task = "check-feature-docs" }]
 
 # npm workspaces: install runs at the repo root and covers tools/, tests/
@@ -220,9 +220,9 @@ node tools/replay.ts tests/smoke/*.jsonl \
     --clice=./build/{{ type }}/bin/clice
 """
 
-# Standalone feature snapshots: `clice inspect` over tests/snap corpora
-# (no server involved). Driver logic lives in tools/snap.ts; the vitest
-# glue schedules one inspect process per fixture concurrently.
+# Feature snapshots exercise `clice inspect` and real server paths over
+# tests/snap corpora. Driver logic lives under tools/snap/; the vitest glue
+# schedules fixture work concurrently within the suite.
 [feature.test.tasks.snap-test]
 args = [{ arg = "type", default = "RelWithDebInfo" }]
 cmd = """

--- a/src/command/toolchain.h
+++ b/src/command/toolchain.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <cstdint>
 #include <expected>
 #include <memory>
 #include <string>
@@ -18,7 +19,7 @@ namespace clice {
 
 struct CompileCommand;
 
-enum class CompilerFamily {
+enum class CompilerFamily : std::uint8_t {
     Unknown,
     GCC,      // Covers gcc, g++, cc, c++, and versioned/arch variants
     Clang,    // Covers clang, clang++, and versioned variants (excluding clang-cl)

--- a/src/compile/compilation.cpp
+++ b/src/compile/compilation.cpp
@@ -1,11 +1,14 @@
 #include "compile/compilation.h"
 
+#include <algorithm>
+
 #include "command/command.h"
 #include "compile/diagnostic.h"
 #include "compile/implement.h"
 #include "semantic/decls.h"
 #include "support/logging.h"
 
+#include "kota/ipc/lsp/position.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/xxhash.h"
 #include "clang/Basic/Stack.h"
@@ -184,7 +187,7 @@ public:
         clang::MultiplexConsumer(std::move(consumer)), unit(unit) {}
 
     void collect_decl(clang::Decl* decl) {
-        if(unit.file_id(unit.expansion_location(decl->getLocation())) != unit.interested_file()) {
+        if(unit.file_id(unit.expansion_location(decl->getLocation())) != unit.main_file()) {
             return;
         }
 
@@ -348,12 +351,8 @@ CompilationUnit run_clang(CompilationParams& params,
 
     using namespace std::chrono;
     self->build_at = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
-    auto build_start = steady_clock::now().time_since_epoch();
 
     self->status = self->run_clang(params, std::move(action), before_execute);
-
-    auto build_end = steady_clock::now().time_since_epoch();
-    self->build_duration = duration_cast<milliseconds>(build_end - build_start);
 
     if(self->status == CompilationStatus::Completed && after_execute) {
         after_execute(self);
@@ -395,7 +394,7 @@ CompilationUnit compile(CompilationParams& params, PCHInfo& out) {
         },
         [&](CompilationUnitRef unit) {
             out.path = params.output_file.str();
-            out.preamble = unit.interested_content();
+            out.preamble = unit.main_content();
             out.deps = unit.deps();
             out.arguments = params.arguments;
         });
@@ -422,8 +421,8 @@ CompilationUnit compile(CompilationParams& params, PCMInfo& out) {
             // build input of its PCM all the same. Canonicalize it like
             // every other dep — srcPath keeps the command line's raw
             // spelling, which consumers cannot stat reliably.
-            out.deps.emplace_back(std::string(unit.file_path(unit.interested_file())),
-                                  llvm::xxh3_64bits(unit.interested_content()));
+            out.deps.emplace_back(std::string(unit.file_path(unit.main_file())),
+                                  llvm::xxh3_64bits(unit.main_content()));
 
             for(auto& [name, path]: params.pcms) {
                 out.mods.emplace_back(name);
@@ -434,22 +433,19 @@ CompilationUnit compile(CompilationParams& params, PCMInfo& out) {
 CompilationUnit complete(CompilationParams& params, clang::CodeCompleteConsumer* consumer) {
     auto& [file, offset] = params.completion;
 
-    /// The location of clang is 1-1 based.
-    std::uint32_t line = 1;
-    std::uint32_t column = 1;
-
     auto buffer = params.buffers.find(file);
     assert(buffer != params.buffers.end() && "completion file must be remapped");
     llvm::StringRef content = buffer->second->getBuffer();
+    kota::ipc::lsp::LineMap map({content.data(), content.size()},
+                                kota::ipc::lsp::PositionEncoding::UTF8);
+    auto completion_offset =
+        static_cast<std::uint32_t>(std::min<std::size_t>(offset, content.size()));
+    auto position = map.to_position(completion_offset);
+    assert(position && "clamped completion offset must be mappable");
 
-    for(auto c: content.substr(0, offset)) {
-        if(c == '\n') {
-            line += 1;
-            column = 1;
-            continue;
-        }
-        column += 1;
-    }
+    /// Clang completion locations are 1-based.
+    auto line = position->line + 1;
+    auto column = position->character + 1;
 
     return run_clang(params,
                      std::make_unique<clang::SyntaxOnlyAction>(),

--- a/src/compile/compilation_unit.cpp
+++ b/src/compile/compilation_unit.cpp
@@ -144,17 +144,17 @@ auto CompilationUnitRef::loaded_file_content(clang::FileID fid) -> std::optional
     return self->SM().getBufferDataOrNone(fid);
 }
 
-auto CompilationUnitRef::interested_file() -> clang::FileID {
+auto CompilationUnitRef::main_file() -> clang::FileID {
     return self->SM().getMainFileID();
 }
 
-auto CompilationUnitRef::interested_content() -> llvm::StringRef {
-    return file_content(interested_file());
+auto CompilationUnitRef::main_content() -> llvm::StringRef {
+    return file_content(main_file());
 }
 
 auto CompilationUnitRef::line_starts() -> std::span<const std::uint32_t> {
     if(self->line_starts_cache.empty()) {
-        auto content = interested_content();
+        auto content = main_content();
         self->line_starts_cache =
             kota::ipc::lsp::build_line_starts({content.data(), content.size()});
     }
@@ -171,14 +171,6 @@ bool CompilationUnitRef::is_builtin_file(clang::FileID fid) {
     }
 
     return false;
-}
-
-auto CompilationUnitRef::start_location(clang::FileID fid) -> clang::SourceLocation {
-    return self->SM().getLocForStartOfFile(fid);
-}
-
-auto CompilationUnitRef::end_location(clang::FileID fid) -> clang::SourceLocation {
-    return self->SM().getLocForEndOfFile(fid);
 }
 
 auto CompilationUnitRef::spelling_location(clang::SourceLocation loc) -> clang::SourceLocation {
@@ -269,10 +261,6 @@ auto CompilationUnitRef::top_level_decls() -> llvm::ArrayRef<clang::Decl*> {
 
 std::chrono::milliseconds CompilationUnitRef::build_at() {
     return self->build_at;
-}
-
-std::chrono::milliseconds CompilationUnitRef::build_duration() {
-    return self->build_duration;
 }
 
 clang::LangOptions& CompilationUnitRef::lang_options() {

--- a/src/compile/compilation_unit.h
+++ b/src/compile/compilation_unit.h
@@ -37,7 +37,7 @@ enum class CompilationKind : std::uint8_t {
     /// From building precompiled module for the module interface unit.
     ModuleInterface,
 
-    /// From building normal AST for source file(except preamble), interested file and top level
+    /// From building normal AST for source file(except preamble), main file and top level
     /// declarations are available.
     Content,
 
@@ -140,25 +140,18 @@ public:
     /// file_content, never falls back to a fake buffer.
     auto loaded_file_content(clang::FileID fid) -> std::optional<llvm::StringRef>;
 
-    /// Get the interested file ID. Currently, it is the same as the main
-    /// file id，i.e. the file id of source file.
-    auto interested_file() -> clang::FileID;
+    /// Return clang's main file ID, the file this unit was built for.
+    auto main_file() -> clang::FileID;
 
-    /// Get the content of interested file.
-    auto interested_content() -> llvm::StringRef;
+    /// Get the content of main file.
+    auto main_content() -> llvm::StringRef;
 
-    /// Get the byte offsets of each line start in the interested file.
+    /// Get the byte offsets of each line start in the main file.
     /// Lazily computed and cached.
     auto line_starts() -> std::span<const std::uint32_t>;
 
     /// Check if a file is a builtin file.
     bool is_builtin_file(clang::FileID fid);
-
-    /// Get the location of the file start of the file id.
-    auto start_location(clang::FileID fid) -> clang::SourceLocation;
-
-    /// Get the location of file end of the file id.
-    auto end_location(clang::FileID fid) -> clang::SourceLocation;
 
     /// Get the include location of the file id, i.e. where the file
     /// was introduced by `#include`.
@@ -236,8 +229,6 @@ public:
 
     std::chrono::milliseconds build_at();
 
-    std::chrono::milliseconds build_duration();
-
     clang::LangOptions& lang_options();
 
     clang::ASTContext& context();
@@ -246,7 +237,7 @@ public:
 
     types::TemplateResolver& resolver();
 
-    /// The semantic map of the interested file (token → owning node), built
+    /// The semantic map of the main file (token → owning node), built
     /// lazily on first use and cached for the unit's lifetime.
     const Semantics& semantics();
 

--- a/src/compile/diagnostic.cpp
+++ b/src/compile/diagnostic.cpp
@@ -1,5 +1,7 @@
 #include "compile/diagnostic.h"
 
+#include <utility>
+
 #include "compile/implement.h"
 #include "support/format.h"
 
@@ -13,6 +15,16 @@
 #include "clang/Lex/Preprocessor.h"
 
 namespace clice {
+
+llvm::StringRef diagnostic_source_name(DiagnosticSource source) {
+    switch(source) {
+        case DiagnosticSource::Unknown: return {};
+        case DiagnosticSource::Clang: return "clang";
+        case DiagnosticSource::ClangTidy: return "clang-tidy";
+        case DiagnosticSource::Clice: return "clice";
+    }
+    std::unreachable();
+}
 
 llvm::StringRef DiagnosticID::diagnostic_code() const {
     switch(value) {
@@ -152,6 +164,8 @@ bool DiagnosticID::is_deserialization_error() const {
            clang::DiagnosticIDs::getCategoryNumberForDiag(value) == category;
 }
 
+namespace {
+
 bool is_note(clang::DiagnosticsEngine::Level level) {
     return level == clang::DiagnosticsEngine::Note || level == clang::DiagnosticsEngine::Remark;
 }
@@ -270,6 +284,8 @@ public:
 private:
     CompilationUnitRef unit;
 };
+
+}  // namespace
 
 std::unique_ptr<clang::DiagnosticConsumer> CompilationUnitRef::Self::create_diagnostic() {
     return std::make_unique<DiagnosticCollector>(this);

--- a/src/compile/diagnostic.h
+++ b/src/compile/diagnostic.h
@@ -27,6 +27,8 @@ enum class DiagnosticSource : std::uint8_t {
     Clice,
 };
 
+llvm::StringRef diagnostic_source_name(DiagnosticSource source);
+
 struct DiagnosticID {
     /// The diagnostic id value.
     std::uint32_t value;

--- a/src/compile/implement.h
+++ b/src/compile/implement.h
@@ -86,7 +86,7 @@ struct CompilationUnitRef::Self {
     /// Cache for symbol id.
     llvm::DenseMap<const void*, std::uint64_t> symbol_hash_cache;
 
-    /// Cache for line starts of the interested file.
+    /// Cache for line starts of the main file.
     std::vector<std::uint32_t> line_starts_cache;
 
     llvm::BumpPtrAllocator path_storage;
@@ -99,11 +99,10 @@ struct CompilationUnitRef::Self {
 
     /// The tidy configuration reports on headers (HeaderFilterRegex or
     /// SystemHeaders), so the matcher traversal must see their
-    /// declarations — top_level_decls holds the interested file only.
+    /// declarations — top_level_decls holds the main file only.
     bool tidy_traverse_headers = false;
 
     std::chrono::milliseconds build_at;
-    std::chrono::milliseconds build_duration;
 
     auto& SM() {
         return instance->getSourceManager();

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -14,8 +14,6 @@
 #include "kota/support/glob_pattern.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
-#include "llvm/Support/Process.h"
-#include "llvm/Support/xxhash.h"
 
 namespace clice {
 
@@ -32,54 +30,6 @@ static void substitute_workspace(std::string& value, llvm::StringRef workspace_r
         pos += workspace_root.size();
     }
 }
-
-// FIXME: Out-of-tree cache placement (XDG/system cache directory) is
-// disabled: the hashed leaf makes logs undiscoverable for bug reports and
-// orphaned directories outlive their workspaces with no GC. The
-// workspace-local `.clice` self-ignores via .gitignore/CACHEDIR.TAG, so
-// the original motivation (polluting the repository) is gone. Revisit
-// whether an out-of-tree location should exist at all before re-enabling.
-#if 0
-/// Try to resolve the default cache directory using XDG_CACHE_HOME.
-/// Returns empty string on failure.
-static std::string resolve_xdg_cache_dir(llvm::StringRef workspace_root) {
-    // Determine base: $XDG_CACHE_HOME or ~/.cache
-    std::string base;
-    if(auto xdg = llvm::sys::Process::GetEnv("XDG_CACHE_HOME"); xdg && !xdg->empty()) {
-        base = std::move(*xdg);
-    } else if(auto home = llvm::sys::Process::GetEnv("HOME"); home && !home->empty()) {
-        base = path::join(*home, ".cache");
-    } else {
-        return {};
-    }
-
-    // "<basename>-<hash>": the basename lets users map cache directories
-    // back to their workspaces, the hash keeps same-named workspaces apart.
-    auto hash = llvm::xxh3_64bits(workspace_root);
-    llvm::StringRef name = path::filename(workspace_root.rtrim("/\\"));
-    if(name.empty() || name == "." || name == "..")
-        name = "workspace";
-    // Keep the leaf well under filesystem name limits (255 bytes on common
-    // filesystems) without splitting a UTF-8 sequence mid-codepoint.
-    if(name.size() > 64) {
-        name = name.take_front(64);
-        while(!name.empty() && (static_cast<unsigned char>(name.back()) & 0xC0) == 0x80)
-            name = name.drop_back();
-        // A complete trailing character loses its continuation bytes above;
-        // drop its lead byte too rather than keep invalid UTF-8.
-        if(!name.empty() && static_cast<unsigned char>(name.back()) >= 0xC0)
-            name = name.drop_back();
-    }
-    auto dir =
-        path::join(base, "clice", std::format("{}-{:08x}", name, static_cast<std::uint32_t>(hash)));
-
-    if(auto ec = llvm::sys::fs::create_directories(dir)) {
-        LOG_WARN("Failed to create XDG cache directory {}: {}", dir, ec.message());
-        return {};
-    }
-    return dir;
-}
-#endif
 
 std::uint32_t default_stateless_worker_count() {
     // Config is constructed on every worker request (QueryParams /
@@ -113,8 +63,6 @@ void Config::finalize(llvm::StringRef workspace_root) {
     reject_zero(p.min_stateless_worker_count,
                 defaults.min_stateless_worker_count,
                 "min_stateless_worker_count");
-    reject_zero(p.worker_memory_limit, defaults.worker_memory_limit, "worker_memory_limit");
-
     if(p.cache_dir.empty() && !workspace_root.empty()) {
         p.cache_dir = path::join(workspace_root, ".clice");
         p.cache_dir_defaulted = true;
@@ -292,8 +240,7 @@ constexpr std::array MACHINE_DERIVED_FIELDS = {"stateless_worker_count",
 /// The fields finalize() rejects `0` for.
 constexpr std::array ZERO_INVALID_FIELDS = {"stateful_worker_count",
                                             "stateless_worker_count",
-                                            "min_stateless_worker_count",
-                                            "worker_memory_limit"};
+                                            "min_stateless_worker_count"};
 
 /// Scrub the machine-derived fields out of a `default` object: sections
 /// carry whole-object defaults, so the values appear below `default`

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -154,14 +154,6 @@ struct ProjectConfig {
                          "means the machine's parallelism, which is also the "
                          "default.")
     <std::uint32_t> max_stateless_worker_count = default_max_stateless_worker_count();
-
-    KOTATSU_ANNOTATE(defaulted = true,
-                     description =
-                         "Per-stateful-worker memory limit in bytes; `0` is "
-                         "invalid and falls back to the default. Not yet "
-                         "enforced: parsed, but memory-based eviction is not "
-                         "implemented.")
-    <std::uint64_t> worker_memory_limit = 4ULL * 1024 * 1024 * 1024;
 };
 
 /// Corresponds to the `[tracker]` section in clice.toml: the stat-polling

--- a/src/driver/worker.cc
+++ b/src/driver/worker.cc
@@ -20,12 +20,6 @@ struct WorkerOptions {
     stateful;
 
     DecoKV(style = KVStyle::JoinedOrSeparate,
-           names = {"--memory-limit", "--memory-limit="},
-           help = "Memory limit in bytes (stateful worker only)",
-           required = false)
-    <std::uint64_t> memory_limit;
-
-    DecoKV(style = KVStyle::JoinedOrSeparate,
            names = {"--max-documents", "--max-documents="},
            help = "Max compiled documents kept before LRU eviction (stateful worker only)",
            required = false)
@@ -58,9 +52,8 @@ void add_worker(kota::deco::cli::SubCommander& root, int& exit_code) {
            auto name = opts.worker_name.value_or("worker");
            auto log_dir = opts.log_dir.value_or("");
            if(opts.stateful) {
-               auto limit = opts.memory_limit.value_or(4ULL * 1024 * 1024 * 1024);
                auto max_docs = opts.max_documents.value_or(default_max_documents);
-               exit_code = run_stateful_worker_mode(limit, name, log_dir, max_docs);
+               exit_code = run_stateful_worker_mode(name, log_dir, max_docs);
            } else {
                exit_code = run_stateless_worker_mode(name, log_dir);
            }

--- a/src/feature/diagnostics.cpp
+++ b/src/feature/diagnostics.cpp
@@ -60,7 +60,7 @@ void add_related(protocol::Diagnostic& diagnostic,
 
 auto diagnostics(CompilationUnitRef unit, PositionEncoding encoding)
     -> std::vector<protocol::Diagnostic> {
-    LineMap map(unit.interested_content(), unit.line_starts(), encoding);
+    LineMap map(unit.main_content(), unit.line_starts(), encoding);
     std::vector<protocol::Diagnostic> result;
     std::optional<protocol::Diagnostic> current;
 
@@ -110,8 +110,7 @@ auto diagnostics(CompilationUnitRef unit, PositionEncoding encoding)
             diagnostic.code_description = protocol::CodeDescription{.href = std::move(*uri)};
         }
 
-        // Keep legacy behavior: always report clang as source.
-        diagnostic.source = "clang";
+        diagnostic.source = diagnostic_source_name(raw.id.source).str();
 
         add_tag(diagnostic, raw.id);
 
@@ -124,7 +123,7 @@ auto diagnostics(CompilationUnitRef unit, PositionEncoding encoding)
             continue;
         }
 
-        if(raw.fid == unit.interested_file()) {
+        if(raw.fid == unit.main_file()) {
             auto range = to_range(map, raw.range);
             if(!range)
                 continue;

--- a/src/feature/document_links.cpp
+++ b/src/feature/document_links.cpp
@@ -59,19 +59,19 @@ auto find_directive_argument(llvm::StringRef content,
 auto document_links(CompilationUnitRef unit) -> std::vector<DocumentLink> {
     std::vector<DocumentLink> links;
 
-    auto interested = unit.interested_file();
-    auto directives_it = unit.directives().find(interested);
+    auto main_fid = unit.main_file();
+    auto directives_it = unit.directives().find(main_fid);
     if(directives_it == unit.directives().end()) {
         return links;
     }
 
-    auto content = unit.interested_content();
+    auto content = unit.main_content();
     auto& directives = directives_it->second;
     auto* lang_opts = &unit.lang_options();
 
     auto add_link = [&](clang::SourceLocation loc, llvm::StringRef target) {
         auto [fid, offset] = unit.decompose_location(loc);
-        if(fid != interested || offset >= content.size())
+        if(fid != main_fid || offset >= content.size())
             return;
         auto range = find_directive_argument(content, offset, lang_opts);
         if(!range)
@@ -114,13 +114,13 @@ auto include_definition(CompilationUnitRef unit, std::uint32_t offset)
     -> std::vector<protocol::Location> {
     std::vector<protocol::Location> locations;
 
-    auto interested = unit.interested_file();
-    auto directives_it = unit.directives().find(interested);
+    auto main_fid = unit.main_file();
+    auto directives_it = unit.directives().find(main_fid);
     if(directives_it == unit.directives().end()) {
         return locations;
     }
 
-    auto content = unit.interested_content();
+    auto content = unit.main_content();
     auto* lang_opts = &unit.lang_options();
 
     auto try_directive = [&](clang::SourceLocation loc, llvm::StringRef target) {
@@ -128,7 +128,7 @@ auto include_definition(CompilationUnitRef unit, std::uint32_t offset)
             return;
         }
         auto [fid, directive_offset] = unit.decompose_location(loc);
-        if(fid != interested || directive_offset >= content.size()) {
+        if(fid != main_fid || directive_offset >= content.size()) {
             return;
         }
         auto range = find_directive_argument(content, directive_offset, lang_opts);

--- a/src/feature/document_symbols.cpp
+++ b/src/feature/document_symbols.cpp
@@ -102,7 +102,7 @@ auto symbol_detail(clang::ASTContext& context, const clang::NamedDecl& decl) -> 
 }
 
 /// Collects the outline by walking the unit's cached Semantics node table —
-/// the DFS pre-order record of the interested file's written AST — instead of
+/// the DFS pre-order record of the main file's written AST — instead of
 /// running another RecursiveASTVisitor over the TU. Nesting comes for free:
 /// a symbol's frame stays open while the walk index is inside its subtree.
 class Collector {
@@ -181,7 +181,7 @@ private:
             childless_instantiation = true;
         }
 
-        if(!is_interested(decl)) {
+        if(!is_supported(decl)) {
             return true;
         }
 
@@ -201,8 +201,7 @@ private:
 
         auto [fid, selection_range] = unit.decompose_range(name_range);
         auto [fid2, range] = unit.decompose_expansion_range(named->getSourceRange());
-        if(fid != fid2 || fid != unit.interested_file() || !selection_range.valid() ||
-           !range.valid()) {
+        if(fid != fid2 || fid != unit.main_file() || !selection_range.valid() || !range.valid()) {
             return false;
         }
 
@@ -279,7 +278,7 @@ private:
         level->push_back(std::move(symbol));
     }
 
-    static bool is_interested(const clang::Decl* decl) {
+    static bool is_supported(const clang::Decl* decl) {
         switch(decl->getKind()) {
             case clang::Decl::Namespace:
             case clang::Decl::Enum:
@@ -374,7 +373,7 @@ auto document_symbols(CompilationUnitRef unit) -> std::vector<DocumentSymbol> {
 auto document_symbols(CompilationUnitRef unit, PositionEncoding encoding)
     -> std::vector<protocol::DocumentSymbol> {
     return document_symbols_to_protocol(document_symbols(unit),
-                                        unit.interested_content(),
+                                        unit.main_content(),
                                         unit.line_starts(),
                                         encoding);
 }

--- a/src/feature/feature.h
+++ b/src/feature/feature.h
@@ -179,7 +179,7 @@ struct HoverInfo {
     /// Name of the symbol, does not contain any "::".
     std::string name;
 
-    /// The range of the symbol in the interested file, used by the client to
+    /// The range of the symbol in the main file, used by the client to
     /// highlight the hovered token.
     std::optional<LocalSourceRange> symbol_range;
 
@@ -309,7 +309,7 @@ struct DocumentLink {
 /// Result of scanning a unit for preprocessor-inactive regions.
 struct InactiveScan {
     /// Byte-offset ranges [begin0, end0, begin1, end1, ...] of inactive
-    /// branch bodies in the interested file; directive lines excluded.
+    /// branch bodies in the main file; directive lines excluded.
     /// Sorted by begin and disjoint — nested inactive conditionals merge
     /// into the enclosing region.
     std::vector<std::uint32_t> regions;
@@ -347,7 +347,7 @@ struct InlayHint {
     bool padding_right = false;
 };
 
-/// Semantic tokens of the interested file. Tokens inside inactive regions
+/// Semantic tokens of the main file. Tokens inside inactive regions
 /// carry the Inactive modifier, and bare identifiers there emit as
 /// Identifier so every word of a dead region has a token to dim. The
 /// overloads without a regions argument scan the unit themselves — correct
@@ -395,7 +395,7 @@ auto inlay_hints(CompilationUnitRef unit,
                  const InlayHintsOptions& options,
                  PositionEncoding encoding) -> std::vector<protocol::InlayHint>;
 
-/// Include-directive links of the interested file, in byte offsets; the
+/// Include-directive links of the main file, in byte offsets; the
 /// reply edge converts them with the session's line map.
 auto document_links(CompilationUnitRef unit) -> std::vector<DocumentLink>;
 
@@ -408,12 +408,12 @@ auto find_directive_argument(llvm::StringRef content,
     -> std::optional<LocalSourceRange>;
 
 /// Go-to-definition on an include directive: when `offset` falls on the
-/// argument of an #include or __has_include in the interested file, the
+/// argument of an #include or __has_include in the main file, the
 /// resolved file's location (at its start). Empty otherwise.
 auto include_definition(CompilationUnitRef unit, std::uint32_t offset)
     -> std::vector<protocol::Location>;
 
-/// Scan the interested file's condition directives. `open_stack` seeds the
+/// Scan the main file's condition directives. `open_stack` seeds the
 /// nesting state (from a preceding preamble scan) and `resume_offset` is
 /// where the scanned content starts — pending inactive levels from the
 /// seed begin there. A scan that ends with open levels closes their
@@ -432,7 +432,7 @@ auto code_complete(CompilationParams& params,
     -> std::vector<protocol::CompletionItem>;
 
 /// Get the hover information for the symbol at the given offset in the
-/// interested file of the unit.
+/// main file of the unit.
 auto hover_info(CompilationUnitRef unit, std::uint32_t offset, const HoverOptions& options = {})
     -> std::optional<HoverInfo>;
 

--- a/src/feature/folding_ranges.cpp
+++ b/src/feature/folding_ranges.cpp
@@ -23,7 +23,7 @@ namespace clice::feature {
 namespace {
 
 /// Collects folding ranges by walking the unit's cached Semantics node table —
-/// the DFS pre-order record of the interested file's written AST — instead of
+/// the DFS pre-order record of the main file's written AST — instead of
 /// running another RecursiveASTVisitor over the TU. Folding needs no nesting
 /// state: every recorded decl and stmt contributes its ranges independently.
 ///
@@ -58,7 +58,7 @@ public:
             index += 1;
         }
 
-        auto directives_it = unit.directives().find(unit.interested_file());
+        auto directives_it = unit.directives().find(unit.main_file());
         if(directives_it != unit.directives().end()) {
             collect_condition_directives(directives_it->second.conditions);
             collect_pragma_region(directives_it->second.pragmas);
@@ -340,7 +340,7 @@ private:
         }
 
         auto [fid, local] = unit.decompose_range(clang::SourceRange(begin, end));
-        if(fid != unit.interested_file() || !local.valid() || local.end <= local.begin) {
+        if(fid != unit.main_file() || !local.valid() || local.end <= local.begin) {
             return;
         }
 
@@ -370,7 +370,7 @@ auto folding_ranges(CompilationUnitRef unit) -> std::vector<FoldingRange> {
 auto folding_ranges(CompilationUnitRef unit, PositionEncoding encoding)
     -> std::vector<protocol::FoldingRange> {
     return folding_ranges_to_protocol(folding_ranges(unit),
-                                      unit.interested_content(),
+                                      unit.main_content(),
                                       unit.line_starts(),
                                       encoding);
 }

--- a/src/feature/hover.cpp
+++ b/src/feature/hover.cpp
@@ -691,13 +691,13 @@ auto attr_hover(const clang::Attr* attr, clang::ASTContext& context) -> std::opt
 
 auto file_directive_hover(CompilationUnitRef unit, std::uint32_t offset)
     -> std::optional<HoverInfo> {
-    auto interested = unit.interested_file();
-    auto directives_it = unit.directives().find(interested);
+    auto main_fid = unit.main_file();
+    auto directives_it = unit.directives().find(main_fid);
     if(directives_it == unit.directives().end()) {
         return std::nullopt;
     }
 
-    auto content = unit.interested_content();
+    auto content = unit.main_content();
     auto* lang_opts = &unit.lang_options();
 
     auto file_name = [&](LocalSourceRange range) -> std::string {
@@ -725,7 +725,7 @@ auto file_directive_hover(CompilationUnitRef unit, std::uint32_t offset)
         /// rejects a cursor inside the argument before find_directive_argument()
         /// can match its range. Remove the same-line restriction once continued
         /// directive hover also handles the spliced argument spelling and range.
-        if(fid != interested || directive_offset < line_start || directive_offset >= line_end)
+        if(fid != main_fid || directive_offset < line_start || directive_offset >= line_end)
             return std::nullopt;
         auto range = find_directive_argument(content, directive_offset, lang_opts);
         if(!range || offset >= range->end || offset < range->begin)
@@ -774,7 +774,7 @@ auto file_directive_hover(CompilationUnitRef unit, std::uint32_t offset)
 /// macro semantics never reach the AST. The card shows the `#define` text,
 /// plus a preview of the expanded tokens at expansion sites.
 auto macro_hover(CompilationUnitRef unit, std::uint32_t offset) -> std::optional<HoverInfo> {
-    auto directives_it = unit.directives().find(unit.interested_file());
+    auto directives_it = unit.directives().find(unit.main_file());
     if(directives_it == unit.directives().end()) {
         return std::nullopt;
     }
@@ -1352,7 +1352,7 @@ auto hover_info(CompilationUnitRef unit, std::uint32_t offset, const HoverOption
         .show_aka = options.show_aka,
     };
 
-    auto location = unit.create_location(unit.interested_file(), offset);
+    auto location = unit.create_location(unit.main_file(), offset);
     auto tokens = unit.spelled_tokens_touch(location);
 
     /// Early exit if there were no tokens around the cursor.
@@ -1441,7 +1441,7 @@ auto hover(CompilationUnitRef unit,
         return std::nullopt;
     }
 
-    LineMap map(unit.interested_content(), unit.line_starts(), encoding);
+    LineMap map(unit.main_content(), unit.line_starts(), encoding);
     return to_protocol_hover(*info, options, map);
 }
 

--- a/src/feature/inactive_regions.cpp
+++ b/src/feature/inactive_regions.cpp
@@ -13,8 +13,8 @@ InactiveScan inactive_regions(CompilationUnitRef unit,
                               std::uint32_t end_offset) {
     InactiveScan result;
 
-    auto interested = unit.interested_file();
-    auto content = unit.file_content(interested);
+    auto main_fid = unit.main_file();
+    auto content = unit.file_content(main_fid);
     if(end_offset > content.size()) {
         end_offset = static_cast<std::uint32_t>(content.size());
     }
@@ -34,7 +34,7 @@ InactiveScan inactive_regions(CompilationUnitRef unit,
 
     auto local_offset = [&](clang::SourceLocation loc) -> std::optional<std::uint32_t> {
         auto [fid, offset] = unit.decompose_location(loc);
-        if(fid != interested) {
+        if(fid != main_fid) {
             return std::nullopt;
         }
         return offset;
@@ -78,7 +78,7 @@ InactiveScan inactive_regions(CompilationUnitRef unit,
         level.inactive_begin.reset();
     };
 
-    auto directives_it = unit.directives().find(interested);
+    auto directives_it = unit.directives().find(main_fid);
     if(directives_it != unit.directives().end()) {
         for(const auto& condition: directives_it->second.conditions) {
             auto offset = local_offset(condition.loc);

--- a/src/feature/index_projection.cpp
+++ b/src/feature/index_projection.cpp
@@ -51,18 +51,6 @@ LangProfile& profile_for(const clang::LangOptions& lang_opts) {
                        lang_opts.LangStd);
 }
 
-/// Line start offsets of `content`, the plain scan (no encoding concerns:
-/// callers index with byte offsets).
-std::vector<std::uint32_t> scan_line_starts(llvm::StringRef content) {
-    std::vector<std::uint32_t> starts{0};
-    for(std::uint32_t i = 0; i < content.size(); i += 1) {
-        if(content[i] == '\n') {
-            starts.push_back(i + 1);
-        }
-    }
-    return starts;
-}
-
 bool outline_kind(SymbolKind kind) {
     switch(kind) {
         case SymbolKind::Macro:
@@ -540,7 +528,7 @@ auto index_folding_ranges(llvm::StringRef content,
 auto index_document_links(llvm::StringRef content,
                           const clang::LangOptions& lang_opts,
                           llvm::ArrayRef<IndexIncludeEdge> edges) -> std::vector<DocumentLink> {
-    auto line_starts = scan_line_starts(content);
+    auto line_starts = kota::ipc::lsp::build_line_starts({content.data(), content.size()});
 
     std::vector<DocumentLink> links;
     for(const auto& edge: edges) {

--- a/src/feature/inlay_hints.cpp
+++ b/src/feature/inlay_hints.cpp
@@ -35,7 +35,7 @@ using llvm::dyn_cast;
 using llvm::dyn_cast_or_null;
 
 // For now, inlay hints are always anchored at the left or right of their range.
-enum class HintSide { Left, Right };
+enum class HintSide : std::uint8_t { Left, Right };
 
 bool is_expanded_from_param_pack(const clang::ParmVarDecl* param) {
     return decls::underlying_pack_type(param) != nullptr;
@@ -123,7 +123,7 @@ struct Callee {
 };
 
 /// Collects hints by walking the unit's cached Semantics node table — the
-/// DFS pre-order record of the interested file's written AST — instead of
+/// DFS pre-order record of the main file's written AST — instead of
 /// running another RecursiveASTVisitor over the TU. The table stores only
 /// structure; everything a hint needs is derived from the recorded node.
 class Collector {
@@ -210,7 +210,7 @@ private:
         auto [end_fid, end_offset] = unit.decompose_location(tokens.back().endLocation());
 
         // Hint must be within the main file, not e.g. a non-preamble include.
-        if(begin_fid != end_fid || begin_fid != unit.interested_file()) {
+        if(begin_fid != end_fid || begin_fid != unit.main_file()) {
             return std::nullopt;
         }
 
@@ -236,12 +236,11 @@ private:
         // require both source location to be in the main file. This prevents hint
         // to be shown in weird cases like '{' is actually in a "#include", but it's
         // rare anyway.
-        if(block_begin_fid != rbrace_fid || block_begin_fid != unit.interested_file()) {
+        if(block_begin_fid != rbrace_fid || block_begin_fid != unit.main_file()) {
             return std::nullopt;
         }
 
-        llvm::StringRef rest_of_line =
-            unit.interested_content().substr(rbrace_offset).split('\n').first;
+        llvm::StringRef rest_of_line = unit.main_content().substr(rbrace_offset).split('\n').first;
         if(!rest_of_line.starts_with("}")) {
             return std::nullopt;
         }
@@ -273,11 +272,11 @@ private:
     bool has_param_name_comment(const clang::Expr* expr, llvm::StringRef name) {
         auto location = unit.file_location(expr->getBeginLoc());
         auto [fid, offset] = unit.decompose_location(location);
-        if(fid != unit.interested_file()) {
+        if(fid != unit.main_file()) {
             return false;
         }
 
-        llvm::StringRef content = unit.interested_content().substr(0, offset);
+        llvm::StringRef content = unit.main_content().substr(0, offset);
 
         // Allow whitespace between comment and expression.
         content = content.rtrim();
@@ -1065,7 +1064,7 @@ auto inlay_hints(CompilationUnitRef unit,
                  const InlayHintsOptions& options,
                  PositionEncoding encoding) -> std::vector<protocol::InlayHint> {
     auto collected = inlay_hints(unit, target, options);
-    LineMap map(unit.interested_content(), unit.line_starts(), encoding);
+    LineMap map(unit.main_content(), unit.line_starts(), encoding);
 
     std::vector<protocol::InlayHint> hints;
     hints.reserve(collected.size());

--- a/src/feature/semantic_tokens.cpp
+++ b/src/feature/semantic_tokens.cpp
@@ -233,7 +233,7 @@ Classified classify_decl(const clang::NamedDecl* decl, RelationKind relation) {
     return {kind, modifiers};
 }
 
-/// Classifies every spelled token of the interested file in one ordered
+/// Classifies every spelled token of the main file in one ordered
 /// pass over the semantic map: lexical kinds straight from the token kind,
 /// macros/includes/imports/attributes from the owning SemanticNode, and
 /// declaration names by collecting the decls anchored at the token from its
@@ -247,7 +247,7 @@ class SemanticTokensCollector {
 public:
     SemanticTokensCollector(CompilationUnitRef unit,
                             llvm::ArrayRef<std::uint32_t> inactive_regions) :
-        unit(unit), semantics(unit.semantics()), content(unit.interested_content()),
+        unit(unit), semantics(unit.semantics()), content(unit.main_content()),
         comments(semantics.comments()), inactive_regions(inactive_regions) {}
 
     auto collect() -> std::vector<SemanticToken> {
@@ -769,7 +769,7 @@ auto semantic_tokens(CompilationUnitRef unit) -> std::vector<SemanticToken> {
 auto semantic_tokens(CompilationUnitRef unit, PositionEncoding encoding)
     -> protocol::SemanticTokens {
     return semantic_tokens_to_protocol(semantic_tokens(unit),
-                                       unit.interested_content(),
+                                       unit.main_content(),
                                        unit.line_starts(),
                                        encoding);
 }
@@ -779,7 +779,7 @@ auto semantic_tokens(CompilationUnitRef unit,
                      PositionEncoding encoding) -> protocol::SemanticTokens {
     SemanticTokensCollector collector(unit, inactive_regions);
     return semantic_tokens_to_protocol(collector.collect(),
-                                       unit.interested_content(),
+                                       unit.main_content(),
                                        unit.line_starts(),
                                        encoding);
 }

--- a/src/index/include_graph.cpp
+++ b/src/index/include_graph.cpp
@@ -43,7 +43,7 @@ static std::uint32_t addIncludeChain(CompilationUnitRef unit,
         // consumers pair `line` with. Recursing on the directive's own fid
         // (not the presumed include loc, which names the containing
         // file's includer and sat one level off) bottoms out at -1 for
-        // directives written in the interested file.
+        // directives written in the main file.
         auto include = addIncludeChain(unit, unit.file_id(include_loc), graph, path_table);
         locations[index].include = include;
     }
@@ -82,9 +82,9 @@ IncludeGraph IncludeGraph::from(CompilationUnitRef unit,
         graph.file_table[fid] = addIncludeChain(unit, fid, graph, path_table);
     }
 
-    auto interested = unit.interested_file();
-    graph.file_table[interested] = addIncludeChain(unit, interested, graph, path_table);
-    graph.paths.emplace_back(unit.file_path(interested));
+    auto main_fid = unit.main_file();
+    graph.file_table[main_fid] = addIncludeChain(unit, main_fid, graph, path_table);
+    graph.paths.emplace_back(unit.file_path(main_fid));
 
     // Hash the consumed bytes per path from the compiler's own buffers.
     // Freshness checks compare the disk against these, so they must
@@ -105,14 +105,14 @@ IncludeGraph IncludeGraph::from(CompilationUnitRef unit,
             hash_fid(fid, graph.locations[location].path_id);
         }
     }
-    hash_fid(interested, graph.paths.size() - 1);
+    hash_fid(main_fid, graph.paths.size() - 1);
     return graph;
 }
 
 std::uint32_t IncludeGraph::include_location_id(clang::FileID fid) const {
     auto it = file_table.find(fid);
     if(it == file_table.end()) [[unlikely]] {
-        LOG_WARN("IncludeGraph: fid {} missing from file table, attributing to interested file",
+        LOG_WARN("IncludeGraph: fid {} missing from file table, attributing to main file",
                  fid.getHashValue());
         return -1;
     }

--- a/src/index/include_graph.h
+++ b/src/index/include_graph.h
@@ -68,7 +68,7 @@ struct IncludeGraph {
     /// Their include chains are recovered through the SourceManager,
     /// which preserves include locations across PCH boundaries.
     ///
-    /// The interested file's path is always the last entry of `paths`;
+    /// The main file's path is always the last entry of `paths`;
     /// serialization and the indexer rely on this convention.
     static IncludeGraph from(CompilationUnitRef unit,
                              llvm::ArrayRef<clang::FileID> indexed_fids = {});
@@ -79,16 +79,16 @@ struct IncludeGraph {
     }
 
     /// The include location introducing `fid`, or -1 for a file entered
-    /// without an include directive (the interested file, synthetic
+    /// without an include directive (the main file, synthetic
     /// buffers) — and, defensively, for a fid missing from the table:
     /// the indexer must never crash on unexpected input.
     std::uint32_t include_location_id(clang::FileID fid) const;
 
     /// The path of the file `fid` refers to. An fid without an include
-    /// location resolves to the interested file's path.
+    /// location resolves to the main file's path.
     ///
     /// FIXME: Synthetic buffers (<built-in>, <command line>) also resolve
-    /// to the interested file here. Once macro definitions from those
+    /// to the main file here. Once macro definitions from those
     /// buffers are indexed (see add_macro in directive.cpp), give them
     /// named path entries so consumers can route them to a preview
     /// document instead of misattributing them.

--- a/src/index/tu_index.cpp
+++ b/src/index/tu_index.cpp
@@ -91,17 +91,17 @@ SymbolScope classify_scope(const clang::NamedDecl* decl) {
 /// relations from the resolve facts, macros from the preprocessor directives.
 class Projector {
 public:
-    Projector(CompilationUnitRef unit, bool interested_only) :
-        unit(unit), interested_only(interested_only) {}
+    Projector(CompilationUnitRef unit, bool main_file_only) :
+        unit(unit), main_file_only(main_file_only) {}
 
     /// The only gate through which rows enter `file_indices`. With
-    /// interested_only, the index covers just the interested file — yet
+    /// main_file_only, the index covers just the main file — yet
     /// AST nodes reachable from its top-level decls can carry locations
     /// in other files: inherited default arguments and base specifiers
     /// of classes defined in a preamble header land there. Such rows
     /// belong to the preamble's own index, so they are dropped here.
     FileIndex* file_index(clang::FileID fid) {
-        if(interested_only && fid != unit.interested_file()) {
+        if(main_file_only && fid != unit.main_file()) {
             return nullptr;
         }
         return &file_indices[fid];
@@ -326,7 +326,7 @@ public:
                                                             : module.partition_parts.back())
                                 .end;
             emit(module_name,
-                 unit.interested_file(),
+                 unit.main_file(),
                  LocalSourceRange{name_begin, name_end},
                  unit.is_module_interface_unit() ? RelationKind::Definition
                                                  : RelationKind::Reference);
@@ -590,14 +590,14 @@ public:
 
     std::string build(const PreambleExtras* extras) {
         ScopedTimer semantics_timer;
-        /// The interested-only shape is the one features share, cached on the
+        /// The main-file-only shape is the one features share, cached on the
         /// unit; the whole-TU shape is transient — projected and dropped.
         /// Both phases below share the one build.
         std::optional<Semantics> full;
-        if(!interested_only) {
+        if(!main_file_only) {
             full.emplace(Semantics::build(unit, false));
         }
-        const Semantics& semantics = interested_only ? unit.semantics() : *full;
+        const Semantics& semantics = main_file_only ? unit.semantics() : *full;
         auto semantics_ms = semantics_timer.ms_f();
 
         ScopedTimer project_timer;
@@ -637,8 +637,8 @@ public:
             // path_id() would misfile them under the source file. Real files
             // forced in via -include are not affected — clang records their
             // include edge in the predefines buffer, which is a valid
-            // location. The interested file legitimately has no edge.
-            if(fid != unit.interested_file() &&
+            // location. The main file legitimately has no edge.
+            if(fid != unit.main_file() &&
                graph.include_location_id(fid) == static_cast<std::uint32_t>(-1)) {
                 continue;
             }
@@ -711,7 +711,7 @@ public:
         LOG_PERF("index_detail",
                  "op=build scope={} semantics_ms={:.2f} project_ms={:.2f} finish_ms={:.2f} "
                  "encode_ms={:.2f} pack_ms={:.2f}",
-                 interested_only ? "interested" : "full",
+                 main_file_only ? "main" : "full",
                  semantics_ms,
                  project_ms,
                  finish_ms,
@@ -722,7 +722,7 @@ public:
 
 private:
     CompilationUnitRef unit;
-    bool interested_only;
+    bool main_file_only;
     IncludeGraph graph;
     SymbolTable symbols;
     /// Build-time working state keyed by FileID — clang::FileID means
@@ -734,8 +734,8 @@ private:
 
 }  // namespace
 
-std::string build_tu_index(CompilationUnitRef unit, bool interested_only) {
-    Projector projector(unit, interested_only);
+std::string build_tu_index(CompilationUnitRef unit, bool main_file_only) {
+    Projector projector(unit, main_file_only);
     return projector.build(nullptr);
 }
 
@@ -744,9 +744,9 @@ std::string build_preamble_index(CompilationUnitRef unit,
                                  llvm::ArrayRef<std::uint32_t> inactive_regions,
                                  llvm::ArrayRef<std::uint8_t> open_conditionals) {
     // The preamble compile remaps the buffer truncated at the bound, so
-    // interested_content() is exactly the preamble text the PCH was built
+    // main_content() is exactly the preamble text the PCH was built
     // from.
-    auto preamble_text = unit.interested_content();
+    auto preamble_text = unit.main_content();
     PreambleExtras extras{
         .hash = llvm::xxh3_64bits(preamble_text),
         .size = static_cast<std::uint32_t>(preamble_text.size()),
@@ -795,7 +795,7 @@ TUIndex TUIndex::from_bytes(llvm::StringRef data) {
     // Structural verification does not constrain field values; every path
     // id the merge dereferences against the path table is bounded here so
     // the accessors stay check-free. The builder ends every path table
-    // with the interested file, so consumers address path_count() - 1
+    // with the main file, so consumers address path_count() - 1
     // unchecked — an empty table marks a corrupt envelope.
     auto count = root[&EnvelopeBlob::paths].size();
     if(count == 0) {

--- a/src/index/tu_index.h
+++ b/src/index/tu_index.h
@@ -30,8 +30,8 @@ namespace clice::index {
 /// merged into the file's disk shard). Rows of a header entered several
 /// times are one union blob. The envelope travels worker→server over IPC
 /// and is dismantled into the three persistent layers on arrival. With
-/// interested_only, only rows in the interested file are kept.
-std::string build_tu_index(CompilationUnitRef unit, bool interested_only = false);
+/// main_file_only, only rows in the main file are kept.
+std::string build_tu_index(CompilationUnitRef unit, bool main_file_only = false);
 
 /// The preamble variant: a preamble is a TU cut off at the preamble
 /// bound, and its index is the same envelope — persisted verbatim as the
@@ -82,7 +82,7 @@ public:
 
     std::int64_t built_at() const;
 
-    /// The interested file's path is always the last id, by IncludeGraph
+    /// The main file's path is always the last id, by IncludeGraph
     /// convention.
     std::uint32_t path_count() const;
 

--- a/src/index/usr_generation.cpp
+++ b/src/index/usr_generation.cpp
@@ -731,7 +731,6 @@ void USRGenerator::VisitType(QualType T) {
             return;
         }
         if(const auto* DeducedSpec = T->getAs<DeducedTemplateSpecializationType>()) {
-            // TODO(sakria9): double check this
             Out << "D";
             VisitTemplateName(DeducedSpec->getTemplateName());
             if(!DeducedSpec->getDeducedType().isNull()) {

--- a/src/sched/batch.cpp
+++ b/src/sched/batch.cpp
@@ -150,7 +150,6 @@ bool start_batch(BatchStack& stack,
     pool_opts.stateless_count = cfg.stateless_worker_count;
     pool_opts.min_stateless = cfg.min_stateless_worker_count;
     pool_opts.max_stateless = cfg.max_stateless_worker_count;
-    pool_opts.worker_memory_limit = cfg.worker_memory_limit;
     pool_opts.log_dir = session_log_dir;
     if(!stack.pool.start(pool_opts)) {
         LOG_ANOMALY(WorkerSpawnFail, "Failed to start worker pool");

--- a/src/sched/families/turun.cpp
+++ b/src/sched/families/turun.cpp
@@ -108,7 +108,7 @@ kota::task<RoundOutcome> TURunFamily::round(RoundContext& ctx, std::uint32_t pat
     // worker reports its own failure if they are not enough.
     bool own_module = workspace.path_to_module.contains(path_id);
     if(own_module || !workspace.path_to_module.empty() ||
-       !workspace.dep_graph.import_candidates().empty() ||
+       !workspace.dep_graph.import_candidate_files().empty() ||
        llvm::any_of(params.arguments, [](const std::string& arg) {
            return llvm::StringRef(arg).starts_with("-include");
        })) {

--- a/src/semantic/resolver.cpp
+++ b/src/semantic/resolver.cpp
@@ -1,5 +1,6 @@
 #include "semantic/resolver.h"
 
+#include <cstdint>
 #include <ranges>
 
 #include "semantic/unifier.h"
@@ -233,7 +234,7 @@ public:
     /// Rewrite policy. The two-phase split is the resolver's core invariant:
     /// typedef/alias expansion must never re-enter heuristic lookup, or
     /// mutually recursive typedefs cycle forever.
-    enum class Policy {
+    enum class Policy : std::uint8_t {
         /// Expand sugar and substitute stack parameters only.
         Substitute,
         /// Substitute plus dependent name resolution through lookup.

--- a/src/semantic/selection.cpp
+++ b/src/semantic/selection.cpp
@@ -135,7 +135,7 @@ bool SelectionTree::create_each(CompilationUnitRef unit,
     // - if no tokens touched, and empty range.
     llvm::SmallVector<LocalSourceRange, 2> ranges;
 
-    auto location = unit.create_location(unit.interested_file(), begin);
+    auto location = unit.create_location(unit.main_file(), begin);
 
     // Prefer right token over left.
     for(const clang::syntax::Token& token: llvm::reverse(unit.spelled_tokens_touch(location))) {

--- a/src/semantic/semantics.cpp
+++ b/src/semantic/semantics.cpp
@@ -298,7 +298,7 @@ clang::SourceRange claimed_source_range(const SemanticNode& node) {
 
 }  // namespace
 
-// Builds the Semantics of the interested file: one full traversal of its AST,
+// Builds the Semantics of the main file: one full traversal of its AST,
 // claiming expanded tokens innermost-first, then attributing every claimed
 // expanded token to the spelled main-file token it came from:
 //   - tokens written in the main file attribute to themselves
@@ -329,8 +329,8 @@ clang::SourceRange claimed_source_range(const SemanticNode& node) {
 // VarDecl in the selection tree.
 class SemanticsBuilder : public clang::RecursiveASTVisitor<SemanticsBuilder> {
 public:
-    static void build(Semantics& semantics, CompilationUnitRef unit, bool interested_only) {
-        SemanticsBuilder builder(semantics, unit, interested_only);
+    static void build(Semantics& semantics, CompilationUnitRef unit, bool main_file_only) {
+        SemanticsBuilder builder(semantics, unit, main_file_only);
         builder.TraverseAST(unit.context());
         assert(builder.stack.size() == 1 && "Unpaired push/pop?");
         builder.append_directives();
@@ -348,7 +348,7 @@ public:
     bool TraverseDecl(clang::Decl* X) {
         if(llvm::isa_and_nonnull<clang::TranslationUnitDecl>(X)) {
             /// The TU decl is not stored; its children become roots.
-            if(interested_only) {
+            if(main_file_only) {
                 for(auto decl: unit.top_level_decls()) {
                     if(!TraverseDecl(decl)) {
                         return false;
@@ -543,10 +543,10 @@ public:
 private:
     using Base = RecursiveASTVisitor<SemanticsBuilder>;
 
-    SemanticsBuilder(Semantics& semantics, CompilationUnitRef unit, bool interested_only) :
-        semantics(semantics), unit(unit), interested_only(interested_only),
+    SemanticsBuilder(Semantics& semantics, CompilationUnitRef unit, bool main_file_only) :
+        semantics(semantics), unit(unit), main_file_only(main_file_only),
         SM(unit.context().getSourceManager()), unclaimed_expanded_tokens(unit.expanded_tokens()) {
-        main_fid = unit.interested_file();
+        main_fid = unit.main_file();
         main_file_range =
             clang::SourceRange(SM.getLocForStartOfFile(main_fid), SM.getLocForEndOfFile(main_fid));
 
@@ -557,7 +557,7 @@ private:
         // Tokens preprocessed to nothing (e.g. a disabled region or an empty
         // macro invocation) never contribute to a selection. Only relevant
         // when token ownership is recorded at all.
-        if(interested_only) {
+        if(main_file_only) {
             for(const clang::syntax::TokenBuffer::Expansion& expansion:
                 unit.expansions_overlapping(semantics.tokens)) {
                 if(expansion.Expanded.empty()) {
@@ -722,7 +722,7 @@ private:
     // preamble-state build runs a whole-TU pass over the preamble unit, and
     // claiming its entire expanded stream would be paid on every PCH build.
     void claim_range(clang::SourceRange S, std::uint32_t self) {
-        if(!interested_only) {
+        if(!main_file_only) {
             return;
         }
 
@@ -927,13 +927,13 @@ private:
         });
     }
 
-    // Append the interested file's preprocessor directives and lexically
+    // Append the main file's preprocessor directives and lexically
     // scanned entities as nodes owning their name tokens. These live outside
     // the AST segment: parent chains do not include them (yet), and selection
     // ignores them, but hover and document links see macros, includes and
     // imports as first-class nodes.
     void append_directives() {
-        semantics.lexical = lexical_scan(unit.interested_content(), &unit.lang_options());
+        semantics.lexical = lexical_scan(unit.main_content(), &unit.lang_options());
         filter_module_declarations();
 
         struct Row {
@@ -1048,7 +1048,7 @@ private:
 
     Semantics& semantics;
     CompilationUnitRef unit;
-    bool interested_only;
+    bool main_file_only;
     clang::SourceManager& SM;
     clang::FileID main_fid;
     clang::SourceRange main_file_range;
@@ -1063,9 +1063,9 @@ private:
     std::vector<std::pair<std::uint32_t, std::uint32_t>> entries;
 };
 
-Semantics Semantics::build(CompilationUnitRef unit, bool interested_only) {
+Semantics Semantics::build(CompilationUnitRef unit, bool main_file_only) {
     Semantics semantics;
-    SemanticsBuilder::build(semantics, unit, interested_only);
+    SemanticsBuilder::build(semantics, unit, main_file_only);
     return semantics;
 }
 

--- a/src/semantic/semantics.h
+++ b/src/semantic/semantics.h
@@ -241,7 +241,7 @@ struct NameOccurrence {
 llvm::SmallVector<NameOccurrence, 2>
     resolve_occurrences(const SemanticNode& node, types::TemplateResolver* resolver = nullptr);
 
-/// The semantic map of the interested file, built once after a successful
+/// The semantic map of the main file, built once after a successful
 /// parse and serving every consumer that used to run its own traversal:
 /// selection, semantic tokens, hover and the TUIndex projection.
 ///
@@ -302,12 +302,12 @@ public:
     /// Build the semantics of the unit: one full traversal claiming tokens
     /// innermost-first, plus one pass over the preprocessor directives.
     ///
-    /// With interested_only (the shape features consume, cached on the unit)
-    /// only the interested file's top-level decls are traversed. Without it
+    /// With main_file_only (the shape features consume, cached on the unit)
+    /// only the main file's top-level decls are traversed. Without it
     /// the whole TU is traversed — the transient shape the full index
-    /// projection uses; token ownership still only covers the interested
+    /// projection uses; token ownership still only covers the main
     /// file's spelled tokens.
-    static Semantics build(CompilationUnitRef unit, bool interested_only = true);
+    static Semantics build(CompilationUnitRef unit, bool main_file_only = true);
 
     /// All recorded nodes in one index space: first the AST segment in DFS
     /// pre-order (a parent always precedes its children), then preprocessor
@@ -320,7 +320,7 @@ public:
         return nodes[index];
     }
 
-    /// The spelled tokens of the interested file (a view into the unit's
+    /// The spelled tokens of the main file (a view into the unit's
     /// TokenBuffer, not a copy). They cover the whole file even under a
     /// preamble PCH — what the PCH consumes is the preamble's AST and
     /// directives (those travel through the pch.idx envelope instead), not its
@@ -329,7 +329,7 @@ public:
         return tokens;
     }
 
-    /// Byte offset of spelled token `index` in the interested file.
+    /// Byte offset of spelled token `index` in the main file.
     std::uint32_t token_offset(std::uint32_t index) const {
         return tokens[index].location().getRawEncoding() - file_begin.getRawEncoding();
     }
@@ -347,13 +347,13 @@ public:
             .slice(owner_begin[index], owner_begin[index + 1] - owner_begin[index]);
     }
 
-    /// The interested file's comments in source order (the spelled token
+    /// The main file's comments in source order (the spelled token
     /// stream drops them). The same objects back the Comment nodes.
     llvm::ArrayRef<LexicalInfo::Comment> comments() const {
         return lexical.comments;
     }
 
-    /// The interested file's module declarations, already cross-checked
+    /// The main file's module declarations, already cross-checked
     /// against the compiled module (bogus lexical matches are dropped at
     /// build time). The same objects back the Module nodes.
     llvm::ArrayRef<LexicalInfo::ModuleDeclaration> module_declarations() const {
@@ -367,7 +367,7 @@ private:
 
     llvm::ArrayRef<clang::syntax::Token> tokens;
 
-    /// Start location of the interested file, for O(1) offset computation.
+    /// Start location of the main file, for O(1) offset computation.
     clang::SourceLocation file_begin;
 
     /// Tokens preprocessed to nothing.

--- a/src/server/service/ast_family.cpp
+++ b/src/server/service/ast_family.cpp
@@ -339,7 +339,7 @@ kota::task<DependResult> ASTFamily::depend_modules(RoundContext& ctx,
     // include. The scan's sentinel edges are what let the name's first
     // provider re-dirty this document.
     bool scan_worth = !workspace.path_to_module.empty() ||
-                      !workspace.dep_graph.import_candidates().empty() ||
+                      !workspace.dep_graph.import_candidate_files().empty() ||
                       contexts.header_context(path_id) != nullptr ||
                       llvm::any_of(arguments, [](const std::string& arg) {
                           return llvm::StringRef(arg).starts_with("-include");
@@ -534,7 +534,8 @@ kota::task<RoundOutcome> ASTFamily::run(RoundContext& ctx, std::uint32_t path_id
                     // lands even if this round goes stale meanwhile.
                     auto dep =
                         pch.prepare(std::move(plan.request), [session](llvm::StringRef death) {
-                            session->quarantine.on_kind_crash(pch_evidence, death);
+                            session->quarantine.on_kind_crash(evidence_kind(EvidenceKind::PCH),
+                                                              death);
                         });
                     switch(co_await ctx.depend(dep)) {
                         case DependResult::Ready:
@@ -550,7 +551,7 @@ kota::task<RoundOutcome> ASTFamily::run(RoundContext& ctx, std::uint32_t path_id
                                 // the session's PCH strikes as surely as
                                 // building one — but only its own; every
                                 // consumer washes for itself.
-                                session->quarantine.on_kind_land(pch_evidence);
+                                session->quarantine.on_kind_land(evidence_kind(EvidenceKind::PCH));
                             }
                             break;
                         case DependResult::Failed: break;

--- a/src/server/service/ast_family.h
+++ b/src/server/service/ast_family.h
@@ -21,12 +21,6 @@
 
 namespace clice {
 
-namespace testing {
-
-struct ASTFixture;
-
-}
-
 class ContextResolver;
 
 /// The AST family's id in the task graph. Node keys are document path_ids
@@ -199,8 +193,6 @@ private:
     /// Detached ensure_compiled joins from request_compile; the rounds
     /// live in the graph's task group.
     kota::task_group<> kicks;
-
-    friend struct testing::ASTFixture;
 };
 
 /// The PCH acquisition plan of a buffer state: whether a PCH is owed at
@@ -220,16 +212,18 @@ PCHPlan plan_pch(Workspace& workspace,
                  const std::string& directory,
                  const std::vector<std::string>& arguments);
 
-/// Evidence-kind discriminators for Quarantine's per-kind ledgers. Queries
-/// and stateless builds share one space, offset so they cannot collide;
-/// document links have no QueryKind and get their own slot. The stateless
-/// slots keep the values of the retired BuildKind enum (0x40 + kind) —
-/// they are in-memory only, but drift within a session would misattribute
-/// evidence.
-constexpr inline std::uint8_t document_link_evidence = 0x20;
-constexpr inline std::uint8_t pch_evidence = 0x40;
-constexpr inline std::uint8_t completion_evidence = 0x43;
-constexpr inline std::uint8_t signature_help_evidence = 0x44;
-constexpr inline std::uint8_t format_evidence = 0x45;
+/// Discriminators for Quarantine's per-kind ledgers.
+enum class EvidenceKind : std::uint8_t {
+    DocumentLink,
+    PCH,
+    Completion,
+    SignatureHelp,
+    Format,
+    Count,
+};
+
+constexpr std::uint8_t evidence_kind(EvidenceKind kind) {
+    return static_cast<std::uint8_t>(kind);
+}
 
 }  // namespace clice

--- a/src/server/service/format.cpp
+++ b/src/server/service/format.cpp
@@ -44,7 +44,7 @@ static protocol::Diagnostic make_inferred_command_diagnostic(CommandSource sourc
     if(auto uri = id.diagnostic_document_uri()) {
         diagnostic.code_description = protocol::CodeDescription{.href = std::move(*uri)};
     }
-    diagnostic.source = "clice";
+    diagnostic.source = diagnostic_source_name(id.source).str();
     diagnostic.message = std::format(
         "No compilation database entry for this file (compile command was {}), so some includes "
         "may not be found. Configure compile_commands.json for accurate diagnostics.",

--- a/src/server/service/query.cpp
+++ b/src/server/service/query.cpp
@@ -1401,7 +1401,6 @@ std::vector<ResolvedSymbol> IndexQuery::locate_symbols(const agentic::ReadSymbol
                 continue;
             bool found = false;
             merged_index.lookup(hash, RelationKind::Definition, [&](const index::Relation& r) {
-                // FIXME: unchecked optional dereference
                 auto range = map.to_range(r.range.begin, r.range.end);
                 if(range && range->start.line == target_line) {
                     found = true;

--- a/src/server/service/worker_forwarder.cpp
+++ b/src/server/service/worker_forwarder.cpp
@@ -71,7 +71,7 @@ static kota::ipc::RequestResult<Params> build_for(WorkerPool& pool,
 }
 
 constexpr static std::uint8_t evidence_kind(worker::QueryKind kind) {
-    return static_cast<std::uint8_t>(kind);
+    return static_cast<std::uint8_t>(EvidenceKind::Count) + static_cast<std::uint8_t>(kind);
 }
 
 WorkerForwarder::WorkerForwarder(Workspace& workspace,
@@ -128,7 +128,7 @@ kota::task<bool> WorkerForwarder::ensure_pch(const std::shared_ptr<Session>& ses
     // count. Joiners of an already-running round install nothing and
     // replay nothing.
     auto outcome = co_await pch.acquire(std::move(plan.request), [session](llvm::StringRef death) {
-        session->quarantine.on_kind_crash(pch_evidence, death);
+        session->quarantine.on_kind_crash(evidence_kind(EvidenceKind::PCH), death);
     });
     if(outcome != PCHFamily::Outcome::Ready) {
         co_return false;
@@ -146,7 +146,7 @@ kota::task<bool> WorkerForwarder::ensure_pch(const std::shared_ptr<Session>& ses
     // Adopting a proven-good artifact disproves the session's PCH strikes
     // as surely as building one — but only its own; every consumer washes
     // for itself.
-    session->quarantine.on_kind_land(pch_evidence);
+    session->quarantine.on_kind_land(evidence_kind(EvidenceKind::PCH));
     co_return true;
 }
 
@@ -314,12 +314,12 @@ kota::task<std::vector<feature::DocumentLink>, kota::ipc::Error>
     }
     auto wait_ms = timer.ms_f();
 
-    if(session->quarantine.kind_blocked(document_link_evidence)) {
+    if(session->quarantine.kind_blocked(evidence_kind(EvidenceKind::DocumentLink))) {
         co_return kota::outcome_error(
             kota::ipc::Error{worker::dispatch_errc::worker_unavailable, "Document is quarantined"});
     }
 
-    bool recovery = session->quarantine.recovery_kind(document_link_evidence);
+    bool recovery = session->quarantine.recovery_kind(evidence_kind(EvidenceKind::DocumentLink));
     auto suspect = recovery ? Suspect::InPlace : Suspect::No;
     std::optional<Quarantine::ProbeGuard> probe_guard;
     if(recovery) {
@@ -331,7 +331,7 @@ kota::task<std::vector<feature::DocumentLink>, kota::ipc::Error>
                                               suspect);
     if(!result.has_value()) {
         if(result.error().code == worker::dispatch_errc::worker_crashed) {
-            session->quarantine.on_kind_crash(document_link_evidence,
+            session->quarantine.on_kind_crash(evidence_kind(EvidenceKind::DocumentLink),
                                               worker::death_of(result.error()));
         }
         if(!worker::is_operational_error(result.error())) {
@@ -351,7 +351,7 @@ kota::task<std::vector<feature::DocumentLink>, kota::ipc::Error>
         co_return std::vector<feature::DocumentLink>{};
     }
     bool was_active = session->quarantine.active();
-    session->quarantine.on_kind_land(document_link_evidence);
+    session->quarantine.on_kind_land(evidence_kind(EvidenceKind::DocumentLink));
     if(was_active && !session->quarantine.active()) {
         ast.publish_recovered(session);
     }
@@ -485,7 +485,7 @@ WorkerForwarder::RawResult
     WorkerForwarder::forward_completion(const protocol::Position& position,
                                         std::shared_ptr<Session> session,
                                         std::optional<kota::cancellation_token> token) {
-    return forward_interactive<worker::CompletionParams>(completion_evidence,
+    return forward_interactive<worker::CompletionParams>(evidence_kind(EvidenceKind::Completion),
                                                          "Completion",
                                                          position,
                                                          std::move(session),
@@ -496,11 +496,12 @@ WorkerForwarder::RawResult
     WorkerForwarder::forward_signature_help(const protocol::Position& position,
                                             std::shared_ptr<Session> session,
                                             std::optional<kota::cancellation_token> token) {
-    return forward_interactive<worker::SignatureHelpParams>(signature_help_evidence,
-                                                            "SignatureHelp",
-                                                            position,
-                                                            std::move(session),
-                                                            std::move(token));
+    return forward_interactive<worker::SignatureHelpParams>(
+        evidence_kind(EvidenceKind::SignatureHelp),
+        "SignatureHelp",
+        position,
+        std::move(session),
+        std::move(token));
 }
 
 WorkerForwarder::RawResult
@@ -514,7 +515,7 @@ WorkerForwarder::RawResult
     // Formatting runs no sema, but it is still this document's content on
     // a worker: while quarantined, only format-as-recovery may run, and a
     // refusal announces the quarantine.
-    bool recovery = session->quarantine.recovery_kind(format_evidence);
+    bool recovery = session->quarantine.recovery_kind(evidence_kind(EvidenceKind::Format));
     if(session->quarantine.active() && !recovery) {
         LOG_WARN("forward_format: {} is quarantined, refusing format", path);
         if(session->quarantine.needs_announcement()) {
@@ -545,7 +546,7 @@ WorkerForwarder::RawResult
     }
     auto result = co_await build_for(pool,
                                      *session,
-                                     format_evidence,
+                                     evidence_kind(EvidenceKind::Format),
                                      wp,
                                      worker::Priority::High,
                                      {.token = std::move(token)});
@@ -560,7 +561,7 @@ WorkerForwarder::RawResult
     }
     if(session->generation == gen) {
         bool was_active = session->quarantine.active();
-        session->quarantine.on_kind_land(format_evidence);
+        session->quarantine.on_kind_land(evidence_kind(EvidenceKind::Format));
         if(was_active && !session->quarantine.active()) {
             ast.publish_recovered(session);
         }

--- a/src/server/state/ast_projection.h
+++ b/src/server/state/ast_projection.h
@@ -62,7 +62,7 @@ struct ASTProjection {
     /// transport push path (see CompileOutput).
     std::optional<CompileOutput> output;
 
-    /// The interested file's rows within `index` (an empty shard when the
+    /// The main file's rows within `index` (an empty shard when the
     /// compile produced none). Callers gate on index_current, which
     /// implies a loaded envelope.
     const index::Shard& file_rows() const {

--- a/src/server/transport/agent_client.cpp
+++ b/src/server/transport/agent_client.cpp
@@ -387,7 +387,6 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                     continue;
 
                 merged_index.lookup(hash, RelationKind::Definition, [&](const index::Relation& r) {
-                    // FIXME: unchecked optional dereference
                     auto range = map.to_range(r.range.begin, r.range.end);
                     if(range) {
                         result.symbols.push_back(DocumentSymbolEntry{

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -160,7 +160,6 @@ void MasterServer::initialize() {
     pool_opts.stateless_count = cfg.stateless_worker_count;
     pool_opts.min_stateless = cfg.min_stateless_worker_count;
     pool_opts.max_stateless = cfg.max_stateless_worker_count;
-    pool_opts.worker_memory_limit = cfg.worker_memory_limit;
     pool_opts.log_dir = session_log_dir;
     if(!pool.start(pool_opts)) {
         LOG_ANOMALY(WorkerSpawnFail, "Failed to start worker pool");

--- a/src/support/doxygen.cpp
+++ b/src/support/doxygen.cpp
@@ -51,7 +51,7 @@ std::vector<std::pair<llvm::StringRef, llvm::ArrayRef<DoxygenInfo::BlockCommandC
     return res;
 }
 
-/// Process inline commands, we only interested in `\b` (bold), `\e` (italic) and `\c` (inline code)
+/// Process only the inline commands `\b` (bold), `\e` (italic) and `\c` (inline code).
 ///
 /// \param line   The line
 /// \param result Where should we output the result to

--- a/src/support/fuzzy_matcher.cpp
+++ b/src/support/fuzzy_matcher.cpp
@@ -52,8 +52,6 @@
 #include <algorithm>
 #include <cassert>
 
-#include "llvm/Support/Format.h"
-
 namespace clice {
 
 static char lower(char C) {
@@ -77,13 +75,13 @@ FuzzyMatcher::FuzzyMatcher(llvm::StringRef pattern) :
     std::copy(pattern.begin(), pattern.begin() + pat_n, Pat);
     for(int I = 0; I < pat_n; ++I)
         low_pat[I] = lower(Pat[I]);
-    scores[0][0][Miss] = {0, Miss};
-    scores[0][0][Match] = {AwfulScore, Miss};
+    scores[0][0][action_index(Action::Miss)] = {0, Action::Miss};
+    scores[0][0][action_index(Action::Match)] = {AwfulScore, Action::Miss};
 
     for(int P = 0; P <= pat_n; ++P) {
         for(int W = 0; W < P; ++W) {
-            for(Action A: {Miss, Match}) {
-                scores[P][W][A] = {AwfulScore, Miss};
+            for(Action action: {Action::Miss, Action::Match}) {
+                scores[P][W][action_index(action)] = {AwfulScore, Action::Miss};
             }
         }
     }
@@ -102,7 +100,8 @@ std::optional<float> FuzzyMatcher::match(llvm::StringRef word) {
     }
 
     build_graph();
-    auto best = std::max(scores[pat_n][word_n][Miss].score, scores[pat_n][word_n][Match].score);
+    auto best = std::max(scores[pat_n][word_n][action_index(Action::Miss)].score,
+                         scores[pat_n][word_n][action_index(Action::Match)].score);
     if(is_awful(best)) {
         return std::nullopt;
     }
@@ -240,33 +239,39 @@ bool FuzzyMatcher::init(llvm::StringRef new_word) {
 // non-matched characters.
 void FuzzyMatcher::build_graph() {
     for(int W = 0; W < word_n; ++W) {
-        scores[0][W + 1][Miss] = {scores[0][W][Miss].score - skip_penalty(W, Miss), Miss};
-        scores[0][W + 1][Match] = {AwfulScore, Miss};
+        scores[0][W + 1][action_index(Action::Miss)] = {
+            scores[0][W][action_index(Action::Miss)].score - skip_penalty(W, Action::Miss),
+            Action::Miss,
+        };
+        scores[0][W + 1][action_index(Action::Match)] = {AwfulScore, Action::Miss};
     }
 
     for(int P = 0; P < pat_n; ++P) {
         for(int W = P; W < word_n; ++W) {
             auto &score = scores[P + 1][W + 1], &PreMiss = scores[P + 1][W];
 
-            auto match_miss_score = PreMiss[Match].score;
-            auto miss_miss_score = PreMiss[Miss].score;
+            auto match_miss_score = PreMiss[action_index(Action::Match)].score;
+            auto miss_miss_score = PreMiss[action_index(Action::Miss)].score;
             if(P < pat_n - 1) {  // Skipping trailing characters is always free.
-                match_miss_score -= skip_penalty(W, Match);
-                miss_miss_score -= skip_penalty(W, Miss);
+                match_miss_score -= skip_penalty(W, Action::Match);
+                miss_miss_score -= skip_penalty(W, Action::Miss);
             }
-            score[Miss] = (match_miss_score > miss_miss_score) ? ScoreInfo{match_miss_score, Match}
-                                                               : ScoreInfo{miss_miss_score, Miss};
+            score[action_index(Action::Miss)] = (match_miss_score > miss_miss_score)
+                                                    ? ScoreInfo{match_miss_score, Action::Match}
+                                                    : ScoreInfo{miss_miss_score, Action::Miss};
 
             auto& pre_match = scores[P][W];
-            auto match_match_score = allow_match(P, W, Match)
-                                         ? pre_match[Match].score + match_bonus(P, W, Match)
+            auto match_match_score = allow_match(P, W, Action::Match)
+                                         ? pre_match[action_index(Action::Match)].score +
+                                               match_bonus(P, W, Action::Match)
                                          : AwfulScore;
-            auto miss_match_score = allow_match(P, W, Miss)
-                                        ? pre_match[Miss].score + match_bonus(P, W, Miss)
-                                        : AwfulScore;
-            score[Match] = (match_match_score > miss_match_score)
-                               ? ScoreInfo{match_match_score, Match}
-                               : ScoreInfo{miss_match_score, Miss};
+            auto miss_match_score =
+                allow_match(P, W, Action::Miss)
+                    ? pre_match[action_index(Action::Miss)].score + match_bonus(P, W, Action::Miss)
+                    : AwfulScore;
+            score[action_index(Action::Match)] = (match_match_score > miss_match_score)
+                                                     ? ScoreInfo{match_match_score, Action::Match}
+                                                     : ScoreInfo{miss_match_score, Action::Miss};
         }
     }
 }
@@ -279,7 +284,7 @@ bool FuzzyMatcher::allow_match(int P, int W, Action last) const {
     // We require a "strong" match:
     // - for the first pattern character.  [foo] !~ "barefoot"
     // - after a gap.                      [pat] !~ "patnther"
-    if(last == Miss) {
+    if(last == Action::Miss) {
         // We're banning matches outright, so conservatively accept some other cases
         // where our segmentation might be wrong:
         //  - allow matching B in ABCDef (but not in NDEBUG)
@@ -321,12 +326,12 @@ int FuzzyMatcher::match_bonus(int P, int W, Action last) const {
 
     // Bonus: a consecutive match. First character match also gets a bonus to
     // ensure prefix final match score normalizes to 1.0.
-    if(W == 0 || last == Match) {
+    if(W == 0 || last == Action::Match) {
         S += 2;
     }
 
     // Penalty: matching inside a segment (and previous char wasn't matched).
-    if(word_role[W] == Tail && P && last == Miss) {
+    if(word_role[W] == Tail && P && last == Action::Miss) {
         S -= 3;
     }
 
@@ -342,108 +347,6 @@ int FuzzyMatcher::match_bonus(int P, int W, Action last) const {
 
     assert(S <= PerfectBonus);
     return S;
-}
-
-llvm::SmallString<256> FuzzyMatcher::dumpLast(llvm::raw_ostream& OS) const {
-    llvm::SmallString<256> result;
-    OS << "=== Match \"" << llvm::StringRef(word, word_n) << "\" against ["
-       << llvm::StringRef(Pat, pat_n) << "] ===\n";
-    if(pat_n == 0) {
-        OS << "Pattern is empty: perfect match.\n";
-        return result = llvm::StringRef(word, word_n);
-    }
-
-    if(word_n == 0) {
-        OS << "Word is empty: no match.\n";
-        return result;
-    }
-
-    if(!word_contains_pattern) {
-        OS << "Substring check failed.\n";
-        return result;
-    }
-
-    if(is_awful(std::max(scores[pat_n][word_n][Match].score, scores[pat_n][word_n][Miss].score))) {
-        OS << "Substring check passed, but all matches are forbidden\n";
-    }
-
-    if(!(pat_type_set & 1 << Upper)) {
-        OS << "Lowercase query, so scoring ignores case\n";
-    }
-
-    // Traverse Matched table backwards to reconstruct the Pattern/Word mapping.
-    // The Score table has cumulative scores, subtracting along this path gives
-    // us the per-letter scores.
-    Action last =
-        (scores[pat_n][word_n][Match].score > scores[pat_n][word_n][Miss].score) ? Match : Miss;
-    int S[MaxWord];
-    Action A[MaxWord];
-    for(int W = word_n - 1, P = pat_n - 1; W >= 0; --W) {
-        A[W] = last;
-        const auto& Cell = scores[P + 1][W + 1][last];
-        if(last == Match)
-            --P;
-        const auto& Prev = scores[P + 1][W][Cell.Prev];
-        S[W] = Cell.score - Prev.score;
-        last = Cell.Prev;
-    }
-    for(int I = 0; I < word_n; ++I) {
-        if(A[I] == Match && (I == 0 || A[I - 1] == Miss)) {
-            result.push_back('[');
-        }
-
-        if(A[I] == Miss && I > 0 && A[I - 1] == Match) {
-            result.push_back(']');
-        }
-
-        result.push_back(word[I]);
-    }
-
-    if(A[word_n - 1] == Match) {
-        result.push_back(']');
-    }
-
-    for(char C: llvm::StringRef(word, word_n))
-        OS << " " << C << " ";
-    OS << "\n";
-    for(int I = 0, J = 0; I < word_n; I++)
-        OS << " " << (A[I] == Match ? Pat[J++] : ' ') << " ";
-    OS << "\n";
-    for(int I = 0; I < word_n; I++)
-        OS << llvm::format("%2d ", S[I]);
-    OS << "\n";
-
-    OS << "\nSegmentation:";
-    OS << "\n'" << llvm::StringRef(word, word_n) << "'\n ";
-    for(int I = 0; I < word_n; ++I)
-        OS << "?-+ "[static_cast<int>(word_role[I])];
-    OS << "\n[" << llvm::StringRef(Pat, pat_n) << "]\n ";
-    for(int I = 0; I < pat_n; ++I)
-        OS << "?-+ "[static_cast<int>(pat_role[I])];
-    OS << "\n";
-
-    OS << "\nScoring table (last-Miss, last-Match):\n";
-    OS << " |    ";
-    for(char C: llvm::StringRef(word, word_n))
-        OS << "  " << C << " ";
-    OS << "\n";
-    OS << "-+----" << std::string(word_n * 4, '-') << "\n";
-    for(int I = 0; I <= pat_n; ++I) {
-        for(Action A: {Miss, Match}) {
-            OS << ((I && A == Miss) ? Pat[I - 1] : ' ') << "|";
-            for(int J = 0; J <= word_n; ++J) {
-                if(!is_awful(scores[I][J][A].score))
-                    OS << llvm::format("%3d%c",
-                                       scores[I][J][A].score,
-                                       scores[I][J][A].Prev == Match ? '*' : ' ');
-                else
-                    OS << "    ";
-            }
-            OS << "\n";
-        }
-    }
-
-    return result;
 }
 
 }  // namespace clice

--- a/src/support/fuzzy_matcher.h
+++ b/src/support/fuzzy_matcher.h
@@ -3,9 +3,7 @@
 #include <optional>
 
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/raw_ostream.h"
 
 namespace clice {
 
@@ -72,21 +70,18 @@ public:
         return pat_n == 0;
     }
 
-    // Dump internal state from the last match() to the stream, for debugging.
-    // Returns the pattern with [] around matched characters, e.g.
-    //   [u_p] + "unique_ptr" --> "[u]nique[_p]tr"
-    llvm::SmallString<256> dumpLast(llvm::raw_ostream&) const;
-
 private:
     // We truncate the pattern and the word to bound the cost of matching.
     constexpr inline static int MaxPat = 63, MaxWord = 127;
-    // Action describes how a word character was matched to the pattern.
-    // It should be an enum, but this causes bitfield problems:
-    //   - for MSVC the enum type must be explicitly unsigned for correctness
-    //   - GCC 4.8 complains not all values fit if the type is unsigned
-    using Action = bool;
-    constexpr static Action Miss = false;  // Word character was skipped.
-    constexpr static Action Match = true;  // Matched against a pattern character.
+    /// How a word character was matched to the pattern.
+    enum class Action : unsigned {
+        Miss,
+        Match,
+    };
+
+    constexpr static unsigned action_index(Action action) {
+        return static_cast<unsigned>(action);
+    }
 
     bool init(llvm::StringRef Word);
     void build_graph();

--- a/src/syntax/dependency_graph.cpp
+++ b/src/syntax/dependency_graph.cpp
@@ -102,11 +102,11 @@ llvm::SmallVector<std::uint32_t> DependencyGraph::get_all_includes(std::uint32_t
 
 llvm::SmallVector<std::uint32_t> DependencyGraph::all_files() const {
     llvm::SmallVector<std::uint32_t> files;
-    files.reserve(file_configs.size() + reverse_includes_.size());
+    files.reserve(file_configs.size() + reverse_includes.size());
     for(auto& [path_id, configs]: file_configs) {
         files.push_back(path_id);
     }
-    for(auto& [path_id, includers]: reverse_includes_) {
+    for(auto& [path_id, includers]: reverse_includes) {
         files.push_back(path_id);
     }
     llvm::sort(files);
@@ -144,11 +144,11 @@ void DependencyGraph::clear_includes(std::uint32_t path_id) {
 }
 
 void DependencyGraph::build_reverse_map() {
-    reverse_includes_.clear();
+    reverse_includes.clear();
     for(auto& [key, ids]: includes) {
         for(auto flagged_id: ids) {
             auto included_id = flagged_id & PATH_ID_MASK;
-            auto& vec = reverse_includes_[included_id];
+            auto& vec = reverse_includes[included_id];
             if(llvm::find(vec, key.path_id) == vec.end()) {
                 vec.push_back(key.path_id);
             }
@@ -157,8 +157,8 @@ void DependencyGraph::build_reverse_map() {
 }
 
 llvm::ArrayRef<std::uint32_t> DependencyGraph::get_includers(std::uint32_t path_id) const {
-    auto it = reverse_includes_.find(path_id);
-    if(it != reverse_includes_.end()) {
+    auto it = reverse_includes.find(path_id);
+    if(it != reverse_includes.end()) {
         return it->second;
     }
     return {};

--- a/src/syntax/dependency_graph.h
+++ b/src/syntax/dependency_graph.h
@@ -128,14 +128,14 @@ public:
     /// reachability approximations have irreducible blind spots.
     void set_import_candidate(std::uint32_t path_id, bool has_import) {
         if(has_import) {
-            import_candidates_.insert(path_id);
+            import_candidates.insert(path_id);
         } else {
-            import_candidates_.erase(path_id);
+            import_candidates.erase(path_id);
         }
     }
 
-    const llvm::DenseSet<std::uint32_t>& import_candidates() const {
-        return import_candidates_;
+    const llvm::DenseSet<std::uint32_t>& import_candidate_files() const {
+        return import_candidates;
     }
 
 private:
@@ -143,7 +143,7 @@ private:
     llvm::StringMap<llvm::SmallVector<std::uint32_t, 2>> module_to_path;
 
     /// See set_import_candidate().
-    llvm::DenseSet<std::uint32_t> import_candidates_;
+    llvm::DenseSet<std::uint32_t> import_candidates;
 
     /// (PathID, ConfigID) -> list of directly included PathIDs.
     /// Each PathID may have bit 31 set to indicate conditional include.
@@ -154,7 +154,7 @@ private:
 
     /// Reverse include map: PathID -> list of PathIDs that directly include it.
     /// Populated by build_reverse_map().
-    llvm::DenseMap<std::uint32_t, llvm::SmallVector<std::uint32_t, 4>> reverse_includes_;
+    llvm::DenseMap<std::uint32_t, llvm::SmallVector<std::uint32_t, 4>> reverse_includes;
 };
 
 /// A (file, search-config) pair used to track per-wave work items.

--- a/src/worker/pool.cpp
+++ b/src/worker/pool.cpp
@@ -106,8 +106,6 @@ std::optional<WorkerPool::SpawnedProcess> WorkerPool::spawn_process(const std::s
     opts.args = {options.self_path, "worker"};
     if(stateful) {
         opts.args.push_back("--stateful");
-        opts.args.push_back("--memory-limit");
-        opts.args.push_back(std::to_string(options.worker_memory_limit));
     }
     opts.args.push_back("--worker-name");
     opts.args.push_back(name);

--- a/src/worker/pool.h
+++ b/src/worker/pool.h
@@ -61,7 +61,6 @@ struct WorkerPoolOptions {
     std::string self_path;
     std::uint32_t stateless_count = 2;
     std::uint32_t stateful_count = 2;
-    std::uint64_t worker_memory_limit = 4ULL * 1024 * 1024 * 1024;  // 4GB default
     std::string log_dir;
 
     /// A slot is given up once it crashes more than this many times in a

--- a/src/worker/protocol.h
+++ b/src/worker/protocol.h
@@ -160,12 +160,11 @@ struct CompileResult {
     int version;
     /// Diagnostics serialized as JSON (RawValue) to avoid bincode/serde annotation conflicts.
     kota::codec::RawValue diagnostics;
-    std::size_t memory_usage;
     /// Milliseconds since epoch, sampled before the compile started. Files
     /// whose mtime is past this moment may differ from what the build read.
     std::int64_t build_at = 0;
     std::vector<DepFile> deps;
-    /// Serialized TUIndex for the main file (interested_only=true).
+    /// Serialized TUIndex for the main file (main_file_only=true).
     std::string tu_index_data;
 };
 

--- a/src/worker/stateful.cpp
+++ b/src/worker/stateful.cpp
@@ -74,7 +74,6 @@ struct [[nodiscard]] StrandGuard {
 
 class StatefulWorker {
     kota::ipc::BincodePeer& peer;
-    std::uint64_t memory_limit;
     std::size_t max_documents;
 
     llvm::StringMap<std::shared_ptr<DocumentEntry>> documents;
@@ -93,8 +92,6 @@ class StatefulWorker {
     }
 
     void shrink_if_over_limit() {
-        // TODO: Implement memory-based eviction using memory_limit.
-        // For now, cap at a fixed number of documents.
         while(documents.size() > max_documents && !lru.empty()) {
             auto path = lru.back();
             lru.pop_back();
@@ -175,10 +172,8 @@ class StatefulWorker {
     }
 
 public:
-    StatefulWorker(kota::ipc::BincodePeer& peer,
-                   std::uint64_t memory_limit,
-                   std::size_t max_documents) :
-        peer(peer), memory_limit(memory_limit), max_documents(max_documents) {}
+    StatefulWorker(kota::ipc::BincodePeer& peer, std::size_t max_documents) :
+        peer(peer), max_documents(max_documents) {}
 
     void register_handlers();
 };
@@ -316,12 +311,11 @@ void StatefulWorker::register_handlers() {
                                  timer.ms(),
                                  doc->unit.setup_fail());
                     }
-                    result.memory_usage = 0;  // TODO: query actual memory
                     if(doc->unit.completed() && !stop->load(std::memory_order_relaxed)) {
                         result.build_at = doc->unit.build_at().count();
                         result.deps = doc->unit.deps();
 
-                        // Build index for main file only (interested_only=true).
+                        // Build index for main file only (main_file_only=true).
                         result.tu_index_data = index::build_tu_index(doc->unit, true);
                     }
 
@@ -435,8 +429,7 @@ void StatefulWorker::register_handlers() {
     });
 }
 
-int run_stateful_worker_mode(std::uint64_t memory_limit,
-                             const std::string& worker_name,
+int run_stateful_worker_mode(const std::string& worker_name,
                              const std::string& log_dir,
                              std::size_t max_documents) {
     logging::stderr_logger(worker_name, logging::options);
@@ -452,7 +445,7 @@ int run_stateful_worker_mode(std::uint64_t memory_limit,
         logging::file_logger(worker_name, log_dir, logging::options, /*mirror_stderr=*/false);
     }
 
-    LOG_INFO("Starting stateful worker, memory_limit={}MB", memory_limit / (1024 * 1024));
+    LOG_INFO("Starting stateful worker");
 
     kota::event_loop loop;
 
@@ -464,7 +457,7 @@ int run_stateful_worker_mode(std::uint64_t memory_limit,
 
     kota::ipc::BincodePeer peer(loop, std::move(*transport_result));
 
-    StatefulWorker worker(peer, memory_limit, max_documents);
+    StatefulWorker worker(peer, max_documents);
     worker.register_handlers();
 
     LOG_INFO("Stateful worker ready, waiting for requests");

--- a/src/worker/stateful.h
+++ b/src/worker/stateful.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstddef>
-#include <cstdint>
 #include <string>
 
 namespace clice {
@@ -15,8 +14,7 @@ constexpr inline std::size_t default_max_documents = 16;
 /// Run the stateful worker process mode.
 /// The worker holds compiled ASTs and handles feature requests
 /// (hover, semantic tokens, etc.) alongside compile requests.
-int run_stateful_worker_mode(std::uint64_t memory_limit,
-                             const std::string& worker_name,
+int run_stateful_worker_mode(const std::string& worker_name,
                              const std::string& log_dir,
                              std::size_t max_documents = default_max_documents);
 

--- a/src/worker/stateless.cpp
+++ b/src/worker/stateless.cpp
@@ -272,7 +272,7 @@ static worker::ArtifactBuildResult handle_build_pcm(const worker::BuildPCMParams
 static void collect_tidy_diagnostics(CompilationUnitRef unit,
                                      const worker::TURunParams& params,
                                      std::vector<worker::TidyDiagnostic>& out) {
-    auto main_fid = unit.interested_file();
+    auto main_fid = unit.main_file();
     std::optional<llvm::Regex> keep;
     if(!params.tidy_header_filter.empty()) {
         keep.emplace(params.tidy_header_filter);

--- a/tests/integration/agentic/agentic.test.ts
+++ b/tests/integration/agentic/agentic.test.ts
@@ -1,6 +1,6 @@
 /// Tests for the agentic protocol handlers.
 
-import { findFreePort, sleep, type CliceClient } from "@clice/tools/client";
+import { findFreePort, SETTLE_TIME, sleep, waitUntil, type CliceClient } from "@clice/tools/client";
 import type { Workspace } from "@clice/tools/workspace";
 import { cliceExecutable, expect, test, type SessionFactory } from "../fixtures.ts";
 import { AgenticRpcClient, jsonSafe, posix, runAgentic } from "./rpc.ts";
@@ -51,20 +51,19 @@ async function indexedAgentic(
     const rpc = new AgenticRpcClient();
     await rpc.connect(host, port);
 
-    let ready = false;
-    for (let i = 0; i < 300; i++) {
-        const resp = await rpc.request<{ symbols: unknown[] }>("agentic/symbolSearch", {
-            query: "add",
-        });
-        if (resp.result?.symbols.length) {
-            ready = true;
-            break;
-        }
-        await sleep(100);
-    }
-    if (!ready) {
-        throw new Error("agentic/symbolSearch never returned indexed symbols");
-    }
+    await waitUntil(
+        async () => {
+            const resp = await rpc.request<{ symbols: unknown[] }>("agentic/symbolSearch", {
+                query: "add",
+            });
+            return resp.result?.symbols.length ?? 0;
+        },
+        {
+            timeout: 30_000,
+            interval: 100,
+            description: "agentic/symbolSearch to return indexed symbols",
+        },
+    );
 
     return { rpc, client, workspace, uri };
 }
@@ -672,7 +671,7 @@ test("shutdown during indexing", async ({ session }) => {
         }
 
         // Give indexing a moment to start, then send shutdown.
-        await sleep(500);
+        await sleep(SETTLE_TIME);
 
         const rpc = new AgenticRpcClient();
         await rpc.connect(host, port);

--- a/tests/integration/agentic/cli.test.ts
+++ b/tests/integration/agentic/cli.test.ts
@@ -1,6 +1,6 @@
 /// CLI-based tests for agentic mode and CLI entry points.
 
-import { findFreePort, sleep } from "@clice/tools/client";
+import { findFreePort, waitUntil } from "@clice/tools/client";
 import type { Workspace } from "@clice/tools/workspace";
 import { cliceExecutable, expect, test, type SessionFactory } from "../fixtures.ts";
 import { AgenticRpcClient, posix, runCli } from "./rpc.ts";
@@ -23,15 +23,19 @@ async function indexedServer(
 
     const rpc = new AgenticRpcClient();
     await rpc.connect(host, port);
-    for (let i = 0; i < 300; i++) {
-        const resp = await rpc.request<{ symbols: unknown[] }>("agentic/symbolSearch", {
-            query: "add",
-        });
-        if (resp.result?.symbols.length) {
-            break;
-        }
-        await sleep(100);
-    }
+    await waitUntil(
+        async () => {
+            const resp = await rpc.request<{ symbols: unknown[] }>("agentic/symbolSearch", {
+                query: "add",
+            });
+            return resp.result?.symbols.length ?? 0;
+        },
+        {
+            timeout: 30_000,
+            interval: 100,
+            description: "agentic/symbolSearch to return indexed symbols",
+        },
+    );
     rpc.close();
 
     return { host, port, workspace };

--- a/tests/integration/compilation/persistent_cache.test.ts
+++ b/tests/integration/compilation/persistent_cache.test.ts
@@ -6,10 +6,12 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { MTIME_GRANULARITY, SETTLE_TIME, sleep } from "@clice/tools/client";
+import { MTIME_GRANULARITY, SETTLE_TIME, sleep, waitUntil } from "@clice/tools/client";
 import { DATA_DIR } from "@clice/tools/compile-commands";
 import type { CacheJson, Workspace } from "@clice/tools/workspace";
 import { expect, test } from "../fixtures.ts";
+
+const KILL_DELAY = 300;
 
 function copySaveRecompile(workspace: Workspace): void {
     const src = path.join(DATA_DIR, "modules", "save_recompile");
@@ -69,24 +71,27 @@ function writeCacheJsonLossless(cachePath: string, cache: CacheJson): void {
 /// Wait until orphaned workers of a killed server release their handles
 /// on tmp residue (a rename probe fails on Windows while a file is open).
 async function waitResidueReleased(workspace: Workspace, deadlineMs = 20_000): Promise<void> {
-    const end = Date.now() + deadlineMs;
-    while (Date.now() < end) {
-        let locked = false;
-        for (const f of workspace.tmpFiles()) {
-            const probe = f + ".probe";
-            try {
-                fs.renameSync(f, probe);
-                fs.renameSync(probe, f);
-            } catch {
-                locked = true;
-                break;
+    await waitUntil(
+        () => {
+            let locked = false;
+            for (const f of workspace.tmpFiles()) {
+                const probe = f + ".probe";
+                try {
+                    fs.renameSync(f, probe);
+                    fs.renameSync(probe, f);
+                } catch {
+                    locked = true;
+                    break;
+                }
             }
-        }
-        if (!locked) {
-            return;
-        }
-        await sleep(500);
-    }
+            return !locked;
+        },
+        {
+            timeout: deadlineMs,
+            interval: 500,
+            description: "orphaned workers to release temporary cache files",
+        },
+    );
 }
 
 test("pch written to cache dir", async ({ session }) => {
@@ -547,7 +552,7 @@ test("kill9 recovery", async ({ session }) => {
     const c1 = session.spawn(workspace);
     await c1.initialize(workspace);
     c1.open("main.cpp");
-    await sleep(300);
+    await sleep(KILL_DELAY);
     c1.killServer();
     c1.dispose();
     await waitResidueReleased(workspace);
@@ -736,7 +741,7 @@ test("cache wiped while running", async ({ session }) => {
     wipeBestEffort(workspace.path(path.join(".clice", "cache")));
 
     // Change the preamble so a fresh PCH build is required.
-    await sleep(1_100);
+    await sleep(MTIME_GRANULARITY);
     workspace.write("header.h", "#pragma once\nstruct W { int x; int y; };\n");
 
     await client.waitForRecompile(uri);

--- a/tests/integration/compilation/self_containment.test.ts
+++ b/tests/integration/compilation/self_containment.test.ts
@@ -8,7 +8,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { sleep } from "@clice/tools/client";
+import { MTIME_GRANULARITY, sleep } from "@clice/tools/client";
 import type { Workspace } from "@clice/tools/workspace";
 import { expect, test } from "../fixtures.ts";
 
@@ -173,7 +173,7 @@ test("header save resets verdict", async ({ session }) => {
     expect(prefixFiles(workspace).length, "Initial verdict: needs context").toBe(1);
 
     // Make the header self-contained on disk and in the buffer, then save.
-    await sleep(1_100);
+    await sleep(MTIME_GRANULARITY);
     const newText = '#include "types.h"\ninline int get_x(Point p) { return p.x; }\n';
     workspace.write("utils.h", newText);
     c.change(utilsUri, 2, newText);
@@ -208,7 +208,7 @@ test("dependency change retries trial", async ({ session }) => {
     expect(prefixFiles(workspace), "Initially self-contained").toEqual([]);
 
     // foo.h stops defining FOO; only the host's #define can provide it now.
-    await sleep(1_100);
+    await sleep(MTIME_GRANULARITY);
     workspace.write("foo.h", "#pragma once\n");
 
     await client.waitForRecompile(hUri);

--- a/tests/integration/compilation/staleness.test.ts
+++ b/tests/integration/compilation/staleness.test.ts
@@ -396,7 +396,7 @@ test("host change resynthesizes preamble", async ({ session }) => {
     client.assertCleanCompile(utilsUri);
 
     // Ensure mtime advances past filesystem granularity (1s on some FSes).
-    await sleep(1_100);
+    await sleep(MTIME_GRANULARITY);
     workspace.write("main.cpp", '#include "utils.h"\nint main() { return 0; }\n');
 
     // No didSave: mtime-based chain snapshot must detect the change.
@@ -421,7 +421,7 @@ test("intermediate change resynthesizes preamble", async ({ session }) => {
     client.assertCleanCompile(targetUri);
 
     // Rename the macro in the intermediate wrapper.h.
-    await sleep(1_100);
+    await sleep(MTIME_GRANULARITY);
     workspace.write("wrapper.h", '#pragma once\n#define OTHER 42\n#include "target.h"\n');
 
     await client.waitForRecompile(targetUri);

--- a/tests/integration/extensions/context_switching.test.ts
+++ b/tests/integration/extensions/context_switching.test.ts
@@ -6,7 +6,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { MTIME_GRANULARITY, SETTLE_TIME, sleep } from "@clice/tools/client";
+import { MTIME_GRANULARITY, SETTLE_TIME, sleep, waitUntil } from "@clice/tools/client";
 import { expect, test } from "../fixtures.ts";
 
 /// Snapshot the artifact directory as name -> mtime (nanoseconds), matching
@@ -223,7 +223,7 @@ test("stale epoch rejected", async ({ session }) => {
 
     // Any save bumps the workspace epoch.
     client.save(mainUri);
-    await sleep(500);
+    await sleep(SETTLE_TIME);
 
     let switched = await client.switchContext(sharedUri, mainUri, { epoch: oldEpoch });
     expect(switched.success).toBe(false);
@@ -436,12 +436,11 @@ test("switched context survives reopen", async ({ session }) => {
     // The close publishes an empty retract that can race the reopen's
     // first publish; poll past it for the real compile's errors.
     const [uri2] = await client.openAndWait("main.cpp");
-    for (let i = 0; i < 50; i++) {
-        if (client.errors(uri2).length > 0) {
-            break;
-        }
-        await sleep(200);
-    }
+    await waitUntil(() => client.errors(uri2).length, {
+        timeout: 10_000,
+        interval: 200,
+        description: "reopened context diagnostics",
+    });
     expect(
         (client.diagnostics.get(uri2) ?? []).some((d) =>
             (typeof d.message === "string" ? d.message : d.message.value).includes(

--- a/tests/integration/features/cancellation.test.ts
+++ b/tests/integration/features/cancellation.test.ts
@@ -8,6 +8,8 @@ import { test, expect } from "../fixtures.ts";
 // cheap to abandon (the worker polls the stop flag per declaration).
 const SLOW = Array.from({ length: 200_000 }, (_, i) => `int v${i};`).join("\n") + "\n";
 const LAST_LINE = 199_999;
+const CANCELLATION_DELAY = 100;
+const EDIT_SUPERSEDE_DELAY = 300;
 
 const FMT: proto.FormattingOptions = { tabSize: 4, insertSpaces: true };
 
@@ -24,7 +26,7 @@ async function cancelAndExpect(
 ): Promise<void> {
     const source = new proto.CancellationTokenSource();
     const task = client.sendRequest(method, params, source.token);
-    await sleep(100);
+    await sleep(CANCELLATION_DELAY);
     source.cancel();
     const err: unknown = await withTimeout(task, timeout, `${method} cancel`).then(
         () => {
@@ -153,7 +155,7 @@ test("edit supersedes compile", async ({ session }) => {
     const [uri] = client.open("edited.cpp");
 
     const first = client.hoverAt(uri, 0, 4);
-    await sleep(300);
+    await sleep(EDIT_SUPERSEDE_DELAY);
     client.change(uri, 1, "int fixed;\n");
 
     expect(await withTimeout(first, 10_000, "first hover")).toBeNull();

--- a/tests/integration/features/file_tracker.test.ts
+++ b/tests/integration/features/file_tracker.test.ts
@@ -2,7 +2,7 @@
 /// clice/internal/poll hook (loops disabled). The first workspace tick only
 /// seeds the stat baseline, so tests poll once before mutating the disk.
 
-import { MTIME_GRANULARITY, sleep, type CliceClient } from "@clice/tools/client";
+import { MTIME_GRANULARITY, sleep, waitUntil, type CliceClient } from "@clice/tools/client";
 import { test, expect } from "../fixtures.ts";
 
 const GATED_MAIN = `#ifndef FEATURE
@@ -183,17 +183,21 @@ test("cdb polling loop live", async ({ session }) => {
     // so poll for the errors to clear instead of trusting one fixed sleep.
     // Until the reload lands the hover fast-paths on a clean AST and no
     // diagnostics arrive — that round just times out and retries.
-    for (let i = 0; i < 30; i++) {
-        await sleep(1_000);
-        try {
-            await client.waitForRecompile(mainUri, 3_000);
-        } catch {
-            continue;
-        }
-        if (client.errors(mainUri).length === 0) {
-            break;
-        }
-    }
+    await waitUntil(
+        async () => {
+            try {
+                await client.waitForRecompile(mainUri, 3_000);
+            } catch {
+                return false;
+            }
+            return client.errors(mainUri).length === 0;
+        },
+        {
+            timeout: 120_000,
+            interval: 1_000,
+            description: "CDB polling to clear diagnostics after a flag change",
+        },
+    );
     client.assertNoErrors(mainUri, "the polling loop must reload the CDB on its own");
 });
 

--- a/tests/integration/features/guidance_diagnostics.test.ts
+++ b/tests/integration/features/guidance_diagnostics.test.ts
@@ -29,9 +29,9 @@ test("fallback guidance lifecycle", async ({ session }) => {
     const first = session.spawn(tmp);
     await first.initialize(tmp);
     const [uri] = await first.openAndWait("main.cpp");
-    expect(fileNotFoundDiags(first, uri).length, "broken include should surface").toBeGreaterThan(
-        0,
-    );
+    const missingIncludes = fileNotFoundDiags(first, uri);
+    expect(missingIncludes.length, "broken include should surface").toBeGreaterThan(0);
+    expect(missingIncludes.every((diagnostic) => diagnostic.source === "clang")).toBe(true);
     const guidance = guidanceDiags(first, uri);
     expect(guidance.length, `expected one guidance diagnostic: ${JSON.stringify(guidance)}`).toBe(
         1,

--- a/tests/integration/features/inactive_regions.test.ts
+++ b/tests/integration/features/inactive_regions.test.ts
@@ -7,7 +7,7 @@
 /// (conditions inside the bound never replay in the AST compile); a #if
 /// cut by the bound resumes via the open-conditional stack.
 
-import { sleep } from "@clice/tools/client";
+import { waitUntil } from "@clice/tools/client";
 import { expect, test } from "../fixtures.ts";
 
 test("inactive after bound", async ({ session }) => {
@@ -99,12 +99,13 @@ test("inactive flips on context switch", async ({ session }) => {
     await client.waitForRecompile(uri);
 
     // The refresh request rides its own task after the diagnostics push.
-    const deadline = Date.now() + 10_000;
     const refreshed = () =>
         client.serverRequests.slice(marker).includes("workspace/semanticTokens/refresh");
-    while (!refreshed() && Date.now() < deadline) {
-        await sleep(50);
-    }
+    await waitUntil(refreshed, {
+        timeout: 10_000,
+        interval: 50,
+        description: "semantic token refresh after a context switch",
+    });
     expect(refreshed(), "no semanticTokens refresh after the switch").toBe(true);
     expect(await client.inactiveLines(uri)).toEqual(before[0] === 4 ? [2] : [4]);
 });

--- a/tests/integration/features/index_staleness.test.ts
+++ b/tests/integration/features/index_staleness.test.ts
@@ -3,7 +3,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { MTIME_GRANULARITY, sleep } from "@clice/tools/client";
+import { MTIME_GRANULARITY, sleep, waitUntil } from "@clice/tools/client";
 import { Workspace } from "@clice/tools/workspace";
 import { expect, test } from "../fixtures.ts";
 
@@ -35,16 +35,6 @@ function globalMtime(workspace: Workspace): bigint {
     return fs.existsSync(p) ? fs.statSync(p, { bigint: true }).mtimeNs : 0n;
 }
 
-async function poll(predicate: () => boolean, timeoutSeconds = 30): Promise<boolean> {
-    for (let i = 0; i < timeoutSeconds; i++) {
-        if (predicate()) {
-            return true;
-        }
-        await sleep(1_000);
-    }
-    return false;
-}
-
 test("touch header no reindex", async ({ session }) => {
     const workspace = session.tmpdir();
     workspace.write("header.h", HEADER);
@@ -54,7 +44,11 @@ test("touch header no reindex", async ({ session }) => {
     // Session 1: background-index the closed TU into a shard.
     const c1 = session.spawn(workspace);
     await c1.initialize(workspace, { initializationOptions: NO_LMDB });
-    expect(await poll(() => shardMtimes(workspace).size > 0), "closed TU never indexed").toBe(true);
+    await waitUntil(() => shardMtimes(workspace).size > 0, {
+        timeout: 30_000,
+        interval: 1_000,
+        description: "the closed translation unit to be indexed",
+    });
     await c1.shutdown();
 
     // Touch the header: bump mtime, keep the bytes identical.
@@ -75,10 +69,11 @@ test("touch header no reindex", async ({ session }) => {
     // staleness check re-hashes, proves a mere touch, and repairs the stamp
     // — which dirties the global blob, so its mtime moving proves both that
     // the round ran and that the repair persisted.
-    expect(
-        await poll(() => globalMtime(workspace) !== globalBefore),
-        "indexing round never ran in session 2",
-    ).toBe(true);
+    await waitUntil(() => globalMtime(workspace) !== globalBefore, {
+        timeout: 30_000,
+        interval: 1_000,
+        description: "the second session's indexing round to persist",
+    });
     const after = shardMtimes(workspace);
     await c2.shutdown();
 

--- a/tests/integration/features/server.test.ts
+++ b/tests/integration/features/server.test.ts
@@ -6,6 +6,7 @@ import { sleep, SETTLE_TIME, withTimeout } from "@clice/tools/client";
 import { cliceExecutable, cliceTest, expect } from "../fixtures.ts";
 
 const test = cliceTest("hello_world");
+const EDIT_INTERVAL = 50;
 
 function capabilityEnabled(capability: unknown): boolean {
     return capability !== undefined && capability !== null && capability !== false;
@@ -102,7 +103,7 @@ test("incremental change", async ({ client }) => {
     for (let i = 0; i < 5; i++) {
         content += `\n// change ${i}`;
         client.change(uri, i + 1, content);
-        await sleep(50);
+        await sleep(EDIT_INTERVAL);
     }
     await sleep(SETTLE_TIME * 2);
     client.close(uri);

--- a/tests/integration/fixtures.ts
+++ b/tests/integration/fixtures.ts
@@ -6,28 +6,18 @@ import { test as base } from "vitest";
 import type { CliceClient } from "@clice/tools/client";
 import {
     cliceExecutable,
-    createSessionFactory,
     type Session,
     type SessionFactory,
     type SessionOptions,
 } from "@clice/tools/session";
 import type { Workspace } from "@clice/tools/workspace";
+import { sessionFixture } from "../session_fixture.ts";
 
 export { expect } from "vitest";
 export { cliceExecutable, type Session, type SessionFactory, type SessionOptions };
 
 export const test = base.extend<{ session: SessionFactory }>({
-    session: async (
-        { task }: { task: { result?: { errors?: unknown[] } } },
-        use: (factory: SessionFactory) => Promise<void>,
-    ) => {
-        const handle = createSessionFactory();
-        try {
-            await use(handle.session);
-        } finally {
-            await handle.teardown((task.result?.errors?.length ?? 0) > 0);
-        }
-    },
+    session: sessionFixture,
 });
 
 /// The zero-boilerplate form for files whose tests all target one

--- a/tests/integration/lifecycle/anomaly.test.ts
+++ b/tests/integration/lifecycle/anomaly.test.ts
@@ -6,7 +6,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { anomaliesInLogFiles, sleep } from "@clice/tools/client";
+import { anomaliesInLogFiles, waitUntil } from "@clice/tools/client";
 import { expect, test } from "../fixtures.ts";
 
 export function childPids(parentPid: number): number[] {
@@ -65,30 +65,34 @@ test.skipIf(process.platform !== "linux")("worker crash reported", async ({ sess
         // worker names, not pids, so per-process association is impossible
         // and readiness of the whole fleet is the usable condition.
         const logsDir = workspace.path(".clice/logs");
-        for (let i = 0; i < 50; i++) {
-            const names = fs.existsSync(logsDir)
-                ? fs.readdirSync(logsDir, { recursive: true, encoding: "utf8" })
-                : [];
-            const workerLogs = names.filter(
-                (name) => name.endsWith(".log") && path.basename(name) !== "master.log",
-            );
-            if (workerLogs.length >= workers.length) {
-                break;
-            }
-            await sleep(200);
-        }
+        await waitUntil(
+            () => {
+                const names = fs.existsSync(logsDir)
+                    ? fs.readdirSync(logsDir, { recursive: true, encoding: "utf8" })
+                    : [];
+                return (
+                    names.filter(
+                        (name) => name.endsWith(".log") && path.basename(name) !== "master.log",
+                    ).length >= workers.length
+                );
+            },
+            {
+                timeout: 10_000,
+                interval: 200,
+                description: "every worker to open its log file",
+            },
+        );
         // SIGABRT: dies via the same signal path as clice's own Debug traps,
         // exercises the crash handler, and is not intercepted by ASan
         // (handle_abort=0), unlike SIGSEGV which ASan turns into its own
         // report and a plain exit(1).
         process.kill(workers[0]!, "SIGABRT");
 
-        for (let i = 0; i < 50; i++) {
-            if (client.anomaliesInLogMessages().includes("WorkerCrash")) {
-                break;
-            }
-            await sleep(200);
-        }
+        await waitUntil(() => client.anomaliesInLogMessages().includes("WorkerCrash"), {
+            timeout: 10_000,
+            interval: 200,
+            description: "the worker crash anomaly message",
+        });
         expect(
             client.anomaliesInLogMessages().includes("WorkerCrash"),
             `expected WorkerCrash anomaly, got messages: ${JSON.stringify(

--- a/tests/integration/lifecycle/crash_recovery.test.ts
+++ b/tests/integration/lifecycle/crash_recovery.test.ts
@@ -8,10 +8,11 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { sleep, type CliceClient } from "@clice/tools/client";
+import { sleep, waitUntil, type CliceClient } from "@clice/tools/client";
 import { expect, test } from "../fixtures.ts";
 
 const FILE_COUNT = 20;
+const OUTAGE_RESPONSE_TIMEOUT = 15_000;
 
 function statelessWorkerPids(serverPid: number): number[] {
     const pids: number[] = [];
@@ -82,18 +83,23 @@ test.skipIf(process.platform !== "linux")(
 
         // Wait until the round demonstrably started (first symbols merged),
         // then kill a stateless worker mid-round.
-        let killed = false;
-        for (let i = 0; i < 300; i++) {
-            if ((await indexedFunctions(client)).size > 0) {
-                const workers = statelessWorkerPids(client.child.pid!);
-                if (workers.length > 0) {
-                    process.kill(workers[0]!, "SIGKILL");
-                    killed = true;
+        const killed = await waitUntil(
+            async () => {
+                if ((await indexedFunctions(client)).size > 0) {
+                    const workers = statelessWorkerPids(client.child.pid!);
+                    if (workers.length > 0) {
+                        process.kill(workers[0]!, "SIGKILL");
+                        return true;
+                    }
                 }
-                break;
-            }
-            await sleep(100);
-        }
+                return false;
+            },
+            {
+                timeout: 30_000,
+                interval: 100,
+                description: "indexing to start with a stateless worker available",
+            },
+        );
         expect(killed, "indexing never started or no stateless worker found").toBe(true);
 
         // The files that were in flight on the killed worker must be
@@ -104,13 +110,17 @@ test.skipIf(process.platform !== "linux")(
         // compiles plus a crash respawn and one round boundary for the
         // requeued file measure ~130s there (~60s locally).
         let found = new Set<string>();
-        for (let i = 0; i < 180; i++) {
-            found = await indexedFunctions(client);
-            if ([...expected].every((f) => found.has(f))) {
-                break;
-            }
-            await sleep(1_000);
-        }
+        await waitUntil(
+            async () => {
+                found = await indexedFunctions(client);
+                return [...expected].every((name) => found.has(name));
+            },
+            {
+                timeout: 180_000,
+                interval: 1_000,
+                description: "every translation unit to be reindexed after a worker crash",
+            },
+        );
         const missing = [...expected].filter((f) => !found.has(f)).sort();
         expect(
             [...expected].every((f) => found.has(f)),
@@ -175,17 +185,24 @@ test.skipIf(process.platform !== "linux")(
         // (a fast-crash streak past max_crash_streak); respawn backoff caps
         // at ~1s, so a few seconds of killing cover every respawn.
         let kills = 0;
-        for (let i = 0; i < 150 && !masterLog().includes("exceeded crash budget"); i += 1) {
-            for (const pid of statelessWorkerPids(client.child.pid!)) {
-                try {
-                    process.kill(pid, "SIGKILL");
-                    kills += 1;
-                } catch {
-                    // Already reaped.
+        await waitUntil(
+            () => {
+                for (const pid of statelessWorkerPids(client.child.pid!)) {
+                    try {
+                        process.kill(pid, "SIGKILL");
+                        kills += 1;
+                    } catch {
+                        // Already reaped.
+                    }
                 }
-            }
-            await sleep(200);
-        }
+                return masterLog().includes("exceeded crash budget");
+            },
+            {
+                timeout: 30_000,
+                interval: 200,
+                description: "the stateless worker pool to exhaust its crash budget",
+            },
+        );
         expect(kills, "no stateless worker was ever seen").toBeGreaterThanOrEqual(3);
         expect(
             masterLog().includes("exceeded crash budget"),
@@ -197,7 +214,7 @@ test.skipIf(process.platform !== "linux")(
         // the test timeout if it wedged.
         const during = await Promise.race([
             indexedFunctions(client),
-            sleep(15_000).then(() => null),
+            sleep(OUTAGE_RESPONSE_TIMEOUT).then(() => null),
         ]);
         expect(during, "master unresponsive during the outage").not.toBeNull();
 
@@ -206,13 +223,17 @@ test.skipIf(process.platform !== "linux")(
         // round snapshot, so no single file burns its budget.
         const expected = new Set(Array.from({ length: FILE_COUNT }, (_, i) => `func_${i}`));
         let found = new Set<string>();
-        for (let i = 0; i < 150; i += 1) {
-            found = await indexedFunctions(client);
-            if ([...expected].every((f) => found.has(f))) {
-                break;
-            }
-            await sleep(1_000);
-        }
+        await waitUntil(
+            async () => {
+                found = await indexedFunctions(client);
+                return [...expected].every((name) => found.has(name));
+            },
+            {
+                timeout: 150_000,
+                interval: 1_000,
+                description: "every translation unit to be indexed after pool revival",
+            },
+        );
         const missing = [...expected].filter((f) => !found.has(f)).sort();
         expect(
             [...expected].every((f) => found.has(f)),

--- a/tests/integration/lifecycle/file_operation.test.ts
+++ b/tests/integration/lifecycle/file_operation.test.ts
@@ -3,6 +3,8 @@
 import { IDLE_TIMEOUT, sleep } from "@clice/tools/client";
 import { test, expect } from "../fixtures.ts";
 
+const EDIT_INTERVAL = 200;
+
 test("did open", async ({ session }) => {
     const { client } = await session("hello_world");
     client.open("main.cpp");
@@ -15,7 +17,7 @@ test("did change", async ({ session }) => {
     let content = initial;
     for (let i = 0; i < 20; i++) {
         content += "\n";
-        await sleep(200);
+        await sleep(EDIT_INTERVAL);
         client.change(uri, i + 1, content);
     }
     await sleep(IDLE_TIMEOUT);

--- a/tests/integration/lifecycle/poison_quarantine.test.ts
+++ b/tests/integration/lifecycle/poison_quarantine.test.ts
@@ -6,7 +6,7 @@
 /// that fixes it earns a probe that brings it back.
 
 import type * as proto from "vscode-languageserver-protocol";
-import { sleep } from "@clice/tools/client";
+import { sleep, waitUntil } from "@clice/tools/client";
 import { expect, test } from "../fixtures.ts";
 
 function poison(n: number): string {
@@ -21,6 +21,7 @@ function poisonPreamble(n: number): string {
 
 const FIXED = "int add(int a, int b) { return a + b; }\n";
 const HEALTHY = "int healthy(int x) { return x * 2; }\n";
+const CRASH_CYCLE_DELAY = 300;
 
 function isQuarantined(diags: proto.Diagnostic[]): boolean {
     return diags.some((d) => {
@@ -57,13 +58,11 @@ test("poison quarantine", async ({ session }) => {
         // The first two crashes may transiently take healthy's worker
         // with them (sub-second respawn); the guarantee under test is
         // that healthy is never PERMANENTLY lost.
-        for (let i = 0; i < 10; i++) {
-            if ((await client.hoverAt(healthyUri, 0, 5)) !== null) {
-                return;
-            }
-            await sleep(500);
-        }
-        throw new Error(`healthy hover permanently lost: ${context}`);
+        await waitUntil(async () => (await client.hoverAt(healthyUri, 0, 5)) !== null, {
+            timeout: 5_000,
+            interval: 500,
+            description: `healthy hover after ${context}`,
+        });
     };
 
     // Hammer the poison document: two crashes reach the quarantine
@@ -72,19 +71,16 @@ test("poison quarantine", async ({ session }) => {
     for (let i = 1; i < 5; i++) {
         await client.hoverAt(poisonUri, 0, 5);
         client.change(poisonUri, i, poison(i));
-        await sleep(300);
+        await sleep(CRASH_CYCLE_DELAY);
         await healthyAnswers(`poison cycle ${i}`);
     }
 
     // The quarantined document explains itself.
-    let deadline = 20;
-    while (deadline > 0) {
-        if (isQuarantined(client.diagnostics.get(poisonUri) ?? [])) {
-            break;
-        }
-        await sleep(500);
-        deadline -= 1;
-    }
+    await waitUntil(() => isQuarantined(client.diagnostics.get(poisonUri) ?? []), {
+        timeout: 10_000,
+        interval: 500,
+        description: "the poison document's quarantine diagnostic",
+    });
     expect(
         isQuarantined(client.diagnostics.get(poisonUri) ?? []),
         `missing quarantine diagnostic: ${JSON.stringify(client.diagnostics.get(poisonUri) ?? [])}`,
@@ -92,14 +88,11 @@ test("poison quarantine", async ({ session }) => {
 
     // Fixing the file earns a probe that brings it back.
     client.change(poisonUri, 100, FIXED);
-    let recovered = null;
-    for (let i = 0; i < 20; i++) {
-        await sleep(500);
-        recovered = await client.hoverAt(poisonUri, 0, 5);
-        if (recovered !== null) {
-            break;
-        }
-    }
+    const recovered = await waitUntil(() => client.hoverAt(poisonUri, 0, 5), {
+        timeout: 10_000,
+        interval: 500,
+        description: "the fixed poison document to recover",
+    });
     expect(recovered, "fixed poison file did not recover").not.toBeNull();
 
     const afterHover = await client.hoverAt(healthyUri, 0, 5);
@@ -129,42 +122,33 @@ test("poison preamble quarantine", async ({ session }) => {
     for (let i = 1; i < 4; i++) {
         await client.hoverAt(poisonUri, 2, 5);
         client.change(poisonUri, i, poisonPreamble(i));
-        await sleep(300);
+        await sleep(CRASH_CYCLE_DELAY);
     }
 
-    let deadline = 20;
-    while (deadline > 0) {
-        if (isQuarantined(client.diagnostics.get(poisonUri) ?? [])) {
-            break;
-        }
-        await sleep(500);
-        deadline -= 1;
-    }
+    await waitUntil(() => isQuarantined(client.diagnostics.get(poisonUri) ?? []), {
+        timeout: 10_000,
+        interval: 500,
+        description: "the poison preamble's quarantine diagnostic",
+    });
     expect(
         isQuarantined(client.diagnostics.get(poisonUri) ?? []),
         `missing quarantine diagnostic: ${JSON.stringify(client.diagnostics.get(poisonUri) ?? [])}`,
     ).toBe(true);
 
     // Healthy documents survive the stateless carnage.
-    let hover = null;
-    for (let i = 0; i < 10; i++) {
-        hover = await client.hoverAt(healthyUri, 0, 5);
-        if (hover !== null) {
-            break;
-        }
-        await sleep(500);
-    }
+    const hover = await waitUntil(() => client.hoverAt(healthyUri, 0, 5), {
+        timeout: 5_000,
+        interval: 500,
+        description: "healthy hover after poison preamble crashes",
+    });
     expect(hover, "healthy hover lost to poison preamble").not.toBeNull();
 
     // Fixing the preamble earns a probe that brings the file back.
     client.change(poisonUri, 100, FIXED);
-    let recovered = null;
-    for (let i = 0; i < 20; i++) {
-        await sleep(500);
-        recovered = await client.hoverAt(poisonUri, 0, 5);
-        if (recovered !== null) {
-            break;
-        }
-    }
+    const recovered = await waitUntil(() => client.hoverAt(poisonUri, 0, 5), {
+        timeout: 10_000,
+        interval: 500,
+        description: "the fixed poison preamble to recover",
+    });
     expect(recovered, "fixed preamble did not recover").not.toBeNull();
 });

--- a/tests/integration/lifecycle/protocol_edges.test.ts
+++ b/tests/integration/lifecycle/protocol_edges.test.ts
@@ -5,7 +5,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as proto from "vscode-languageserver-protocol";
-import { sleep, withTimeout, type CliceClient } from "@clice/tools/client";
+import { waitUntil, withTimeout, type CliceClient } from "@clice/tools/client";
 import type { Workspace } from "@clice/tools/workspace";
 import { expect, test, type SessionFactory } from "../fixtures.ts";
 
@@ -112,23 +112,25 @@ test("desync range clamped", async ({ session }) => {
     expect(client.errors(uri).length).toBeGreaterThan(0);
 
     const logsDir = workspace.path(".clice/logs");
-    let clamped = false;
-    for (let i = 0; i < 50; i++) {
-        const logs = fs.existsSync(logsDir)
-            ? fs
-                  .readdirSync(logsDir, { recursive: true, encoding: "utf8" })
-                  .filter((name) => name.endsWith(".log"))
-                  .map((name) => fs.readFileSync(path.join(logsDir, name), "utf8"))
-                  .join("")
-            : "";
-        if (
-            logs.split("\n").some((ln) => ln.includes("didChange range") && ln.includes("clamped"))
-        ) {
-            clamped = true;
-            break;
-        }
-        await sleep(100);
-    }
+    const clamped = await waitUntil(
+        () => {
+            const logs = fs.existsSync(logsDir)
+                ? fs
+                      .readdirSync(logsDir, { recursive: true, encoding: "utf8" })
+                      .filter((name) => name.endsWith(".log"))
+                      .map((name) => fs.readFileSync(path.join(logsDir, name), "utf8"))
+                      .join("")
+                : "";
+            return logs
+                .split("\n")
+                .some((line) => line.includes("didChange range") && line.includes("clamped"));
+        },
+        {
+            timeout: 5_000,
+            interval: 100,
+            description: "the clamped out-of-sync edit log",
+        },
+    );
     expect(clamped, "clamped out-of-sync edit never produced a clamp log").toBe(true);
 });
 
@@ -243,14 +245,17 @@ test("startup guidance delivered", async ({ session }) => {
             // receive it (drained from the server's notify log).
         },
         async (client) => {
-            let delivered = false;
-            for (let i = 0; i < 300; i++) {
-                if (client.guidanceMessages().some((m) => m.includes("compile_commands.json"))) {
-                    delivered = true;
-                    break;
-                }
-                await sleep(100);
-            }
+            const delivered = await waitUntil(
+                () =>
+                    client
+                        .guidanceMessages()
+                        .some((message) => message.includes("compile_commands.json")),
+                {
+                    timeout: 30_000,
+                    interval: 100,
+                    description: "startup guidance to reach the client",
+                },
+            );
             expect(delivered, "startup guidance never reached the client").toBe(true);
         },
     );

--- a/tests/integration/lifecycle/subcommands.test.ts
+++ b/tests/integration/lifecycle/subcommands.test.ts
@@ -1,6 +1,5 @@
 import { spawnSync } from "node:child_process";
-import type { CliceClient } from "@clice/tools/client";
-import { sleep } from "@clice/tools/client";
+import { waitUntil, type CliceClient } from "@clice/tools/client";
 import { cliceExecutable, expect, test } from "../fixtures.ts";
 
 const SUBCOMMANDS = ["serve", "query", "worker", "index", "doc", "lint", "format"];
@@ -11,14 +10,17 @@ function runClice(...args: string[]) {
 }
 
 async function waitSymbol(client: CliceClient, name: string): Promise<boolean> {
-    for (let i = 0; i < 30; i += 1) {
-        const symbols = await client.workspaceSymbols(name);
-        if (symbols?.some((s) => s.name === name)) {
-            return true;
-        }
-        await sleep(1_000);
-    }
-    return false;
+    return waitUntil(
+        async () => {
+            const symbols = await client.workspaceSymbols(name);
+            return symbols?.some((symbol) => symbol.name === name) ?? false;
+        },
+        {
+            timeout: 30_000,
+            interval: 1_000,
+            description: `workspace symbol ${name}`,
+        },
+    );
 }
 
 test("root usage lists subcommands", () => {

--- a/tests/integration/lifecycle/symbolize.test.ts
+++ b/tests/integration/lifecycle/symbolize.test.ts
@@ -8,7 +8,7 @@
 import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { CliceClient, sleep } from "@clice/tools/client";
+import { CliceClient, waitUntil } from "@clice/tools/client";
 import { REPO_ROOT } from "@clice/tools/compile-commands";
 import { Workspace } from "@clice/tools/workspace";
 import { cliceExecutable, expect, test } from "../fixtures.ts";
@@ -128,12 +128,11 @@ test.skipIf(process.platform !== "linux" || isDebugBuild())(
             // handler and is not intercepted by sanitizers.
             process.kill(workers[0]!, "SIGABRT");
 
-            for (let i = 0; i < 50; i++) {
-                if (client.anomaliesInLogMessages().includes("WorkerCrash")) {
-                    break;
-                }
-                await sleep(200);
-            }
+            await waitUntil(() => client.anomaliesInLogMessages().includes("WorkerCrash"), {
+                timeout: 10_000,
+                interval: 200,
+                description: "the worker crash anomaly message",
+            });
         } finally {
             await client.shutdown();
         }

--- a/tests/integration/server/memory_ownership.test.ts
+++ b/tests/integration/server/memory_ownership.test.ts
@@ -5,9 +5,11 @@
 /// back to disk after a save, saves write only the true dirty set, and
 /// cancelled builds leave no tmp blobs behind.
 
-import { MTIME_GRANULARITY, sleep, type CliceClient } from "@clice/tools/client";
+import { MTIME_GRANULARITY, sleep, waitUntil, type CliceClient } from "@clice/tools/client";
 import type { StatsResult } from "@clice/tools/protocol";
 import { expect, test } from "../fixtures.ts";
+
+const EDIT_INTERVAL = 50;
 
 /// Poll clice/internal/stats until predicate(stats) holds.
 async function waitStats(
@@ -15,17 +17,19 @@ async function waitStats(
     predicate: (stats: StatsResult) => boolean,
     message = "",
 ): Promise<StatsResult> {
-    const deadline = Date.now() + 30_000;
-    for (;;) {
-        const stats = await client.stats();
-        if (predicate(stats)) {
-            return stats;
-        }
-        if (Date.now() > deadline) {
-            throw new Error(`${message || "stats condition"} not met: ${JSON.stringify(stats)}`);
-        }
-        await sleep(200);
-    }
+    let last: StatsResult;
+    await waitUntil(
+        async () => {
+            last = await client.stats();
+            return predicate(last);
+        },
+        {
+            timeout: 30_000,
+            interval: 200,
+            description: message || "stats condition",
+        },
+    );
+    return last!;
 }
 
 test("shards flip back after save", async ({ session }) => {
@@ -120,7 +124,7 @@ test("cancel storm leaves no tmp", async ({ session }) => {
             i + 2,
             `#define STORM ${i}\n#include "header.h"\nint main() { return base_val; }\n`,
         );
-        await sleep(50);
+        await sleep(EDIT_INTERVAL);
     }
 
     await client.waitForRecompile(uri);

--- a/tests/integration/stress/rapid_edit.test.ts
+++ b/tests/integration/stress/rapid_edit.test.ts
@@ -4,6 +4,7 @@ import { SETTLE_TIME, sleep, withTimeout } from "@clice/tools/client";
 import { cliceTest, expect } from "../fixtures.ts";
 
 const test = cliceTest("hello_world");
+const EDIT_INTERVAL = 20;
 
 /// 50 rapid edits, each followed by a hover on 'add' function.
 ///
@@ -24,7 +25,7 @@ test("rapid edits with hover", async ({ client }) => {
         // We don't await the result here to simulate real editor behavior
         // where requests overlap.
         void client.hoverAt(uri, 2, 4).catch(() => undefined);
-        await sleep(20); // ~20ms between edits
+        await sleep(EDIT_INTERVAL);
     }
 
     // Wait a moment for in-flight requests to settle.

--- a/tests/package.json
+++ b/tests/package.json
@@ -16,7 +16,6 @@
     "typescript": "~5.5.4",
     "typescript-eslint": "^8.65.0",
     "vitest": "^3.2.0",
-    "vscode-jsonrpc": "^8.2.1",
     "vscode-languageserver-protocol": "^3.17.5",
     "vscode-uri": "^3.1.0",
     "@clice/tools": "*"

--- a/tests/session_fixture.ts
+++ b/tests/session_fixture.ts
@@ -1,0 +1,13 @@
+import { createSessionFactory, type SessionFactory } from "@clice/tools/session";
+
+export async function sessionFixture(
+    { task }: { task: { result?: { errors?: unknown[] } } },
+    use: (factory: SessionFactory) => Promise<void>,
+): Promise<void> {
+    const handle = createSessionFactory();
+    try {
+        await use(handle.session);
+    } finally {
+        await handle.teardown((task.result?.errors?.length ?? 0) > 0);
+    }
+}

--- a/tests/snap/fixtures.ts
+++ b/tests/snap/fixtures.ts
@@ -4,21 +4,12 @@
 /// integration suite — bound independently, per suite.
 
 import { test as base } from "vitest";
-import { cliceExecutable, createSessionFactory, type SessionFactory } from "@clice/tools/session";
+import { cliceExecutable, type SessionFactory } from "@clice/tools/session";
+import { sessionFixture } from "../session_fixture.ts";
 
 export { expect } from "vitest";
 export { cliceExecutable };
 
 export const test = base.extend<{ session: SessionFactory }>({
-    session: async (
-        { task }: { task: { result?: { errors?: unknown[] } } },
-        use: (factory: SessionFactory) => Promise<void>,
-    ) => {
-        const handle = createSessionFactory();
-        try {
-            await use(handle.session);
-        } finally {
-            await handle.teardown((task.result?.errors?.length ?? 0) > 0);
-        }
-    },
+    session: sessionFixture,
 });

--- a/tests/tools/perf.test.ts
+++ b/tests/tools/perf.test.ts
@@ -48,7 +48,7 @@ test("summarize discriminates by kind and keeps only durations", () => {
                 "[perf:startup] phase=dep_scan elapsed_ms=25",
                 "[perf:index_detail] op=serialize copy_ms=17.4 pack_ms=155.3",
                 "[perf:index_detail] op=build scope=full semantics_ms=80 finish_ms=5",
-                "[perf:index_detail] op=build scope=interested semantics_ms=8 finish_ms=1",
+                "[perf:index_detail] op=build scope=main semantics_ms=8 finish_ms=1",
                 "[perf:index_query] kind=relations rel=Definition path=/w/a.cpp elapsed_ms=3",
                 "[perf:index_query] kind=relations rel=Reference path=/w/a.cpp elapsed_ms=7",
             ].join("\n"),
@@ -62,7 +62,7 @@ test("summarize discriminates by kind and keeps only durations", () => {
     // The secondary scope/rel discriminators keep materially different
     // operations in separate series.
     expect(summary["index_detail.build.full.semantics_ms"]?.p50).toBe(80);
-    expect(summary["index_detail.build.interested.semantics_ms"]?.p50).toBe(8);
+    expect(summary["index_detail.build.main.semantics_ms"]?.p50).toBe(8);
     expect(summary["index_query.relations.Definition.elapsed_ms"]?.p50).toBe(3);
     expect(summary["index_query.relations.Reference.elapsed_ms"]?.p50).toBe(7);
     // Non-duration keys (file=, kind=) never become series.

--- a/tests/tools/process_gate.test.ts
+++ b/tests/tools/process_gate.test.ts
@@ -36,6 +36,29 @@ test("process gate rejects every incomplete or unsafe process outcome", () => {
     ]);
 });
 
+test("anomaly gate ignores logs predating the session", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "process-gate-"));
+    try {
+        const stale = path.join(root, ".clice", "logs", "old-session");
+        fs.mkdirSync(stale, { recursive: true });
+        const staleLog = path.join(stale, "worker.log");
+        fs.writeFileSync(staleLog, "[anomaly:WorkerCrash] leftover\n");
+        const preexisting = new Set([staleLog]);
+
+        expect(anomalyGateFailure([], root, preexisting)).toBeNull();
+
+        const fresh = path.join(root, ".clice", "logs", "new-session");
+        fs.mkdirSync(fresh, { recursive: true });
+        fs.writeFileSync(path.join(fresh, "master.log"), "[anomaly:MasterCrash] current\n");
+
+        const failure = anomalyGateFailure([], root, preexisting);
+        expect(failure).toContain("MasterCrash");
+        expect(failure).not.toContain("WorkerCrash");
+    } finally {
+        fs.rmSync(root, { recursive: true });
+    }
+});
+
 test("anomaly gate scans notification IDs and workspace logs", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "process-gate-"));
     try {

--- a/tests/tools/process_gate.test.ts
+++ b/tests/tools/process_gate.test.ts
@@ -1,0 +1,56 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { expect, test } from "vitest";
+import { anomalyGateFailure, processGateFailures } from "../../tools/process_gate.ts";
+
+test("process gate accepts a clean exit with complete stderr", () => {
+    expect(
+        processGateFailures({
+            exitCode: 0,
+            signalCode: null,
+            stderrText: "",
+            stderrComplete: true,
+            stderrDrainedFromStart: true,
+        }),
+    ).toEqual([]);
+});
+
+test("process gate rejects every incomplete or unsafe process outcome", () => {
+    expect(
+        processGateFailures({
+            exitCode: null,
+            signalCode: "SIGABRT",
+            stderrText:
+                "[logging] dropped 3 stderr line(s): client not draining\n" +
+                "runtime error: invalid value",
+            stderrComplete: false,
+            stderrFailure: "timed out",
+            stderrDrainedFromStart: true,
+        }),
+    ).toEqual([
+        "server exited from signal SIGABRT",
+        "stderr pump did not complete: timed out",
+        "stderr mirror shed lines despite a draining client",
+        "server stderr contains sanitizer/runtime error output",
+    ]);
+});
+
+test("anomaly gate scans notification IDs and workspace logs", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "process-gate-"));
+    try {
+        const logs = path.join(root, ".clice", "logs", "session");
+        fs.mkdirSync(logs, { recursive: true });
+        fs.writeFileSync(
+            path.join(logs, "worker.log"),
+            "[anomaly:WorkerCrash] worker failed\n=== CRASH STACK TRACE ===\nframe 0\n",
+        );
+
+        const failure = anomalyGateFailure(["MasterCrash"], root);
+        expect(failure).toContain("MasterCrash");
+        expect(failure).toContain("WorkerCrash");
+        expect(failure).toContain("=== CRASH STACK TRACE ===");
+    } finally {
+        fs.rmSync(root, { recursive: true });
+    }
+});

--- a/tests/tools/snapshot.test.ts
+++ b/tests/tools/snapshot.test.ts
@@ -22,7 +22,7 @@ test("snap format round trip", () => {
 
 test("snapshot check flows", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "snap-"));
-    const snapPath = path.join(dir, "a.cpp.snap.yml");
+    const snapPath = path.join(dir, "a.snap.yml");
 
     const ctx = new SnapshotContext(dir);
     ctx.check("a.cpp", "one\n"); // first run creates
@@ -51,13 +51,13 @@ test("snapshot check flows", () => {
     ctx.check("a.cpp", "two\n");
 });
 
-test("colocated snapshot layout", () => {
-    const ctx = new SnapshotContext("/corpus", { colocated: true });
+test("snapshot layout", () => {
+    const ctx = new SnapshotContext("/corpus");
     expect(ctx.snapPath("group/a.cpp")).toBe(path.join("/corpus", "group/a.snap.yml"));
     expect(ctx.snapPath("group/a.cpp", "server")).toBe(
         path.join("/corpus", "group/a.server.snap.yml"),
     );
-    expect(new SnapshotContext("/dir").snapPath("a.cpp")).toBe(path.join("/dir", "a.cpp.snap.yml"));
+    expect(new SnapshotContext("/dir").snapPath("a.cpp")).toBe(path.join("/dir", "a.snap.yml"));
 });
 
 test("normalize file uri", () => {

--- a/tests/unit/command/toolchain_tests.cpp
+++ b/tests/unit/command/toolchain_tests.cpp
@@ -85,10 +85,6 @@ TEST_CASE(GCC, skip = !(CIEnvironment && (Windows || Linux))) {
     ASSERT_TRUE(unit.diagnostics().empty());
 };
 
-TEST_CASE(MSVC, skip = !CIEnvironment) {
-    // TODO: add MSVC toolchain test when CI provides toolchain.
-}
-
 TEST_CASE(Clang, skip = !CIEnvironment) {
     auto file = fs::createTemporaryFile("clice", "cpp");
     if(!file) {
@@ -118,10 +114,6 @@ TEST_CASE(Clang, skip = !CIEnvironment) {
     ASSERT_TRUE(unit.completed());
     ASSERT_TRUE(unit.diagnostics().empty());
 };
-
-TEST_CASE(Zig, skip = !CIEnvironment) {
-    // TODO: add Zig toolchain test when available in CI.
-}
 
 TEST_CASE(NVCC, skip = !(CIEnvironment && Linux)) {
     auto file = fs::createTemporaryFile("clice", "cu");

--- a/tests/unit/compile/diagnostic_tests.cpp
+++ b/tests/unit/compile/diagnostic_tests.cpp
@@ -140,7 +140,7 @@ TEST_CASE(Error) {
     EXPECT_EQ(diag.id.diagnostic_code(), "err_expected_semi_after_stmt");
     EXPECT_EQ(diag.id.level, DiagnosticLevel::Error);
     EXPECT_EQ(diag.id.source, DiagnosticSource::Clang);
-    EXPECT_EQ(diag.fid, unit.interested_file());
+    EXPECT_EQ(diag.fid, unit.main_file());
     EXPECT_TRUE(diag.range.valid());
     EXPECT_EQ(diag.message, "expected ';' after return statement");
 };

--- a/tests/unit/compile/directive_tests.cpp
+++ b/tests/unit/compile/directive_tests.cpp
@@ -21,7 +21,7 @@ using u32 = std::uint32_t;
 void run(llvm::StringRef code) {
     add_files("main.cpp", code);
     ASSERT_TRUE(compile("-std=c++23"));
-    auto fid = unit->interested_file();
+    auto fid = unit->main_file();
     includes = unit->directives()[fid].includes;
     has_includes = unit->directives()[fid].has_includes;
     conditions = unit->directives()[fid].conditions;

--- a/tests/unit/compile/tidy_tests.cpp
+++ b/tests/unit/compile/tidy_tests.cpp
@@ -82,7 +82,7 @@ TEST_CASE(HeaderFilterTraversesHeaders) {
     std::string main_path = TestVFS::path("main.cpp");
     CompilationParams params;
     // A header-reporting configuration widens the matcher traversal past
-    // the interested file; the finding lands with the header's location.
+    // the main file; the finding lands with the header's location.
     params.kind = CompilationKind::Content;
     params.tidy = tidy::TidyParams{.checks = "-*,bugprone-integer-division",
                                    .fast_only = false,
@@ -94,7 +94,7 @@ TEST_CASE(HeaderFilterTraversesHeaders) {
 
     bool header_finding = false;
     for(auto& diag: unit.diagnostics()) {
-        if(diag.id.source == DiagnosticSource::ClangTidy && diag.fid != unit.interested_file()) {
+        if(diag.id.source == DiagnosticSource::ClangTidy && diag.fid != unit.main_file()) {
             ASSERT_EQ(diag.id.name, "bugprone-integer-division");
             header_finding = true;
         }

--- a/tests/unit/config/config_tests.cpp
+++ b/tests/unit/config/config_tests.cpp
@@ -1,5 +1,3 @@
-#include <cstdlib>
-
 #include "test/temp_dir.h"
 #include "test/test.h"
 #include "config/config.h"
@@ -10,27 +8,6 @@
 #include "kota/codec/toml/toml.h"
 
 namespace clice::testing {
-
-// POSIX setenv/unsetenv don't exist on Windows; map to _putenv_s
-// (passing an empty value to _putenv_s removes the variable).
-// Used only by the disabled XDG cache-dir tests below.
-#if 0
-static void set_env(const char* name, const char* value) {
-#ifdef _WIN32
-    ::_putenv_s(name, value);
-#else
-    ::setenv(name, value, 1);
-#endif
-}
-
-static void unset_env(const char* name) {
-#ifdef _WIN32
-    ::_putenv_s(name, "");
-#else
-    ::unsetenv(name);
-#endif
-}
-#endif
 
 /// The schema object of a property named `name`, found anywhere in the
 /// document's nested `properties` maps.
@@ -222,7 +199,6 @@ TEST_CASE(BornValidDefaults) {
               default_max_stateless_worker_count());
     EXPECT_GE(config.project.max_stateless_worker_count.value,
               config.project.min_stateless_worker_count.value);
-    EXPECT_EQ(config.project.worker_memory_limit.value, 4ULL * 1024 * 1024 * 1024);
     EXPECT_EQ(config.tracker.cdb_poll_seconds.value, 3u);
     EXPECT_EQ(config.tracker.workspace_poll_seconds.value, 30u);
     EXPECT_EQ(config.inlay_hints.enabled.value, true);
@@ -300,14 +276,15 @@ TEST_CASE(LoadMalformedToml) {
     EXPECT_FALSE(result.has_value());
 }
 
-TEST_CASE(LegacyIndexDirIgnored) {
-    // Configs written for older clice may still set the removed
-    // project.index_dir key; unknown keys must not fail the parse.
+TEST_CASE(LegacyProjectKeysIgnored) {
+    // Configs written for older clice may still set removed project keys;
+    // unknown keys must not fail the parse.
     TempDir tmp;
     tmp.touch("clice.toml", R"(
 [project]
 cache_dir = "/opt/cache"
 index_dir = "/opt/index"
+worker_memory_limit = 4294967296
 )");
     auto result = Config::load(tmp.path("clice.toml"), tmp.root.str().str());
     EXPECT_TRUE(result.has_value());
@@ -329,28 +306,6 @@ TEST_CASE(WorkspaceVarSubst) {
     EXPECT_EQ(std::string_view(config.project.logging_dir), "/my/ws/logs");
     EXPECT_EQ(config.project.compile_commands_paths[0], "/my/ws/build");
 }
-
-// FIXME: Out-of-tree cache placement is disabled (see
-// resolve_xdg_cache_dir in src/config/config.cpp); these tests pin its
-// behavior and return with it.
-#if 0
-TEST_CASE(XdgCacheDir) {
-    TempDir tmp;
-    auto cache_base = tmp.path("xdg");
-    set_env("XDG_CACHE_HOME", cache_base.c_str());
-    Config config;
-    config.finalize("/some/ws");
-    unset_env("XDG_CACHE_HOME");
-
-    // Compare in the canonical spelling — finalize canonicalizes
-    // cache_dir (a no-op on POSIX).
-    std::string cache = path::convert_to_slash(std::string_view(config.project.cache_dir));
-    std::string base = path::convert_to_slash(cache_base);
-    path::canonicalize(base);
-    EXPECT_TRUE(llvm::StringRef(cache).starts_with(base));
-    EXPECT_TRUE(cache.find("/clice/") != std::string::npos);
-}
-#endif
 
 TEST_CASE(InvalidGlobPattern) {
     Config config;
@@ -383,120 +338,6 @@ TEST_CASE(ConfigPriorityJson) {
     EXPECT_EQ(from_json->project.enable_indexing.value, true);
     EXPECT_EQ(from_json->project.stateful_worker_count.value, 2u);
 }
-
-#if 0
-TEST_CASE(XdgHashUnique) {
-    // Different workspace roots must map to different cache dirs,
-    // same workspace root must map to the same dir (deterministic).
-    TempDir tmp;
-    auto cache_base = tmp.path("xdg");
-    set_env("XDG_CACHE_HOME", cache_base.c_str());
-
-    Config a, b, c;
-    a.finalize("/ws/project-a");
-    b.finalize("/ws/project-b");
-    c.finalize("/ws/project-a");
-    unset_env("XDG_CACHE_HOME");
-
-    EXPECT_NE(std::string_view(a.project.cache_dir), std::string_view(b.project.cache_dir));
-    EXPECT_EQ(std::string_view(a.project.cache_dir), std::string_view(c.project.cache_dir));
-}
-
-TEST_CASE(XdgNameHashFormat) {
-    // The cache leaf is "<basename>-<8 hex digits>" so users can map
-    // directories back to their workspaces.
-    TempDir tmp;
-    auto cache_base = tmp.path("xdg");
-    set_env("XDG_CACHE_HOME", cache_base.c_str());
-    Config config;
-    config.finalize("/some/ws/myproject");
-    unset_env("XDG_CACHE_HOME");
-
-    llvm::StringRef leaf = path::filename(std::string_view(config.project.cache_dir));
-    EXPECT_TRUE(leaf.starts_with("myproject-"));
-    llvm::StringRef hex = leaf.drop_front(std::string_view("myproject-").size());
-    EXPECT_EQ(hex.size(), 8u);
-    EXPECT_EQ(hex.find_first_not_of("0123456789abcdef"), llvm::StringRef::npos);
-}
-
-TEST_CASE(XdgSameNameDiffer) {
-    // Same basename under different parents: the hash must keep them apart.
-    TempDir tmp;
-    auto cache_base = tmp.path("xdg");
-    set_env("XDG_CACHE_HOME", cache_base.c_str());
-    Config a, b;
-    a.finalize("/first/proj");
-    b.finalize("/second/proj");
-    unset_env("XDG_CACHE_HOME");
-
-    EXPECT_TRUE(path::filename(std::string_view(a.project.cache_dir)).starts_with("proj-"));
-    EXPECT_TRUE(path::filename(std::string_view(b.project.cache_dir)).starts_with("proj-"));
-    EXPECT_NE(std::string_view(a.project.cache_dir), std::string_view(b.project.cache_dir));
-}
-
-TEST_CASE(XdgRootWorkspace) {
-    // A root workspace has no basename; the leaf must not degenerate to "-<hash>".
-    TempDir tmp;
-    auto cache_base = tmp.path("xdg");
-    set_env("XDG_CACHE_HOME", cache_base.c_str());
-    Config config;
-    config.finalize("/");
-    unset_env("XDG_CACHE_HOME");
-
-    EXPECT_TRUE(
-        path::filename(std::string_view(config.project.cache_dir)).starts_with("workspace-"));
-}
-
-TEST_CASE(XdgLongBasename) {
-    // A basename near the filesystem's 255-byte component limit must be
-    // truncated so the leaf (name + "-" + 8 hex) still fits.
-    TempDir tmp;
-    auto cache_base = tmp.path("xdg");
-    set_env("XDG_CACHE_HOME", cache_base.c_str());
-    Config config;
-    config.finalize("/ws/" + std::string(200, 'x'));
-    unset_env("XDG_CACHE_HOME");
-
-    llvm::StringRef leaf = path::filename(std::string_view(config.project.cache_dir));
-    EXPECT_TRUE(leaf.starts_with(std::string(64, 'x')));
-    EXPECT_EQ(leaf.size(), 64u + 9u);
-}
-
-TEST_CASE(XdgTrailingSlash) {
-    TempDir tmp;
-    auto cache_base = tmp.path("xdg");
-    set_env("XDG_CACHE_HOME", cache_base.c_str());
-    Config config;
-    config.finalize("/some/ws/");
-    unset_env("XDG_CACHE_HOME");
-
-    EXPECT_TRUE(path::filename(std::string_view(config.project.cache_dir)).starts_with("ws-"));
-}
-
-TEST_CASE(HomeFallback) {
-    // With XDG_CACHE_HOME unset but HOME set, cache dir should be under $HOME/.cache/clice.
-    TempDir tmp;
-    unset_env("XDG_CACHE_HOME");
-    auto home = tmp.path("home");
-    // Save prior value so we restore cleanly.
-    const char* prior = std::getenv("HOME");
-    std::string prior_home = prior ? prior : "";
-    set_env("HOME", home.c_str());
-
-    Config config;
-    config.finalize("/some/ws");
-
-    if(prior_home.empty())
-        unset_env("HOME");
-    else
-        set_env("HOME", prior_home.c_str());
-
-    std::string cache = path::convert_to_slash(std::string_view(config.project.cache_dir));
-    std::string home_posix = path::convert_to_slash(home);
-    path::canonicalize(home_posix);
-    EXPECT_TRUE(llvm::StringRef(cache).starts_with(home_posix + "/.cache/clice/"));
-}
-#endif
 
 TEST_CASE(DefaultWorkspaceCache) {
     Config config;
@@ -572,15 +413,15 @@ TEST_CASE(TypeIssueReported) {
     EXPECT_NE(issues[0].message.find("test_hooks"), std::string::npos);
 }
 
-TEST_CASE(UnknownKeyIssueWarns) {
+TEST_CASE(RemovedKeyIssueWarns) {
     TempDir tmp;
-    tmp.touch("clice.toml", "[project]\nclang_tdy = true\n");
+    tmp.touch("clice.toml", "[project]\nworker_memory_limit = 4294967296\n");
     std::vector<ConfigIssue> issues;
     auto result = Config::load(tmp.path("clice.toml"), tmp.root.str(), &issues);
     EXPECT_TRUE(result.has_value());
     ASSERT_EQ(issues.size(), 1u);
     EXPECT_EQ(issues[0].severity, ConfigIssue::Severity::Warning);
-    EXPECT_NE(issues[0].message.find("clang_tdy"), std::string::npos);
+    EXPECT_NE(issues[0].message.find("worker_memory_limit"), std::string::npos);
 }
 
 TEST_CASE(UnknownFeatureKeyWarns) {
@@ -604,12 +445,10 @@ TEST_CASE(ZeroWorkerCountRejected) {
     config.project.stateful_worker_count = 0;
     config.project.stateless_worker_count = 0;
     config.project.min_stateless_worker_count = 0;
-    config.project.worker_memory_limit = 0;
     config.finalize("");
     EXPECT_EQ(config.project.stateful_worker_count.value, 2u);
     EXPECT_GE(config.project.stateless_worker_count.value, 2u);
     EXPECT_EQ(config.project.min_stateless_worker_count.value, 1u);
-    EXPECT_EQ(config.project.worker_memory_limit.value, 4ULL * 1024 * 1024 * 1024);
 }
 
 TEST_CASE(NullOptionRejected) {
@@ -819,10 +658,8 @@ TEST_CASE(JsonSchema) {
     EXPECT_TRUE(find_property(*doc, "compiled_rules") == nullptr);
 
     // The fields finalize() rejects `0` for carry the matching lower bound.
-    for(auto field: {"stateful_worker_count",
-                     "stateless_worker_count",
-                     "min_stateless_worker_count",
-                     "worker_memory_limit"}) {
+    for(auto field:
+        {"stateful_worker_count", "stateless_worker_count", "min_stateless_worker_count"}) {
         const auto* property = find_property(*doc, field);
         ASSERT_TRUE(property != nullptr);
         const auto* minimum = property->get_object()->find("minimum");

--- a/tests/unit/feature/inactive_region_tests.cpp
+++ b/tests/unit/feature/inactive_region_tests.cpp
@@ -26,7 +26,7 @@ int b();
 )cpp");
 
     ASSERT_EQ(scan.regions.size(), 2u);
-    auto content = unit->interested_content();
+    auto content = unit->main_content();
     auto begin = scan.regions[0];
     auto end = scan.regions[1];
     EXPECT_EQ(content.substr(begin, end - begin), "int dead();\n");
@@ -43,7 +43,7 @@ int dead();
 )cpp");
 
     ASSERT_EQ(scan.regions.size(), 2u);
-    auto content = unit->interested_content();
+    auto content = unit->main_content();
     EXPECT_EQ(content.substr(scan.regions[0], scan.regions[1] - scan.regions[0]), "int dead();\n");
 }
 
@@ -66,7 +66,7 @@ int dead();
 )cpp");
 
     ASSERT_EQ(scan.regions.size(), 2u);
-    auto content = unit->interested_content();
+    auto content = unit->main_content();
     EXPECT_EQ(content.substr(scan.regions[0], scan.regions[1] - scan.regions[0]), "int dead();\n");
 }
 
@@ -79,7 +79,7 @@ int b();
 )cpp");
 
     ASSERT_EQ(scan.regions.size(), 2u);
-    auto content = unit->interested_content();
+    auto content = unit->main_content();
     EXPECT_EQ(content.substr(scan.regions[0], scan.regions[1] - scan.regions[0]), "int dead();\n");
 }
 
@@ -96,7 +96,7 @@ int b();
 )cpp");
 
     ASSERT_EQ(scan.regions.size(), 2u);
-    auto content = unit->interested_content();
+    auto content = unit->main_content();
     EXPECT_EQ(content.substr(scan.regions[0], scan.regions[1] - scan.regions[0]),
               "int dead();\n#ifdef INNER\nint deeper();\n#endif\nint tail();\n");
 }

--- a/tests/unit/feature/index_projection_tests.cpp
+++ b/tests/unit/feature/index_projection_tests.cpp
@@ -95,7 +95,7 @@ int total(Point point, int base) {
     extract_rows();
 
     auto ast = feature::semantic_tokens(*unit);
-    auto projected = feature::index_semantic_tokens(unit->interested_content(),
+    auto projected = feature::index_semantic_tokens(unit->main_content(),
                                                     feature::index_lang_options("main.cpp", false),
                                                     occurrences,
                                                     decls,
@@ -180,7 +180,7 @@ int compute() {
     extract_rows();
 
     auto ast = feature::folding_ranges(*unit);
-    auto projected = feature::index_folding_ranges(unit->interested_content(),
+    auto projected = feature::index_folding_ranges(unit->main_content(),
                                                    feature::index_lang_options("main.cpp", false),
                                                    decls,
                                                    resolver());
@@ -195,7 +195,7 @@ int compute() {
 
     // The constructor's fold anchors at its body, not the member
     // initializer's braces.
-    auto body = unit->interested_content().find("{\n        value += 1;");
+    auto body = unit->main_content().find("{\n        value += 1;");
     bool anchored = std::ranges::any_of(projected, [&](const feature::FoldingRange& fold) {
         return fold.range.begin == body;
     });

--- a/tests/unit/feature/inlay_hint_tests.cpp
+++ b/tests/unit/feature/inlay_hint_tests.cpp
@@ -31,11 +31,11 @@ void run(llvm::StringRef code,
     add_main("main.cpp", code);
     ASSERT_TRUE(compile_with_pch("-std=c++23"));
 
-    LocalSourceRange range = LocalSourceRange(0, unit->interested_content().size());
+    LocalSourceRange range = LocalSourceRange(0, unit->main_content().size());
     hints = feature::inlay_hints(*unit, range, options, feature::PositionEncoding::UTF8);
 
     hints_map.clear();
-    auto content = unit->interested_content();
+    auto content = unit->main_content();
     auto line_starts = unit->line_starts();
     lsp::LineMap map(content, line_starts, feature::PositionEncoding::UTF8);
     for(auto& hint: hints) {

--- a/tests/unit/feature/semantic_tokens_tests.cpp
+++ b/tests/unit/feature/semantic_tokens_tests.cpp
@@ -128,7 +128,7 @@ void run_utf8(llvm::StringRef code) {
     add_main("main.cpp", code);
     ASSERT_TRUE(compile_with_pch());
     tokens = feature::semantic_tokens(*unit, feature::PositionEncoding::UTF8);
-    decoded = decode_utf8_tokens(unit->interested_content(), tokens);
+    decoded = decode_utf8_tokens(unit->main_content(), tokens);
 }
 
 auto find_by_range(llvm::StringRef name) -> const DecodedToken* {
@@ -204,7 +204,7 @@ int main() {
     auto utf8_tokens = feature::semantic_tokens(*unit, feature::PositionEncoding::UTF8);
     auto utf16_tokens = feature::semantic_tokens(*unit, feature::PositionEncoding::UTF16);
 
-    auto utf8 = decode_utf8_tokens(unit->interested_content(), utf8_tokens);
+    auto utf8 = decode_utf8_tokens(unit->main_content(), utf8_tokens);
     auto utf16 = decode_relative_tokens(utf16_tokens);
 
     auto string_type = static_cast<std::uint32_t>(SymbolKind::String);
@@ -271,7 +271,7 @@ int y = x;
 )");
     ASSERT_TRUE(compile_with_modules());
     tokens = feature::semantic_tokens(*unit, feature::PositionEncoding::UTF8);
-    decoded = decode_utf8_tokens(unit->interested_content(), tokens);
+    decoded = decode_utf8_tokens(unit->main_content(), tokens);
 
     EXPECT_TOKEN("kw", SymbolKind::Keyword);
     EXPECT_TOKEN("mod", SymbolKind::Module);
@@ -302,7 +302,7 @@ import :part;
     // The preprocessor callback channel must record every import form the
     // AST records: a named import, an export-import and a partition import
     // (whose full name resolves through the owning module).
-    auto& imports = unit->directives()[unit->interested_file()].imports;
+    auto& imports = unit->directives()[unit->main_file()].imports;
     ASSERT_EQ(imports.size(), 3U);
     ASSERT_EQ(imports[0].name, "a");
     ASSERT_EQ(imports[1].name, "b");
@@ -337,7 +337,7 @@ export §(kw)⟦import⟧ :§(part)⟦part⟧;
 )");
     ASSERT_TRUE(compile_with_modules());
     tokens = feature::semantic_tokens(*unit, feature::PositionEncoding::UTF8);
-    decoded = decode_utf8_tokens(unit->interested_content(), tokens);
+    decoded = decode_utf8_tokens(unit->main_content(), tokens);
 
     EXPECT_TOKEN("kw", SymbolKind::Keyword);
     EXPECT_TOKEN("part", SymbolKind::Module);
@@ -355,7 +355,7 @@ int y = §(ref)⟦x⟧;
 )");
     ASSERT_TRUE(compile_with_modules());
     tokens = feature::semantic_tokens(*unit, feature::PositionEncoding::UTF8);
-    decoded = decode_utf8_tokens(unit->interested_content(), tokens);
+    decoded = decode_utf8_tokens(unit->main_content(), tokens);
 
     EXPECT_TOKEN("kw", SymbolKind::Keyword);
     EXPECT_TOKEN("mod", SymbolKind::Module);
@@ -374,7 +374,7 @@ export §(kw)⟦import⟧ §(mod)⟦foo⟧;
 )");
     ASSERT_TRUE(compile_with_modules());
     tokens = feature::semantic_tokens(*unit, feature::PositionEncoding::UTF8);
-    decoded = decode_utf8_tokens(unit->interested_content(), tokens);
+    decoded = decode_utf8_tokens(unit->main_content(), tokens);
 
     EXPECT_TOKEN("kw", SymbolKind::Keyword);
     EXPECT_TOKEN("mod", SymbolKind::Module);

--- a/tests/unit/index/index_query_tests.cpp
+++ b/tests/unit/index/index_query_tests.cpp
@@ -201,7 +201,7 @@ TEST_CASE(OpenSessionServedByShard) {
     // Open the document with exactly the indexed content and never
     // compile it: freshness clause 4 serves it from its shard.
     auto session = store.open(main_id);
-    store.apply_open(*session, unit->interested_content().str(), 1);
+    store.apply_open(*session, unit->main_content().str(), 1);
     ASSERT_FALSE(projections.index_current(session->path_id));
 
     auto position = feature::to_position(session->line_map(), point("use"));
@@ -220,7 +220,7 @@ TEST_CASE(DivergedBufferWithdrawsShard) {
     merge_into_workspace();
 
     auto session = store.open(main_id);
-    auto edited = unit->interested_content().str() + "// edited\n";
+    auto edited = unit->main_content().str() + "// edited\n";
     store.apply_open(*session, edited, 1);
 
     // The buffer no longer matches the rows' content: the shard withdraws
@@ -255,7 +255,7 @@ TEST_CASE(HeaderEdgesFromHostManifest) {
 
     // The TU's own manifest still answers for the TU itself.
     auto main_session = store.open(main_id);
-    store.apply_open(*main_session, unit->interested_content().str(), 1);
+    store.apply_open(*main_session, unit->main_content().str(), 1);
     auto main_edges = query.include_edges(*main_session);
     ASSERT_EQ(main_edges.size(), std::size_t(1));
     ASSERT_TRUE(llvm::StringRef(main_edges[0].target).ends_with("header.h"));

--- a/tests/unit/index/preamble_index_tests.cpp
+++ b/tests/unit/index/preamble_index_tests.cpp
@@ -340,7 +340,7 @@ int other = 1;
 
     // The preamble text itself is not stored; the envelope keeps only the
     // identity of the exact prefix it was built from.
-    auto content = unit->interested_content();
+    auto content = unit->main_content();
     EXPECT_TRUE(state->matches_prefix(content));
     EXPECT_TRUE(state->matches_prefix(content.str() + "\nint more = 2;"));
     EXPECT_FALSE(state->matches_prefix(content.drop_back(1)));

--- a/tests/unit/index/shard_tests.cpp
+++ b/tests/unit/index/shard_tests.cpp
@@ -37,7 +37,7 @@ std::string write_fresh(const index::FileIndex& rows, llvm::StringRef content) {
     return bytes;
 }
 
-/// The interested file's worker-encoded blob, straight from the envelope.
+/// The main file's worker-encoded blob, straight from the envelope.
 std::string main_blob() {
     auto section = tu_index.section_of(tu_index.path_count() - 1);
     if(!section) {

--- a/tests/unit/index/tu_index_tests.cpp
+++ b/tests/unit/index/tu_index_tests.cpp
@@ -1154,7 +1154,7 @@ Derived* use();
 
 TEST_CASE(HeaderMacroDropped) {
     // Macro occurrences flow through the same gate: a definition in an
-    // included header is dropped from an interested-only build, while
+    // included header is dropped from an main-file-only build, while
     // the reference in the main file is kept.
     add_file("baz.h", R"(
 #define BAZ 1
@@ -1172,8 +1172,8 @@ int x = §(1)BAZ;
 
 TEST_CASE(UnknownFidFallback) {
     // A preamble header's loaded FileID is unknown to a graph built
-    // without indexed fids; lookups must degrade to the interested
-    // file instead of crashing.
+    // without indexed fids; lookups must degrade to the main file
+    // instead of crashing.
     add_file("foo.h", R"(
 struct Foo {};
 )");
@@ -1304,7 +1304,7 @@ TEST_CASE(EnvelopeSections) {
     auto& view = tu_index.view;
     ASSERT_TRUE(view.built_at() > 0);
 
-    // Sections ascend by path id and the interested file's rows are the
+    // Sections ascend by path id and the main file's rows are the
     // last path id's section.
     for(std::uint32_t i = 1; i < view.section_count(); i += 1) {
         ASSERT_TRUE(view.section_path(i - 1) < view.section_path(i));
@@ -1485,7 +1485,7 @@ TEST_CASE(FromRejectsOutOfRangePathIds) {
 }
 
 TEST_CASE(FromRejectsEmptyPathTable) {
-    // The builder ends every path table with the interested file, and
+    // The builder ends every path table with the main file, and
     // consumers address path_count() - 1 unchecked — an envelope with no
     // paths at all is corrupt.
     MirrorEnvelope hostile;

--- a/tests/unit/sched/graph_tests.cpp
+++ b/tests/unit/sched/graph_tests.cpp
@@ -1,6 +1,7 @@
 #include <optional>
 #include <random>
 
+#include "test/async.h"
 #include "test/test.h"
 #include "sched/graph.h"
 
@@ -148,17 +149,6 @@ kota::task<> run_request(NodeId id, Probe& probe, JoinOptions options = {}) {
     if(result.has_value()) {
         probe.outcome = *result;
     }
-}
-
-/// Zero-interest cancellation is deferred by one event-loop tick per
-/// cascade level; wait (bounded) until `pred` holds before asserting
-/// settled state.
-template <typename Pred>
-kota::task<> settle(Pred pred) {
-    for(int i = 0; i < 100 && !pred(); i += 1) {
-        co_await kota::sleep(1);
-    }
-    EXPECT_TRUE(pred());
 }
 
 /// ============================================================================

--- a/tests/unit/sched/pch_family_tests.cpp
+++ b/tests/unit/sched/pch_family_tests.cpp
@@ -69,7 +69,6 @@ void execute(F&& fn) {
         opts.stateless_count = 1;
         opts.stateful_count = 0;
         CO_ASSERT_TRUE(pool->start(opts));
-        co_await kota::sleep(500);
 
         co_await fn();
 

--- a/tests/unit/sched/pcm_graph_integration_tests.cpp
+++ b/tests/unit/sched/pcm_graph_integration_tests.cpp
@@ -1,3 +1,4 @@
+#include "test/async.h"
 #include "test/cdb_helper.h"
 #include "test/temp_dir.h"
 #include "test/test.h"
@@ -194,16 +195,6 @@ void make_graph(DispatchFn dispatch, ResolveFn resolve) {
 
 void make_graph() {
     make_graph(default_dispatch(), default_resolver());
-}
-
-/// Zero-interest cancellation is deferred by one event-loop tick per cascade
-/// level; wait (bounded) until `pred` holds before asserting settled state.
-template <typename Pred>
-kota::task<> settle(Pred pred) {
-    for(int i = 0; i < 100 && !pred(); i++) {
-        co_await kota::sleep(1);
-    }
-    EXPECT_TRUE(pred());
 }
 
 /// Run the test body, then verify the shutdown protocol leaves the graph idle.

--- a/tests/unit/semantic/template_resolver_tests.cpp
+++ b/tests/unit/semantic/template_resolver_tests.cpp
@@ -19,7 +19,7 @@ struct InputFinder : clang::RecursiveASTVisitor<InputFinder> {
 
     bool TraverseDecl(clang::Decl* decl) {
         if(decl && (llvm::isa<clang::TranslationUnitDecl>(decl) ||
-                    unit.file_id(decl->getLocation()) == unit.interested_file())) {
+                    unit.file_id(decl->getLocation()) == unit.main_file())) {
             Base::TraverseDecl(decl);
         }
 

--- a/tests/unit/server/ast_family_tests.cpp
+++ b/tests/unit/server/ast_family_tests.cpp
@@ -211,7 +211,6 @@ TEST_CASE(ShutdownUnblocksWaiters) {
         opts.stateless_count = 0;
         opts.stateful_count = 1;
         CO_ASSERT_TRUE(stack.pool.start(opts));
-        co_await kota::sleep(500);
 
         kota::task_group<> group(stack.loop);
         auto waiter = [&]() -> kota::task<> {
@@ -285,7 +284,6 @@ TEST_CASE(EditInterruptsStaleCompile) {
         opts.stateless_count = 0;
         opts.stateful_count = 1;
         CO_ASSERT_TRUE(stack.pool.start(opts));
-        co_await kota::sleep(500);
 
         kota::task_group<> group(stack.loop);
         auto waiter = [&]() -> kota::task<> {
@@ -365,7 +363,6 @@ TEST_CASE(SupersededCompileCancelled) {
         opts.stateless_count = 0;
         opts.stateful_count = 1;
         CO_ASSERT_TRUE(stack.pool.start(opts));
-        co_await kota::sleep(500);
 
         kota::task_group<> group(stack.loop);
         auto first = [&]() -> kota::task<> {
@@ -461,7 +458,6 @@ TEST_CASE(BufferImportBuildsPCM) {
         opts.stateless_count = 1;
         opts.stateful_count = 1;
         CO_ASSERT_TRUE(stack.pool.start(opts));
-        co_await kota::sleep(500);
 
         ok = co_await stack.ast.ensure_compiled(session);
 
@@ -503,7 +499,6 @@ TEST_CASE(BufferImportRecorded) {
         opts.stateless_count = 0;
         opts.stateful_count = 1;
         CO_ASSERT_TRUE(stack.pool.start(opts));
-        co_await kota::sleep(500);
 
         [[maybe_unused]] bool ok = co_await stack.ast.ensure_compiled(session);
 
@@ -551,7 +546,6 @@ TEST_CASE(IncludeImportRecorded) {
         opts.stateless_count = 0;
         opts.stateful_count = 1;
         CO_ASSERT_TRUE(stack.pool.start(opts));
-        co_await kota::sleep(500);
 
         [[maybe_unused]] bool ok = co_await stack.ast.ensure_compiled(session);
 
@@ -682,7 +676,6 @@ TEST_CASE(PCHCrashCountsStreak) {
         opts.stateless_count = 1;
         opts.stateful_count = 0;
         CO_ASSERT_TRUE(stack.pool.start(opts));
-        co_await kota::sleep(500);
 
         bool built =
             co_await ForwarderFixture::ensure_pch(stack.forwarder,
@@ -729,7 +722,6 @@ TEST_CASE(PCHCrashBlocksBuild) {
         opts.stateless_count = 1;
         opts.stateful_count = 0;
         CO_ASSERT_TRUE(stack.pool.start(opts));
-        co_await kota::sleep(500);
 
         auto result = co_await stack.forwarder.forward_completion({}, session);
         CO_ASSERT_FALSE(result.has_value());
@@ -776,7 +768,6 @@ TEST_CASE(ClientCancelSparesCompile) {
         opts.stateless_count = 0;
         opts.stateful_count = 1;
         CO_ASSERT_TRUE(stack.pool.start(opts));
-        co_await kota::sleep(500);
 
         kota::cancellation_source source;
         kota::task_group<> group(stack.loop);
@@ -867,7 +858,6 @@ TEST_CASE(PoisonPreambleBudget) {
         opts.stateless_count = 1;
         opts.stateful_count = 0;
         CO_ASSERT_TRUE(stack.pool.start(opts));
-        co_await kota::sleep(500);
 
         auto build = [&](const std::shared_ptr<Session>& session) {
             return ForwarderFixture::ensure_pch(stack.forwarder,
@@ -913,7 +903,7 @@ TEST_CASE(EpochGuardsPCHWash) {
     stack.register_pch_store(tmp);
     auto session = stack.open(src, "#define X 1\nint x;\n");
     // One prior strike on the PCH ledger.
-    session->quarantine.on_kind_crash(pch_evidence, "w-1");
+    session->quarantine.on_kind_crash(evidence_kind(EvidenceKind::PCH), "w-1");
     ASSERT_EQ(session->quarantine.crashes(), 1u);
 
     std::string directory = tmp.path(".");
@@ -926,7 +916,6 @@ TEST_CASE(EpochGuardsPCHWash) {
         opts.stateless_count = 1;
         opts.stateful_count = 0;
         CO_ASSERT_TRUE(stack.pool.start(opts));
-        co_await kota::sleep(500);
 
         auto gen = session->generation;
         auto epoch = stack.ast.projections.epoch(session->path_id);
@@ -1019,7 +1008,6 @@ TEST_CASE(StaleDepsNoAdopt) {
         opts.stateless_count = 1;
         opts.stateful_count = 0;
         CO_ASSERT_TRUE(stack.pool.start(opts));
-        co_await kota::sleep(500);
 
         CO_ASSERT_TRUE(co_await build(builder));
         auto adopted = stack.ast.projections.projection(builder->path_id);

--- a/tests/unit/server/cancel_chain_tests.cpp
+++ b/tests/unit/server/cancel_chain_tests.cpp
@@ -24,7 +24,7 @@ TEST_CASE(HandlerCancelChainsThrough) {
     auto src = tmp.path("probe.cpp");
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(w.spawn(true));
 
     bool observed_cancelled_reply = false;
     bool handler_resumed = false;

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -3056,7 +3056,6 @@ TEST_CASE(ModuleLintScanParity) {
         opts.stateless_count = 1;
         opts.stateful_count = 0;
         CO_ASSERT_TRUE(f.pool.start(opts));
-        co_await kota::sleep(500);
 
         outcome = co_await f.turun.run(n_id, std::move(plan), {});
 

--- a/tests/unit/server/module_worker_tests.cpp
+++ b/tests/unit/server/module_worker_tests.cpp
@@ -66,7 +66,7 @@ TEST_CASE(BuildPCMThenCompileWithImport) {
     ASSERT_FALSE(pcm_path.empty());
 
     WorkerHandle sf;
-    ASSERT_TRUE(sf.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(sf.spawn(true));
 
     bool phase2_done = false;
 
@@ -178,7 +178,7 @@ TEST_CASE(BuildPCMChainThenCompile) {
 
     // Compile consumer with BOTH PCMs via stateful worker.
     WorkerHandle sf;
-    ASSERT_TRUE(sf.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(sf.spawn(true));
 
     bool compile_done = false;
 
@@ -261,7 +261,7 @@ TEST_CASE(ModuleImplementationUnitWithWorker) {
 
     // Compile implementation unit with the PCM via stateful worker.
     WorkerHandle sf;
-    ASSERT_TRUE(sf.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(sf.spawn(true));
 
     bool compile_done = false;
 

--- a/tests/unit/server/pch_worker_tests.cpp
+++ b/tests/unit/server/pch_worker_tests.cpp
@@ -83,7 +83,7 @@ TEST_CASE(BuildPCHThenCompile) {
     EXPECT_TRUE(has_common_link);
 
     WorkerHandle sf;
-    ASSERT_TRUE(sf.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(sf.spawn(true));
 
     bool phase2_done = false;
 
@@ -177,7 +177,7 @@ TEST_CASE(CompileWithoutPCHStillWorks) {
     auto dir = std::string(tmp.root);
 
     WorkerHandle sf;
-    ASSERT_TRUE(sf.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(sf.spawn(true));
 
     bool compile_done = false;
 

--- a/tests/unit/server/query_overlay_tests.cpp
+++ b/tests/unit/server/query_overlay_tests.cpp
@@ -50,7 +50,7 @@ std::string main_path;
 
 /// Compile the added sources, persist the preamble envelope (exactly what
 /// the PCH build produces), and open a session whose pch_key points at
-/// it. The session's own index is the interested-only envelope, mirroring
+/// it. The session's own index is the main-file-only envelope, mirroring
 /// the production per-edit index.
 void open_with_overlay(std::source_location location = std::source_location::current()) {
     ASSERT_TRUE(compile());

--- a/tests/unit/server/stateful_worker_tests.cpp
+++ b/tests/unit/server/stateful_worker_tests.cpp
@@ -16,7 +16,7 @@ TEST_SUITE(StatefulWorker) {
 
 TEST_CASE(SpawnAndExit) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(w.spawn(true));
 
     w.peer->close_output();
     w.loop.schedule(w.peer->run());
@@ -29,7 +29,7 @@ TEST_CASE(CompileRequest) {
     auto src = tmp.path("compile_test.cpp");
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(w.spawn(true));
 
     bool test_done = false;
 
@@ -58,7 +58,7 @@ TEST_CASE(CancelledCompileFreesStrand) {
     auto src = tmp.path("cancel_test.cpp");
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(w.spawn(true));
 
     bool test_done = false;
 
@@ -134,7 +134,7 @@ TEST_CASE(CancelNotificationInterruptsCompile) {
     auto src = tmp.path("interrupt.cpp");
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(w.spawn(true));
 
     bool test_done = false;
 
@@ -190,7 +190,7 @@ TEST_CASE(CancelledQueryFreesStrand) {
     auto src = tmp.path("query_cancel.cpp");
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(w.spawn(true));
 
     bool test_done = false;
 
@@ -238,7 +238,7 @@ TEST_CASE(CancelledQueryFreesStrand) {
 
 TEST_CASE(HoverWithoutCompile) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(w.spawn(true));
 
     bool test_done = false;
 
@@ -266,7 +266,7 @@ TEST_CASE(CompileThenHover) {
     auto src = tmp.path("hover_test.cpp");
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(w.spawn(true));
 
     bool test_done = false;
 
@@ -302,7 +302,7 @@ TEST_CASE(CompileThenHover) {
 
 TEST_CASE(CodeActionReturnsEmpty) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(w.spawn(true));
 
     bool test_done = false;
 
@@ -323,7 +323,7 @@ TEST_CASE(CodeActionReturnsEmpty) {
 
 TEST_CASE(GoToDefinitionWithoutCompile) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(w.spawn(true));
 
     bool test_done = false;
 
@@ -345,7 +345,7 @@ TEST_CASE(GoToDefinitionWithoutCompile) {
 
 TEST_CASE(SemanticTokensWithoutCompile) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(w.spawn(true));
 
     bool test_done = false;
 
@@ -365,7 +365,7 @@ TEST_CASE(SemanticTokensWithoutCompile) {
 
 TEST_CASE(FoldingRangeWithoutCompile) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(w.spawn(true));
 
     bool test_done = false;
 
@@ -385,7 +385,7 @@ TEST_CASE(FoldingRangeWithoutCompile) {
 
 TEST_CASE(DocumentSymbolWithoutCompile) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(w.spawn(true));
 
     bool test_done = false;
 
@@ -405,7 +405,7 @@ TEST_CASE(DocumentSymbolWithoutCompile) {
 
 TEST_CASE(DocumentLinkWithoutCompile) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(w.spawn(true));
 
     bool test_done = false;
 
@@ -424,7 +424,7 @@ TEST_CASE(DocumentLinkWithoutCompile) {
 
 TEST_CASE(InlayHintsWithoutCompile) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(w.spawn(true));
 
     bool test_done = false;
 
@@ -454,7 +454,7 @@ TEST_CASE(MultipleSequentialRequests) {
     auto src = tmp.path("seq_test.cpp");
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(w.spawn(true));
 
     bool test_done = false;
 
@@ -525,7 +525,7 @@ TEST_CASE(MultipleDocuments) {
     }
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(w.spawn(true));
 
     bool test_done = false;
 
@@ -562,7 +562,7 @@ TEST_CASE(MultipleDocuments) {
 
 TEST_CASE(EvictNotification) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(w.spawn(true));
 
     bool test_done = false;
 
@@ -588,7 +588,7 @@ TEST_CASE(EvictNotification) {
     ASSERT_TRUE(test_done);
 }
 
-TEST_CASE(LowLimitDrivesEviction) {
+TEST_CASE(DocumentLimitEvicts) {
     TempDir tmp;
     std::vector<std::string> paths;
     std::vector<std::string> texts;
@@ -601,7 +601,7 @@ TEST_CASE(LowLimitDrivesEviction) {
     }
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024, /*max_documents=*/2));
+    ASSERT_TRUE(w.spawn(true, /*max_documents=*/2));
 
     std::vector<std::string> evicted;
     w.peer->on_notification(
@@ -638,44 +638,6 @@ TEST_CASE(LowLimitDrivesEviction) {
 
     ASSERT_TRUE(test_done);
     ASSERT_EQ(evicted, std::vector<std::string>{paths[0]});
-}
-
-TEST_CASE(SpawnWithMemoryLimit) {
-    TempDir tmp;
-    tmp.touch("memlimit_test.cpp", "int memlimit_var = 42;\n");
-    auto src = tmp.path("memlimit_test.cpp");
-
-    WorkerHandle w;
-    // Spawn with a specific memory limit to test the CLI flag is accepted.
-    ASSERT_TRUE(w.spawn(2ULL * 1024 * 1024 * 1024));
-
-    bool test_done = false;
-
-    w.run([&]() -> kota::task<> {
-        // Compile first.
-        worker::CompileParams cp;
-        cp.path = src;
-        cp.version = 1;
-        cp.text = "int memlimit_var = 42;\n";
-        cp.directory = "/tmp";
-        cp.arguments = make_args(src);
-
-        auto cr = co_await w.peer->send_request(cp);
-        EXPECT_TRUE(cr.has_value());
-
-        // Feature request should work after compilation.
-        worker::QueryParams hp;
-        hp.kind = worker::QueryKind::Hover;
-        hp.path = src;
-        hp.offset = 4;  // 'memlimit_var'
-
-        auto result = co_await w.peer->send_request(hp);
-        EXPECT_TRUE(result.has_value());
-
-        test_done = true;
-    });
-
-    ASSERT_TRUE(test_done);
 }
 
 };  // TEST_SUITE(StatefulWorker)

--- a/tests/unit/server/stateless_worker_tests.cpp
+++ b/tests/unit/server/stateless_worker_tests.cpp
@@ -50,7 +50,6 @@ TEST_CASE(CompileResultRoundTrip) {
     worker::CompileResult result;
     result.version = 1;
     result.diagnostics = {};  // empty
-    result.memory_usage = 0;
 
     auto bytes = bincode::to_bytes(result);
     ASSERT_TRUE(bytes.has_value());

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -1734,7 +1734,6 @@ TEST_CASE(StatelessRequest) {
     bool done = false;
     f.run([&]() -> kota::task<> {
         CO_ASSERT_TRUE(f.start(2, 0));
-        co_await kota::sleep(500);
 
         worker::TURunParams params;
         params.index = true;
@@ -1769,7 +1768,6 @@ TEST_CASE(AdvisoryCancelCooperates) {
     bool done = false;
     f.run([&]() -> kota::task<> {
         CO_ASSERT_TRUE(f.start(1, 0));
-        co_await kota::sleep(500);
 
         worker::TURunParams params;
         params.index = true;
@@ -1843,7 +1841,6 @@ TEST_CASE(DeadSlotRevives) {
         CO_ASSERT_TRUE(f.start(1, 0));
         f.set_revive_after(std::chrono::milliseconds(300));
         f.set_max_crash_streak(0);
-        co_await kota::sleep(500);
 
         // The very first crash exceeds the zero budget: the slot dies...
         f.kill_worker(0);
@@ -1871,7 +1868,6 @@ TEST_CASE(InPlaceKeepsOwner) {
     bool done = false;
     f.run([&]() -> kota::task<> {
         CO_ASSERT_TRUE(f.start(0, 2));
-        co_await kota::sleep(500);
 
         // Two documents pin worker 0: it is the owner but not expendable.
         f.force_owner(7, 0);
@@ -1954,7 +1950,6 @@ TEST_CASE(ScaleUpRevivesDead) {
         // Cooldown far in the future: only scale-up can bring the slot back.
         f.set_revive_after(std::chrono::minutes(10));
         f.set_max_crash_streak(0);
-        co_await kota::sleep(500);
 
         f.kill_worker(0);
         for(int i = 0; i < 50 && !f.slot_dead(0); ++i) {
@@ -2013,7 +2008,6 @@ TEST_CASE(CrashDuringRequest) {
     bool done = false;
     f.run([&]() -> kota::task<> {
         CO_ASSERT_TRUE(f.start(2, 0));
-        co_await kota::sleep(500);
 
         // Kill both workers, then send without yielding: the claim lands on
         // a dead-but-not-yet-reaped slot, and the pool must surface
@@ -2046,7 +2040,6 @@ TEST_CASE(PreemptCancelsRequest) {
     bool done = false;
     f.run([&]() -> kota::task<> {
         CO_ASSERT_TRUE(f.start(2, 0));
-        co_await kota::sleep(500);
 
         worker::TURunParams params;
         params.index = true;
@@ -2098,7 +2091,6 @@ TEST_CASE(CancelledCrashRetiresSlot) {
     bool done = false;
     f.run([&]() -> kota::task<> {
         CO_ASSERT_TRUE(f.start(1, 0));
-        co_await kota::sleep(500);
 
         worker::TURunParams params;
         params.index = true;

--- a/tests/unit/server/worker_test_helpers.h
+++ b/tests/unit/server/worker_test_helpers.h
@@ -65,9 +65,9 @@ struct WorkerHandle {
     std::unique_ptr<kota::ipc::BincodePeer> peer;
     int stderr_fd = -1;
 
-    bool spawn(std::uint64_t memory_limit = 0, std::size_t max_documents = 0) {
+    bool spawn(bool stateful = false, std::size_t max_documents = 0) {
         auto binary = clice_binary();
-        auto label = memory_limit > 0 ? "stateful" : "stateless";
+        auto label = stateful ? "stateful" : "stateless";
 
 #ifndef _WIN32
         std::string stderr_path = std::string("/tmp/clice_worker_stderr_") + label + ".log";
@@ -77,10 +77,8 @@ struct WorkerHandle {
         kota::process::options opts;
         opts.file = binary;
         opts.args = {binary, "worker"};
-        if(memory_limit > 0) {
+        if(stateful) {
             opts.args.push_back("--stateful");
-            opts.args.push_back("--memory-limit");
-            opts.args.push_back(std::to_string(memory_limit));
         }
         if(max_documents > 0) {
             opts.args.push_back("--max-documents");

--- a/tests/unit/test/async.h
+++ b/tests/unit/test/async.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "test/test.h"
+
+#include "kota/async/async.h"
+
+namespace clice::testing {
+
+/// Wait for event-loop cancellation cascades to settle before asserting state.
+template <typename Pred>
+kota::task<> settle(Pred pred) {
+    for(int i = 0; i < 100 && !pred(); ++i) {
+        co_await kota::sleep(1);
+    }
+    EXPECT_TRUE(pred());
+}
+
+}  // namespace clice::testing

--- a/tests/unit/test/platform.h
+++ b/tests/unit/test/platform.h
@@ -7,43 +7,16 @@
 
 namespace clice::testing {
 
-/// Set by --test-dir from the command line; empty if not specified.
-inline std::string test_dir;
-
 #ifdef _WIN32
 constexpr inline bool Windows = true;
 #else
 constexpr inline bool Windows = false;
 #endif
 
-#ifdef __APPLE__
-constexpr inline bool macOS = true;
-#else
-constexpr inline bool macOS = false;
-#endif
-
 #ifdef __linux__
 constexpr inline bool Linux = true;
 #else
 constexpr inline bool Linux = false;
-#endif
-
-#if defined(__clang__)
-constexpr inline bool Clang = true;
-#else
-constexpr inline bool Clang = false;
-#endif
-
-#if defined(__GNUC__) && !defined(__clang__)
-constexpr inline bool GCC = true;
-#else
-constexpr inline bool GCC = false;
-#endif
-
-#if defined(_MSC_VER) && !defined(__clang__)
-constexpr inline bool MSVC = true;
-#else
-constexpr inline bool MSVC = false;
 #endif
 
 #ifdef CLICE_CI_ENVIRONMENT

--- a/tests/unit/test/tester.cpp
+++ b/tests/unit/test/tester.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <format>
 
+#include "support/logging.h"
 #include "syntax/scan.h"
 
 namespace clice::testing {
@@ -262,17 +263,6 @@ bool Tester::compile_with_modules(llvm::StringRef standard) {
     return true;
 }
 
-bool Tester::compile_file(llvm::StringRef path, llvm::StringRef standard) {
-    auto buffer = llvm::MemoryBuffer::getFile(path);
-    if(!buffer) {
-        LOG_ERROR("Failed to read file: {}", path);
-        return false;
-    }
-    auto filename = llvm::sys::path::filename(path);
-    add_main(filename, (*buffer)->getBuffer());
-    return compile(standard);
-}
-
 std::uint32_t Tester::point(llvm::StringRef name, llvm::StringRef file) {
     if(file.empty()) {
         file = src_path;
@@ -346,60 +336,6 @@ void Tester::prepare_driver(llvm::StringRef standard) {
 
 bool Tester::compile_driver(llvm::StringRef standard) {
     prepare_driver(standard);
-    return try_compile();
-}
-
-bool Tester::compile_driver_with_pch(llvm::StringRef standard) {
-    prepare_driver(standard);
-
-    auto pch_path = fs::createTemporaryFile("clice", "pch");
-    if(!pch_path) {
-        LOG_ERROR("{}", pch_path.error().message());
-        return false;
-    }
-
-    // Phase 1: Build PCH from the preamble portion.
-    params.kind = CompilationKind::Preamble;
-    params.output_file = *pch_path;
-
-    // Clear buffers from prepare_driver() so we can re-add with preamble bound.
-    params.buffers.clear();
-    for(auto& [file, source]: sources.all_files) {
-        if(file == src_path) {
-            auto bound = compute_preamble_bound(source.content);
-            params.add_remapped_file(file, source.content, bound);
-        } else {
-            std::string path = path::is_absolute(file) ? file.str() : path::join(".", file);
-            params.add_remapped_file(path, source.content);
-        }
-    }
-
-    PCHInfo info;
-    {
-        auto preamble_unit = clice::compile(params, info);
-        if(!preamble_unit.completed()) {
-            for(auto& diag: preamble_unit.diagnostics()) {
-                LOG_ERROR("{}", diag.message);
-            }
-            return false;
-        }
-    }
-
-    // Phase 2: Compile content using the PCH. Re-add the buffers phase 1
-    // consumed: content compiles read the sources through remapping too.
-    params.output_file.clear();
-    params.kind = CompilationKind::Content;
-    params.pch = {info.path, static_cast<std::uint32_t>(info.preamble.size())};
-    params.buffers.clear();
-    for(auto& [file, source]: sources.all_files) {
-        if(file == src_path) {
-            params.add_remapped_file(file, source.content);
-        } else {
-            std::string path = path::is_absolute(file) ? file.str() : path::join(".", file);
-            params.add_remapped_file(path, source.content);
-        }
-    }
-
     return try_compile();
 }
 

--- a/tests/unit/test/tester.h
+++ b/tests/unit/test/tester.h
@@ -9,8 +9,6 @@
 #include "command/command.h"
 #include "command/toolchain.h"
 #include "compile/compilation.h"
-#include "feature/feature.h"
-#include "support/logging.h"
 #include "syntax/annotation.h"
 
 namespace clice::testing {
@@ -72,15 +70,10 @@ struct Tester {
 
     bool compile_with_modules(llvm::StringRef standard = "-std=c++20");
 
-    /// Read a file from disk and compile it directly (no VFS content needed).
-    bool compile_file(llvm::StringRef path, llvm::StringRef standard = "-std=c++20");
-
     /// Driver path: uses CompilationDatabase + toolchain cache, has system headers.
     void prepare_driver(llvm::StringRef standard = "-std=c++20");
 
     bool compile_driver(llvm::StringRef standard = "-std=c++20");
-
-    bool compile_driver_with_pch(llvm::StringRef standard = "-std=c++20");
 
     bool try_compile();
 
@@ -93,26 +86,6 @@ struct Tester {
     llvm::ArrayRef<std::uint32_t> nameless_points(llvm::StringRef file = "");
 
     LocalSourceRange range(llvm::StringRef name = "", llvm::StringRef file = "");
-
-    /// Convert a protocol range back to byte offsets in the compiled unit's
-    /// interested file. Shared by feature tests that compare protocol results
-    /// against annotation ranges. An unmappable range is a test bug — fail
-    /// loudly instead of dereferencing an empty optional.
-    LocalSourceRange to_local_range(const kota::ipc::protocol::Range& range) {
-        feature::LineMap map(unit->interested_content(),
-                             unit->line_starts(),
-                             feature::PositionEncoding::UTF8);
-        auto begin = map.to_offset(range.start);
-        auto end = map.to_offset(range.end);
-        if(!begin || !end) {
-            LOG_FATAL("to_local_range: unmappable range {}:{}-{}:{}",
-                      range.start.line,
-                      range.start.character,
-                      range.end.line,
-                      range.end.character);
-        }
-        return LocalSourceRange(*begin, *end);
-    }
 
     void clear();
 };

--- a/tests/unit/unit_tests.cc
+++ b/tests/unit/unit_tests.cc
@@ -17,10 +17,6 @@ struct TestOptions {
     DecoKVStyled(KVStyle::JoinedOrSeparate, help = "log level: trace/debug/info/warn/err";
                  required = false)
     <std::string> log_level;
-
-    DecoKVStyled(KVStyle::JoinedOrSeparate, meta_var = "<DIR>"; help = "test data directory";
-                 required = false)
-    <std::string> test_dir;
 };
 
 }  // namespace
@@ -34,9 +30,6 @@ int main(int argc, const char** argv) {
     }
 
     auto& opts = parsed->options;
-
-    if(opts.test_dir.has_value())
-        clice::testing::test_dir = *opts.test_dir;
 
     if(opts.log_level.has_value()) {
         auto level = *opts.log_level;

--- a/tools/client/client.ts
+++ b/tools/client/client.ts
@@ -1,4 +1,5 @@
-/// CliceClient — LSP client for integration testing, on vscode-jsonrpc.
+/// CliceClient — LSP client for integration testing, on
+/// vscode-languageserver-protocol.
 ///
 /// The client owns its whole lifecycle: spawn (stdio or socket), typed
 /// requests including clice's custom protocol, diagnostics tracking,
@@ -31,7 +32,21 @@ import {
     type StatsResult,
     type SwitchContextResult,
 } from "../protocol/protocol.ts";
+import {
+    anomalyGateFailure,
+    anomaliesInMessages,
+    processGateFailures,
+    SANITIZER_MARKERS,
+    serverStderrExcerpt,
+} from "../process_gate.ts";
 import { canonicalUri, Workspace } from "./workspace.ts";
+
+export {
+    anomaliesInLogFiles,
+    crashTracesInLogFiles,
+    logFiles,
+    SANITIZER_MARKERS,
+} from "../process_gate.ts";
 
 // Standard timing constants — use these instead of hardcoded sleep values.
 export const MTIME_GRANULARITY = 1_100; // Filesystem mtime precision + margin
@@ -40,6 +55,43 @@ export const IDLE_TIMEOUT = 5_000; // Idle soak time in lifecycle tests
 
 export function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export interface WaitUntilOptions {
+    timeout: number;
+    interval: number;
+    description: string;
+}
+
+function formatWaitState(state: unknown): string {
+    try {
+        return JSON.stringify({ value: state });
+    } catch {
+        return String(state);
+    }
+}
+
+export async function waitUntil<T>(
+    predicate: () => T | Promise<T>,
+    { timeout, interval, description }: WaitUntilOptions,
+): Promise<T> {
+    const deadline = Date.now() + timeout;
+    let lastState: T;
+    for (;;) {
+        lastState = await predicate();
+        if (lastState) {
+            return lastState;
+        }
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) {
+            break;
+        }
+        await sleep(Math.min(interval, remaining));
+    }
+    throw new Error(
+        `Timed out after ${timeout}ms waiting for ${description}; ` +
+            `last state: ${formatWaitState(lastState)}`,
+    );
 }
 
 /// Normalize a definition/references response to a list of Locations.
@@ -55,19 +107,6 @@ export function locationsOf<T>(result: T | T[] | null | undefined): T[] {
 export function asLocations(result: unknown): proto.Location[] {
     return locationsOf(result as proto.Location | proto.Location[] | null);
 }
-
-// Sanitizer/crash fingerprints scanned in server stderr. Detection happens
-// incrementally in the pump: a mid-session report (e.g. relayed from a
-// crashed worker) must survive the retention cap's eviction.
-export const SANITIZER_MARKERS = [
-    "AddressSanitizer",
-    "LeakSanitizer",
-    "MemorySanitizer",
-    "ThreadSanitizer",
-    "UndefinedBehaviorSanitizer",
-    "==ERROR:",
-    "runtime error:",
-] as const;
 
 const SANITIZER_MARKER_BUFFERS = SANITIZER_MARKERS.map((m) => Buffer.from(m));
 
@@ -122,69 +161,6 @@ export async function findFreePort(): Promise<number> {
         }
     }
     throw new Error(`no free port in range ${base}-${base + 99}`);
-}
-
-const ANOMALY_PATTERN = /\[anomaly:([A-Za-z]+)\]/;
-const CRASH_TRACE_MARKER = "=== CRASH STACK TRACE ===";
-
-/// All .log files under <workspace>/.clice/logs — one directory per server
-/// session, master and worker logs side by side.
-export function logFiles(root: string | null): string[] {
-    if (root === null) {
-        return [];
-    }
-    const logsDir = path.join(root, ".clice", "logs");
-    if (!fs.existsSync(logsDir)) {
-        return [];
-    }
-    return fs
-        .readdirSync(logsDir, { recursive: true, encoding: "utf8" })
-        .filter((name) => name.endsWith(".log"))
-        .sort()
-        .map((name) => path.join(logsDir, name));
-}
-
-/// Anomaly IDs from master/worker log files under <workspace>/.clice/logs.
-/// Workers don't forward logMessage in v1.0, so their anomalies are only
-/// visible in their log files.
-export function anomaliesInLogFiles(root: string | null): string[] {
-    const found: string[] = [];
-    for (const logFile of logFiles(root)) {
-        for (const line of fs.readFileSync(logFile, "utf8").split("\n")) {
-            const match = ANOMALY_PATTERN.exec(line);
-            if (match) {
-                found.push(`${match[1]} (${path.basename(logFile)}: ${line.trim()})`);
-            }
-        }
-    }
-    return found;
-}
-
-/// Crash stack traces recorded by crashed processes in their log files.
-export function crashTracesInLogFiles(root: string | null): string[] {
-    const traces: string[] = [];
-    for (const logFile of logFiles(root)) {
-        const text = fs.readFileSync(logFile, "utf8");
-        const pos = text.indexOf(CRASH_TRACE_MARKER);
-        if (pos !== -1) {
-            traces.push(`--- ${path.basename(logFile)} ---\n${text.slice(pos)}`);
-        }
-    }
-    return traces;
-}
-
-function serverStderrExcerpt(stderrText: string): string {
-    const interesting = stderrText
-        .split("\n")
-        .filter(
-            (line) =>
-                line.includes("[warn]") ||
-                line.includes("[error]") ||
-                line.includes("Sanitizer") ||
-                line.includes("==ERROR:") ||
-                line.includes("runtime error:"),
-        );
-    return interesting.slice(-80).join("\n");
 }
 
 export interface StartOptions {
@@ -518,12 +494,13 @@ export class CliceClient {
         // reports, late crash text) must reach the scan below. The pump owns
         // the stream — wait for it to see EOF instead of racing it with a
         // second reader.
+        let stderrComplete = true;
+        let stderrFailure: string | undefined;
         try {
             await withTimeout(this.stderrEof, 2_000, "stderr EOF");
         } catch (exc) {
-            // A pump that never saw EOF means the transcript below may be
-            // partial — the sanitizer scan must not silently pass on it.
-            failures.push(`stderr pump did not complete: ${String(exc)}`);
+            stderrComplete = false;
+            stderrFailure = String(exc);
         }
         const stderrText = this.drainedStderr().toString("utf8");
 
@@ -533,23 +510,17 @@ export class CliceClient {
             }
         }
 
-        if (this.child.exitCode !== 0) {
-            failures.push(`server exited with code ${this.child.exitCode}`);
-        }
-
-        // A client that drained continuously must never see the drop report:
-        // shedding under a live reader would mean ordinary tests silently
-        // lose parts of the stderr transcript they later assert on.
-        if (this.stderrDrainedFromStart && stderrText.includes("client not draining")) {
-            failures.push("stderr mirror shed lines despite a draining client");
-        }
-
-        if (this.stderrMarkerHit !== null) {
-            const excerpt = this.stderrMarkerHit.toString("utf8");
-            failures.push(`server stderr contains sanitizer/runtime error output:\n${excerpt}`);
-        } else if (SANITIZER_MARKERS.some((marker) => stderrText.includes(marker))) {
-            failures.push("server stderr contains sanitizer/runtime error output");
-        }
+        failures.push(
+            ...processGateFailures({
+                exitCode: this.child.exitCode,
+                signalCode: this.child.signalCode,
+                stderrText,
+                stderrComplete,
+                stderrFailure,
+                stderrDrainedFromStart: this.stderrDrainedFromStart,
+                sanitizerMarkerHit: this.stderrMarkerHit?.toString("utf8"),
+            }),
+        );
 
         if (failures.length > 0) {
             const excerpt = serverStderrExcerpt(stderrText);
@@ -605,9 +576,11 @@ export class CliceClient {
         });
     }
 
-    /// Latch the earliest sanitizer fingerprint and keep appending context
-    /// from later reads; the carry covers markers split across read
-    /// boundaries.
+    /// Detection happens incrementally in the pump: a mid-session report
+    /// (e.g. relayed from a crashed worker) must survive the retention
+    /// cap's eviction. Latch the earliest sanitizer fingerprint and keep
+    /// appending context from later reads; the carry covers markers split
+    /// across read boundaries.
     private scanForMarkers(data: Buffer): void {
         if (this.stderrMarkerHit !== null) {
             if (this.stderrMarkerHit.length < 4096) {
@@ -636,10 +609,6 @@ export class CliceClient {
 
     normalizeUri(uri: string): string {
         return canonicalUri(uri);
-    }
-
-    pathToUri(filepath: string): string {
-        return this.normalizeUri(URI.file(this.resolvePath(filepath)).toString());
     }
 
     /// Workspace-relative paths resolve against the bound workspace;
@@ -769,19 +738,6 @@ export class CliceClient {
         }
     }
 
-    assertDiagnosticsCount(uri: string, count: number, severity?: number): void {
-        let diags = this.diagnostics.get(uri) ?? [];
-        if (severity !== undefined) {
-            diags = diags.filter((d) => d.severity === severity);
-        }
-        if (diags.length !== count) {
-            throw new Error(
-                `Expected ${count} diagnostics (severity=${severity}), ` +
-                    `got ${diags.length}: ${JSON.stringify(diags)}`,
-            );
-        }
-    }
-
     assertCleanCompile(uri: string): void {
         const diags = this.diagnostics.get(uri) ?? [];
         if (diags.length > 0) {
@@ -793,14 +749,7 @@ export class CliceClient {
 
     /// Anomaly IDs from window/logMessage notifications (master process).
     anomaliesInLogMessages(): string[] {
-        const found: string[] = [];
-        for (const msg of this.logMessages) {
-            const id = ANOMALY_PATTERN.exec(msg.message)?.[1];
-            if (id !== undefined) {
-                found.push(id);
-            }
-        }
-        return found;
+        return anomaliesInMessages(this.logMessages.map((message) => message.message));
     }
 
     /// Assert the session produced zero anomalies (client messages + logs).
@@ -809,14 +758,9 @@ export class CliceClient {
     /// the log directory (defaults to the bound workspace).
     assertNoAnomaly(root?: string | null): void {
         const logsRoot = root !== undefined ? root : (this.workspace?.root ?? null);
-        const found = [...this.anomaliesInLogMessages(), ...anomaliesInLogFiles(logsRoot)];
-        // A crashed worker leaves its stack trace in its own log file;
-        // surface it here so a one-off CI crash is diagnosable from the
-        // test output.
-        const traces = found.length > 0 ? crashTracesInLogFiles(logsRoot) : [];
-        const detail = traces.length > 0 ? "\n" + traces.join("\n") : "";
-        if (found.length > 0) {
-            throw new Error(`clice reported internal anomalies: ${found.join(", ")}${detail}`);
+        const failure = anomalyGateFailure(this.anomaliesInLogMessages(), logsRoot);
+        if (failure !== null) {
+            throw new Error(failure);
         }
     }
 

--- a/tools/client/session.ts
+++ b/tools/client/session.ts
@@ -180,8 +180,6 @@ export interface SessionFactory {
     /// Spawn a server initialized on tests/data/<name>. Acquire sessions
     /// for multiple workspaces in alphabetical order to avoid lock cycles.
     (name: string, options?: SessionOptions): Promise<Session>;
-    /// Spawn a bare server with no workspace/initialize.
-    bare(options?: SessionOptions): CliceClient;
     /// Spawn a server bound to a fresh, empty temp workspace, without
     /// initializing. The caller writes fixture files (and a CDB) then calls
     /// client.initialize(workspace). The whole temp directory is removed in
@@ -261,7 +259,6 @@ export function createSessionFactory(): SessionHandle {
         });
         return { client, workspace };
     };
-    factory.bare = (options: SessionOptions = {}): CliceClient => spawnTracked(null, options);
     factory.spawn = spawnTracked;
     factory.tmpdir = (): Workspace => {
         const workspace = Workspace.tmp();

--- a/tools/client/workspace.ts
+++ b/tools/client/workspace.ts
@@ -6,7 +6,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { URI } from "vscode-uri";
-import { generateCDB } from "../compile_commands.ts";
+import { buildCDBEntry, generateCDB } from "../compile_commands.ts";
 
 /// Versioned root of the unified cache store; bump together with
 /// cache_format_version in src/server/state/workspace.h.
@@ -105,17 +105,12 @@ export class Workspace {
     /// Write a compile_commands.json with per-file extra arguments; a file
     /// may appear multiple times to model multi-configuration projects.
     writeEntries(entries: [string, string[]][], options: CDBOptions = {}): void {
-        const data = entries.map(([f, args]) => ({
-            directory: this.root,
-            file: this.path(f),
-            arguments: [
-                "clang++",
-                `-std=${options.std ?? "c++17"}`,
-                "-fsyntax-only",
-                ...args,
-                this.path(f),
-            ],
-        }));
+        const data = entries.map(([f, args]) =>
+            buildCDBEntry(this.root, this.path(f), {
+                extraArgs: args,
+                std: options.std,
+            }),
+        );
         this.write("compile_commands.json", JSON.stringify(data, null, 2));
     }
 

--- a/tools/compile_commands.ts
+++ b/tools/compile_commands.ts
@@ -10,14 +10,38 @@ export const TESTS_DIR = path.join(REPO_ROOT, "tests");
 export const DATA_DIR = path.join(TESTS_DIR, "data");
 export const SNAP_DIR = path.join(TESTS_DIR, "snap");
 
-interface CDBEntry {
+export interface CDBEntry {
     directory: string;
     file: string;
     arguments: string[];
 }
 
+export interface CDBEntryOptions {
+    extraArgs?: string[] | undefined;
+    std?: string | undefined;
+}
+
 function posix(p: string): string {
     return p.split(path.sep).join("/");
+}
+
+export function buildCDBEntry(
+    directory: string,
+    source: string,
+    options: CDBEntryOptions = {},
+): CDBEntry {
+    const file = posix(source);
+    return {
+        directory: posix(directory),
+        file,
+        arguments: [
+            "clang++",
+            `-std=${options.std ?? "c++17"}`,
+            "-fsyntax-only",
+            ...(options.extraArgs ?? []),
+            file,
+        ],
+    };
 }
 
 /// Generate compile_commands.json using CMake with Ninja backend.
@@ -51,17 +75,11 @@ export function generateTestDataCDBs(dataDir: string = DATA_DIR): void {
         fs.renameSync(tmp, target);
     };
 
-    const entry = (directory: string, source: string, extraArgs: string[] = []): CDBEntry => ({
-        directory: posix(directory),
-        file: posix(source),
-        arguments: ["clang++", "-std=c++17", "-fsyntax-only", ...extraArgs, posix(source)],
-    });
-
     const single = (name: string, extraArgs: string[] = []) => {
         const dir = path.join(dataDir, name);
         const main = path.join(dir, "main.cpp");
         if (fs.existsSync(main)) {
-            write(dir, [entry(dir, main, extraArgs)]);
+            write(dir, [buildCDBEntry(dir, main, { extraArgs })]);
         }
     };
 
@@ -75,7 +93,10 @@ export function generateTestDataCDBs(dataDir: string = DATA_DIR): void {
     const mcDir = path.join(dataDir, "multi_context");
     const mcMain = path.join(mcDir, "main.cpp");
     if (fs.existsSync(mcMain)) {
-        write(mcDir, [entry(mcDir, mcMain, ["-DCONFIG_A"]), entry(mcDir, mcMain, ["-DCONFIG_B"])]);
+        write(mcDir, [
+            buildCDBEntry(mcDir, mcMain, { extraArgs: ["-DCONFIG_A"] }),
+            buildCDBEntry(mcDir, mcMain, { extraArgs: ["-DCONFIG_B"] }),
+        ]);
     }
 
     single("include_completion", ["-I."]);
@@ -94,7 +115,7 @@ export function generateTestDataCDBs(dataDir: string = DATA_DIR): void {
         const entries = ["main.cpp", "no_includes.cpp"]
             .map((name) => path.join(ptDir, name))
             .filter((src) => fs.existsSync(src))
-            .map((src) => entry(ptDir, src));
+            .map((src) => buildCDBEntry(ptDir, src));
         if (entries.length > 0) {
             write(ptDir, entries);
         }

--- a/tools/package.json
+++ b/tools/package.json
@@ -12,7 +12,6 @@
     "./snap/snapshot": "./snap/snapshot.ts",
     "./snap/corpus": "./snap/corpus.ts",
     "./snap/registry": "./snap/registry.ts",
-    "./snap/render": "./snap/render.ts",
     "./snap/features/*": "./snap/features/*.ts",
     "./snap/server": "./snap/server.ts",
     "./snap/inspect": "./snap/inspect.ts",
@@ -26,7 +25,6 @@
   },
   "dependencies": {
     "diff": "^9.0.0",
-    "vscode-jsonrpc": "^8.2.1",
     "vscode-languageserver-protocol": "^3.17.5",
     "vscode-uri": "^3.1.0"
   },

--- a/tools/prepare.ts
+++ b/tools/prepare.ts
@@ -13,35 +13,9 @@ import { DATA_DIR, generateCDB, generateTestDataCDBs } from "./compile_commands.
 
 const USAGE = "Usage: node tools/prepare.ts <fixture> [<fixture> ...]";
 
-/// The XDG cache base older clice builds used ($XDG_CACHE_HOME/clice or
-/// ~/.cache/clice, per-workspace <basename>-<hash8> leaves). XDG placement
-/// is disabled (caches are workspace-local now), but dev machines keep
-/// leftovers from before the switch, so cleanup still globs them.
-function xdgCliceDir(): string | null {
-    let base = process.env["XDG_CACHE_HOME"] ?? "";
-    if (!base) {
-        const home = process.env["HOME"] ?? "";
-        if (!home) {
-            return null;
-        }
-        base = path.join(home, ".cache");
-    }
-    return path.join(base, "clice");
-}
-
-/// Remove clice caches for the workspace (both in-tree and XDG).
+/// Remove the clice cache for the workspace.
 function cleanCache(workspace: string): void {
     fs.rmSync(path.join(workspace, ".clice"), { recursive: true, force: true });
-
-    const xdg = xdgCliceDir();
-    if (xdg === null || !fs.existsSync(xdg)) {
-        return;
-    }
-    for (const child of fs.readdirSync(xdg, { withFileTypes: true })) {
-        if (child.isDirectory() && /^.+-[0-9a-f]{8}$/.test(child.name)) {
-            fs.rmSync(path.join(xdg, child.name), { recursive: true, force: true });
-        }
-    }
 }
 
 function main(fixtures: string[]): number {

--- a/tools/process_gate.ts
+++ b/tools/process_gate.ts
@@ -15,7 +15,7 @@ export const SANITIZER_MARKERS = [
 const ANOMALY_PATTERN = /\[anomaly:([A-Za-z]+)\]/;
 const CRASH_TRACE_MARKER = "=== CRASH STACK TRACE ===";
 
-export function logFiles(root: string | null): string[] {
+export function logFiles(root: string | null, ignoreLogs?: ReadonlySet<string>): string[] {
     if (root === null) {
         return [];
     }
@@ -27,12 +27,16 @@ export function logFiles(root: string | null): string[] {
         .readdirSync(logsDir, { recursive: true, encoding: "utf8" })
         .filter((name) => name.endsWith(".log"))
         .sort()
-        .map((name) => path.join(logsDir, name));
+        .map((name) => path.join(logsDir, name))
+        .filter((file) => !(ignoreLogs?.has(file) ?? false));
 }
 
-export function anomaliesInLogFiles(root: string | null): string[] {
+export function anomaliesInLogFiles(
+    root: string | null,
+    ignoreLogs?: ReadonlySet<string>,
+): string[] {
     const found: string[] = [];
-    for (const logFile of logFiles(root)) {
+    for (const logFile of logFiles(root, ignoreLogs)) {
         for (const line of fs.readFileSync(logFile, "utf8").split("\n")) {
             const match = ANOMALY_PATTERN.exec(line);
             if (match) {
@@ -50,9 +54,12 @@ export function anomaliesInMessages(messages: string[]): string[] {
     });
 }
 
-export function crashTracesInLogFiles(root: string | null): string[] {
+export function crashTracesInLogFiles(
+    root: string | null,
+    ignoreLogs?: ReadonlySet<string>,
+): string[] {
     const traces: string[] = [];
-    for (const logFile of logFiles(root)) {
+    for (const logFile of logFiles(root, ignoreLogs)) {
         const text = fs.readFileSync(logFile, "utf8");
         const pos = text.indexOf(CRASH_TRACE_MARKER);
         if (pos !== -1) {
@@ -113,12 +120,16 @@ export function processGateFailures(input: ProcessGateInput): string[] {
     return failures;
 }
 
-export function anomalyGateFailure(notifications: string[], root: string | null): string | null {
-    const found = [...notifications, ...anomaliesInLogFiles(root)];
+export function anomalyGateFailure(
+    notifications: string[],
+    root: string | null,
+    ignoreLogs?: ReadonlySet<string>,
+): string | null {
+    const found = [...notifications, ...anomaliesInLogFiles(root, ignoreLogs)];
     if (found.length === 0) {
         return null;
     }
-    const traces = crashTracesInLogFiles(root);
+    const traces = crashTracesInLogFiles(root, ignoreLogs);
     const detail = traces.length > 0 ? "\n" + traces.join("\n") : "";
     return `clice reported internal anomalies: ${found.join(", ")}${detail}`;
 }

--- a/tools/process_gate.ts
+++ b/tools/process_gate.ts
@@ -1,0 +1,124 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/// Sanitizer/crash fingerprints scanned in server stderr.
+export const SANITIZER_MARKERS = [
+    "AddressSanitizer",
+    "LeakSanitizer",
+    "MemorySanitizer",
+    "ThreadSanitizer",
+    "UndefinedBehaviorSanitizer",
+    "==ERROR:",
+    "runtime error:",
+] as const;
+
+const ANOMALY_PATTERN = /\[anomaly:([A-Za-z]+)\]/;
+const CRASH_TRACE_MARKER = "=== CRASH STACK TRACE ===";
+
+export function logFiles(root: string | null): string[] {
+    if (root === null) {
+        return [];
+    }
+    const logsDir = path.join(root, ".clice", "logs");
+    if (!fs.existsSync(logsDir)) {
+        return [];
+    }
+    return fs
+        .readdirSync(logsDir, { recursive: true, encoding: "utf8" })
+        .filter((name) => name.endsWith(".log"))
+        .sort()
+        .map((name) => path.join(logsDir, name));
+}
+
+export function anomaliesInLogFiles(root: string | null): string[] {
+    const found: string[] = [];
+    for (const logFile of logFiles(root)) {
+        for (const line of fs.readFileSync(logFile, "utf8").split("\n")) {
+            const match = ANOMALY_PATTERN.exec(line);
+            if (match) {
+                found.push(`${match[1]} (${path.basename(logFile)}: ${line.trim()})`);
+            }
+        }
+    }
+    return found;
+}
+
+export function anomaliesInMessages(messages: string[]): string[] {
+    return messages.flatMap((message) => {
+        const id = ANOMALY_PATTERN.exec(message)?.[1];
+        return id === undefined ? [] : [id];
+    });
+}
+
+export function crashTracesInLogFiles(root: string | null): string[] {
+    const traces: string[] = [];
+    for (const logFile of logFiles(root)) {
+        const text = fs.readFileSync(logFile, "utf8");
+        const pos = text.indexOf(CRASH_TRACE_MARKER);
+        if (pos !== -1) {
+            traces.push(`--- ${path.basename(logFile)} ---\n${text.slice(pos)}`);
+        }
+    }
+    return traces;
+}
+
+export function serverStderrExcerpt(stderrText: string): string {
+    const interesting = stderrText
+        .split("\n")
+        .filter(
+            (line) =>
+                line.includes("[warn]") ||
+                line.includes("[error]") ||
+                line.includes("Sanitizer") ||
+                line.includes("==ERROR:") ||
+                line.includes("runtime error:"),
+        );
+    return interesting.slice(-80).join("\n");
+}
+
+export interface ProcessGateInput {
+    exitCode: number | null;
+    signalCode: string | null;
+    stderrText: string;
+    stderrComplete: boolean;
+    stderrFailure?: string | undefined;
+    stderrDrainedFromStart: boolean;
+    sanitizerMarkerHit?: string | null | undefined;
+}
+
+export function processGateFailures(input: ProcessGateInput): string[] {
+    const failures: string[] = [];
+    if (input.signalCode !== null) {
+        failures.push(`server exited from signal ${input.signalCode}`);
+    } else if (input.exitCode !== 0) {
+        failures.push(`server exited with code ${input.exitCode}`);
+    }
+    if (!input.stderrComplete) {
+        failures.push(
+            input.stderrFailure === undefined
+                ? "stderr pump did not complete"
+                : `stderr pump did not complete: ${input.stderrFailure}`,
+        );
+    }
+    if (input.stderrDrainedFromStart && input.stderrText.includes("client not draining")) {
+        failures.push("stderr mirror shed lines despite a draining client");
+    }
+    if (input.sanitizerMarkerHit) {
+        failures.push(
+            `server stderr contains sanitizer/runtime error output:\n${input.sanitizerMarkerHit}`,
+        );
+    } else if (SANITIZER_MARKERS.some((marker) => input.stderrText.includes(marker))) {
+        failures.push("server stderr contains sanitizer/runtime error output");
+    }
+    return failures;
+}
+
+export function anomalyGateFailure(notifications: string[], root: string | null): string | null {
+    const found = [...notifications, ...anomaliesInLogFiles(root)];
+    if (found.length === 0) {
+        return null;
+    }
+    const traces = crashTracesInLogFiles(root);
+    const detail = traces.length > 0 ? "\n" + traces.join("\n") : "";
+    return `clice reported internal anomalies: ${found.join(", ")}${detail}`;
+}

--- a/tools/replay.ts
+++ b/tools/replay.ts
@@ -12,7 +12,12 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Readable, Writable } from "node:stream";
-import { anomalyGateFailure, anomaliesInMessages, processGateFailures } from "./process_gate.ts";
+import {
+    anomalyGateFailure,
+    anomaliesInMessages,
+    logFiles,
+    processGateFailures,
+} from "./process_gate.ts";
 
 // tools/ -> repo root.
 const REPO_ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
@@ -357,6 +362,10 @@ async function replayOne(
 
     printTraceInfo(name, records, displayWs);
 
+    // The corpus workspace persists across runs and traces; only logs born
+    // in this session may gate it.
+    const preexistingLogs = new Set(logFiles(displayWs));
+
     const env = { ...process.env };
     if (process.platform === "darwin") {
         const prev = env["ASAN_OPTIONS"] ?? "";
@@ -606,7 +615,11 @@ async function replayOne(
         stderrComplete,
         stderrDrainedFromStart: true,
     });
-    const anomalyFailure = anomalyGateFailure(anomaliesInMessages(anomalies), displayWs);
+    const anomalyFailure = anomalyGateFailure(
+        anomaliesInMessages(anomalies),
+        displayWs,
+        preexistingLogs,
+    );
     if (anomalyFailure !== null) {
         failures.push(anomalyFailure);
     }

--- a/tools/replay.ts
+++ b/tools/replay.ts
@@ -3,8 +3,8 @@
 /// Usage: node tools/replay.ts tests/smoke/session.jsonl --clice build/clice
 ///
 /// Node builtins only — no npm dependencies — so it runs standalone with
-/// `node tools/replay.ts ...`. LSP framing, response defaults and the
-/// pass/fail rules mirror the former replay.py 1:1.
+/// `node tools/replay.ts ...`. LSP framing and response defaults mirror the
+/// former replay.py; process success uses the same gate as the test client.
 
 import { spawn } from "node:child_process";
 import * as fs from "node:fs";
@@ -12,6 +12,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Readable, Writable } from "node:stream";
+import { anomalyGateFailure, anomaliesInMessages, processGateFailures } from "./process_gate.ts";
 
 // tools/ -> repo root.
 const REPO_ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
@@ -576,14 +577,18 @@ async function replayOne(
     await waitExitOrKill(proc, exited, 10000);
     await withTimeout(readerPromise, 2000).catch(() => undefined);
 
-    await withTimeout(stderrEnded, 2000).catch(() => undefined);
+    let stderrComplete = true;
+    try {
+        await withTimeout(stderrEnded, 2000);
+    } catch {
+        stderrComplete = false;
+    }
     const stderrData = Buffer.concat(stderrChunks);
-    const returncode = exitStatus(proc);
-    const signalName = proc.signalCode;
+    const stderrText = stderrData.toString("utf8");
 
     const printStderr = (): void => {
         if (stderrData.length > 0) {
-            for (const line of splitLines(stderrData.toString("utf-8")).slice(-20)) {
+            for (const line of splitLines(stderrText).slice(-20)) {
                 console.log(`  | ${line}`);
             }
         }
@@ -594,16 +599,22 @@ async function replayOne(
         return false;
     }
 
-    if (returncode !== null && returncode !== 0) {
-        const sig = signalName !== null ? ` (${signalName})` : "";
-        console.log(`  result: CRASH (exit=${returncode}${sig}, ${elapsed()}s)`);
-        printStderr();
-        return false;
+    const failures = processGateFailures({
+        exitCode: proc.exitCode,
+        signalCode: proc.signalCode,
+        stderrText,
+        stderrComplete,
+        stderrDrainedFromStart: true,
+    });
+    const anomalyFailure = anomalyGateFailure(anomaliesInMessages(anomalies), displayWs);
+    if (anomalyFailure !== null) {
+        failures.push(anomalyFailure);
     }
-
-    if (anomalies.length > 0) {
-        // Anomalies are internal clice bugs; a replay session must be clean.
-        console.log(`  result: FAIL (${anomalies.length} anomaly report(s), ${elapsed()}s)`);
+    if (failures.length > 0) {
+        console.log(`  result: FAIL (${failures.length} process gate failure(s), ${elapsed()}s)`);
+        for (const failure of failures) {
+            console.log(`  gate: ${failure}`);
+        }
         printStderr();
         return false;
     }

--- a/tools/snap/inspect.ts
+++ b/tools/snap/inspect.ts
@@ -174,6 +174,6 @@ export async function checkInspectFixture(
 
     const variant =
         fixture.meta.verify === "both" && fixture.meta.snap === "separate" ? "inspect" : "";
-    const snapshots = new SnapshotContext(corpus.corpus, { colocated: true });
+    const snapshots = new SnapshotContext(corpus.corpus);
     snapshots.check(fixture.rel, body.join("\n"), variant);
 }

--- a/tools/snap/server.ts
+++ b/tools/snap/server.ts
@@ -150,8 +150,8 @@ export async function checkServerSnapFixture(
 
     const shared = fixture.meta.verify === "both" && fixture.meta.snap === "shared";
     const snapshots = shared
-        ? new SnapshotContext(corpus.corpus, { colocated: true, update: false })
-        : new SnapshotContext(corpus.corpus, { colocated: true });
+        ? new SnapshotContext(corpus.corpus, { update: false })
+        : new SnapshotContext(corpus.corpus);
     const variant =
         fixture.meta.verify === "both" && fixture.meta.snap === "separate" ? "server" : "";
     snapshots.check(fixture.rel, body.join("\n"), variant);

--- a/tools/snap/snapshot.ts
+++ b/tools/snap/snapshot.ts
@@ -184,10 +184,8 @@ function renderDiff(oldBody: string, newBody: string): string {
 
 /// One feature's snapshot directory plus the run-wide update flag.
 ///
-/// Legacy layout stores `<input>.cpp.snap.yml` under a snapshot tree that
-/// mirrors the corpus; the colocated layout used by tests/snap/ stores
-/// `<input>.snap.yml` (source extension replaced) next to the source
-/// itself, with an optional variant infix: `<input>.inspect.snap.yml` /
+/// Snapshots replace the source extension and sit next to the input, with
+/// an optional variant infix: `<input>.inspect.snap.yml` /
 /// `<input>.server.snap.yml` for `snap: separate` fixtures.
 export class SnapshotContext {
     readonly directory: string;
@@ -196,22 +194,18 @@ export class SnapshotContext {
     /// server driver on a shared snapshot) — for it a missing snapshot is
     /// an error, not something to create from its own output.
     readonly create: boolean;
-    readonly colocated: boolean;
 
     // Plain field assignments: parameter properties are not erasable
     // syntax, and tools/ scripts run under bare `node` in strip-only mode.
-    constructor(directory: string, options: { update?: boolean; colocated?: boolean } = {}) {
+    constructor(directory: string, options: { update?: boolean } = {}) {
         this.directory = directory;
         this.update = options.update ?? process.env["UPDATE_SNAPSHOTS"] === "1";
         this.create = options.update !== false;
-        this.colocated = options.colocated ?? false;
     }
 
     snapPath(inputFile: string, variant = ""): string {
         const suffix = (variant ? `.${variant}` : "") + ".snap.yml";
-        const name = this.colocated
-            ? inputFile.replace(/\.(cpp|cc|cxx)$/, "") + suffix
-            : inputFile + suffix;
+        const name = inputFile.replace(/\.(cpp|cc|cxx)$/, "") + suffix;
         return path.join(this.directory, name);
     }
 


### PR DESCRIPTION
## What changed

A codebase-wide technical-debt sweep (net −680 lines), driven by a full audit of `src/`, `tests/`, and `tools/`. Everything here is cleanup or truth-telling; no new features.

**Dead surface removed**
- Finish the XDG cache removal: delete the disabled resolver, its environment helpers, the disabled config tests, and the global legacy-cache sweep in editor preparation.
- Delete dead APIs left by finished migrations: `FuzzyMatcher::dumpLast`, `CompilationUnitRef::{start_location,end_location,build_duration}` (and its per-build timing), `Tester::{compile_file,compile_driver_with_pch,to_local_range}`, unused platform flags, `CliceClient.{pathToUri,assertDiagnosticsCount}`, `SessionFactory.bare`, the unit runner's `--test-dir`, the legacy non-colocated snapshot layout, a friend declaration for a test fixture that does not exist, and two vacuous toolchain test cases.
- Drop the never-imported `vscode-jsonrpc` direct dependencies and the unused `./snap/render` export.

**Renames and truth-telling**
- `interested_file()` → `main_file()` (with `interested_only` → `main_file_only`): the "interested" concept never diverged from clang's main file and newer code already speaks "main file".
- Diagnostics now report their real source (`clang` / `clang-tidy` / `clice`) instead of always `clang`.
- Remove the `worker_memory_limit` config: it was plumbed end-to-end but never enforced eviction. A config still containing the key starts fine and gets a named warning from strict validation (now pinned by a test).
- Replace retired-enum magic bytes in the quarantine evidence ledger with a typed `EvidenceKind`; query-kind evidence is offset structurally so the two spaces cannot collide.
- Correct stale docs/comments: code-action docs no longer claim the capability is advertised, the ThinLTO blocker comment reflects LLVM 22, the pixi snap-task description matches reality.

**Correctness in test infrastructure**
- Smoke replay previously gated success only on exit status and anomaly notifications: a sanitizer report or an anomaly that only reached the on-disk log could still PASS. Replay now shares the same process gate as the test client (sanitizer/runtime-error scan, stderr-pump completeness, anomaly-log scan), scoped to logs born in the current session so a persistent corpus workspace cannot poison later runs.
- Code completion's hand-rolled line/column scan and the index projection's private line-start scanner both use the shared line-map path now.

**Timing hygiene**
- Raw copies of timing constants replaced with the named constants; ad hoc bounded polling loops converted to a shared `waitUntil` with descriptive timeout errors; intentional race-injection sleeps kept and named.
- Deleted the 22 `sleep(500)` calls after `WorkerPool::start()` in unit tests — `start()` spawns synchronously, and newer tests already dispatch immediately.

## Tests

- All four suites locally on RelWithDebInfo: unit (1360 passed, ×3 consecutive runs to guard the sleep removals), integration (378 passed), smoke (3/3), snap (630 passed, zero snapshot diffs).
- `npm run check` (strict tsc + ESLint) green; config/feature doc generators verified.
- New tests: unknown-config-key warning pinned in `config_tests.cpp`; the shared process gate covered by `tests/tools/process_gate.test.ts`, including a regression case for stale-log scoping.
