### PR TITLE
refactor(command): parse-once structured commands with ConfigID core

### DIFF
--- a/benchmarks/index_stats_benchmark.cpp
+++ b/benchmarks/index_stats_benchmark.cpp
@@ -36,7 +36,6 @@
 #include <vector>
 
 #include "command/command.h"
-#include "command/toolchain.h"
 #include "compile/compilation.h"
 #include "index/tu_index.h"
 #include "support/filesystem.h"
@@ -1069,7 +1068,6 @@ int main(int argc, const char** argv) {
     clice::logging::stderr_logger("index_stats_benchmark", clice::logging::options);
 
     CompilationDatabase cdb;
-    Toolchain toolchain;
     auto count = cdb.load(*opts.cdb_path);
     if(!count) {
         std::println(stderr, "Error: failed to load {}", *opts.cdb_path);
@@ -1081,8 +1079,8 @@ int main(int argc, const char** argv) {
     // file at once, and the --limit selection sizes files, not entries.
     std::vector<llvm::StringRef> files;
     llvm::StringSet<> seen_files;
-    for(auto& entry: cdb.get_entries()) {
-        auto path = cdb.resolve_path(entry.file);
+    for(auto& entry: cdb.entries()) {
+        auto path = cdb.paths().resolve(entry.file);
         if(opts.filter.has_value() && !path.contains(*opts.filter)) {
             continue;
         }
@@ -1125,9 +1123,12 @@ int main(int argc, const char** argv) {
     jobs.reserve(files.size());
     llvm::DenseSet<std::uint64_t> seen_commands;
     for(auto file: files) {
-        for(auto& command: cdb.lookup(file)) {
-            toolchain.resolve_or_warn(command);
-            auto argv = command.to_argv();
+        for(auto& entry: cdb.candidate_entries(file)) {
+            CommandRef ref{entry.file,
+                           entry.config,
+                           cdb.input_kind(entry.config, file),
+                           CommandSource::CDBExact};
+            auto argv = cdb.render(ref);
             std::string joined;
             for(auto* arg: argv) {
                 joined += arg;

--- a/benchmarks/pipeline_benchmark.cpp
+++ b/benchmarks/pipeline_benchmark.cpp
@@ -30,7 +30,6 @@
 
 #include "stats.h"
 #include "command/command.h"
-#include "command/toolchain.h"
 #include "compile/compilation.h"
 #include "feature/feature.h"
 #include "index/tu_index.h"
@@ -449,7 +448,6 @@ int main(int argc, const char** argv) {
     }
 
     CompilationDatabase cdb;
-    Toolchain toolchain;
     auto count = cdb.load(*opts.cdb_path);
     if(!count) {
         std::println(stderr, "Error: failed to load {}", *opts.cdb_path);
@@ -461,8 +459,8 @@ int main(int argc, const char** argv) {
     // several commands (multi-config CDB) is profiled under the first one,
     // like the server picks.
     std::vector<llvm::StringRef> files;
-    for(auto& entry: cdb.get_entries()) {
-        auto path = cdb.resolve_path(entry.file);
+    for(auto& entry: cdb.entries()) {
+        auto path = cdb.paths().resolve(entry.file);
         if(opts.filter.has_value() && !path.contains(*opts.filter)) {
             continue;
         }
@@ -504,12 +502,16 @@ int main(int argc, const char** argv) {
     BenchmarkOutput output;
     output.cdb = *opts.cdb_path;
     for(auto file: files) {
-        auto commands = cdb.lookup(file);
-        if(commands.empty()) {
+        auto candidates = cdb.candidate_entries(file);
+        if(candidates.empty()) {
             continue;
         }
-        toolchain.resolve_or_warn(commands[0]);
-        auto arguments = commands[0].to_argv();
+        auto& entry = candidates.front();
+        CommandRef ref{entry.file,
+                       entry.config,
+                       cdb.input_kind(entry.config, file),
+                       CommandSource::CDBExact};
+        auto arguments = cdb.render(ref);
 
         auto file_result = profile_file(file, arguments, runs, opts.time_trace_dir.value_or(""));
         print_file(file_result);

--- a/benchmarks/scan_benchmark.cpp
+++ b/benchmarks/scan_benchmark.cpp
@@ -21,7 +21,6 @@
 #include <thread>
 
 #include "command/command.h"
-#include "command/toolchain.h"
 #include "support/filesystem.h"
 #include "support/logging.h"
 #include "support/path_pool.h"
@@ -269,8 +268,9 @@ int main(int argc, const char** argv) {
     // Load compilation database.
     auto t0 = std::chrono::steady_clock::now();
 
-    CompilationDatabase cdb;
-    Toolchain toolchain;
+    std::optional<CompilationDatabase> cdb_storage;
+    cdb_storage.emplace();
+    auto& cdb = *cdb_storage;
     auto loaded = cdb.load(cdb_path);
     if(!loaded) {
         std::println(stderr, "Error: failed to load {}", cdb_path);
@@ -284,72 +284,20 @@ int main(int argc, const char** argv) {
     std::println("CDB loaded: {} entries in {}ms", count, load_ms);
 
     {
-        std::set<const CompilationInfo*> unique_contexts;
-        std::set<const CanonicalCommand*> unique_canonicals;
-        std::map<const CanonicalCommand*, int> canonical_hist;
-        for(auto& entry: cdb.get_entries()) {
-            unique_contexts.insert(entry.info.ptr);
-            unique_canonicals.insert(entry.info->canonical.ptr);
-            canonical_hist[entry.info->canonical.ptr] += 1;
+        std::set<ConfigID> unique_configs;
+        for(auto& entry: cdb.entries()) {
+            unique_configs.insert(entry.config);
         }
         double dedup_ratio =
-            unique_contexts.empty() ? 0.0 : static_cast<double>(count) / unique_contexts.size();
-        std::println(
-            "Context dedup: {} files -> {} unique contexts ({:.1f}x), {} unique canonicals",
-            count,
-            unique_contexts.size(),
-            dedup_ratio,
-            unique_canonicals.size());
-
-        // If canonical dedup is poor, dump diagnostics.
-        if(unique_canonicals.size() > 200) {
-            // Sort canonicals by frequency (descending).
-            std::vector<std::pair<int, const CanonicalCommand*>> sorted;
-            for(auto& [ptr, cnt]: canonical_hist)
-                sorted.push_back({cnt, ptr});
-            std::ranges::sort(sorted,
-                              std::greater{},
-                              &std::pair<int, const CanonicalCommand*>::first);
-
-            // Show top-5 canonical commands.
-            for(int i = 0; i < std::min(5, (int)sorted.size()); i += 1) {
-                auto [cnt, cmd] = sorted[i];
-                std::println("  canonical[{}] ({} files, {} args):", i, cnt, cmd->arguments.size());
-                for(auto arg: cmd->arguments)
-                    std::println("    {}", arg);
-            }
-
-            // Show a singleton canonical (count==1) to see what per-file arg leaks in.
-            for(auto& [cnt, cmd]: sorted) {
-                if(cnt == 1) {
-                    std::println("  singleton canonical ({} args):", cmd->arguments.size());
-                    for(auto arg: cmd->arguments)
-                        std::println("    {}", arg);
-                    break;
-                }
-            }
-
-            // Find two canonicals that differ by only a few args.
-            if(sorted.size() >= 2) {
-                auto* a = sorted[0].second;
-                auto* b = sorted[1].second;
-                std::println("  --- Canonical diff (top-1 vs top-2) ---");
-                auto max_len = std::max(a->arguments.size(), b->arguments.size());
-                for(std::size_t i = 0; i < max_len; i += 1) {
-                    llvm::StringRef av = i < a->arguments.size() ? a->arguments[i] : "<missing>";
-                    llvm::StringRef bv = i < b->arguments.size() ? b->arguments[i] : "<missing>";
-                    if(av != bv)
-                        std::println("    DIFF[{}]: '{}' vs '{}'", i, av, bv);
-                    else
-                        std::println("    SAME[{}]: '{}'", i, av);
-                }
-            }
-        }
+            unique_configs.empty() ? 0.0 : static_cast<double>(count) / unique_configs.size();
+        std::println("Config dedup: {} files -> {} unique configs ({:.1f}x)",
+                     count,
+                     unique_configs.size(),
+                     dedup_ratio);
     }
 
     std::println("\nRunning {} cold start scan(s)...\n", runs);
 
-    PathPool path_pool;
     DependencyGraph graph;
     std::vector<std::int64_t> elapsed_times;
     std::vector<std::int64_t> config_times;
@@ -361,15 +309,13 @@ int main(int argc, const char** argv) {
     phase2_times.reserve(runs);
 
     for(int i = 0; i < runs; i += 1) {
-        // True cold start: rebuild CDB (clears toolchain & config caches),
-        // reset PathPool and DependencyGraph.
-        cdb = CompilationDatabase{};
-        toolchain = Toolchain{};
-        cdb.load(cdb_path);
-        path_pool = PathPool{};
+        // True cold start: rebuild CDB (clears toolchain & config caches)
+        // and the DependencyGraph.
+        cdb_storage.emplace();
+        cdb_storage->load(cdb_path);
         graph = DependencyGraph{};
 
-        auto report = scan_dependency_graph(cdb, toolchain, path_pool, graph);
+        auto report = scan_dependency_graph(*cdb_storage, graph);
 
         elapsed_times.push_back(report.elapsed_ms);
         config_times.push_back(report.config_ms);
@@ -412,7 +358,7 @@ int main(int argc, const char** argv) {
 
     // Export dependency graph as JSON if requested.
     if(opts.export_path.has_value()) {
-        export_graph_json(path_pool, graph, *opts.export_path);
+        export_graph_json(cdb_storage->paths(), graph, *opts.export_path);
     }
 
     return 0;

--- a/src/command/argument_parser.cpp
+++ b/src/command/argument_parser.cpp
@@ -366,8 +366,9 @@ unsigned default_visibility(llvm::StringRef driver) {
     if(is_cl(name) || is_cl(name.rtrim("0123456789.-"))) {
         return ~0u;
     }
-    /// Exclude CLOption to prevent /U, /D, /I from matching Unix paths.
-    return ~static_cast<unsigned>(CLOption);
+    /// Exclude the slash-prefixed CL and DXC options (/D and /I carry both
+    /// bits) to prevent /U, /D, /I from matching Unix paths.
+    return ~static_cast<unsigned>(CLOption | DXCOption);
 }
 
 bool is_c_family_file(llvm::StringRef filename) {

--- a/src/command/argument_parser.cpp
+++ b/src/command/argument_parser.cpp
@@ -11,7 +11,6 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Support/xxhash.h"
 #include "clang/Driver/Types.h"
 #include "clang/Options/OptionUtils.h"
 
@@ -332,16 +331,6 @@ std::string canonicalize(llvm::ArrayRef<std::string> args, ArgsProfile profile) 
     }
 
     return buf;
-}
-
-std::string canonical_command_hash(llvm::ArrayRef<std::string> args, llvm::StringRef directory) {
-    auto canonical = canonicalize(args, ArgsProfile::Frontend);
-    // Identical argv can still mean different compiles when relative paths
-    // (-include config.h) resolve against different working directories.
-    canonical += '\0';
-    canonical += directory;
-    auto hash = llvm::xxh3_64bits(llvm::StringRef(canonical));
-    return std::format("{:016x}", hash);
 }
 
 std::string print_argv(llvm::ArrayRef<const char*> args) {

--- a/src/command/argument_parser.h
+++ b/src/command/argument_parser.h
@@ -105,13 +105,6 @@ enum class ArgsProfile : std::uint8_t {
 /// not.
 std::string canonicalize(llvm::ArrayRef<std::string> args, ArgsProfile profile);
 
-/// Stable identity of a compile configuration: hex xxh3 hash over the
-/// frontend-relevant canonical form of the arguments. Entries that would
-/// produce the same compilation result share one hash — used to dedupe
-/// contexts in clice/queryContext and to address a CDB entry in
-/// clice/switchContext.
-std::string canonical_command_hash(llvm::ArrayRef<std::string> args, llvm::StringRef directory);
-
 /// Get the resource directory for clang builtin headers. Computed once
 /// from the current executable path using Driver::GetResourcesPath.
 llvm::StringRef resource_dir();

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -757,6 +757,7 @@ std::optional<std::size_t> CompilationDatabase::load(llvm::StringRef path) {
         llvm::SmallString<256> dir_abs;
         if(!path::is_absolute(dir_ref)) {
             dir_abs = path::parent_path(path);
+            fs::make_absolute(dir_abs);
             path::append(dir_abs, dir_ref);
             path::remove_dots(dir_abs, /*remove_dot_dot=*/true);
             dir_ref = dir_abs;

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -751,12 +751,12 @@ std::optional<std::size_t> CompilationDatabase::load(llvm::StringRef path) {
         llvm::StringRef dir_ref(dir_sv.data(), dir_sv.size());
         llvm::StringRef file_ref(file_sv.data(), file_sv.size());
 
-        // A relative `directory` anchors to the workspace root (the
-        // set_workspace_root contract); without a root it stays relative
-        // and downstream consumers see the process working directory.
+        // A relative `directory` anchors to the CDB file's own location —
+        // self-contained, so every consumer of the same file (server,
+        // batch, inspect) resolves it identically.
         llvm::SmallString<256> dir_abs;
-        if(!path::is_absolute(dir_ref) && !workspace_root.empty()) {
-            dir_abs = workspace_root;
+        if(!path::is_absolute(dir_ref)) {
+            dir_abs = path::parent_path(path);
             path::append(dir_abs, dir_ref);
             path::remove_dots(dir_abs, /*remove_dot_dot=*/true);
             dir_ref = dir_abs;

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -189,12 +189,13 @@ void render_arg(const Arg& arg, llvm::function_ref<void(std::string_view)> cb) {
 }
 
 unsigned family_visibility(CompilerFamily family) {
-    /// Exclude CLOption otherwise, to prevent /U, /D, /I from matching Unix
-    /// absolute paths like /Users/... .
+    /// Exclude the slash-prefixed CL and DXC options otherwise (/D and /I
+    /// carry both bits), to prevent /U, /D, /I from matching Unix absolute
+    /// paths like /Users/... .
     if(family == CompilerFamily::MSVC || family == CompilerFamily::ClangCL) {
         return ~0u;
     }
-    return ~static_cast<unsigned>(option::CLOption);
+    return ~static_cast<unsigned>(option::CLOption | option::DXCOption);
 }
 
 std::vector<std::string> to_strings(llvm::ArrayRef<const char*> argv) {
@@ -287,13 +288,17 @@ std::optional<CompilationDatabase::NormalizeResult>
         config.subcommand = strings.save(arguments[0]).data();
         arguments = arguments.drop_front();
     }
-    for(llvm::StringRef token: arguments) {
-        if(token.consume_front("--driver-mode=")) {
-            if(token == "cl") {
+    /// --driver-mode may also arrive from inside a response file (clang
+    /// interprets it post-expansion); the pre-expansion scan only picks the
+    /// response tokenization style.
+    auto scan_driver_mode = [&](llvm::ArrayRef<const char*> argv) {
+        for(llvm::StringRef token: argv) {
+            if(token.consume_front("--driver-mode=") && token == "cl") {
                 config.family = CompilerFamily::ClangCL;
             }
         }
-    }
+    };
+    scan_driver_mode(arguments);
 
     /// Response-file expansion, driver-mode aware: CL commands tokenize
     /// with Windows rules regardless of the server platform. Relative
@@ -302,6 +307,7 @@ std::optional<CompilationDatabase::NormalizeResult>
     llvm::StringSaver local_saver(local_alloc);
     llvm::SmallVector<const char*, 32> tokens(arguments.begin(), arguments.end());
     expand_response_files(tokens, directory, config.family, local_saver);
+    scan_driver_mode(tokens);
 
     /// ccache's --ccache-skip guards the NEXT token from ccache's own
     /// processing; the token itself belongs to the compiler command.
@@ -556,6 +562,7 @@ void CompilationDatabase::expand_response_files(llvm::SmallVectorImpl<const char
             llvm::ArrayRef<char> bytes(text.data(), text.size());
             if(!llvm::convertUTF16ToUTF8String(bytes, utf8)) {
                 LOG_WARN("Cannot decode UTF-16 response file {}", full);
+                expanded.push_back(token);
                 continue;
             }
             text = utf8;
@@ -621,12 +628,15 @@ void CompilationDatabase::sort_entries(std::vector<CompilationEntry>& list) {
     /// differences) still need a stable order: the full render decides,
     /// content-based, so generator reordering never flips the default
     /// selection.
-    llvm::DenseMap<std::uint32_t, std::string> full_keys;
+    /// Memoized in a pre-sized vector: the comparator materializes two keys
+    /// in one expression, so the memo storage must not relocate mid-compare
+    /// (a growing map would).
+    std::vector<std::optional<std::string>> full_keys(list.size());
     auto full_key = [&](std::size_t index) -> const std::string& {
-        auto [it, inserted] = full_keys.try_emplace(static_cast<std::uint32_t>(index));
-        if(inserted) {
+        auto& slot = full_keys[index];
+        if(!slot) {
             auto& entry = list[index];
-            auto& out = it->second;
+            auto& out = slot.emplace();
             auto append = [&](std::string_view fragment) {
                 out += fragment;
                 out += '\0';
@@ -655,7 +665,7 @@ void CompilationDatabase::sort_entries(std::vector<CompilationEntry>& list) {
                 render_arg(arg, append);
             }
         }
-        return it->second;
+        return *slot;
     };
 
     std::vector<std::size_t> order(list.size());
@@ -1070,9 +1080,11 @@ ConfigID CompilationDatabase::apply_rules(ConfigID id, const CommandOptions& opt
     };
 
     /// Parse an edit list into structured args, absolutizing include paths
-    /// against the config's directory like the load pipeline. Input tokens
-    /// make no sense in an edit and drop; unknown tokens keep the user's
-    /// spelling and stay renderable (the user asked for them explicitly).
+    /// against the config's directory like the load pipeline. Unknown tokens
+    /// keep the user's spelling and stay renderable (the user asked for them
+    /// explicitly) — including input-classified ones: an edit cannot name
+    /// the entry's input, so such a token is really the separate value of an
+    /// option the table does not know.
     auto parse_edit = [&](llvm::ArrayRef<std::string> edit_flags, std::vector<LocalArg>& out) {
         std::vector<std::string> flags(edit_flags.begin(), edit_flags.end());
         for(auto& parsed: option::table().parse(flags, remove_parse_options)) {
@@ -1086,10 +1098,7 @@ ConfigID CompilationDatabase::apply_rules(ConfigID id, const CommandOptions& opt
                 continue;
             }
             auto& arg = *parsed;
-            if(arg.id == option::OPT_INPUT) {
-                continue;
-            }
-            if(arg.id == option::OPT_UNKNOWN) {
+            if(arg.id == option::OPT_INPUT || arg.id == option::OPT_UNKNOWN) {
                 if(arg.index < flags.size()) {
                     out.push_back({.opt_id = option::OPT_UNKNOWN,
                                    .cls = ArgClass::Semantic,
@@ -1367,28 +1376,33 @@ SearchConfig CompilationDatabase::search_config(const CommandRef& ref) {
 
 #ifdef CLICE_ENABLE_TEST
 
-void CompilationDatabase::add_command(llvm::StringRef directory,
-                                      llvm::StringRef file,
-                                      llvm::ArrayRef<const char*> arguments) {
+std::optional<CompilationEntry>
+    CompilationDatabase::add_command(llvm::StringRef directory,
+                                     llvm::StringRef file,
+                                     llvm::ArrayRef<const char*> arguments) {
     auto path_id = pool.intern(file);
     auto normalized = normalize(directory, path_id, arguments);
     if(!normalized) {
-        return;
+        return std::nullopt;
     }
-    entry_list.push_back({path_id, normalized->config, normalized->wrapper});
+    CompilationEntry entry{path_id, normalized->config, normalized->wrapper};
+    entry_list.push_back(entry);
     sort_entries(entry_list);
+    return entry;
 }
 
-void CompilationDatabase::add_command(llvm::StringRef directory,
-                                      llvm::StringRef file,
-                                      llvm::StringRef command) {
+std::optional<CompilationEntry> CompilationDatabase::add_command(llvm::StringRef directory,
+                                                                 llvm::StringRef file,
+                                                                 llvm::StringRef command) {
     auto path_id = pool.intern(file);
     auto normalized = normalize(directory, path_id, command);
     if(!normalized) {
-        return;
+        return std::nullopt;
     }
-    entry_list.push_back({path_id, normalized->config, normalized->wrapper});
+    CompilationEntry entry{path_id, normalized->config, normalized->wrapper};
+    entry_list.push_back(entry);
     sort_entries(entry_list);
+    return entry;
 }
 
 #endif

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -1,20 +1,24 @@
 #include "command/command.h"
 
 #include <algorithm>
-#include <array>
 #include <cassert>
-#include <cctype>
+#include <format>
 #include <ranges>
 #include <string_view>
 
 #include "simdjson.h"
 #include "command/nvcc.h"
+#include "command/search_config.h"
 #include "command/toolchain.h"
 #include "support/filesystem.h"
 #include "support/logging.h"
 
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/StringSaver.h"
+#include "llvm/Support/xxhash.h"
+#include "clang/Driver/Types.h"
 
 namespace clice {
 
@@ -22,198 +26,470 @@ namespace {
 
 namespace ranges = std::ranges;
 
-}  // namespace
+/// Version salt of the persistent command identity: entry hashes change
+/// wholesale on schema changes even when old and new renders happen to
+/// produce the same bytes.
+constexpr llvm::StringRef identity_salt = "clice-cmd-v8";
 
-std::vector<const char*> CompileCommand::to_argv() const {
-    std::vector<const char*> argv;
-    argv.reserve(resolved.flags.size() + 4);
+/// Pre-dedup form of an argument: value storage owned locally until the
+/// config wins insertion into the pool.
+struct LocalArg {
+    std::uint32_t opt_id = 0;
+    ArgClass cls = ArgClass::Semantic;
+    const char* spelling = nullptr;
+    llvm::SmallVector<const char*, 2> values;
+};
 
-    if(resolved.is_cc1 && source_file) {
-        // cc1 mode requires TWO file-related arguments (both are needed):
-        //   1. -main-file-name <basename>  — used by clang for diagnostics/debug info
-        //   2. <source_file> at the end    — the actual input file path
-        // These are NOT duplicates: (1) is just the basename, (2) is the full path.
-        for(std::size_t i = 0; i < resolved.flags.size(); ++i) {
-            argv.push_back(resolved.flags[i]);
-            if(resolved.flags[i] == llvm::StringRef("-cc1")) {
-                argv.push_back("-main-file-name");
-                // path::filename returns a suffix of source_file (a pointer into
-                // the same buffer), so .data() is null-terminated because source_file is.
-                argv.push_back(path::filename(source_file).data());
-            }
-        }
-    } else {
-        argv.insert(argv.end(), resolved.flags.begin(), resolved.flags.end());
+ArgClass classify(unsigned id, llvm::ArrayRef<const char*> values) {
+    /// -fmodule-file has two shapes: `name=path` names a prebuilt module
+    /// (clice builds its own PCMs — irrelevant), a bare path is a header
+    /// unit that stays part of the frontend semantics.
+    if(id == option::OPT_fmodule_file) {
+        bool named = values.size() == 1 && llvm::StringRef(values[0]).contains('=');
+        return named ? ArgClass::Discarded : ArgClass::Semantic;
     }
-
-    if(source_file) {
-        argv.push_back(source_file);
+    if(is_discarded_option(id)) {
+        return ArgClass::Discarded;
     }
-    return argv;
+    if(is_codegen_option(id)) {
+        return ArgClass::Codegen;
+    }
+    if(is_user_content_option(id)) {
+        return ArgClass::UserContent;
+    }
+    if(is_diagnostics_option(id)) {
+        return ArgClass::Diagnostics;
+    }
+    return ArgClass::Semantic;
 }
 
-std::vector<std::string> CompileCommand::to_string_argv() const {
-    auto argv = to_argv();
+/// clang's own extension→language mapping (Types.def), the prediction of
+/// how the driver classifies a file it is handed bare. Returns the -x
+/// language name, or empty when clang has no mapping for the extension.
+llvm::StringRef driver_language_for_extension(llvm::StringRef ext) {
+    namespace types = clang::driver::types;
+    if(ext.empty()) {
+        return {};
+    }
+    auto type = types::lookupTypeForExtension(ext);
+    if(type == types::TY_INVALID) {
+        return {};
+    }
+    return types::getTypeName(type);
+}
+
+/// The language selector governing the input slot, or empty. `-x` is
+/// positional (applies to inputs after it, `-x none` resets); cl's global
+/// /TC and /TP apply regardless of position.
+llvm::StringRef language_state_at_slot(llvm::ArrayRef<Arg> args) {
+    llvm::StringRef x_state, cl_state;
+    bool before_slot = true;
+    for(auto& arg: args) {
+        if(arg.cls == ArgClass::Input) {
+            before_slot = false;
+            continue;
+        }
+        switch(arg.opt_id) {
+            case option::OPT_x:
+                if(before_slot && arg.values.size() == 1) {
+                    llvm::StringRef value = arg.values[0];
+                    x_state = value == "none" ? llvm::StringRef() : value;
+                }
+                break;
+            case option::OPT__SLASH_TC: cl_state = "c"; break;
+            case option::OPT__SLASH_TP: cl_state = "c++"; break;
+        }
+    }
+    return cl_state.empty() ? x_state : cl_state;
+}
+
+bool is_wrapper_name(llvm::StringRef filename) {
+    filename.consume_back(".exe");
+    return filename == "ccache" || filename == "sccache" || filename == "distcc" ||
+           filename == "icecc";
+}
+
+/// An appended -gencode adds its architecture next to the base's, the way
+/// nvcc itself accumulates them — resolve the arch flags to the newest.
+void collapse_gpu_arch_args(std::vector<LocalArg>& args) {
+    llvm::SmallVector<std::pair<ArchFlagKind, llvm::StringRef>> sequence;
+    llvm::SmallVector<std::size_t> positions;
+    for(std::size_t i = 0; i < args.size(); i += 1) {
+        auto& arg = args[i];
+        std::optional<ArchFlagKind> kind;
+        switch(arg.opt_id) {
+            case option::OPT_cuda_gpu_arch_EQ: kind = ArchFlagKind::GpuArch; break;
+            case option::OPT_offload_arch_EQ: kind = ArchFlagKind::OffloadArch; break;
+            case option::OPT_no_offload_arch_EQ: kind = ArchFlagKind::NoOffloadArch; break;
+        }
+        if(kind && arg.values.size() == 1) {
+            sequence.push_back({*kind, arg.values[0]});
+            positions.push_back(i);
+        }
+    }
+
+    auto dropped = collapse_gpu_archs(sequence);
+    if(!dropped) {
+        return;
+    }
+    for(auto index: *dropped | std::views::reverse) {
+        args.erase(args.begin() + positions[index]);
+    }
+}
+
+/// Leading tokens forming a compiler-launcher prefix (ccache, distcc, ...,
+/// possibly chained), including the wrapper's own leading options. Zero when
+/// the command starts with the compiler itself.
+std::size_t wrapper_prefix_len(llvm::ArrayRef<const char*> argv) {
+    std::size_t i = 0;
+    while(i < argv.size() && is_wrapper_name(path::filename(argv[i]))) {
+        i += 1;
+        while(i < argv.size() && llvm::StringRef(argv[i]).starts_with("-")) {
+            i += 1;
+        }
+    }
+    return i;
+}
+
+std::uint64_t hash_bytes(llvm::StringRef bytes) {
+    return llvm::xxh3_64bits(bytes);
+}
+
+}  // namespace
+
+void render_arg(const Arg& arg, llvm::function_ref<void(std::string_view)> cb) {
+    if(arg.opt_id == option::OPT_UNKNOWN) {
+        cb(arg.spelling);
+        for(const char* value: arg.values) {
+            cb(value);
+        }
+        return;
+    }
+    kota::option::ParsedArg parsed;
+    parsed.id = arg.opt_id;
+    for(const char* value: arg.values) {
+        parsed.add_value(value);
+    }
+    auto forward = [&](std::string_view fragment) {
+        cb(fragment);
+    };
+    option::table().render(parsed, forward);
+}
+
+unsigned family_visibility(CompilerFamily family) {
+    /// Exclude CLOption otherwise, to prevent /U, /D, /I from matching Unix
+    /// absolute paths like /Users/... .
+    if(family == CompilerFamily::MSVC || family == CompilerFamily::ClangCL) {
+        return ~0u;
+    }
+    return ~static_cast<unsigned>(option::CLOption);
+}
+
+std::vector<std::string> to_strings(llvm::ArrayRef<const char*> argv) {
     std::vector<std::string> result;
     result.reserve(argv.size());
-    for(auto* arg: argv) {
+    for(const char* arg: argv) {
         result.emplace_back(arg);
     }
     return result;
 }
 
-CompilationDatabase::CompilationDatabase() = default;
+CompilationDatabase::CompilationDatabase() : chain(std::make_unique<Toolchain>(*this)) {}
 
 CompilationDatabase::~CompilationDatabase() = default;
 
-llvm::ArrayRef<CompilationEntry> CompilationDatabase::find_entries(std::uint32_t path_id) const {
-    auto [first, last] = ranges::equal_range(entries, path_id, {}, &CompilationEntry::file);
-    if(first == last)
-        return {};
-    return {&*first, static_cast<size_t>(last - first)};
+void CompilationDatabase::set_workspace_root(llvm::StringRef root) {
+    workspace_root = root.str();
 }
 
-llvm::ArrayRef<const char*> CompilationDatabase::persist_args(llvm::ArrayRef<const char*> args) {
-    if(args.empty())
-        return {};
-    auto* buf = allocator->Allocate<const char*>(args.size());
-    ranges::copy(args, buf);
-    return {buf, args.size()};
+const CompileConfig& CompilationDatabase::config(ConfigID id) const {
+    auto ptr = const_cast<ObjectSet<CompileConfig>&>(configs).get(static_cast<std::uint32_t>(id));
+    assert(ptr && "invalid ConfigID");
+    return *ptr;
 }
 
-object_ptr<CompilationInfo>
-    CompilationDatabase::save_compilation_info(llvm::StringRef file,
-                                               llvm::StringRef directory,
-                                               llvm::ArrayRef<const char*> arguments) {
-    assert(!arguments.empty() && "arguments must contain at least the driver");
+llvm::ArrayRef<const char*>
+    CompilationDatabase::persist_strings(llvm::ArrayRef<const char*> values) {
+    if(values.empty()) {
+        return {};
+    }
+    auto* buf = allocator->Allocate<const char*>(values.size());
+    ranges::copy(values, buf);
+    return {buf, values.size()};
+}
 
-    /// clang's option table cannot parse nvcc's own spellings, and the loop
-    /// below discards what it cannot parse — rewrite them first so the
-    /// regular classification applies.
-    std::vector<std::string> nvcc_translated;
-    llvm::SmallVector<const char*, 32> nvcc_arguments;
-    if(Toolchain::driver_family(arguments[0]) == CompilerFamily::NVCC) {
-        nvcc_translated = translate_nvcc_command(arguments, directory);
-        for(auto& arg: nvcc_translated)
-            nvcc_arguments.push_back(arg.c_str());
-        arguments = nvcc_arguments;
+ConfigID CompilationDatabase::save_config(CompileConfig config, llvm::ArrayRef<Arg> local_args) {
+    config.args = local_args;
+    auto id = configs.get(config);
+    auto stored = configs.get(id);
+    if(stored->args.data() == local_args.data()) {
+        /// Freshly inserted: deep-persist the argument array (values are
+        /// interned strings already; their arrays still live in the local
+        /// staging storage).
+        auto* args = allocator->Allocate<Arg>(local_args.size());
+        for(std::size_t i = 0; i < local_args.size(); i += 1) {
+            args[i] = local_args[i];
+            args[i].values = persist_strings(local_args[i].values);
+        }
+        stored->args = {args, local_args.size()};
+    }
+    return ConfigID(id);
+}
+
+std::optional<CompilationDatabase::NormalizeResult>
+    CompilationDatabase::normalize(llvm::StringRef directory,
+                                   std::uint32_t file,
+                                   llvm::ArrayRef<const char*> arguments) {
+    if(arguments.empty()) {
+        return std::nullopt;
     }
 
-    auto render_arg = [&](auto& out, const kota::option::ParsedArg& arg) {
-        auto cb = [&](std::string_view s) {
-            out.push_back(strings.save(s).data());
-        };
-        option::table().render(arg, cb);
+    NormalizeResult result;
+
+    /// Wrapper stripping: the prefix is entry provenance, not config
+    /// identity — `ccache clang++ X` and `clang++ X` dedupe to one config.
+    std::size_t wrapper_len = wrapper_prefix_len(arguments);
+    if(wrapper_len > 0) {
+        if(wrapper_len >= arguments.size()) {
+            LOG_WARN("Compiler launcher without a compiler: {}", print_argv(arguments));
+            return std::nullopt;
+        }
+        llvm::SmallVector<const char*, 4> wrapper;
+        for(const char* token: arguments.take_front(wrapper_len)) {
+            wrapper.push_back(strings.save(token).data());
+        }
+        result.wrapper = persist_strings(wrapper);
+        arguments = arguments.drop_front(wrapper_len);
+    }
+
+    CompileConfig config;
+    config.directory = directory.empty() ? "" : strings.save(directory).data();
+    config.driver = strings.save(arguments[0]).data();
+    arguments = arguments.drop_front();
+
+    config.family = Toolchain::driver_family(config.driver);
+
+    /// zig cc / zig c++: the two tokens together are the driver identity.
+    if(config.family == CompilerFamily::Zig && !arguments.empty() &&
+       (llvm::StringRef(arguments[0]) == "cc" || llvm::StringRef(arguments[0]) == "c++")) {
+        config.subcommand = strings.save(arguments[0]).data();
+        arguments = arguments.drop_front();
+    }
+    for(llvm::StringRef token: arguments) {
+        if(token.consume_front("--driver-mode=")) {
+            if(token == "cl") {
+                config.family = CompilerFamily::ClangCL;
+            }
+        }
+    }
+
+    /// Response-file expansion, driver-mode aware: CL commands tokenize
+    /// with Windows rules regardless of the server platform. Relative
+    /// @paths resolve against the entry directory; contents may nest.
+    llvm::BumpPtrAllocator local_alloc;
+    llvm::StringSaver local_saver(local_alloc);
+    llvm::SmallVector<const char*, 32> tokens(arguments.begin(), arguments.end());
+    expand_response_files(tokens, directory, config.family, local_saver);
+
+    /// ccache's --ccache-skip guards the NEXT token from ccache's own
+    /// processing; the token itself belongs to the compiler command.
+    if(wrapper_len > 0) {
+        llvm::erase_if(tokens,
+                       [](const char* token) { return llvm::StringRef(token) == "--ccache-skip"; });
+    }
+
+    /// nvcc spellings are rewritten into clang's before the table parse —
+    /// the table cannot parse them, and unparsed tokens keep no semantics.
+    std::vector<std::string> nvcc_translated;
+    if(config.family == CompilerFamily::NVCC) {
+        llvm::SmallVector<const char*, 32> argv;
+        argv.push_back(config.driver);
+        argv.append(tokens.begin(), tokens.end());
+        nvcc_translated = translate_nvcc_command(argv, directory);
+        tokens.clear();
+        for(auto& token: llvm::ArrayRef(nvcc_translated).drop_front()) {
+            tokens.push_back(token.c_str());
+        }
+    }
+
+    std::vector<std::string> parse_args(tokens.begin(), tokens.end());
+    auto parse_options = kota::option::ParseOptions{.dash_dash_parsing = true,
+                                                    .visibility = family_visibility(config.family)};
+
+    /// Two passes: the staging pass keeps every parse result alive, so the
+    /// classification pass can decide input pairing (which /Tc-/Tp names
+    /// the entry file) before it lays down arguments.
+    std::vector<std::expected<kota::option::ParsedArg, kota::option::ParseError>> staged;
+    for(auto& parsed: option::table().parse(parse_args, parse_options)) {
+        staged.push_back(parsed);
+    }
+
+    /// Does this token name the entry's file? Compared through the path
+    /// pool (canonical spelling + dot removal), relative tokens resolved
+    /// against the entry directory — and as spelled, for entries interned
+    /// under a relative spelling (tests, hand-built databases).
+    auto matches_entry = [&](llvm::StringRef token) {
+        if(file == ~0u || token.empty()) {
+            return false;
+        }
+        llvm::SmallString<256> abs;
+        if(path::is_absolute(token)) {
+            abs = token;
+        } else {
+            abs = directory;
+            path::append(abs, token);
+        }
+        path::remove_dots(abs, /*remove_dot_dot=*/true);
+        return pool.intern(abs) == file || pool.intern(token) == file;
     };
 
-    llvm::SmallVector<const char*, 32> canonical_args;
-    llvm::SmallVector<const char*, 16> patch_args;
+    /// A per-file selector naming the entry file forces its language and
+    /// suppresses any global /TC-/TP (cl gives per-file precedence).
+    std::optional<unsigned> forced_selector;
+    for(auto& parsed: staged) {
+        if(!parsed.has_value()) {
+            continue;
+        }
+        auto id = parsed->id;
+        if((id == option::OPT__SLASH_Tc || id == option::OPT__SLASH_Tp) &&
+           parsed->values.size() == 1 && matches_entry(parsed->values[0])) {
+            forced_selector =
+                id == option::OPT__SLASH_Tc ? option::OPT__SLASH_TC : option::OPT__SLASH_TP;
+        }
+    }
 
-    /// Driver goes into canonical.
-    canonical_args.push_back(strings.save(arguments[0]).data());
-
+    std::vector<LocalArg> args;
+    args.reserve(staged.size() + 1);
+    bool slot_placed = false;
     bool remove_pch = false;
 
-    std::vector<std::string> parse_args(arguments.begin() + 1, arguments.end());
-    auto options = kota::option::ParseOptions{.dash_dash_parsing = true,
-                                              .visibility = default_visibility(arguments[0])};
-    for(auto& result: option::table().parse(parse_args, options)) {
-        if(!result.has_value()) {
-            auto& err = result.error();
-            LOG_WARN("parse error at index {}: {} when parse: {}", err.index, err.message, file);
+    auto place_slot = [&] {
+        args.push_back({.opt_id = option::OPT_INPUT, .cls = ArgClass::Input});
+        slot_placed = true;
+    };
+
+    for(auto& parsed: staged) {
+        if(!parsed.has_value()) {
+            /// Unparseable tokens keep their verbatim spelling: dropping an
+            /// option we don't understand could merge identities that must
+            /// differ. They never reach a compile render.
+            auto index = parsed.error().index;
+            if(index < parse_args.size()) {
+                args.push_back({.opt_id = option::OPT_UNKNOWN,
+                                .cls = ArgClass::Unknown,
+                                .spelling = strings.save(parse_args[index]).data()});
+            }
             continue;
         }
-        auto& arg = *result;
+
+        auto& arg = *parsed;
         auto id = arg.id;
 
-        /// Discard options irrelevant to frontend.
-        if(is_discarded_option(id)) {
+        if(id == option::OPT_UNKNOWN) {
+            if(arg.index < parse_args.size()) {
+                args.push_back({.opt_id = option::OPT_UNKNOWN,
+                                .cls = ArgClass::Unknown,
+                                .spelling = strings.save(parse_args[arg.index]).data()});
+            }
             continue;
         }
 
-        /// Discard codegen-only options.
-        if(is_codegen_option(id)) {
-            continue;
-        }
-
-        /// Handle CMake's Xclang PCH workaround:
-        /// -Xclang -include-pch -Xclang <pchfile> → discard both pairs.
+        /// The entry's own input token becomes the slot, preserving its
+        /// position (language selectors before it govern it). Other inputs
+        /// — nvcc probe leftovers aside, a multi-input command — drop,
+        /// paired with their per-file selectors. Input args carry their
+        /// token as the spelling.
         ///
-        /// TODO: Dropping the project's own PCH here (and OPT_include_pch in
-        /// the parser table) is required for correctness: it may be produced
-        /// by GCC or a different clang version we cannot load. Open sessions
-        /// lose nothing — the plain -include survives and our own preamble
-        /// PCH covers it. Background indexing however compiles without any
-        /// PCH at all, so projects that use one to speed up their build
-        /// (e.g. LLVM's cmake_pch) index noticeably slower than they
-        /// compile. Index results are unaffected; consider building a
-        /// clice-owned PCH for indexing to win that speed back.
+        /// NVCC is the exception: the translation already resolved every
+        /// positional semantic (nvcc options are command-wide last-wins)
+        /// and parks accumulated state after the original input's spot —
+        /// the slot goes to the end so edits keep landing after it.
+        if(id == option::OPT_INPUT) {
+            if(config.family == CompilerFamily::NVCC) {
+                continue;
+            }
+            llvm::StringRef token =
+                arg.values.empty() ? llvm::StringRef(arg.spelling) : llvm::StringRef(arg.values[0]);
+            if(!slot_placed && matches_entry(token)) {
+                place_slot();
+            }
+            continue;
+        }
+
+        if(id == option::OPT__SLASH_Tc || id == option::OPT__SLASH_Tp) {
+            if(!slot_placed && arg.values.size() == 1 && matches_entry(arg.values[0])) {
+                /// Rewritten to the equivalent global selector: a slot
+                /// attribute keyed by the file would break the
+                /// (config, rule set) memo — the same config can serve
+                /// entries with different per-file selector values.
+                args.push_back({.opt_id = *forced_selector, .cls = ArgClass::Semantic});
+                place_slot();
+            }
+            continue;
+        }
+
+        if((id == option::OPT__SLASH_TC || id == option::OPT__SLASH_TP) && forced_selector) {
+            continue;
+        }
+
+        /// CMake's Xclang PCH workaround:
+        /// -Xclang -include-pch -Xclang <pchfile> → discard both pairs.
+        /// The PCH may be produced by GCC or a different clang version we
+        /// cannot load; the plain -include survives and our own preamble
+        /// PCH covers it.
         if(is_xclang_option(id) && arg.values.size() == 1) {
             if(remove_pch) {
                 remove_pch = false;
                 continue;
             }
-            std::string_view value = arg.values[0];
-            if(value == "-include-pch") {
+            if(std::string_view(arg.values[0]) == "-include-pch") {
                 remove_pch = true;
                 continue;
             }
         }
 
-        /// User-content options go into per-file patch.
-        if(is_user_content_option(id)) {
-            /// Absolutize relative paths for include-path options.
-            if(is_include_path_option(id) && arg.values.size() == 1) {
-                patch_args.push_back(
-                    strings.save(option::table().option(id)->prefixed_name()).data());
-                llvm::StringRef value(arg.values[0]);
-                if(!value.empty() && !path::is_absolute(value)) {
-                    patch_args.push_back(strings.save(path::join(directory, value)).data());
-                } else {
-                    patch_args.push_back(strings.save(value).data());
-                }
-                continue;
-            }
-            render_arg(patch_args, arg);
-            continue;
+        LocalArg local;
+        local.opt_id = id;
+        for(auto value: arg.values) {
+            local.values.push_back(strings.save(value).data());
         }
+        local.cls = classify(id, local.values);
 
-        /// Everything else goes into canonical.
-        render_arg(canonical_args, arg);
-    }
-
-    /// The probe-flag tokens the translation appended are unknown to the
-    /// table and were dropped above — the NVCC toolchain query needs them
-    /// in canonical.
-    if(!nvcc_translated.empty()) {
-        for(llvm::StringRef arg: arguments) {
-            if(is_nvcc_probe_flag(arg)) {
-                canonical_args.push_back(strings.save(arg).data());
+        /// Include-path values absolutize against the entry directory, so
+        /// the config keeps meaning when consumed away from it.
+        if(is_include_path_option(id) && local.values.size() == 1) {
+            llvm::StringRef value(local.values[0]);
+            if(!value.empty() && !path::is_absolute(value)) {
+                local.values[0] = strings.save(path::join(directory, value)).data();
             }
         }
+
+        args.push_back(std::move(local));
     }
 
-    /// Dedup canonical command.
-    auto canonical_id = canonicals.get(CanonicalCommand{canonical_args});
-    auto canonical = canonicals.get(canonical_id);
-    if(canonical->arguments.data() == canonical_args.data()) {
-        canonical->arguments = persist_args(canonical_args);
+    if(!slot_placed) {
+        place_slot();
     }
 
-    /// Build and dedup CompilationInfo.
-    auto dir = strings.save(directory).data();
-    auto info_id = infos.get(CompilationInfo{dir, canonical, patch_args});
-    auto info = infos.get(info_id);
-    if(info->patch.data() == patch_args.data()) {
-        info->patch = persist_args(patch_args);
+    /// Build the pointer-stable Arg view over the staging storage; the
+    /// values arrays are deep-persisted only if the config wins insertion.
+    llvm::SmallVector<Arg, 32> local_args;
+    local_args.reserve(args.size());
+    for(auto& local: args) {
+        local_args.push_back({.opt_id = local.opt_id,
+                              .cls = local.cls,
+                              .spelling = local.spelling,
+                              .values = local.values});
     }
 
-    return info;
+    result.config = save_config(config, local_args);
+    return result;
 }
 
-object_ptr<CompilationInfo> CompilationDatabase::save_compilation_info(llvm::StringRef file,
-                                                                       llvm::StringRef directory,
-                                                                       llvm::StringRef command) {
+std::optional<CompilationDatabase::NormalizeResult>
+    CompilationDatabase::normalize(llvm::StringRef directory,
+                                   std::uint32_t file,
+                                   llvm::StringRef command) {
     llvm::BumpPtrAllocator local;
     llvm::StringSaver saver(local);
 
@@ -226,10 +502,175 @@ object_ptr<CompilationInfo> CompilationDatabase::save_compilation_info(llvm::Str
 #endif
 
     if(arguments.empty()) {
-        return {nullptr};
+        return std::nullopt;
     }
 
-    return save_compilation_info(file, directory, arguments);
+    return normalize(directory, file, arguments);
+}
+
+void CompilationDatabase::expand_response_files(llvm::SmallVectorImpl<const char*>& tokens,
+                                                llvm::StringRef directory,
+                                                CompilerFamily family,
+                                                llvm::StringSaver& saver,
+                                                unsigned depth) {
+    /// Depth cap breaks @a → @b → @a cycles.
+    if(depth >= 8 || ranges::none_of(tokens, [](const char* token) { return token[0] == '@'; })) {
+        return;
+    }
+
+    llvm::SmallVector<const char*, 32> expanded;
+    for(const char* token: tokens) {
+        llvm::StringRef ref(token);
+        if(!ref.starts_with("@")) {
+            expanded.push_back(token);
+            continue;
+        }
+
+        llvm::StringRef spec = ref.drop_front();
+        std::string full = path::is_absolute(spec) ? spec.str() : path::join(directory, spec);
+        auto content = fs::read(full);
+        if(!content) {
+            /// Unreadable response file: the token survives verbatim (the
+            /// real compile would fail the same way), recorded as a missing
+            /// dependency so its appearance is noticed.
+            rsp_deps[full] = 0;
+            expanded.push_back(token);
+            continue;
+        }
+        rsp_deps[full] = hash_bytes(*content);
+
+        /// UTF-16 response files (MSVC tooling emits them) convert first.
+        llvm::StringRef text(*content);
+        std::string utf8;
+        if(text.size() >= 2 &&
+           ((text[0] == '\xff' && text[1] == '\xfe') || (text[0] == '\xfe' && text[1] == '\xff'))) {
+            llvm::ArrayRef<char> bytes(text.data(), text.size());
+            if(!llvm::convertUTF16ToUTF8String(bytes, utf8)) {
+                LOG_WARN("Cannot decode UTF-16 response file {}", full);
+                continue;
+            }
+            text = utf8;
+        }
+
+        llvm::SmallVector<const char*, 32> inner;
+        if(family == CompilerFamily::MSVC || family == CompilerFamily::ClangCL) {
+            llvm::cl::TokenizeWindowsCommandLineFull(text, saver, inner);
+        } else {
+            llvm::cl::TokenizeGNUCommandLine(text, saver, inner);
+        }
+        expand_response_files(inner, directory, family, saver, depth + 1);
+        expanded.append(inner.begin(), inner.end());
+    }
+    tokens = std::move(expanded);
+}
+
+void CompilationDatabase::render_identity(ConfigID id, std::string& out) {
+    auto& cfg = config(id);
+    auto append = [&](std::string_view fragment) {
+        out += fragment;
+        out += '\0';
+    };
+
+    append(cfg.driver);
+    if(cfg.subcommand) {
+        append(cfg.subcommand);
+    }
+    for(auto& arg: cfg.args) {
+        switch(arg.cls) {
+            case ArgClass::Semantic:
+            case ArgClass::UserContent:
+            case ArgClass::Diagnostics: render_arg(arg, append); break;
+            case ArgClass::Unknown: append(arg.spelling); break;
+            case ArgClass::Input: append("\x01input"); break;
+            case ArgClass::Codegen:
+            case ArgClass::Discarded: break;
+        }
+    }
+}
+
+std::uint64_t CompilationDatabase::entry_hash(ConfigID id) {
+    auto [it, inserted] = entry_hashes.try_emplace(static_cast<std::uint32_t>(id), 0);
+    if(!inserted) {
+        return it->second;
+    }
+
+    std::string buf;
+    buf += identity_salt;
+    buf += '\0';
+    render_identity(id, buf);
+    buf += config(id).directory;
+    it->second = hash_bytes(buf);
+    return it->second;
+}
+
+std::string CompilationDatabase::entry_hash_hex(ConfigID id) {
+    return std::format("{:016x}", entry_hash(id));
+}
+
+void CompilationDatabase::sort_entries(std::vector<CompilationEntry>& list) {
+    /// Hash-equal candidates (codegen-only differences, wrapper-only
+    /// differences) still need a stable order: the full render decides,
+    /// content-based, so generator reordering never flips the default
+    /// selection.
+    llvm::DenseMap<std::uint32_t, std::string> full_keys;
+    auto full_key = [&](std::size_t index) -> const std::string& {
+        auto [it, inserted] = full_keys.try_emplace(static_cast<std::uint32_t>(index));
+        if(inserted) {
+            auto& entry = list[index];
+            auto& out = it->second;
+            auto append = [&](std::string_view fragment) {
+                out += fragment;
+                out += '\0';
+            };
+            for(const char* token: entry.wrapper) {
+                append(token);
+            }
+            auto& cfg = config(entry.config);
+            append(cfg.driver);
+            if(cfg.subcommand) {
+                append(cfg.subcommand);
+            }
+            std::size_t index_of_slot = 0;
+            for(auto& arg: cfg.args) {
+                if(arg.cls == ArgClass::Input) {
+                    break;
+                }
+                index_of_slot += 1;
+            }
+            out += std::format("{}", index_of_slot);
+            out += '\0';
+            for(auto& arg: cfg.args) {
+                if(arg.cls == ArgClass::Input) {
+                    continue;
+                }
+                render_arg(arg, append);
+            }
+        }
+        return it->second;
+    };
+
+    std::vector<std::size_t> order(list.size());
+    for(std::size_t i = 0; i < order.size(); i += 1) {
+        order[i] = i;
+    }
+    ranges::sort(order, [&](std::size_t a, std::size_t b) {
+        if(list[a].file != list[b].file) {
+            return list[a].file < list[b].file;
+        }
+        auto ha = entry_hash(list[a].config);
+        auto hb = entry_hash(list[b].config);
+        if(ha != hb) {
+            return ha < hb;
+        }
+        return full_key(a) < full_key(b);
+    });
+
+    std::vector<CompilationEntry> sorted;
+    sorted.reserve(list.size());
+    for(auto index: order) {
+        sorted.push_back(list[index]);
+    }
+    list = std::move(sorted);
 }
 
 std::optional<std::size_t> CompilationDatabase::load(llvm::StringRef path) {
@@ -264,9 +705,12 @@ std::optional<std::size_t> CompilationDatabase::load(llvm::StringRef path) {
     // entries before the cut still swap in) — the CDB poll's two-tick
     // settle debounce is what keeps half-written files from being read.
     std::vector<CompilationEntry> new_entries;
+    rsp_deps.clear();
 
     std::size_t index = 0;
     for(auto element: arr) {
+        auto skip = llvm::make_scope_exit([&] { index += 1; });
+
         simdjson::ondemand::object obj;
         if(element.get_object().get(obj)) {
             LOG_ERROR(
@@ -274,7 +718,6 @@ std::optional<std::size_t> CompilationDatabase::load(llvm::StringRef path) {
                 "item is not an object.",
                 path,
                 index);
-            ++index;
             continue;
         }
 
@@ -285,7 +728,6 @@ std::optional<std::size_t> CompilationDatabase::load(llvm::StringRef path) {
                 "'directory' key is missing.",
                 path,
                 index);
-            ++index;
             continue;
         }
 
@@ -295,7 +737,6 @@ std::optional<std::size_t> CompilationDatabase::load(llvm::StringRef path) {
                 "'file' key is missing.",
                 path,
                 index);
-            ++index;
             continue;
         }
 
@@ -305,20 +746,23 @@ std::optional<std::size_t> CompilationDatabase::load(llvm::StringRef path) {
         // Skip non-C-family files (e.g. .rc, .asm, .def) that some build
         // systems emit into compile_commands.json.
         if(!is_c_family_file(file_ref)) {
-            ++index;
             continue;
         }
 
-        // Resolve relative file paths against the directory so that entries
-        // from different directories don't collide in the PathPool.
-        // TODO: remove_dots here — a "file" carrying "./" or "../" segments
-        // interns under a spelling that clang's realpath'd paths never use,
-        // so lookups against clang-reported paths miss the entry.
-        std::string file_abs;
-        if(!path::is_absolute(file_ref)) {
-            file_abs = path::join(dir_ref, file_ref);
-            file_ref = file_abs;
+        // Resolve relative file paths against the directory and drop . and
+        // .. segments: clang reports realpath'd spellings, and an entry
+        // interned with dot segments would never match them.
+        llvm::SmallString<256> file_abs;
+        if(path::is_absolute(file_ref)) {
+            file_abs = file_ref;
+        } else {
+            file_abs = dir_ref;
+            path::append(file_abs, file_ref);
         }
+        path::remove_dots(file_abs, /*remove_dot_dot=*/true);
+        auto path_id = pool.intern(file_abs);
+
+        std::optional<NormalizeResult> normalized;
 
         simdjson::ondemand::array args_arr;
         if(!obj["arguments"].get_array().get(args_arr)) {
@@ -334,12 +778,10 @@ std::optional<std::size_t> CompilationDatabase::load(llvm::StringRef path) {
                 }
                 args.push_back(saver.save(llvm::StringRef(sv.data(), sv.size())).data());
             }
-            if(!malformed && !args.empty()) {
-                auto info = save_compilation_info(file_ref, dir_ref, args);
-                assert(info && "save_compilation_info must succeed with non-empty args");
-                auto path_id = paths.intern(file_ref);
-                new_entries.push_back({path_id, info});
+            if(malformed || args.empty()) {
+                continue;
             }
+            normalized = normalize(dir_ref, path_id, args);
         } else {
             std::string_view cmd_sv;
             if(obj["command"].get_string().get(cmd_sv)) {
@@ -348,56 +790,42 @@ std::optional<std::size_t> CompilationDatabase::load(llvm::StringRef path) {
                     "neither 'arguments' nor 'command' key is present.",
                     path,
                     index);
-                ++index;
                 continue;
             }
-            auto info = save_compilation_info(file_ref,
-                                              dir_ref,
-                                              llvm::StringRef(cmd_sv.data(), cmd_sv.size()));
-            if(!info) {
-                ++index;
-                continue;
-            }
-            auto path_id = paths.intern(file_ref);
-            new_entries.push_back({path_id, info});
+            normalized = normalize(dir_ref, path_id, llvm::StringRef(cmd_sv.data(), cmd_sv.size()));
         }
 
-        ++index;
+        if(!normalized) {
+            continue;
+        }
+        new_entries.push_back({path_id, normalized->config, normalized->wrapper});
     }
 
-    // Sort by file path_id for binary search.
-    ranges::sort(new_entries, {}, &CompilationEntry::file);
-
-    entries = std::move(new_entries);
-    return entries.size();
+    sort_entries(new_entries);
+    entry_list = std::move(new_entries);
+    return entry_list.size();
 }
 
 llvm::DenseMap<std::uint32_t, llvm::SmallVector<std::string, 1>>
-    CompilationDatabase::command_hash_snapshot() const {
+    CompilationDatabase::command_hash_snapshot() {
     llvm::DenseMap<std::uint32_t, llvm::SmallVector<std::string, 1>> snapshot;
-
-    for(auto& entry: entries) {
-        // The file-independent argv (driver + canonical flags + per-file
-        // -I/-D patch). The source file stays out: entries under one path_id
-        // share it, so it carries no signal for this comparison.
-        std::vector<std::string> args;
-        args.reserve(entry.info->canonical->arguments.size() + entry.info->patch.size());
-        for(const char* arg: entry.info->canonical->arguments) {
-            args.emplace_back(arg);
-        }
-        for(const char* arg: entry.info->patch) {
-            args.emplace_back(arg);
-        }
-        snapshot[entry.file].emplace_back(canonical_command_hash(args, entry.info->directory));
+    for(auto& entry: entry_list) {
+        snapshot[entry.file].push_back(entry_hash_hex(entry.config));
     }
-
-    // A file's entries have no inherent order, so sort each list to make the
-    // comparison in reload_and_diff() order-independent.
+    // A file's entries have no inherent order for the diff, so sort each
+    // list to make the comparison in reload_and_diff() order-independent.
     for(auto& bucket: snapshot) {
         ranges::sort(bucket.second);
     }
-
     return snapshot;
+}
+
+std::optional<std::string> CompilationDatabase::selected_hash(std::uint32_t path_id) {
+    auto candidates = candidate_entries(path_id);
+    if(candidates.empty()) {
+        return std::nullopt;
+    }
+    return entry_hash_hex(candidates.front().config);
 }
 
 std::optional<CDBDiff> CompilationDatabase::reload_and_diff(llvm::StringRef path) {
@@ -422,7 +850,7 @@ std::optional<CDBDiff> CompilationDatabase::reload_and_diff(llvm::StringRef path
     }
 
     for(auto& bucket: before) {
-        if(after.find(bucket.first) == after.end()) {
+        if(!after.contains(bucket.first)) {
             diff.removed.push_back(bucket.first);
         }
     }
@@ -434,29 +862,77 @@ std::optional<CDBDiff> CompilationDatabase::reload_and_diff(llvm::StringRef path
     return diff;
 }
 
-CompileCommand CompilationDatabase::build_command(std::uint32_t path_id,
-                                                  object_ptr<CompilationInfo> info,
-                                                  const CommandOptions& options) {
-    auto render_arg = [&](auto& out, const kota::option::ParsedArg& arg) {
-        auto cb = [&](std::string_view s) {
-            out.push_back(strings.save(s).data());
-        };
-        option::table().render(arg, cb);
+llvm::ArrayRef<CompilationEntry>
+    CompilationDatabase::candidate_entries(std::uint32_t path_id) const {
+    auto [first, last] = ranges::equal_range(entry_list, path_id, {}, &CompilationEntry::file);
+    if(first == last) {
+        return {};
+    }
+    return {&*first, static_cast<std::size_t>(last - first)};
+}
+
+llvm::ArrayRef<CompilationEntry> CompilationDatabase::candidate_entries(llvm::StringRef file) {
+    return candidate_entries(pool.intern(file));
+}
+
+bool CompilationDatabase::has_entry(llvm::StringRef file) {
+    return !candidate_entries(file).empty();
+}
+
+llvm::StringRef CompilationDatabase::forced_language(ConfigID id) const {
+    return language_state_at_slot(config(id).args);
+}
+
+InputKind CompilationDatabase::input_kind(ConfigID id, llvm::StringRef file) {
+    auto state = language_state_at_slot(config(id).args);
+    if(!state.empty()) {
+        return {strings.save(state).data()};
+    }
+
+    auto ext = path::extension(file);
+    ext.consume_front(".");
+    /// CUDA's header convention is missing from clang's extension table.
+    if(ext == "cuh") {
+        return {strings.save("cuda").data()};
+    }
+    if(auto lang = driver_language_for_extension(ext); !lang.empty()) {
+        return {strings.save(lang).data()};
+    }
+    /// No mapping: the raw extension keys the probe (the driver sees a
+    /// temp file with the same extension, exactly as confused as it would
+    /// be by the real file).
+    return {strings.save(ext).data()};
+}
+
+ConfigID CompilationDatabase::apply_rules(ConfigID id, const CommandOptions& options) {
+    if(options.empty()) {
+        return id;
+    }
+
+    /// Rule-set identity for the memo: the exact edit content.
+    std::string rule_key;
+    auto append_section = [&](llvm::ArrayRef<std::string> section) {
+        for(auto& item: section) {
+            rule_key += item;
+            rule_key += '\0';
+        }
+        rule_key += '\1';
     };
+    append_section(options.remove);
+    append_section(options.append);
+    append_section(options.extra_prepend);
+    append_section(options.extra_append);
 
-    llvm::StringRef directory = info->directory;
-    std::vector<const char*> flags;
+    auto rule_set_id = rule_set_ids.try_emplace(rule_key, rule_set_ids.size()).first->second;
+    auto [memo, inserted] =
+        rule_applied.try_emplace({static_cast<std::uint32_t>(id), rule_set_id}, 0);
+    if(!inserted) {
+        return ConfigID(memo->second);
+    }
 
-    auto append_arg = [&](llvm::StringRef s) {
-        flags.emplace_back(strings.save(s).data());
-    };
-
-    auto append_args = [&](llvm::ArrayRef<const char*> args) {
-        flags.insert(flags.end(), args.begin(), args.end());
-    };
-
-    bool is_nvcc =
-        Toolchain::driver_family(info->canonical->arguments.front()) == CompilerFamily::NVCC;
+    const auto& cfg = config(id);
+    bool is_nvcc = cfg.family == CompilerFamily::NVCC;
+    llvm::StringRef directory = cfg.directory;
 
     /// Rule flags for an NVCC entry arrive in the same nvcc spellings as
     /// the command they edit — rewrite them like the command itself.
@@ -464,33 +940,22 @@ CompileCommand CompilationDatabase::build_command(std::uint32_t path_id,
     /// (`-rdc=false` over an rdc base) cancels the base's translated state
     /// instead of vanishing.
     auto translate_rule_flags = [&](llvm::ArrayRef<std::string> rule_flags, bool edit) {
-        std::vector<std::string> result(rule_flags.begin(), rule_flags.end());
-        if(result.empty() || !is_nvcc) {
-            return result;
+        std::vector<std::string> flags(rule_flags.begin(), rule_flags.end());
+        if(flags.empty() || !is_nvcc) {
+            return flags;
         }
         std::vector<const char*> argv;
-        argv.reserve(result.size() + 1);
-        argv.push_back(info->canonical->arguments.front());
-        for(auto& arg: result) {
-            argv.push_back(arg.c_str());
+        argv.reserve(flags.size() + 1);
+        argv.push_back(cfg.driver);
+        for(auto& flag: flags) {
+            argv.push_back(flag.c_str());
         }
         auto translated = translate_nvcc_command(argv, directory, edit);
-        result.assign(std::make_move_iterator(translated.begin() + 1),
-                      std::make_move_iterator(translated.end()));
-        return result;
+        flags.assign(std::make_move_iterator(translated.begin() + 1),
+                     std::make_move_iterator(translated.end()));
+        return flags;
     };
 
-    append_args(info->canonical->arguments);
-    append_args(info->patch);
-
-    // Inject our resource dir if not already present.
-    if(options.inject_resource_dir && !resource_dir().empty() &&
-       !ranges::contains(flags, llvm::StringRef("-resource-dir"))) {
-        append_arg("-resource-dir");
-        append_arg(resource_dir());
-    }
-
-    // Apply remove filter.
     std::vector<std::string> remove_source(options.remove.begin(), options.remove.end());
     if(is_nvcc) {
         /// A wildcard arch removal (`-arch=*`, `--generate-code=*`) must
@@ -517,6 +982,7 @@ CompileCommand CompilationDatabase::build_command(std::uint32_t path_id,
             }
         }
     }
+
     /// Remove patterns are an independent list, not one command: translated
     /// whole, nvcc's last-wins would swallow every alternative value of a
     /// stateful option but the last. Each pattern translates alone —
@@ -528,8 +994,9 @@ CompileCommand CompilationDatabase::build_command(std::uint32_t path_id,
         for(std::size_t i = 0; i < remove_source.size(); i += 1) {
             std::size_t count = 1;
             if(llvm::StringRef(remove_source[i]).starts_with("-") && i + 1 < remove_source.size() &&
-               !llvm::StringRef(remove_source[i + 1]).starts_with("-"))
+               !llvm::StringRef(remove_source[i + 1]).starts_with("-")) {
                 count = 2;
+            }
             auto pattern = translate_rule_flags(llvm::ArrayRef(remove_source).slice(i, count),
                                                 /*edit=*/false);
             remove_flags.insert(remove_flags.end(),
@@ -540,177 +1007,342 @@ CompileCommand CompilationDatabase::build_command(std::uint32_t path_id,
     } else {
         remove_flags = std::move(remove_source);
     }
-    if(!remove_flags.empty()) {
-        std::vector<kota::option::ParsedArg> remove_args;
-        for(auto& result: option::table().parse(remove_flags)) {
-            if(result.has_value()) {
-                remove_args.push_back(*result);
-            }
+
+    std::vector<kota::option::ParsedArg> remove_args;
+    auto remove_parse_options =
+        kota::option::ParseOptions{.visibility = family_visibility(cfg.family)};
+    for(auto& parsed: option::table().parse(remove_flags, remove_parse_options)) {
+        if(parsed.has_value()) {
+            remove_args.push_back(*parsed);
         }
-        auto get_id = [](const kota::option::ParsedArg& arg) {
-            return arg.id;
-        };
-        ranges::sort(remove_args, {}, get_id);
+    }
+    auto get_id = [](const kota::option::ParsedArg& arg) {
+        return arg.id;
+    };
+    ranges::sort(remove_args, {}, get_id);
 
-        auto saved_flags = std::move(flags);
-        flags.clear();
-        flags.push_back(saved_flags.front());
-
-        std::vector<std::string> saved_parse_args(saved_flags.begin() + 1, saved_flags.end());
-        for(auto& result: option::table().parse(saved_parse_args)) {
-            if(!result.has_value()) {
+    auto matches_remove = [&](const Arg& arg) {
+        auto range = ranges::equal_range(remove_args, arg.opt_id, {}, get_id);
+        for(auto& remove: range) {
+            /// All unknown options share one id; their identity is the
+            /// spelling (NVCC probe flags persist as unknown tokens). A
+            /// trailing `=*` wildcards the value part, mirroring the
+            /// known-option value wildcard below.
+            if(arg.opt_id == option::OPT_UNKNOWN) {
+                llvm::StringRef pattern = remove.spelling;
+                bool wildcard = pattern.consume_back("*") && pattern.ends_with("=");
+                if(wildcard ? llvm::StringRef(arg.spelling).starts_with(pattern)
+                            : arg.spelling == llvm::StringRef(remove.spelling)) {
+                    return true;
+                }
                 continue;
             }
-            auto& arg = *result;
-            auto id = arg.id;
-            auto range = ranges::equal_range(remove_args, id, {}, get_id);
-            bool removed = false;
-            for(auto& remove: range) {
-                /// All unknown options share one id; their identity is the
-                /// spelling (NVCC probe flags persist as unknown tokens). A
-                /// trailing `=*` wildcards the value part, mirroring the
-                /// known-option value wildcard below.
-                if(id == option::OPT_UNKNOWN) {
-                    llvm::StringRef pattern = remove.spelling;
-                    bool wildcard = pattern.consume_back("*") && pattern.ends_with("=");
-                    if(wildcard ? llvm::StringRef(arg.spelling).starts_with(pattern)
-                                : arg.spelling == remove.spelling) {
-                        removed = true;
-                        break;
-                    }
-                    continue;
-                }
-                if(remove.values.size() == 1 && remove.values[0] == "*") {
-                    removed = true;
-                    break;
-                }
-                if(ranges::equal(arg.values, remove.values)) {
-                    removed = true;
-                    break;
-                }
+            if(remove.values.size() == 1 && remove.values[0] == "*") {
+                return true;
             }
-            if(!removed) {
-                render_arg(flags, arg);
+            if(ranges::equal(arg.values, remove.values, [](const char* a, std::string_view b) {
+                   return std::string_view(a) == b;
+               })) {
+                return true;
             }
         }
-    }
+        return false;
+    };
 
-    std::size_t prepend_at = 1;
-    for(auto& arg: options.extra_prepend) {
-        flags.insert(flags.begin() + prepend_at, strings.save(arg).data());
-        prepend_at += 1;
-    }
+    /// Parse an edit list into structured args, absolutizing include paths
+    /// against the config's directory like the load pipeline. Input tokens
+    /// make no sense in an edit and drop; unknown tokens keep the user's
+    /// spelling and stay renderable (the user asked for them explicitly).
+    auto parse_edit = [&](llvm::ArrayRef<std::string> edit_flags, std::vector<LocalArg>& out) {
+        std::vector<std::string> flags(edit_flags.begin(), edit_flags.end());
+        for(auto& parsed: option::table().parse(flags, remove_parse_options)) {
+            if(!parsed.has_value()) {
+                auto index = parsed.error().index;
+                if(index < flags.size()) {
+                    out.push_back({.opt_id = option::OPT_UNKNOWN,
+                                   .cls = ArgClass::Semantic,
+                                   .spelling = strings.save(flags[index]).data()});
+                }
+                continue;
+            }
+            auto& arg = *parsed;
+            if(arg.id == option::OPT_INPUT) {
+                continue;
+            }
+            if(arg.id == option::OPT_UNKNOWN) {
+                if(arg.index < flags.size()) {
+                    out.push_back({.opt_id = option::OPT_UNKNOWN,
+                                   .cls = ArgClass::Semantic,
+                                   .spelling = strings.save(flags[arg.index]).data()});
+                }
+                continue;
+            }
+            LocalArg local;
+            local.opt_id = arg.id;
+            for(auto value: arg.values) {
+                local.values.push_back(strings.save(value).data());
+            }
+            local.cls = classify(arg.id, local.values);
+            if(is_include_path_option(arg.id) && local.values.size() == 1) {
+                llvm::StringRef value(local.values[0]);
+                if(!value.empty() && !path::is_absolute(value)) {
+                    local.values[0] = strings.save(path::join(directory, value)).data();
+                }
+            }
+            out.push_back(std::move(local));
+        }
+    };
 
-    for(auto& arg: translate_rule_flags(options.append, /*edit=*/true)) {
-        append_arg(arg);
-    }
+    std::vector<LocalArg> prepend_args;
+    parse_edit(options.extra_prepend, prepend_args);
 
-    for(auto& arg: options.extra_append) {
-        append_arg(arg);
+    std::vector<LocalArg> append_args;
+    parse_edit(translate_rule_flags(options.append, /*edit=*/true), append_args);
+    parse_edit(options.extra_append, append_args);
+
+    /// Rebuild the sequence: prepends first, base args with removes
+    /// cancelled, appends inserted before the input slot — an append always
+    /// takes effect for the compile, and with the common input-at-end CDB
+    /// the byte order matches the old tail-append exactly.
+    std::vector<LocalArg> edited;
+    edited.reserve(prepend_args.size() + cfg.args.size() + append_args.size());
+    for(auto& local: prepend_args) {
+        edited.push_back(local);
+    }
+    for(auto& arg: cfg.args) {
+        if(arg.cls == ArgClass::Input) {
+            for(auto& local: append_args) {
+                edited.push_back(local);
+            }
+            edited.push_back({.opt_id = option::OPT_INPUT, .cls = ArgClass::Input});
+            continue;
+        }
+        if(matches_remove(arg)) {
+            continue;
+        }
+        LocalArg local;
+        local.opt_id = arg.opt_id;
+        local.cls = arg.cls;
+        local.spelling = arg.spelling;
+        local.values.assign(arg.values.begin(), arg.values.end());
+        edited.push_back(std::move(local));
     }
 
     /// An appended -gencode adds its architecture next to the base's, the
     /// way nvcc itself accumulates them — resolve them to the newest.
     if(is_nvcc) {
-        collapse_gpu_arch_flags(flags);
+        collapse_gpu_arch_args(edited);
     }
 
-    return CompileCommand{
-        ResolvedFlags{directory, std::move(flags), false},
-        paths.resolve(path_id).data()
-    };
+    llvm::SmallVector<Arg, 32> local_args;
+    local_args.reserve(edited.size());
+    for(auto& local: edited) {
+        local_args.push_back({.opt_id = local.opt_id,
+                              .cls = local.cls,
+                              .spelling = local.spelling,
+                              .values = local.values});
+    }
+
+    CompileConfig result = cfg;
+    auto result_id = save_config(result, local_args);
+    rule_applied[{static_cast<std::uint32_t>(id), rule_set_id}] =
+        static_cast<std::uint32_t>(result_id);
+    return result_id;
 }
 
-llvm::SmallVector<CompileCommand> CompilationDatabase::lookup(llvm::StringRef file,
-                                                              const CommandOptions& options) {
-    auto path_id = paths.intern(file);
-    auto matched = find_entries(path_id);
-
-    llvm::SmallVector<CompileCommand> results;
-
-    if(!matched.empty()) {
-        for(auto& entry: matched) {
-            results.push_back(build_command(path_id, entry.info, options));
-        }
+ConfigID CompilationDatabase::fallback_config(llvm::StringRef file) {
+    // Synthesize a default command so the file still compiles and produces
+    // diagnostics instead of failing silently. Config rule appends apply on
+    // top through the regular apply_rules path: users without a CDB rely on
+    // them to supply include paths.
+    llvm::SmallVector<const char*, 8> arguments;
+    llvm::StringRef variant;
+    if(file.ends_with(".cpp") || file.ends_with(".hpp") || file.ends_with(".cc")) {
+        variant = "c++";
+        arguments = {"clang++", "-std=c++20"};
+    } else if(file.ends_with(".cu") || file.ends_with(".cuh")) {
+        /// Device-only pins the same device-side view NVCC-backed commands
+        /// default to, instead of whichever job the toolchain query happens
+        /// to pick from a two-sided compilation; a config rule appending
+        /// --cuda-host-only still wins as the later flag.
+        variant = "cuda";
+        arguments = {"clang++", "-std=c++20", "-x", "cuda", "--cuda-device-only"};
     } else {
-        // No matching entry — synthesize a default command. Config rule
-        // appends still apply: users without a CDB rely on them to supply
-        // include paths. (Removes target flags of real CDB commands; there
-        // is nothing to remove from the two-flag default.)
-        std::vector<const char*> flags;
-        if(file.ends_with(".cpp") || file.ends_with(".hpp") || file.ends_with(".cc")) {
-            flags = {"clang++", "-std=c++20"};
-        } else if(file.ends_with(".cu") || file.ends_with(".cuh")) {
-            /// .cuh is not a clang-known extension: without -x the driver
-            /// classifies it as linker input and builds no compile job.
-            /// Device-only pins the same device-side view NVCC-backed
-            /// commands default to, instead of whichever job the toolchain
-            /// query happens to pick from a two-sided compilation; a config
-            /// rule appending --cuda-host-only still wins as the later flag.
-            flags = {"clang++", "-std=c++20", "-x", "cuda", "--cuda-device-only"};
-        } else {
-            flags = {"clang"};
-        }
-        if(options.inject_resource_dir && !resource_dir().empty()) {
-            flags.push_back(strings.save("-resource-dir").data());
-            flags.push_back(strings.save(resource_dir()).data());
-        }
-        for(auto& arg: options.append) {
-            flags.push_back(strings.save(arg).data());
-        }
-        results.push_back(CompileCommand{
-            ResolvedFlags{{}, std::move(flags), false},
-            paths.resolve(path_id).data()
-        });
+        variant = "c";
+        arguments = {"clang"};
     }
 
-    return results;
+    auto [it, inserted] = fallback_configs.try_emplace(variant, invalid_config);
+    if(inserted) {
+        auto normalized = normalize("", ~0u, arguments);
+        assert(normalized && "fallback synthesis cannot fail");
+        it->second = normalized->config;
+    }
+    return it->second;
 }
 
-llvm::StringRef CompilationDatabase::resolve_path(std::uint32_t path_id) {
-    return paths.resolve(path_id);
-}
+std::vector<const char*> CompilationDatabase::render_driver(const CommandRef& ref,
+                                                            const RenderOptions& opts) {
+    auto& cfg = config(ref.config);
+    auto source = pool.resolve(ref.file);
 
-std::uint32_t CompilationDatabase::intern_path(llvm::StringRef path) {
-    return paths.intern(path);
-}
+    std::vector<const char*> argv;
+    argv.reserve(cfg.args.size() + 8);
+    argv.push_back(cfg.driver);
+    if(cfg.subcommand) {
+        argv.push_back(cfg.subcommand);
+    }
 
-bool CompilationDatabase::has_entry(llvm::StringRef file) {
-    auto path_id = paths.intern(file);
-    return !find_entries(path_id).empty();
-}
+    // Inject our resource dir if the command names none, so the embedded
+    // frontend and its builtin headers stay version-matched.
+    bool has_resource_dir = ranges::any_of(cfg.args, [](const Arg& arg) {
+        return arg.opt_id == option::OPT_resource_dir || arg.opt_id == option::OPT_resource_dir_EQ;
+    });
+    if(!has_resource_dir && !resource_dir().empty()) {
+        argv.push_back("-resource-dir");
+        argv.push_back(resource_dir().data());
+    }
 
-llvm::ArrayRef<CompilationEntry> CompilationDatabase::get_entries() const {
-    return entries;
-}
+    auto emit = [&](std::string_view fragment) {
+        argv.push_back(strings.save(fragment).data());
+    };
 
-llvm::SmallVector<CompilationDatabase::ConfigGroup>
-    CompilationDatabase::unique_configs(const CommandOptions& options) {
-    // Group entries by CompilationInfo pointer — entries with the same pointer
-    // share identical (directory, canonical, patch) and thus identical flags.
-    llvm::DenseMap<const CompilationInfo*, std::size_t> group_indices;
-    llvm::SmallVector<ConfigGroup> result;
-    result.reserve(entries.size());
+    auto state = language_state_at_slot(cfg.args);
+    std::size_t last_user_content = argv.size();
 
-    for(auto& entry: entries) {
-        auto [it, inserted] = group_indices.try_emplace(entry.info.ptr, result.size());
-        if(inserted) {
-            result.push_back({{}, build_command(entry.file, entry.info, options), entry.info});
-        }
-
-        auto& file_ids = result[it->second].file_ids;
-        if(file_ids.empty() || file_ids.back() != entry.file) {
-            file_ids.push_back(entry.file);
+    for(auto& arg: cfg.args) {
+        switch(arg.cls) {
+            case ArgClass::Semantic:
+            case ArgClass::UserContent:
+            case ArgClass::Diagnostics:
+                render_arg(arg, emit);
+                if(arg.cls == ArgClass::UserContent) {
+                    last_user_content = argv.size();
+                }
+                break;
+            case ArgClass::Input: {
+                /// The slot contract: with no governing selector and an
+                /// extension the driver would classify differently from
+                /// the ref's language (a borrowed header, a driver-unknown
+                /// extension), an explicit selector precedes the file.
+                if(state.empty()) {
+                    auto ext = path::extension(source);
+                    ext.consume_front(".");
+                    auto driver_lang = driver_language_for_extension(ext);
+                    if(driver_lang != llvm::StringRef(ref.input.value)) {
+                        if(cfg.family == CompilerFamily::MSVC ||
+                           cfg.family == CompilerFamily::ClangCL) {
+                            if(llvm::StringRef(ref.input.value) == "c++") {
+                                emit("/TP");
+                            } else if(llvm::StringRef(ref.input.value) == "c") {
+                                emit("/TC");
+                            }
+                        } else {
+                            emit("-x");
+                            emit(ref.input.value);
+                        }
+                    }
+                }
+                argv.push_back(source.data());
+                break;
+            }
+            case ArgClass::Codegen:
+            case ArgClass::Discarded:
+            case ArgClass::Unknown: break;
         }
     }
 
-    return result;
+    if(opts.preamble) {
+        /// After the command's own user-content flags: the host's -include
+        /// runs before the synthesized preamble.
+        argv.insert(argv.begin() + last_user_content, {"-include", opts.preamble});
+    }
+
+    return argv;
 }
 
-CompileCommand CompilationDatabase::group_command(const ConfigGroup& group,
-                                                  const CommandOptions& options) {
-    assert(!group.file_ids.empty() && group.info && "group must come from unique_configs()");
-    return build_command(group.file_ids.front(), group.info, options);
+std::vector<const char*> CompilationDatabase::render(const CommandRef& ref,
+                                                     const RenderOptions& opts) {
+    auto resolved = chain->resolve(ref.config, ref.input);
+    if(!resolved) {
+        LOG_WARN("Toolchain resolve failed for {}: {}", pool.resolve(ref.file), resolved.error());
+        return render_driver(ref, opts);
+    }
+
+    auto& rc = chain->resolved(*resolved);
+    auto source = pool.resolve(ref.file);
+
+    std::vector<const char*> argv;
+    argv.reserve(rc.args.size() + 8);
+    argv.push_back(rc.driver);
+    if(rc.is_cc1) {
+        argv.push_back("-cc1");
+        argv.push_back("-main-file-name");
+        // path::filename returns a suffix of the interned path (a pointer
+        // into the same buffer), so .data() is null-terminated.
+        argv.push_back(path::filename(source).data());
+    }
+
+    auto emit = [&](std::string_view fragment) {
+        argv.push_back(strings.save(fragment).data());
+    };
+
+    std::size_t last_user_content = argv.size();
+    for(auto& arg: rc.args) {
+        render_arg(arg, emit);
+        if(arg.cls == ArgClass::UserContent) {
+            last_user_content = argv.size();
+        }
+    }
+
+    if(opts.preamble) {
+        argv.insert(argv.begin() + last_user_content, {"-include", opts.preamble});
+    }
+
+    argv.push_back(source.data());
+    return argv;
+}
+
+std::vector<const char*> CompilationDatabase::render_full(ConfigID id) {
+    auto& cfg = config(id);
+    std::vector<const char*> argv;
+    argv.reserve(cfg.args.size() + 2);
+    argv.push_back(cfg.driver);
+    if(cfg.subcommand) {
+        argv.push_back(cfg.subcommand);
+    }
+    auto emit = [&](std::string_view fragment) {
+        argv.push_back(strings.save(fragment).data());
+    };
+    for(auto& arg: cfg.args) {
+        if(arg.cls == ArgClass::Input) {
+            continue;
+        }
+        render_arg(arg, emit);
+    }
+    return argv;
+}
+
+void CompilationDatabase::warm(llvm::ArrayRef<CommandRef> refs) {
+    llvm::SmallVector<std::pair<ConfigID, InputKind>> pairs;
+    pairs.reserve(refs.size());
+    for(auto& ref: refs) {
+        pairs.push_back({ref.config, ref.input});
+    }
+    chain->warm(pairs);
+}
+
+SearchConfig CompilationDatabase::search_config(const CommandRef& ref) {
+    llvm::StringRef directory = config(ref.config).directory;
+    auto resolved = chain->resolve(ref.config, ref.input);
+    if(!resolved) {
+        return extract_search_config(config(ref.config).args, directory);
+    }
+    auto [it, inserted] = search_configs.try_emplace(*resolved);
+    if(inserted) {
+        it->second = extract_search_config(chain->resolved(*resolved).args, directory);
+    }
+    return it->second;
 }
 
 #ifdef CLICE_ENABLE_TEST
@@ -718,20 +1350,25 @@ CompileCommand CompilationDatabase::group_command(const ConfigGroup& group,
 void CompilationDatabase::add_command(llvm::StringRef directory,
                                       llvm::StringRef file,
                                       llvm::ArrayRef<const char*> arguments) {
-    auto path_id = paths.intern(file);
-    auto info = save_compilation_info(file, directory, arguments);
-    // Insert in sorted position to maintain sort invariant.
-    auto it = ranges::lower_bound(entries, path_id, {}, &CompilationEntry::file);
-    entries.insert(it, {path_id, info});
+    auto path_id = pool.intern(file);
+    auto normalized = normalize(directory, path_id, arguments);
+    if(!normalized) {
+        return;
+    }
+    entry_list.push_back({path_id, normalized->config, normalized->wrapper});
+    sort_entries(entry_list);
 }
 
 void CompilationDatabase::add_command(llvm::StringRef directory,
                                       llvm::StringRef file,
                                       llvm::StringRef command) {
-    auto path_id = paths.intern(file);
-    auto info = save_compilation_info(file, directory, command);
-    auto it = ranges::lower_bound(entries, path_id, {}, &CompilationEntry::file);
-    entries.insert(it, {path_id, info});
+    auto path_id = pool.intern(file);
+    auto normalized = normalize(directory, path_id, command);
+    if(!normalized) {
+        return;
+    }
+    entry_list.push_back({path_id, normalized->config, normalized->wrapper});
+    sort_entries(entry_list);
 }
 
 #endif

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -104,9 +104,11 @@ llvm::StringRef language_state_at_slot(llvm::ArrayRef<Arg> args) {
 }
 
 bool is_wrapper_name(llvm::StringRef filename) {
-    filename.consume_back(".exe");
-    return filename == "ccache" || filename == "sccache" || filename == "distcc" ||
-           filename == "icecc";
+    /// Windows tools emit spellings like CCACHE.EXE — match lowercased.
+    std::string lowered = filename.lower();
+    llvm::StringRef name = lowered;
+    name.consume_back(".exe");
+    return name == "ccache" || name == "sccache" || name == "distcc" || name == "icecc";
 }
 
 /// An appended -gencode adds its architecture next to the base's, the way

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -137,6 +137,17 @@ void collapse_gpu_arch_args(std::vector<LocalArg>& args) {
     }
 }
 
+/// KEY=VAL-shaped token — a wrapper option's separate value (`ccache
+/// --set-config max_size=1G`), never the compiler: the key admits only
+/// [A-Za-z0-9_], which no driver path satisfies up to an '='.
+bool is_assignment_token(llvm::StringRef token) {
+    auto eq = token.find('=');
+    if(eq == llvm::StringRef::npos || eq == 0) {
+        return false;
+    }
+    return llvm::all_of(token.take_front(eq), [](char c) { return llvm::isAlnum(c) || c == '_'; });
+}
+
 /// Leading tokens forming a compiler-launcher prefix (ccache, distcc, ...,
 /// possibly chained), including the wrapper's own leading options. Zero when
 /// the command starts with the compiler itself.
@@ -144,7 +155,8 @@ std::size_t wrapper_prefix_len(llvm::ArrayRef<const char*> argv) {
     std::size_t i = 0;
     while(i < argv.size() && is_wrapper_name(path::filename(argv[i]))) {
         i += 1;
-        while(i < argv.size() && llvm::StringRef(argv[i]).starts_with("-")) {
+        while(i < argv.size() &&
+              (llvm::StringRef(argv[i]).starts_with("-") || is_assignment_token(argv[i]))) {
             i += 1;
         }
     }
@@ -531,13 +543,10 @@ void CompilationDatabase::expand_response_files(llvm::SmallVectorImpl<const char
         auto content = fs::read(full);
         if(!content) {
             /// Unreadable response file: the token survives verbatim (the
-            /// real compile would fail the same way), recorded as a missing
-            /// dependency so its appearance is noticed.
-            rsp_deps[full] = 0;
+            /// real compile would fail the same way).
             expanded.push_back(token);
             continue;
         }
-        rsp_deps[full] = hash_bytes(*content);
 
         /// UTF-16 response files (MSVC tooling emits them) convert first.
         llvm::StringRef text(*content);
@@ -705,7 +714,6 @@ std::optional<std::size_t> CompilationDatabase::load(llvm::StringRef path) {
     // entries before the cut still swap in) — the CDB poll's two-tick
     // settle debounce is what keeps half-written files from being read.
     std::vector<CompilationEntry> new_entries;
-    rsp_deps.clear();
 
     std::size_t index = 0;
     for(auto element: arr) {
@@ -742,6 +750,17 @@ std::optional<std::size_t> CompilationDatabase::load(llvm::StringRef path) {
 
         llvm::StringRef dir_ref(dir_sv.data(), dir_sv.size());
         llvm::StringRef file_ref(file_sv.data(), file_sv.size());
+
+        // A relative `directory` anchors to the workspace root (the
+        // set_workspace_root contract); without a root it stays relative
+        // and downstream consumers see the process working directory.
+        llvm::SmallString<256> dir_abs;
+        if(!path::is_absolute(dir_ref) && !workspace_root.empty()) {
+            dir_abs = workspace_root;
+            path::append(dir_abs, dir_ref);
+            path::remove_dots(dir_abs, /*remove_dot_dot=*/true);
+            dir_ref = dir_abs;
+        }
 
         // Skip non-C-family files (e.g. .rc, .asm, .def) that some build
         // systems emit into compile_commands.json.

--- a/src/command/command.h
+++ b/src/command/command.h
@@ -237,9 +237,8 @@ public:
     CompilationDatabase(const CompilationDatabase&) = delete;
     CompilationDatabase& operator=(const CompilationDatabase&) = delete;
 
-    /// Where probes of cwd-insensitive configs run (and the base for
-    /// resolving a relative CDB `directory`). Set before load; empty means
-    /// the process working directory.
+    /// Where probes of cwd-insensitive configs run. Set before load; empty
+    /// means the process working directory.
     void set_workspace_root(llvm::StringRef root);
 
     /// The single path-id space, shared with the whole workspace.

--- a/src/command/command.h
+++ b/src/command/command.h
@@ -389,7 +389,7 @@ private:
                                              llvm::StringRef command);
 
     /// Expand @file tokens in place, driver-mode aware (CL commands
-    /// tokenize with Windows rules), recording each file into rsp_deps.
+    /// tokenize with Windows rules).
     void expand_response_files(llvm::SmallVectorImpl<const char*>& tokens,
                                llvm::StringRef directory,
                                CompilerFamily family,
@@ -422,10 +422,6 @@ private:
     std::vector<CompilationEntry> entry_list;
 
     std::string workspace_root;
-
-    /// Response files expanded during the last load: path → content hash.
-    /// The command-domain dependency set the file tracker watches.
-    llvm::StringMap<std::uint64_t> rsp_deps;
 
     /// Derivation memos, append-only alongside the pools.
     llvm::DenseMap<std::uint32_t, std::uint64_t> entry_hashes;

--- a/src/command/command.h
+++ b/src/command/command.h
@@ -359,11 +359,16 @@ public:
 
 #ifdef CLICE_ENABLE_TEST
 
-    void add_command(llvm::StringRef directory,
-                     llvm::StringRef file,
-                     llvm::ArrayRef<const char*> arguments);
+    /// Append one command and return its entry (candidate order among a
+    /// file's accumulated entries is content-based, not insertion-based);
+    /// nullopt when normalization fails.
+    std::optional<CompilationEntry> add_command(llvm::StringRef directory,
+                                                llvm::StringRef file,
+                                                llvm::ArrayRef<const char*> arguments);
 
-    void add_command(llvm::StringRef directory, llvm::StringRef file, llvm::StringRef command);
+    std::optional<CompilationEntry> add_command(llvm::StringRef directory,
+                                                llvm::StringRef file,
+                                                llvm::StringRef command);
 
 #endif
 

--- a/src/command/command.h
+++ b/src/command/command.h
@@ -7,28 +7,162 @@
 #include <vector>
 
 #include "command/argument_parser.h"
+#include "command/search_config.h"
 #include "support/object_pool.h"
 #include "support/path_pool.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 
+namespace llvm {
+
+class StringSaver;
+
+}
+
 namespace clice {
 
+class Toolchain;
+
+enum class CompilerFamily : std::uint8_t {
+    Unknown,
+    GCC,      // Covers gcc, g++, cc, c++, and versioned/arch variants
+    Clang,    // Covers clang, clang++, and versioned variants (excluding clang-cl)
+    MSVC,     // Covers cl
+    ClangCL,  // Covers clang-cl explicitly, and clang --driver-mode=cl
+    NVCC,     // Covers nvcc
+    Intel,    // Covers icc, icpc, icx, dpcpp
+    Zig,      // Covers zig cc / zig c++ (assumed GCC/Clang compatible for query)
+};
+
+/// How an argument participates in compilation semantics. Every parsed
+/// argument is kept in the structured command with a class; renders select
+/// by class instead of re-parsing.
+enum class ArgClass : std::uint8_t {
+    /// Affects frontend semantics (language, target, macros defined by mode).
+    Semantic,
+
+    /// Per-file user content: -I, -D, -U, -include, -isystem, -iquote,
+    /// -idirafter. Excluded from toolchain probes and re-attached after.
+    UserContent,
+
+    /// Diagnostics presentation (-W*, -R*, -pedantic*, -w): affects which
+    /// warnings are emitted but never the token stream.
+    Diagnostics,
+
+    /// Pure backend/linker concerns (-g, -fPIC, -flto, ...): kept for the
+    /// Full view, skipped by compile renders and identity hashes.
+    Codegen,
+
+    /// Irrelevant to an LSP (outputs, PCH building, dependency scan, module
+    /// flags we manage ourselves): kept for the Full view only.
+    Discarded,
+
+    /// Unrecognized token, kept verbatim (identity is the spelling). In the
+    /// identity hash — dropping an option we don't understand could merge
+    /// commands that must differ — but never in compile renders; forwarded
+    /// to toolchain probes only for NVCC probe tokens.
+    Unknown,
+
+    /// The input slot: where the source file sat in the original command.
+    /// A pure position marker — it stores no path (the file is the entry's,
+    /// not the config's). Language selectors before it govern the input;
+    /// renders inject the actual file here.
+    Input,
+};
+
+struct Arg {
+    std::uint32_t opt_id = 0;
+    ArgClass cls = ArgClass::Semantic;
+
+    /// Interned verbatim token, only for ArgClass::Unknown (nullptr otherwise).
+    const char* spelling = nullptr;
+
+    /// Interned option values (paths already absolutized for include-path
+    /// options). Elements are pointer-comparable.
+    llvm::ArrayRef<const char*> values;
+
+    friend bool operator==(const Arg& lhs, const Arg& rhs) {
+        return lhs.opt_id == rhs.opt_id && lhs.cls == rhs.cls && lhs.spelling == rhs.spelling &&
+               lhs.values == rhs.values;
+    }
+};
+
+/// A driver-level compile configuration, parsed and classified once at load.
+/// Deduped via ObjectSet — identity is the ConfigID. Wrapper prefixes
+/// (ccache etc.) are entry provenance, not part of the config: `ccache
+/// clang++ X` and `clang++ X` dedupe to one config.
+struct CompileConfig {
+    /// Working directory (interned).
+    const char* directory = nullptr;
+
+    /// argv[0] as invoked (interned). Never realpath'ed: the invoked name
+    /// selects driver behavior (clang vs clang++).
+    const char* driver = nullptr;
+
+    /// Zig's subcommand token ("cc" / "c++"); nullptr for everything else.
+    const char* subcommand = nullptr;
+
+    /// From the driver filename plus an explicit --driver-mode= scan.
+    CompilerFamily family = CompilerFamily::Unknown;
+
+    /// Ordered arguments, exactly one ArgClass::Input slot among them.
+    llvm::ArrayRef<Arg> args;
+
+    friend bool operator==(const CompileConfig&, const CompileConfig&) = default;
+};
+
+enum class ConfigID : std::uint32_t {};
+
+constexpr inline ConfigID invalid_config = ConfigID(~0u);
+
+/// The language dimension of a command for one input file: the clang
+/// language name ("c++", "cuda", ...) selected by the governing selector or
+/// derived from the file extension; the raw extension itself when no table
+/// maps it. Interned — pointer-comparable.
+struct InputKind {
+    const char* value = nullptr;
+
+    friend bool operator==(const InputKind&, const InputKind&) = default;
+};
+
+/// Where the compile command for a file came from. Anything other than
+/// CDBExact means the command was guessed to some degree, which is why
+/// diagnostics produced with it may deserve a guidance note (see
+/// format_diagnostics).
+enum class CommandSource : std::uint8_t {
+    /// Direct compilation database entry for the file.
+    CDBExact,
+    /// Header compiled in the context of a host source found through the
+    /// include graph (automatic or via clice/switchContext).
+    IncludeGraph,
+    /// Reserved for command transfer heuristics (e.g. nearest CDB entry);
+    /// no producer yet.
+    Inferred,
+    /// Synthesized default command — no CDB entry and no usable host source.
+    Fallback,
+};
+
+/// A resolved command selection for one file: the final (rules-applied)
+/// config plus the language the toolchain layer probes with. For a header
+/// borrowing a host command, `input` is the host's.
+struct CommandRef {
+    std::uint32_t file = ~0u;
+    ConfigID config = invalid_config;
+    InputKind input;
+    CommandSource source = CommandSource::Fallback;
+};
+
+/// Config-rule edits applied on top of a base config (structured, no
+/// re-parse). Applied as remove first, then append; appends insert before
+/// the input slot so they always take effect for the compile.
 struct CommandOptions {
-    /// Inject our resource dir into the flags if not already present.
-    /// Enabled by default so clang tools always use matching builtin headers.
-    /// Disable in unit tests that assert exact argument counts.
-    bool inject_resource_dir = true;
-
-    /// Extra arguments to remove from the original command line.
     llvm::ArrayRef<std::string> remove;
-
-    /// Extra arguments to append to the original command line.
     llvm::ArrayRef<std::string> append;
 
     /// Per-run additions in the resolved command's own dialect (a lint
@@ -39,141 +173,47 @@ struct CommandOptions {
     /// appends land after the rule appends and win.
     llvm::ArrayRef<std::string> extra_prepend;
     llvm::ArrayRef<std::string> extra_append;
+
+    bool empty() const {
+        return remove.empty() && append.empty() && extra_prepend.empty() && extra_append.empty();
+    }
 };
 
-/// File-independent compilation flags (shareable, suitable as cache key input).
-/// Does NOT contain source file path or -main-file-name.
-struct ResolvedFlags {
-    /// The working directory of compilation.
-    llvm::StringRef directory;
-
-    /// All flags excluding source file path and -main-file-name.
-    std::vector<const char*> flags;
-
-    /// Whether flags come from toolchain query (cc1 mode).
-    /// When true, flags are cc1 frontend args (resolved clang binary + "-cc1" + ...),
-    /// NOT the original driver command. to_argv() scans for "-cc1" in flags and
-    /// inserts -main-file-name immediately after it.
-    bool is_cc1 = false;
+struct RenderOptions {
+    /// Synthesized preamble to inject as `-include <path>`, after the
+    /// command's own user-content flags so the host's -include runs first.
+    const char* preamble = nullptr;
 };
 
-/// Compilation command = resolved flags + source file identity.
-struct CompileCommand {
-    ResolvedFlags resolved;
-
-    /// Interned, pointer-stable. Must be null-terminated (required by to_argv()
-    /// and path::filename().data() which relies on the suffix being null-terminated).
-    const char* source_file = nullptr;
-
-    /// Produce full argv: flags + [-main-file-name <basename> if cc1] + source_file.
-    std::vector<const char*> to_argv() const;
-
-    /// Convenience: to_argv() converted to vector<string>.
-    std::vector<std::string> to_string_argv() const;
-};
-
-/// Shared compiler identity — driver + all semantics-affecting flags.
-/// Deduped via ObjectSet so most files share one instance. This directly
-/// serves as the toolchain cache key (no re-parsing needed at query time).
-struct CanonicalCommand {
-    /// Driver path followed by semantics-affecting flags (e.g. -std=, -target, -W*).
-    /// All pointers are interned in StringSet and pointer-stable.
-    llvm::ArrayRef<const char*> arguments;
-
-    friend bool operator==(const CanonicalCommand&, const CanonicalCommand&) = default;
-};
-
-/// Per-file compilation entry = shared canonical + per-file user-content patch.
-/// Parsed and classified once at CDB load time; no further parsing needed.
-struct CompilationInfo {
-    /// Working directory (interned in StringSet, pointer-stable).
-    const char* directory = nullptr;
-
-    /// Shared canonical command (driver + semantic flags).
-    object_ptr<CanonicalCommand> canonical = {nullptr};
-
-    /// Per-file user-content options: -I, -D, -U, -include, -isystem, -iquote,
-    /// -idirafter. Pre-rendered as flat arg list with -I paths already absolutized.
-    llvm::ArrayRef<const char*> patch;
-
-    friend bool operator==(const CompilationInfo&, const CompilationInfo&) = default;
-};
-
-/// A single entry in the compilation database, stored in a flat sorted vector.
+/// A single entry in the compilation database.
 struct CompilationEntry {
-    /// Interned path ID for the source file (from PathPool).
-    std::uint32_t file;
+    /// Path id of the source file (shared PathPool).
+    std::uint32_t file = ~0u;
 
-    /// Parsed compilation info (directory + canonical + patch).
-    object_ptr<CompilationInfo> info;
+    ConfigID config = invalid_config;
+
+    /// Wrapper prefix stripped at load (ccache, distcc, ...): display
+    /// provenance and the last tie-break of candidate ordering. Not part of
+    /// config identity.
+    llvm::ArrayRef<const char*> wrapper;
 };
 
-}  // namespace clice
+/// Render one structured argument back into argv fragments. Unknown args
+/// render as their verbatim spelling; known options render through the
+/// option table (canonical name + render style). Never called on the
+/// input slot.
+void render_arg(const Arg& arg, llvm::function_ref<void(std::string_view)> cb);
 
-namespace llvm {
+/// The option-table visibility mask of a driver family: CL families see
+/// /U-, /D-style options; the rest exclude them so Unix absolute paths
+/// are not misparsed.
+unsigned family_visibility(CompilerFamily family);
 
-template <>
-struct DenseMapInfo<clice::CanonicalCommand> {
-    using T = clice::CanonicalCommand;
+/// Owned copy of a rendered argv (worker IPC and other string-owning edges).
+std::vector<std::string> to_strings(llvm::ArrayRef<const char*> argv);
 
-    inline static T getEmptyKey() {
-        return T{
-            llvm::ArrayRef<const char*>(reinterpret_cast<const char**>(~uintptr_t(0)), size_t(0))};
-    }
-
-    inline static T getTombstoneKey() {
-        return T{llvm::ArrayRef<const char*>(reinterpret_cast<const char**>(~uintptr_t(0) - 1),
-                                             size_t(0))};
-    }
-
-    static unsigned getHashValue(const T& cmd) {
-        return llvm::hash_combine_range(cmd.arguments);
-    }
-
-    static bool isEqual(const T& lhs, const T& rhs) {
-        // Sentinels have distinct data pointers but both have size 0,
-        // and ArrayRef equality is content-based — so we must compare
-        // data pointers first to keep sentinels distinguishable.
-        if(lhs.arguments.data() == rhs.arguments.data())
-            return lhs.arguments.size() == rhs.arguments.size();
-        if(lhs.arguments.data() == getEmptyKey().arguments.data() ||
-           lhs.arguments.data() == getTombstoneKey().arguments.data() ||
-           rhs.arguments.data() == getEmptyKey().arguments.data() ||
-           rhs.arguments.data() == getTombstoneKey().arguments.data())
-            return false;
-        return lhs == rhs;
-    }
-};
-
-template <>
-struct DenseMapInfo<clice::CompilationInfo> {
-    using T = clice::CompilationInfo;
-
-    inline static T getEmptyKey() {
-        return T{llvm::DenseMapInfo<const char*>::getEmptyKey()};
-    }
-
-    inline static T getTombstoneKey() {
-        return T{llvm::DenseMapInfo<const char*>::getTombstoneKey()};
-    }
-
-    static unsigned getHashValue(const T& info) {
-        return llvm::hash_combine(info.directory,
-                                  info.canonical.ptr,
-                                  llvm::hash_combine_range(info.patch));
-    }
-
-    static bool isEqual(const T& lhs, const T& rhs) {
-        return lhs == rhs;
-    }
-};
-
-}  // namespace llvm
-
-namespace clice {
-
-/// Per-file delta of a compilation database reload. Path ids are this
-/// database's own pool ids (stable across reloads).
+/// Per-file delta of a compilation database reload. Path ids are the shared
+/// pool's ids (stable across reloads).
 struct CDBDiff {
     /// Files present only after the reload (gained their first entry).
     llvm::SmallVector<std::uint32_t> added;
@@ -196,28 +236,34 @@ public:
 
     CompilationDatabase(const CompilationDatabase&) = delete;
     CompilationDatabase& operator=(const CompilationDatabase&) = delete;
-    CompilationDatabase(CompilationDatabase&&) = default;
-    CompilationDatabase& operator=(CompilationDatabase&&) = default;
 
-public:
+    /// Where probes of cwd-insensitive configs run (and the base for
+    /// resolving a relative CDB `directory`). Set before load; empty means
+    /// the process working directory.
+    void set_workspace_root(llvm::StringRef root);
+
+    /// The single path-id space, shared with the whole workspace.
+    PathPool& paths() {
+        return pool;
+    }
+
     /// Load (or reload) the compilation database from the given file.
-    /// On success old entries are replaced, but the string pool and canonical
-    /// commands survive (path ids stay stable across reloads).
+    /// On success old entries are replaced, but the pools and configs
+    /// survive (path ids stay stable across reloads).
     ///
     /// Parsing is atomic at the top level: if the file cannot be read, is
     /// not valid JSON, or has a root that is not an array, the previously
     /// loaded entries are kept and nullopt is returned. Individual
-    /// malformed entries are still skipped as before — which means a file
-    /// truncated mid-array loads as a partial set; the poll-side settle
-    /// debounce is what guards against reading half-written files. On
-    /// success returns the number of entries loaded.
+    /// malformed entries are still skipped — which means a file truncated
+    /// mid-array loads as a partial set; the poll-side settle debounce is
+    /// what guards against reading half-written files. On success returns
+    /// the number of entries loaded.
     std::optional<std::size_t> load(llvm::StringRef path);
 
     /// Reload the database from `path` and report the per-file delta against
-    /// the previously loaded entries. Path ids in the result are this
-    /// database's own pool ids (stable across reloads).
+    /// the previously loaded entries.
     ///
-    /// Entry identity is the canonical command hash (Frontend profile), the
+    /// Entry identity is the entry hash (Frontend profile + directory), the
     /// same identity the rest of the system uses to pin a CDB entry (e.g.
     /// clice/switchContext). A change confined to codegen-only flags (-g,
     /// -fPIC, -flto, ...) is therefore not reported as `changed` — this is
@@ -229,55 +275,88 @@ public:
     /// rather than treat the failure as "no change".
     std::optional<CDBDiff> reload_and_diff(llvm::StringRef path);
 
-    /// Lookup the compile commands for a file. A file may have multiple
-    /// compilation commands (e.g. different build configurations); all are returned.
-    llvm::SmallVector<CompileCommand> lookup(llvm::StringRef file,
-                                             const CommandOptions& options = {});
+    /// All entries for a file, in deterministic candidate order (the first
+    /// is the default selection). Empty when the file has none.
+    llvm::ArrayRef<CompilationEntry> candidate_entries(std::uint32_t path_id) const;
+    llvm::ArrayRef<CompilationEntry> candidate_entries(llvm::StringRef file);
 
-    /// Resolve a path_id back to the file path string.
-    llvm::StringRef resolve_path(std::uint32_t path_id);
-
-    /// Intern a file path and return its path_id.
-    std::uint32_t intern_path(llvm::StringRef path);
-
-    /// Check if a file has an explicit entry in the compilation database
-    /// (as opposed to a synthesized default).
     bool has_entry(llvm::StringRef file);
 
-    /// All compilation entries (sorted by path_id).
-    llvm::ArrayRef<CompilationEntry> get_entries() const;
+    /// All entries, sorted by (file, candidate order).
+    llvm::ArrayRef<CompilationEntry> entries() const {
+        return entry_list;
+    }
 
-    /// Map each file's path_id to the sorted canonical command hashes of its
-    /// entries (a file may own several entries with different flags). The
-    /// entry identity reload_and_diff() diffs on and the indexer persists to
-    /// catch command changes across sessions.
-    llvm::DenseMap<std::uint32_t, llvm::SmallVector<std::string, 1>> command_hash_snapshot() const;
+    const CompileConfig& config(ConfigID id) const;
 
-    /// A group of files that share the same compilation configuration.
-    /// CDB internally deduplicates by (directory, canonical flags, user-content flags),
-    /// so each group corresponds to one unique CompilationInfo — files within a group
-    /// have identical -I, -D, -std=, --target, etc.
-    ///
-    /// This is the right granularity for SearchConfig extraction: different -I paths
-    /// need different SearchConfigs. For toolchain queries (keyed by driver +
-    /// non-user-content flags), callers should further deduplicate across groups
-    /// since many groups often share the same toolchain key.
-    struct ConfigGroup {
-        llvm::SmallVector<std::uint32_t> file_ids;
-        CompileCommand command;
-        object_ptr<CompilationInfo> info = {nullptr};
-    };
+    /// Apply config-rule edits to a base config, producing a (deduped)
+    /// result config. Structured editing on the arg sequence: remove
+    /// cancels matching args, appends insert before the input slot. NVCC
+    /// commands translate the edits into clang spellings first, the way
+    /// the base command itself was translated. Memoized per
+    /// (config, rule set).
+    ConfigID apply_rules(ConfigID id, const CommandOptions& options);
 
-    /// Return one ConfigGroup per unique CompilationInfo, each containing
-    /// a representative CompileCommand and all file path_ids that share it.
-    /// The returned CompileCommands use driver-level flags (not cc1); callers
-    /// that need cc1 args should pass them through Toolchain::resolve().
-    llvm::SmallVector<ConfigGroup> unique_configs(const CommandOptions& options = {});
+    /// The synthesized default command for a file without a CDB entry.
+    ConfigID fallback_config(llvm::StringRef file);
 
-    /// Build a fresh CompileCommand for a ConfigGroup, applying the given
-    /// options (e.g. per-config rule remove/append) to the group's own
-    /// CompilationInfo rather than reusing the representative command.
-    CompileCommand group_command(const ConfigGroup& group, const CommandOptions& options = {});
+    /// Derive the language of `file` compiled under `id`: walk the
+    /// language-selector state machine (-x applies to inputs after it,
+    /// -x none resets, /TC and /TP set globally) up to the input slot;
+    /// with no governing selector, map the file extension.
+    InputKind input_kind(ConfigID id, llvm::StringRef file);
+
+    /// The selector-forced language of the config's input, empty when the
+    /// extension decides (what input_kind() falls back to).
+    llvm::StringRef forced_language(ConfigID id) const;
+
+    /// Identity hash of a config (Frontend view + slot position + directory
+    /// + schema salt). The CDB diff identity, the index snapshot command
+    /// identity, and — computed over a rules-applied config — the pin
+    /// identity of clice/switchContext.
+    std::uint64_t entry_hash(ConfigID id);
+
+    /// entry_hash formatted as the persistent/protocol form (16 hex chars).
+    std::string entry_hash_hex(ConfigID id);
+
+    /// Map each file's path_id to the sorted entry hashes of its entries (a
+    /// file may own several entries with different flags) — the identity
+    /// reload_and_diff() diffs on and the indexer persists to catch command
+    /// changes across sessions.
+    llvm::DenseMap<std::uint32_t, llvm::SmallVector<std::string, 1>> command_hash_snapshot();
+
+    /// The entry hash of a file's default selection (its first candidate);
+    /// nullopt when the file has no entry. Persisted so an offline change
+    /// of the winning candidate is detected at startup.
+    std::optional<std::string> selected_hash(std::uint32_t path_id);
+
+    /// Render the full compile argv for a ref: resolve the config through
+    /// the toolchain (probe cached; may spawn the driver once per unique
+    /// toolchain key) and render at cc1 level; on probe failure degrade to
+    /// the driver-level render. Pointers are interned and stable for the
+    /// database's lifetime.
+    std::vector<const char*> render(const CommandRef& ref, const RenderOptions& opts = {});
+
+    /// Driver-level render only (no toolchain probe): the probe-failure
+    /// degradation path, and the base of display forms.
+    std::vector<const char*> render_driver(const CommandRef& ref, const RenderOptions& opts = {});
+
+    /// Every argument including codegen and discarded ones: the
+    /// debug/display form. No file injection.
+    std::vector<const char*> render_full(ConfigID id);
+
+    /// Pre-probe the toolchains of the given refs in parallel (deduped by
+    /// toolchain key), so later render() calls hit the cache.
+    void warm(llvm::ArrayRef<CommandRef> refs);
+
+    /// Header search configuration of a ref, extracted from the resolved
+    /// (cc1) config when the toolchain probe succeeds — memoized — else
+    /// from the driver-level config.
+    SearchConfig search_config(const CommandRef& ref);
+
+    Toolchain& toolchain() {
+        return *chain;
+    }
 
 #ifdef CLICE_ENABLE_TEST
 
@@ -290,45 +369,108 @@ public:
 #endif
 
 private:
-    CompileCommand build_command(std::uint32_t path_id,
-                                 object_ptr<CompilationInfo> info,
-                                 const CommandOptions& options);
+    friend class Toolchain;
 
-    /// Find all CompilationEntry items for a file by path_id (binary search).
-    /// Returns a sub-range of `entries`; may be empty.
-    llvm::ArrayRef<CompilationEntry> find_entries(std::uint32_t path_id) const;
+    struct NormalizeResult {
+        ConfigID config = invalid_config;
+        llvm::ArrayRef<const char*> wrapper;
+    };
 
-    /// Allocate a persistent copy of a const char* array on the bump allocator.
-    llvm::ArrayRef<const char*> persist_args(llvm::ArrayRef<const char*> args);
+    /// The normalization pipeline (§ wrapper strip → driver info → @rsp
+    /// expansion → nvcc translation → parse → classify → path normalize →
+    /// dedup). `file` is the entry's normalized path used to pick the input
+    /// slot among the command's inputs; ~0u synthesizes the slot at the end.
+    std::optional<NormalizeResult> normalize(llvm::StringRef directory,
+                                             std::uint32_t file,
+                                             llvm::ArrayRef<const char*> arguments);
 
-    /// Parse and classify a compilation command into canonical + patch.
-    object_ptr<CompilationInfo> save_compilation_info(llvm::StringRef file,
-                                                      llvm::StringRef directory,
-                                                      llvm::ArrayRef<const char*> arguments);
+    std::optional<NormalizeResult> normalize(llvm::StringRef directory,
+                                             std::uint32_t file,
+                                             llvm::StringRef command);
 
-    object_ptr<CompilationInfo> save_compilation_info(llvm::StringRef file,
-                                                      llvm::StringRef directory,
-                                                      llvm::StringRef command);
+    /// Expand @file tokens in place, driver-mode aware (CL commands
+    /// tokenize with Windows rules), recording each file into rsp_deps.
+    void expand_response_files(llvm::SmallVectorImpl<const char*>& tokens,
+                               llvm::StringRef directory,
+                               CompilerFamily family,
+                               llvm::StringSaver& saver,
+                               unsigned depth = 0);
 
-    /// The memory pool which holds all elements of compilation database.
-    /// Heap-allocated so its address is stable across moves.
+    ConfigID save_config(CompileConfig config, llvm::ArrayRef<Arg> local_args);
+
+    llvm::ArrayRef<const char*> persist_strings(llvm::ArrayRef<const char*> values);
+
+    /// Append the Frontend-view fragments of `id` (the hash input) to out.
+    void render_identity(ConfigID id, std::string& out);
+
+    /// Stable candidate order within one file: entry hash first, then the
+    /// full render + wrapper bytes for hash-equal entries. Content-based —
+    /// generator reordering must not change the default selection.
+    void sort_entries(std::vector<CompilationEntry>& list);
+
     std::unique_ptr<llvm::BumpPtrAllocator> allocator = std::make_unique<llvm::BumpPtrAllocator>();
 
     /// Keep all strings (arguments, directories, etc.).
     StringSet strings{allocator.get()};
 
-    /// Shared canonical commands — most files share one instance.
-    ObjectSet<CanonicalCommand> canonicals{allocator.get()};
+    ObjectSet<CompileConfig> configs{allocator.get()};
 
-    /// Per-file compilation infos (canonical + patch + directory).
-    ObjectSet<CompilationInfo> infos{allocator.get()};
+    /// The workspace's single path-id space (Workspace::path_pool aliases it).
+    PathPool pool;
 
-    /// Intern pool for file paths → compact uint32_t IDs.
-    PathPool paths;
+    /// All compilation entries, sorted by (file, candidate order).
+    std::vector<CompilationEntry> entry_list;
 
-    /// All compilation entries, sorted by file path_id.
-    /// Multiple entries for the same file are adjacent.
-    std::vector<CompilationEntry> entries;
+    std::string workspace_root;
+
+    /// Response files expanded during the last load: path → content hash.
+    /// The command-domain dependency set the file tracker watches.
+    llvm::StringMap<std::uint64_t> rsp_deps;
+
+    /// Derivation memos, append-only alongside the pools.
+    llvm::DenseMap<std::uint32_t, std::uint64_t> entry_hashes;
+    llvm::StringMap<std::uint32_t> rule_set_ids;
+    llvm::DenseMap<std::pair<std::uint32_t, std::uint32_t>, std::uint32_t> rule_applied;
+    llvm::StringMap<ConfigID> fallback_configs;
+    llvm::DenseMap<std::uint32_t, SearchConfig> search_configs;
+
+    std::unique_ptr<Toolchain> chain;
 };
 
 }  // namespace clice
+
+namespace llvm {
+
+template <>
+struct DenseMapInfo<clice::CompileConfig> {
+    using T = clice::CompileConfig;
+
+    inline static T getEmptyKey() {
+        return T{.directory = DenseMapInfo<const char*>::getEmptyKey()};
+    }
+
+    inline static T getTombstoneKey() {
+        return T{.directory = DenseMapInfo<const char*>::getTombstoneKey()};
+    }
+
+    static unsigned getHashValue(const T& config) {
+        llvm::hash_code hash = llvm::hash_combine(config.directory,
+                                                  config.driver,
+                                                  config.subcommand,
+                                                  static_cast<unsigned>(config.family));
+        for(auto& arg: config.args) {
+            hash = llvm::hash_combine(hash,
+                                      arg.opt_id,
+                                      static_cast<unsigned>(arg.cls),
+                                      arg.spelling,
+                                      llvm::hash_combine_range(arg.values));
+        }
+        return hash;
+    }
+
+    static bool isEqual(const T& lhs, const T& rhs) {
+        return lhs == rhs;
+    }
+};
+
+}  // namespace llvm

--- a/src/command/nvcc.cpp
+++ b/src/command/nvcc.cpp
@@ -527,7 +527,8 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
     return result;
 }
 
-void collapse_gpu_arch_flags(std::vector<const char*>& flags) {
+std::optional<llvm::SmallVector<std::size_t>>
+    collapse_gpu_archs(llvm::ArrayRef<std::pair<ArchFlagKind, llvm::StringRef>> sequence) {
     struct ActiveArch {
         std::size_t index;
         llvm::SmallVector<ArchToken, 1> tokens;
@@ -538,17 +539,17 @@ void collapse_gpu_arch_flags(std::vector<const char*>& flags) {
     /// --no-offload-arch=all erases everything before it, a specific
     /// --no-offload-arch=sm_NN only its matches.
     llvm::SmallVector<ActiveArch> active;
-    for(std::size_t i = 0; i < flags.size(); i += 1) {
-        llvm::StringRef arg = flags[i];
-        if(arg == "--no-offload-arch=all") {
-            active.clear();
-            continue;
-        }
-        if(arg.starts_with("--no-offload-arch=")) {
+    for(std::size_t i = 0; i < sequence.size(); i += 1) {
+        auto [kind, value] = sequence[i];
+        if(kind == ArchFlagKind::NoOffloadArch) {
+            if(value == "all") {
+                active.clear();
+                continue;
+            }
             llvm::SmallVector<ArchToken> removed;
-            collect_archs(arg.substr(arg.find('=') + 1), removed);
+            collect_archs(value, removed);
             if(removed.empty())
-                return;
+                return std::nullopt;
             auto matched = [&](const ArchToken& token) {
                 return std::ranges::contains(removed, token);
             };
@@ -560,32 +561,32 @@ void collapse_gpu_arch_flags(std::vector<const char*>& flags) {
                 /// A flag naming both erased and surviving architectures
                 /// cannot drop at flag granularity — bail like below.
                 if(!std::ranges::all_of(entry.tokens, matched))
-                    return;
+                    return std::nullopt;
                 active.erase(active.begin() + j);
             }
             continue;
         }
-        if(!arg.starts_with("--cuda-gpu-arch=") && !arg.starts_with("--offload-arch="))
-            continue;
 
         llvm::SmallVector<ArchToken> tokens;
-        collect_archs(arg.substr(arg.find('=') + 1), tokens);
+        collect_archs(value, tokens);
         /// A value without an sm_NN/compute_NN token (a raw clang spelling
         /// like --offload-arch=native in a config append) is outside the
         /// ranking — leave the whole command to clang's own semantics.
         if(tokens.empty())
-            return;
+            return std::nullopt;
         auto rank = arch_rank(*std::ranges::max_element(tokens, {}, arch_rank));
         active.push_back({.index = i, .tokens = std::move(tokens), .rank = rank});
     }
     if(active.size() < 2)
-        return;
+        return llvm::SmallVector<std::size_t>{};
 
     auto best = std::ranges::max(active, {}, &ActiveArch::rank).rank;
-    for(auto& arch: active | std::views::reverse) {
+    llvm::SmallVector<std::size_t> dropped;
+    for(auto& arch: active) {
         if(arch.rank < best)
-            flags.erase(flags.begin() + arch.index);
+            dropped.push_back(arch.index);
     }
+    return dropped;
 }
 
 std::expected<NVCCDryrunInfo, std::string> parse_nvcc_dryrun(llvm::StringRef output) {

--- a/src/command/nvcc.h
+++ b/src/command/nvcc.h
@@ -1,10 +1,14 @@
 #pragma once
 
+#include <cstdint>
 #include <expected>
+#include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace clice {
@@ -67,7 +71,20 @@ std::vector<std::string> translate_nvcc_command(llvm::ArrayRef<const char*> argu
 /// accumulated, clang would build one device job per architecture in
 /// ascending order and the toolchain query reads the first — pinning the
 /// oldest architecture instead of the newest.
-void collapse_gpu_arch_flags(std::vector<const char*>& flags);
+///
+/// The caller hands the arch-flag values in command order (the value of
+/// each --cuda-gpu-arch= / --offload-arch= / --no-offload-arch= argument)
+/// and erases the returned indices. nullopt means a value outside the
+/// ranking (a raw clang spelling like --offload-arch=native) was present —
+/// leave the whole command to clang's own semantics.
+enum class ArchFlagKind : std::uint8_t {
+    GpuArch,
+    OffloadArch,
+    NoOffloadArch,
+};
+
+std::optional<llvm::SmallVector<std::size_t>>
+    collapse_gpu_archs(llvm::ArrayRef<std::pair<ArchFlagKind, llvm::StringRef>> sequence);
 
 /// What one `nvcc --dryrun` run reveals about the toolchain. The dryrun
 /// prints the whole compilation pipeline (host preprocess, cudafe++, device

--- a/src/command/search_config.cpp
+++ b/src/command/search_config.cpp
@@ -1,6 +1,7 @@
 #include "command/search_config.h"
 
 #include "command/argument_parser.h"
+#include "command/command.h"
 
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringSet.h"
@@ -11,8 +12,7 @@ namespace clice {
 
 using namespace option;
 
-SearchConfig extract_search_config(llvm::ArrayRef<const char*> arguments,
-                                   llvm::StringRef directory) {
+SearchConfig extract_search_config(llvm::ArrayRef<Arg> args, llvm::StringRef directory) {
     // Replicate clang's InitHeaderSearch::Realize layout:
     //   Quoted (-iquote) → Angled (-I) → System (-isystem, -internal-isystem, etc.)
     // Then deduplicate across [Angled..end) matching clang's RemoveDuplicates.
@@ -34,39 +34,35 @@ SearchConfig extract_search_config(llvm::ArrayRef<const char*> arguments,
     // Track -iprefix state for -iwithprefix/-iwithprefixbefore.
     std::string prefix;
 
-    std::vector<std::string> parse_args(arguments.begin() + 1, arguments.end());
-    auto options = kota::option::ParseOptions{.dash_dash_parsing = true,
-                                              .visibility = default_visibility(arguments[0])};
-    for(auto& result: option::table().parse(parse_args, options)) {
-        if(!result.has_value()) {
+    for(auto& arg: args) {
+        if(arg.values.empty()) {
             continue;
         }
-        auto& arg = *result;
-        auto vals = arg.values;
-        switch(arg.id) {
+        std::string_view value = arg.values[0];
+        switch(arg.opt_id) {
             // Quoted group (clang: frontend::Quoted)
-            case OPT_iquote: quoted.push_back({make_absolute(vals[0])}); break;
+            case OPT_iquote: quoted.push_back({make_absolute(value)}); break;
 
             // Angled group (clang: frontend::Angled)
-            case OPT_I: angled.push_back({make_absolute(vals[0])}); break;
+            case OPT_I: angled.push_back({make_absolute(value)}); break;
 
             // System group (clang: frontend::System / ExternCSystem)
             case OPT_isystem:
             case OPT_internal_isystem:
-            case OPT_internal_externc_isystem: system.push_back({make_absolute(vals[0])}); break;
+            case OPT_internal_externc_isystem: system.push_back({make_absolute(value)}); break;
 
             // Prefix options: must be processed in argument order.
-            case OPT_iprefix: prefix = vals[0]; break;
+            case OPT_iprefix: prefix = value; break;
             case OPT_iwithprefix:
                 // clang maps to After group.
-                after.push_back({make_absolute(prefix + std::string(vals[0]))});
+                after.push_back({make_absolute(prefix + std::string(value))});
                 break;
             case OPT_iwithprefixbefore:
                 // clang maps to Angled group.
-                angled.push_back({make_absolute(prefix + std::string(vals[0]))});
+                angled.push_back({make_absolute(prefix + std::string(value))});
                 break;
 
-            case OPT_idirafter: after.push_back({make_absolute(vals[0])}); break;
+            case OPT_idirafter: after.push_back({make_absolute(value)}); break;
 
             // TODO: -cxx-isystem (clang: frontend::CXXSystem, C++-only system dirs)
             // TODO: -iwithsysroot (prepends sysroot to path, then adds to System)

--- a/src/command/search_config.h
+++ b/src/command/search_config.h
@@ -8,6 +8,8 @@
 
 namespace clice {
 
+struct Arg;
+
 struct SearchDir {
     std::string path;
 };
@@ -32,16 +34,10 @@ struct SearchConfig {
     unsigned after_start_idx = 0;
 };
 
-/// Extract header search configuration from compilation arguments.
-///
-/// Parses user-level flags (-I, -isystem, -iquote) and cc1-level flags
-/// (-internal-isystem, -internal-externc-isystem) using the clang argument
-/// parser. Relative paths are resolved against the given working directory
-/// and normalized with remove_dots().
-///
-/// This is intentionally a standalone function (not tied to CompilationDatabase)
-/// so it can be tested and improved independently to match clang's behavior.
-SearchConfig extract_search_config(llvm::ArrayRef<const char*> arguments,
-                                   llvm::StringRef directory);
+/// Extract header search configuration from a structured command (driver
+/// level or resolved cc1 level — the internal cc1 spellings are covered).
+/// Relative paths are resolved against the given working directory and
+/// normalized with remove_dots().
+SearchConfig extract_search_config(llvm::ArrayRef<Arg> args, llvm::StringRef directory);
 
 }  // namespace clice

--- a/src/command/toolchain.cpp
+++ b/src/command/toolchain.cpp
@@ -309,12 +309,22 @@ kota::task<std::expected<std::vector<std::string>, std::string>> query_one(const
     /// would lose the context needed for the driver to behave correctly (and break caching).
     llvm::SmallString<128> resolved_path;
     if(!path::is_absolute(driver)) {
-        /// If the path is not absolute path like g++, find it in the env vars.
-        auto program = llvm::sys::findProgramByName(driver);
-        if(!program)
-            co_return std::unexpected(std::format("Cannot find driver: {}", driver.str()));
-        resolved_path = *program;
-        driver = resolved_path.c_str();
+        if(driver.contains('/') || driver.contains('\\')) {
+            /// Relative with a separator (`./toolchain/clang++`): relative
+            /// to the probe working directory, never a PATH lookup.
+            if(!spec.cwd.empty()) {
+                resolved_path = spec.cwd;
+                path::append(resolved_path, driver);
+                driver = resolved_path.c_str();
+            }
+        } else {
+            /// A bare name like g++: find it in the env vars.
+            auto program = llvm::sys::findProgramByName(driver);
+            if(!program)
+                co_return std::unexpected(std::format("Cannot find driver: {}", driver.str()));
+            resolved_path = *program;
+            driver = resolved_path.c_str();
+        }
     }
 
     if(!fs::exists(driver) || !fs::can_execute(driver))
@@ -692,7 +702,10 @@ bool is_path_taking_option(unsigned id) {
         case option::OPT_gcc_install_dir_EQ:
         case option::OPT_cuda_path_EQ:
         case option::OPT_resource_dir:
-        case option::OPT_resource_dir_EQ: return true;
+        case option::OPT_resource_dir_EQ:
+        case option::OPT_config:
+        case option::OPT_config_system_dir_EQ:
+        case option::OPT_config_user_dir_EQ: return true;
         default: return false;
     }
 }

--- a/src/command/toolchain.cpp
+++ b/src/command/toolchain.cpp
@@ -268,11 +268,24 @@ kota::task<std::expected<GCCToolchainFlags, std::string>> query_gcc_flags(std::s
 /// suffix when the kind is a known language, the raw extension itself
 /// otherwise (the driver ends up exactly as confused as it would be by the
 /// real file — the probe fails the same way the real compile would).
+/// The probe working directory, empty when the wanted one does not exist
+/// (a stale CDB directory, or a foreign-platform path): probing from the
+/// process cwd degrades the answer instead of failing the spawn.
+std::string probe_cwd(llvm::StringRef wanted) {
+    if(wanted.empty() || !fs::is_directory(wanted)) {
+        return {};
+    }
+    return wanted.str();
+}
+
 std::string temp_suffix_for(llvm::StringRef kind) {
     namespace types = clang::driver::types;
     auto type = types::lookupTypeForTypeSpecifier(kind.str().c_str());
     if(type != types::TY_INVALID) {
-        return types::getTypeTempSuffix(type);
+        /// TY_Nothing ("-x none") has no temp suffix.
+        if(const char* suffix = types::getTypeTempSuffix(type)) {
+            return suffix;
+        }
     }
     return kind.str();
 }
@@ -785,7 +798,10 @@ CompilerFamily Toolchain::driver_family(llvm::StringRef driver) {
         return CompilerFamily::Unknown;
     };
 
-    auto name = llvm::sys::path::filename(driver);
+    /// Windows resolves executable names case-insensitively, and CDBs record
+    /// spellings like CL.exe or Clang-Cl.EXE — match lowercased.
+    std::string lowered = llvm::sys::path::filename(driver).lower();
+    llvm::StringRef name = lowered;
     if(auto f = try_get(name); f != CompilerFamily::Unknown)
         return f;
 
@@ -815,9 +831,20 @@ std::expected<std::vector<std::string>, std::string>
     spec.slot = spec.argv.size();
     spec.family = driver_family(arguments[0]);
 
+    /// The kind is a clang language name ("cuda", "c++"), the convention
+    /// every consumer speaks (`spec.kind == "cuda"`, temp_suffix_for's -x
+    /// table). `.cuh` is absent from clang's extension table; a raw
+    /// extension only survives when there is no mapping at all.
     auto ext = path::extension(file);
     ext.consume_front(".");
-    spec.kind = ext == "cuh" ? "cuda" : ext.str();
+    auto lang = clang::driver::types::lookupTypeForExtension(ext);
+    if(ext == "cuh") {
+        spec.kind = "cuda";
+    } else if(lang != clang::driver::types::TY_INVALID) {
+        spec.kind = clang::driver::types::getTypeName(lang);
+    } else {
+        spec.kind = ext.str();
+    }
     for(std::size_t i = 0; i + 1 < arguments.size(); i += 1) {
         if(llvm::StringRef(arguments[i]) == "-x")
             spec.kind = arguments[i + 1];
@@ -1119,7 +1146,7 @@ std::expected<Toolchain::ResolvedID, std::string> Toolchain::resolve(ConfigID id
         spec.slot = argv.slot;
         spec.kind = input.value;
         spec.family = config.family;
-        spec.cwd = pk.cwd_sensitive ? config.directory : db.workspace_root;
+        spec.cwd = probe_cwd(pk.cwd_sensitive ? config.directory : db.workspace_root);
 
         std::expected<std::vector<std::string>, std::string> result;
         kota::event_loop loop;
@@ -1180,7 +1207,7 @@ void Toolchain::warm(llvm::ArrayRef<std::pair<ConfigID, InputKind>> pairs) {
         spec.slot = argv.slot;
         spec.kind = input.value;
         spec.family = config.family;
-        spec.cwd = pk.cwd_sensitive ? config.directory : db.workspace_root;
+        spec.cwd = probe_cwd(pk.cwd_sensitive ? config.directory : db.workspace_root);
         pending.push_back({std::move(pk.key), std::move(spec)});
     }
 

--- a/src/command/toolchain.cpp
+++ b/src/command/toolchain.cpp
@@ -1,14 +1,15 @@
 #include "command/toolchain.h"
 
+#include <cstdlib>
 #include <expected>
 #include <format>
 #include <optional>
 #include <ranges>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "command/argument_parser.h"
-#include "command/command.h"
 #include "command/nvcc.h"
 #include "support/filesystem.h"
 #include "support/logging.h"
@@ -26,6 +27,7 @@
 #include "clang/Driver/Driver.h"
 #include "clang/Driver/Tool.h"
 #include "clang/Driver/ToolChain.h"
+#include "clang/Driver/Types.h"
 
 #ifndef _WIN32
 #include <unistd.h>
@@ -73,10 +75,13 @@ kota::task<std::string> drain_pipe(kota::pipe p) {
 }
 
 kota::task<std::expected<std::string, std::string>>
-    execute_async(std::vector<std::string> arguments, bool capture_stdout = false) {
+    execute_async(std::vector<std::string> arguments,
+                  bool capture_stdout = false,
+                  std::string cwd = {}) {
     kota::process::options opts;
     opts.file = arguments[0];
     opts.args = std::move(arguments);
+    opts.cwd = std::move(cwd);
 #ifndef _WIN32
     opts.env = process_env();
 #endif
@@ -232,12 +237,13 @@ struct GCCToolchainFlags {
     std::string install_dir;
 };
 
-kota::task<std::expected<GCCToolchainFlags, std::string>> query_gcc_flags(std::string driver) {
-    auto target = co_await execute_async({driver, "-dumpmachine"}, true);
+kota::task<std::expected<GCCToolchainFlags, std::string>> query_gcc_flags(std::string driver,
+                                                                          std::string cwd) {
+    auto target = co_await execute_async({driver, "-dumpmachine"}, true, cwd);
     if(!target)
         co_return std::unexpected(std::move(target.error()));
 
-    auto search_dirs = co_await execute_async({driver, "-print-search-dirs"}, true);
+    auto search_dirs = co_await execute_async({driver, "-print-search-dirs"}, true, cwd);
     if(!search_dirs)
         co_return std::unexpected(std::move(search_dirs.error()));
 
@@ -258,12 +264,42 @@ kota::task<std::expected<GCCToolchainFlags, std::string>> query_gcc_flags(std::s
     };
 }
 
-kota::task<std::expected<std::vector<std::string>, std::string>>
-    query_one(llvm::ArrayRef<const char*> arguments, llvm::StringRef file) {
-    if(arguments.empty())
+/// The temp-file extension a probe input uses for `kind`: clang's own
+/// suffix when the kind is a known language, the raw extension itself
+/// otherwise (the driver ends up exactly as confused as it would be by the
+/// real file — the probe fails the same way the real compile would).
+std::string temp_suffix_for(llvm::StringRef kind) {
+    namespace types = clang::driver::types;
+    auto type = types::lookupTypeForTypeSpecifier(kind.str().c_str());
+    if(type != types::TY_INVALID) {
+        return types::getTypeTempSuffix(type);
+    }
+    return kind.str();
+}
+
+/// One probe request: everything query_one() needs, self-contained so warm()
+/// can move it into a coroutine frame.
+struct QuerySpec {
+    /// Driver (+ subcommand) + non-user-content flags; no input among them.
+    std::vector<const char*> argv;
+
+    /// Where the temp input is inserted (an index into argv).
+    std::size_t slot = 0;
+
+    /// The input language (InputKind value).
+    std::string kind;
+
+    CompilerFamily family = CompilerFamily::Unknown;
+
+    /// Probe working directory; empty inherits the process cwd.
+    std::string cwd;
+};
+
+kota::task<std::expected<std::vector<std::string>, std::string>> query_one(const QuerySpec& spec) {
+    if(spec.argv.empty())
         co_return std::unexpected(std::string("Empty arguments"));
 
-    llvm::StringRef driver = arguments[0];
+    llvm::StringRef driver = spec.argv[0];
 
     /// Note: The name used to invoke the compiler driver affects its behavior.
     /// For example, `/usr/bin/clang++` is often a symbolic link to
@@ -285,38 +321,34 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
         co_return std::unexpected(
             std::format("Driver {} not found or not executable", driver.str()));
 
-    llvm::SmallVector<const char*, 256> args;
-    args.emplace_back(driver.data());
-    args.append(arguments.begin() + 1, arguments.end());
+    auto suffix = temp_suffix_for(spec.kind);
 
-    auto ext = path::extension(file);
-    ext.consume_front(".");
-
-    /// Create a file with same suffix of input file, because the input file may
-    /// not exist in the disk.
+    /// Create a file with the kind's suffix, because the real input may not
+    /// exist on disk (and a borrowed header must probe as the host's
+    /// language, not as its own extension).
     llvm::SmallString<64> src_path;
-    if(auto e = fs::createTemporaryFile("query-toolchain", ext, src_path))
+    if(auto e = fs::createTemporaryFile("query-toolchain", suffix, src_path))
         co_return std::unexpected(std::format("Failed to create temp file: {}", e.message()));
     auto cleanup = llvm::make_scope_exit([&] {
         if(auto e = fs::remove(src_path))
             LOG_ERROR("Fail to remove temporary file: {}", e);
     });
 
-    /// .cuh is not a clang-known extension: without a language override the
-    /// probe counts as linker input and the driver builds no compile job.
-    if(ext == "cuh" && !ranges::any_of(args, [](llvm::StringRef arg) { return arg == "-x"; }))
-        args.append({"-x", "cuda"});
+    /// The input sits at the slot recorded from the structured command:
+    /// selectors after the slot must not govern it (`clang foo.c -x c++`
+    /// compiles foo.c as C).
+    llvm::SmallVector<const char*, 256> args;
+    args.emplace_back(driver.data());
+    args.append(spec.argv.begin() + 1, spec.argv.end());
+    args.insert(args.begin() + spec.slot, src_path.c_str());
 
-    args.emplace_back(src_path.c_str());
-
-    auto family = Toolchain::driver_family(driver);
     std::vector<std::string> cc1_args;
 
-    switch(family) {
+    switch(spec.family) {
         // Query g++ or mingw toolchain info. We detect the target and corresponding
         // gcc toolchain install path as default behavior.
         case CompilerFamily::GCC: {
-            auto gcc = co_await query_gcc_flags(driver.str());
+            auto gcc = co_await query_gcc_flags(driver.str(), spec.cwd);
             if(!gcc)
                 co_return std::unexpected(std::move(gcc.error()));
 
@@ -346,7 +378,7 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
             std::vector<std::string> exec_args;
             auto remaining = llvm::ArrayRef(args);
 
-            if(family == CompilerFamily::Zig) {
+            if(spec.family == CompilerFamily::Zig) {
                 /// zig cc or zig c++ consumes two arguments.
                 exec_args.emplace_back(remaining[0]);
                 exec_args.emplace_back(remaining[1]);
@@ -360,7 +392,7 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
             for(auto arg: remaining)
                 exec_args.emplace_back(arg);
 
-            auto content = co_await execute_async(std::move(exec_args));
+            auto content = co_await execute_async(std::move(exec_args), false, spec.cwd);
             if(!content)
                 co_return std::unexpected(std::move(content.error()));
 
@@ -399,17 +431,9 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
             /// nvcc only offloads CUDA-language inputs; a host-language
             /// entry (`nvcc -c foo.cpp`, or an explicit `-x c++`) compiles
             /// in a single host step. The dryrun probe follows the effective
-            /// language so it reports the pipeline the real file gets —
-            /// only a .cu input makes nvcc print the offload pipeline (the
-            /// shared probe keeps the real file's extension).
-            bool cuda_input = ext == "cu" || ext == "cuh";
-            for(std::size_t i = 0; i + 1 < args.size(); i += 1) {
-                if(llvm::StringRef(args[i]) == "-x")
-                    cuda_input = llvm::StringRef(args[i + 1]) == "cuda";
-            }
-            llvm::StringRef probe_ext = "cu";
-            if(!cuda_input)
-                probe_ext = (ext == "cu" || ext == "cuh") ? "cpp" : ext;
+            /// language so it reports the pipeline the real file gets.
+            bool cuda_input = spec.kind == "cuda";
+            llvm::StringRef probe_ext = cuda_input ? "cu" : llvm::StringRef(suffix);
 
             llvm::SmallString<64> nvcc_probe;
             if(auto e = fs::createTemporaryFile("query-toolchain", probe_ext, nvcc_probe))
@@ -429,7 +453,7 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
                     dryrun_args.push_back(arg.str());
             }
 
-            auto dryrun = co_await execute_async(std::move(dryrun_args));
+            auto dryrun = co_await execute_async(std::move(dryrun_args), false, spec.cwd);
             if(!dryrun)
                 co_return std::unexpected(std::move(dryrun.error()));
 
@@ -470,7 +494,7 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
 
             switch(Toolchain::driver_family(host)) {
                 case CompilerFamily::GCC: {
-                    auto gcc = co_await query_gcc_flags(host);
+                    auto gcc = co_await query_gcc_flags(host, spec.cwd);
                     if(!gcc)
                         co_return std::unexpected(std::move(gcc.error()));
                     cuda_args.push_back(std::move(gcc->target));
@@ -513,9 +537,11 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
                 /// the forwarded flags.
                 std::optional<bool> selected_host;
                 for(llvm::StringRef arg: args) {
-                    if(arg == "--cuda-host-only")
+                    /// The structured render spells aliases unaliased
+                    /// (--offload-*-only); accept both forms.
+                    if(arg == "--cuda-host-only" || arg == "--offload-host-only")
                         selected_host = true;
-                    else if(arg == "--cuda-device-only")
+                    else if(arg == "--cuda-device-only" || arg == "--offload-device-only")
                         selected_host = false;
                 }
                 bool host_view = selected_host.value_or(false);
@@ -574,7 +600,7 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
         default: {
             /// TODO: intel compilers need further exploration.
             LOG_ERROR("Unsupported compiler family: {}, driver is {}",
-                      kota::meta::enum_name(family),
+                      kota::meta::enum_name(spec.family),
                       driver);
 
             auto queried = query_driver(args, [&](const char* d, llvm::ArrayRef<const char*> cc1) {
@@ -590,7 +616,7 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
     }
 
     // Strip the temporary probe file so results contain no input path
-    // (to_argv() appends the real source file at the end). Also strip module
+    // (render appends the real source file at the end). Also strip module
     // output flags the driver derives from the probe input (clang >= 22 emits
     // -fmodules-reduced-bmi -fmodule-output=<probe>.pcm for module units);
     // they reference the deleted temp file and clice manages outputs itself.
@@ -602,24 +628,125 @@ kota::task<std::expected<std::vector<std::string>, std::string>>
     });
 
     if(cc1_args.empty())
-        co_return std::unexpected(std::format("No cc1 args produced for {}", file.str()));
+        co_return std::unexpected(std::format("No cc1 args produced for kind {}", spec.kind));
 
     co_return cc1_args;
 }
 
-struct PendingQuery {
-    std::string key;
-    std::vector<const char*> query_args;
-    /// Points to interned, pointer-stable storage in CompileCommand::source_file;
-    /// valid for the whole warm() call.
-    llvm::StringRef file;
-};
+/// Every component of a search-path-style environment value is absolute and
+/// non-empty (an empty component means the cwd).
+bool components_all_absolute(llvm::StringRef value, char separator) {
+    llvm::SmallVector<llvm::StringRef, 16> parts;
+    value.split(parts, separator, -1, /*KeepEmpty=*/true);
+    return ranges::all_of(parts, [](llvm::StringRef part) {
+        return !part.empty() && path::is_absolute(part);
+    });
+}
+
+/// Whether every search-path environment variable the compiler consults is
+/// absolute — one of the cwd-insensitivity conditions. Computed once: the
+/// server never mutates its environment.
+bool search_env_all_absolute() {
+    const static bool result = [] {
+#ifdef _WIN32
+        for(const char* name: {"INCLUDE", "LIB", "PATH"}) {
+            if(const char* value = std::getenv(name)) {
+                if(!components_all_absolute(value, ';'))
+                    return false;
+            }
+        }
+#else
+        for(const char* name: {"PATH",
+                               "CPATH",
+                               "C_INCLUDE_PATH",
+                               "CPLUS_INCLUDE_PATH",
+                               "OBJC_INCLUDE_PATH",
+                               "COMPILER_PATH",
+                               "LIBRARY_PATH"}) {
+            if(const char* value = std::getenv(name)) {
+                if(!components_all_absolute(value, ':'))
+                    return false;
+            }
+        }
+        /// A single path, not a list.
+        if(const char* prefix = std::getenv("GCC_EXEC_PREFIX")) {
+            if(!path::is_absolute(prefix))
+                return false;
+        }
+#endif
+        return true;
+    }();
+    return result;
+}
+
+/// Options whose value names a filesystem location the driver resolves
+/// itself — a relative value ties the probe to the working directory even
+/// when it carries no separator (--sysroot=sdk).
+bool is_path_taking_option(unsigned id) {
+    switch(id) {
+        case option::OPT__sysroot_EQ:
+        case option::OPT__sysroot:
+        case option::OPT_isysroot:
+        case option::OPT_B:
+        case option::OPT_gcc_toolchain:
+        case option::OPT_gcc_install_dir_EQ:
+        case option::OPT_cuda_path_EQ:
+        case option::OPT_resource_dir:
+        case option::OPT_resource_dir_EQ: return true;
+        default: return false;
+    }
+}
+
+bool relative_suspect(llvm::StringRef value) {
+    if(value.empty() || path::is_absolute(value)) {
+        return false;
+    }
+    return value.contains('/') || value.contains('\\') || value.starts_with(".");
+}
+
+/// Whether the command targets windows-gnu: an explicit target flag wins
+/// (the last one, matching the driver's getLastArg); otherwise a
+/// target-prefixed driver name (llvm-mingw installs
+/// `x86_64-w64-mingw32-clang++`-style wrappers that derive the target
+/// implicitly) decides. Parsing resolved aliases, so the legacy `-target`
+/// and `=` spellings arrive as the canonical id.
+bool uses_windows_gnu_target(const CompileConfig& config) {
+    std::optional<bool> from_flags;
+    for(auto& arg: config.args) {
+        if(arg.opt_id == option::OPT_target && arg.values.size() == 1) {
+            from_flags =
+                llvm::Triple(llvm::Triple::normalize(arg.values[0])).isWindowsGNUEnvironment();
+        }
+    }
+    if(from_flags)
+        return *from_flags;
+
+    auto parsed = clang::driver::ToolChain::getTargetAndModeFromProgramName(config.driver);
+    return !parsed.TargetPrefix.empty() &&
+           llvm::Triple(llvm::Triple::normalize(parsed.TargetPrefix)).isWindowsGNUEnvironment();
+}
+
+/// Which args feed the probe (and its key): everything that may change
+/// driver behavior. User-content never does; unknown tokens only as NVCC
+/// probe tokens (junk from the CDB must not fail an otherwise good probe).
+bool in_probe_view(const Arg& arg, CompilerFamily family) {
+    switch(arg.cls) {
+        case ArgClass::Semantic:
+        case ArgClass::Diagnostics: return true;
+        case ArgClass::Unknown:
+            return family == CompilerFamily::NVCC && is_nvcc_probe_flag(arg.spelling);
+        case ArgClass::UserContent:
+        case ArgClass::Codegen:
+        case ArgClass::Discarded:
+        case ArgClass::Input: return false;
+    }
+    std::unreachable();
+}
 
 }  // namespace
 
-Toolchain::Toolchain(std::chrono::steady_clock::duration failed_retry) :
-    allocator(std::make_unique<llvm::BumpPtrAllocator>()), strings(allocator.get()),
-    failed_retry(failed_retry) {}
+Toolchain::Toolchain(CompilationDatabase& db, std::chrono::steady_clock::duration failed_retry) :
+    db(db), failed_retry(failed_retry) {}
 
 Toolchain::~Toolchain() = default;
 
@@ -666,114 +793,302 @@ CompilerFamily Toolchain::driver_family(llvm::StringRef driver) {
 
 std::expected<std::vector<std::string>, std::string>
     Toolchain::query(llvm::ArrayRef<const char*> arguments, llvm::StringRef file) {
+    if(arguments.empty()) {
+        return std::unexpected(std::string("Empty arguments"));
+    }
+
+    QuerySpec spec;
+    spec.argv.assign(arguments.begin(), arguments.end());
+    spec.slot = spec.argv.size();
+    spec.family = driver_family(arguments[0]);
+
+    auto ext = path::extension(file);
+    ext.consume_front(".");
+    spec.kind = ext == "cuh" ? "cuda" : ext.str();
+    for(std::size_t i = 0; i + 1 < arguments.size(); i += 1) {
+        if(llvm::StringRef(arguments[i]) == "-x")
+            spec.kind = arguments[i + 1];
+    }
+
     std::expected<std::vector<std::string>, std::string> result;
     kota::event_loop loop;
     auto task = [&]() -> kota::task<> {
-        result = co_await query_one(arguments, file);
+        result = co_await query_one(spec);
     };
     loop.schedule(task());
     loop.run();
     return result;
 }
 
-/// Whether the command targets windows-gnu: an explicit target flag wins
-/// (the last one, matching the driver's getLastArg); otherwise a
-/// target-prefixed driver name (llvm-mingw installs
-/// `x86_64-w64-mingw32-clang++`-style wrappers that derive the target
-/// implicitly) decides. Parsing resolves aliases, so the legacy `-target`
-/// and `=` spellings arrive as the canonical ids.
-static bool uses_windows_gnu_target(llvm::ArrayRef<const char*> arguments) {
-    std::vector<std::string> parse_args(arguments.begin() + 1, arguments.end());
-    auto options = kota::option::ParseOptions{.dash_dash_parsing = true,
-                                              .visibility = default_visibility(arguments[0])};
-    std::optional<bool> from_flags;
-    for(auto& result: option::table().parse(parse_args, options)) {
-        if(!result.has_value())
+Toolchain::ProbeKey Toolchain::probe_key(ConfigID id, InputKind input) {
+    auto& config = db.config(id);
+    ProbeKey out;
+
+    /// cwd-insensitivity is an exemption earned by four orthogonal
+    /// conditions; any miss keys (and runs) the probe in the entry
+    /// directory. The conditions are independent — an absolute driver does
+    /// not excuse a relative CPATH.
+    bool known_family = config.family != CompilerFamily::Unknown;
+
+    llvm::StringRef driver = config.driver;
+#ifdef _WIN32
+    /// Windows resolves bare names against the current directory first
+    /// (plus PATHEXT variants) — never exempt.
+    bool driver_cwd_free = path::is_absolute(driver);
+#else
+    /// A bare name resolves through PATH alone (whose components the env
+    /// condition below covers); a relative path is cwd-bound.
+    bool driver_cwd_free =
+        path::is_absolute(driver) || (!driver.contains('/') && !driver.contains('\\'));
+#endif
+
+    bool values_clean = true;
+    for(auto& arg: config.args) {
+        if(!in_probe_view(arg, config.family)) {
             continue;
-        auto& arg = *result;
-        if(arg.id == option::OPT_target && arg.values.size() == 1) {
-            from_flags =
-                llvm::Triple(llvm::Triple::normalize(arg.values[0])).isWindowsGNUEnvironment();
+        }
+        if(arg.opt_id == option::OPT_UNKNOWN) {
+            llvm::StringRef spelling(arg.spelling);
+            if(relative_suspect(spelling.substr(spelling.find('=') + 1))) {
+                values_clean = false;
+            }
+            continue;
+        }
+        for(llvm::StringRef value: arg.values) {
+            if(relative_suspect(value) ||
+               (is_path_taking_option(arg.opt_id) && !path::is_absolute(value))) {
+                values_clean = false;
+            }
         }
     }
-    if(from_flags)
-        return *from_flags;
 
-    auto parsed = clang::driver::ToolChain::getTargetAndModeFromProgramName(arguments[0]);
-    return !parsed.TargetPrefix.empty() &&
-           llvm::Triple(llvm::Triple::normalize(parsed.TargetPrefix)).isWindowsGNUEnvironment();
-}
+    out.cwd_sensitive =
+        !(known_family && driver_cwd_free && search_env_all_absolute() && values_clean);
 
-Toolchain::ToolchainExtract Toolchain::extract_flags(llvm::StringRef file,
-                                                     llvm::ArrayRef<const char*> arguments) {
-    ToolchainExtract result;
+    auto append = [&](llvm::StringRef fragment) {
+        out.key += fragment;
+        out.key += '\0';
+    };
 
-    // LLVM-MinGW's resource headers and libc++ are a matched installation.
-    // Let its driver derive those implicit paths instead of forcing clice's
-    // resource tree: the injected -resource-dir is dropped from the query
-    // (and the key) below. Other targets keep it so the embedded frontend
-    // and builtin headers stay version-matched.
-    result.preserve_external_resource = uses_windows_gnu_target(arguments);
+    append(config.driver);
+    if(config.subcommand) {
+        append(config.subcommand);
+    }
+    append(input.value ? input.value : "");
+    if(out.cwd_sensitive) {
+        append(config.directory);
+    }
 
-    result.key += arguments[0];
-    result.key += '\0';
-
-    result.key += path::extension(file);
-    result.key += '\0';
-
-    result.query_args.push_back(arguments[0]);
-
-    std::vector<std::string> parse_args(arguments.begin() + 1, arguments.end());
-    auto options = kota::option::ParseOptions{.dash_dash_parsing = true,
-                                              .visibility = default_visibility(arguments[0])};
-    for(auto& r: option::table().parse(parse_args, options)) {
-        if(!r.has_value())
+    for(auto& arg: config.args) {
+        if(!in_probe_view(arg, config.family)) {
             continue;
-        auto& arg = *r;
-
-        // User-content options (-I, -D, ...) don't affect the toolchain query;
-        // resolve() re-appends them from the original command. Everything else
-        // may change driver behavior, so it goes into both key and query.
-        if(is_user_content_option(arg.id))
-            continue;
-
-        if(result.preserve_external_resource && arg.id == option::OPT_resource_dir &&
-           arg.values.size() == 1 && llvm::StringRef(arg.values[0]) == resource_dir())
-            continue;
-
-        result.key += std::to_string(arg.id);
-        result.key += '\0';
+        }
+        out.key += std::to_string(arg.opt_id);
+        out.key += '\0';
         /// All unknown options share one id; their identity is the spelling
         /// (the NVCC translation carries `-ccbin=<path>` through here, and
         /// two commands differing only in host compiler must not collide).
-        if(arg.id == option::OPT_UNKNOWN) {
-            result.key += arg.spelling;
-            result.key += '\0';
+        if(arg.opt_id == option::OPT_UNKNOWN) {
+            append(arg.spelling);
         }
-        for(auto value: arg.values) {
-            result.key += value;
-            result.key += '\0';
+        for(const char* value: arg.values) {
+            append(value);
         }
-
-        auto cb = [&](std::string_view s) {
-            result.query_args.push_back(strings.save(s).data());
-        };
-        option::table().render(arg, cb);
     }
 
-    return result;
+    return out;
 }
 
-std::expected<void, std::string> Toolchain::resolve(CompileCommand& cmd) {
-    if(cmd.resolved.flags.empty())
-        return std::unexpected("empty flags");
+Toolchain::ProbeArgv Toolchain::probe_argv(const CompileConfig& config, bool cwd_sensitive) {
+    ProbeArgv out;
+    out.argv.push_back(config.driver);
+    if(config.subcommand) {
+        out.argv.push_back(config.subcommand);
+    }
 
-    auto [key, query_args, preserve_external_resource] =
-        extract_flags(cmd.source_file, cmd.resolved.flags);
+    auto emit = [&](std::string_view fragment) {
+        out.argv.push_back(db.strings.save(fragment).data());
+    };
 
-    auto it = cache.find(key);
-    if(it == cache.end()) {
-        if(auto failed_it = failed.find(key); failed_it != failed.end()) {
+    out.slot = out.argv.size();
+    for(auto& arg: config.args) {
+        if(arg.cls == ArgClass::Input) {
+            out.slot = out.argv.size();
+            continue;
+        }
+        if(!in_probe_view(arg, config.family)) {
+            continue;
+        }
+        if(arg.opt_id == option::OPT_UNKNOWN) {
+            out.argv.push_back(arg.spelling);
+            continue;
+        }
+
+        /// A cwd-sensitive probe cannot rely on the working directory for
+        /// the in-process driver branches — relative path values absolutize
+        /// here (the subprocess branches also run with cwd = directory,
+        /// which resolves everything else, e.g. driver config files).
+        if(cwd_sensitive) {
+            Arg adjusted = arg;
+            llvm::SmallVector<const char*, 2> values;
+            bool changed = false;
+            for(llvm::StringRef value: arg.values) {
+                bool pathy =
+                    relative_suspect(value) || (is_path_taking_option(arg.opt_id) &&
+                                                !path::is_absolute(value) && !value.empty());
+                if(pathy) {
+                    values.push_back(db.strings.save(path::join(config.directory, value)).data());
+                    changed = true;
+                } else {
+                    values.push_back(value.data());
+                }
+            }
+            if(changed) {
+                adjusted.values = values;
+                render_arg(adjusted, emit);
+                continue;
+            }
+        }
+
+        render_arg(arg, emit);
+    }
+
+    return out;
+}
+
+Toolchain::ResolvedID Toolchain::synthesize(ConfigID id, llvm::ArrayRef<const char*> tokens) {
+    auto& config = db.config(id);
+
+    Resolved resolved;
+    resolved.driver = tokens[0];
+    tokens = tokens.drop_front();
+
+    resolved.is_cc1 = ranges::contains(tokens, llvm::StringRef("-cc1"), [](const char* token) {
+        return llvm::StringRef(token);
+    });
+
+    std::vector<std::string> parse_args;
+    parse_args.reserve(tokens.size());
+    for(llvm::StringRef token: tokens) {
+        if(token != "-cc1") {
+            parse_args.push_back(token.str());
+        }
+    }
+
+    auto parse_options = kota::option::ParseOptions{
+        .visibility = resolved.is_cc1 ? static_cast<unsigned>(option::CC1Option)
+                                      : family_visibility(config.family)};
+
+    struct Staged {
+        std::uint32_t opt_id;
+        ArgClass cls;
+        const char* spelling = nullptr;
+        llvm::SmallVector<const char*, 2> values;
+    };
+
+    std::vector<Staged> staged;
+    staged.reserve(parse_args.size());
+    for(auto& parsed: option::table().parse(parse_args, parse_options)) {
+        if(!parsed.has_value()) {
+            auto index = parsed.error().index;
+            if(index < parse_args.size()) {
+                staged.push_back({.opt_id = option::OPT_UNKNOWN,
+                                  .cls = ArgClass::Unknown,
+                                  .spelling = db.strings.save(parse_args[index]).data()});
+            }
+            continue;
+        }
+        auto& arg = *parsed;
+        /// -main-file-name is per-input identity; render re-injects it with
+        /// the real file's basename. A leftover input token cannot reach
+        /// the compile argv (the probe input was erased by exact match; a
+        /// canonicalized echo would slip through here).
+        if(arg.id == option::OPT_main_file_name || arg.id == option::OPT_INPUT) {
+            continue;
+        }
+        if(arg.id == option::OPT_UNKNOWN) {
+            if(arg.index < parse_args.size()) {
+                staged.push_back({.opt_id = option::OPT_UNKNOWN,
+                                  .cls = ArgClass::Unknown,
+                                  .spelling = db.strings.save(parse_args[arg.index]).data()});
+            }
+            continue;
+        }
+        Staged local;
+        local.opt_id = arg.id;
+        for(auto value: arg.values) {
+            local.values.push_back(db.strings.save(value).data());
+        }
+        local.cls = is_user_content_option(arg.id) ? ArgClass::UserContent : ArgClass::Semantic;
+        staged.push_back(std::move(local));
+    }
+
+    /// Preserve a real LLVM-MinGW resource tree (a matched installation:
+    /// resource headers and libc++ belong together). Other external
+    /// resource paths are replaced with ours to keep the embedded frontend
+    /// and builtin headers version-matched.
+    if(!resource_dir().empty()) {
+        llvm::StringRef old_resource_dir;
+        for(auto& arg: staged) {
+            if((arg.opt_id == option::OPT_resource_dir ||
+                arg.opt_id == option::OPT_resource_dir_EQ) &&
+               arg.values.size() == 1) {
+                old_resource_dir = arg.values[0];
+                break;
+            }
+        }
+        bool keep_external =
+            uses_windows_gnu_target(config) && llvm::sys::fs::is_directory(old_resource_dir);
+        if(!old_resource_dir.empty() && old_resource_dir != resource_dir() && !keep_external) {
+            for(auto& arg: staged) {
+                for(auto& value: arg.values) {
+                    llvm::StringRef s(value);
+                    if(s.starts_with(old_resource_dir)) {
+                        auto replaced =
+                            resource_dir().str() + s.substr(old_resource_dir.size()).str();
+                        value = db.strings.save(replaced).data();
+                    }
+                }
+            }
+        }
+    }
+
+    /// Re-attach the config's own user-content flags (-I, -D, -include, ...)
+    /// — they never fed the probe. Structured already; no re-parse.
+    for(auto& arg: config.args) {
+        if(arg.cls == ArgClass::UserContent) {
+            Staged local;
+            local.opt_id = arg.opt_id;
+            local.cls = ArgClass::UserContent;
+            local.spelling = arg.spelling;
+            local.values.assign(arg.values.begin(), arg.values.end());
+            staged.push_back(std::move(local));
+        }
+    }
+
+    auto* args = db.allocator->Allocate<Arg>(staged.size());
+    for(std::size_t i = 0; i < staged.size(); i += 1) {
+        args[i] = Arg{.opt_id = staged[i].opt_id,
+                      .cls = staged[i].cls,
+                      .spelling = staged[i].spelling,
+                      .values = db.persist_strings(staged[i].values)};
+    }
+    resolved.args = {args, staged.size()};
+
+    resolved_configs.push_back(resolved);
+    return static_cast<ResolvedID>(resolved_configs.size() - 1);
+}
+
+std::expected<Toolchain::ResolvedID, std::string> Toolchain::resolve(ConfigID id, InputKind input) {
+    auto synth_key = std::pair{static_cast<std::uint32_t>(id), input.value};
+    if(auto it = synth_cache.find(synth_key); it != synth_cache.end()) {
+        return it->second;
+    }
+
+    auto pk = probe_key(id, input);
+    auto it = probes.find(pk.key);
+    if(it == probes.end()) {
+        if(auto failed_it = failed.find(pk.key); failed_it != failed.end()) {
             if(std::chrono::steady_clock::now() - failed_it->second.second < failed_retry) {
                 return std::unexpected(failed_it->second.first);
             }
@@ -782,119 +1097,83 @@ std::expected<void, std::string> Toolchain::resolve(CompileCommand& cmd) {
             failed.erase(failed_it);
         }
 
-        LOG_WARN("Toolchain cache miss: file={}", cmd.source_file);
+        auto& config = db.config(id);
+        LOG_WARN("Toolchain probe miss: driver={} kind={}", config.driver, input.value);
 
-        auto result = query(query_args, cmd.source_file);
+        QuerySpec spec;
+        auto argv = probe_argv(config, pk.cwd_sensitive);
+        spec.argv = std::move(argv.argv);
+        spec.slot = argv.slot;
+        spec.kind = input.value;
+        spec.family = config.family;
+        spec.cwd = pk.cwd_sensitive ? config.directory : db.workspace_root;
+
+        std::expected<std::vector<std::string>, std::string> result;
+        kota::event_loop loop;
+        auto task = [&]() -> kota::task<> {
+            result = co_await query_one(spec);
+        };
+        loop.schedule(task());
+        loop.run();
+
         if(!result) {
-            failed.try_emplace(key, std::pair{result.error(), std::chrono::steady_clock::now()});
+            failed.try_emplace(pk.key, std::pair{result.error(), std::chrono::steady_clock::now()});
             return std::unexpected(std::move(result.error()));
         }
 
-        std::vector<const char*> saved;
+        llvm::SmallVector<const char*, 64> saved;
         saved.reserve(result->size());
-        for(auto& s: *result)
-            saved.push_back(strings.save(s).data());
-        it = cache.try_emplace(std::move(key), std::move(saved)).first;
+        for(auto& token: *result) {
+            saved.push_back(db.strings.save(token).data());
+        }
+        it = probes.try_emplace(pk.key, std::move(saved)).first;
     }
 
-    auto cached = llvm::ArrayRef(it->second);
-    std::vector<const char*> new_flags(cached.begin(), cached.end());
-
-    // Preserve a real LLVM-MinGW resource tree. Other external resource paths
-    // are replaced with ours to keep the embedded frontend and builtin headers
-    // version-matched.
-    if(!resource_dir().empty()) {
-        llvm::StringRef old_resource_dir;
-        for(std::size_t i = 0; i + 1 < new_flags.size(); ++i) {
-            if(new_flags[i] == llvm::StringRef("-resource-dir")) {
-                old_resource_dir = new_flags[i + 1];
-                break;
-            }
-        }
-        bool keep_external =
-            preserve_external_resource && llvm::sys::fs::is_directory(old_resource_dir);
-        if(!old_resource_dir.empty() && old_resource_dir != resource_dir() && !keep_external) {
-            for(auto& arg: new_flags) {
-                llvm::StringRef s(arg);
-                if(s.starts_with(old_resource_dir)) {
-                    auto replaced = resource_dir().str() + s.substr(old_resource_dir.size()).str();
-                    arg = strings.save(replaced).data();
-                }
-            }
-        }
-    }
-
-    // Extract user-content flags from original command and append to cc1 result.
-    std::vector<std::string> resolve_parse_args(cmd.resolved.flags.begin() + 1,
-                                                cmd.resolved.flags.end());
-    auto resolve_options =
-        kota::option::ParseOptions{.dash_dash_parsing = true,
-                                   .visibility = default_visibility(cmd.resolved.flags[0])};
-    for(auto& r: option::table().parse(resolve_parse_args, resolve_options)) {
-        if(!r.has_value())
-            continue;
-        auto& arg = *r;
-        if(is_user_content_option(arg.id)) {
-            auto cb = [&](std::string_view s) {
-                new_flags.push_back(strings.save(s).data());
-            };
-            option::table().render(arg, cb);
-        }
-    }
-
-    // Strip -main-file-name and its value (to_argv() will re-inject with correct basename).
-    std::vector<const char*> cleaned;
-    cleaned.reserve(new_flags.size());
-    for(std::size_t i = 0; i < new_flags.size(); ++i) {
-        if(new_flags[i] == llvm::StringRef("-main-file-name") && i + 1 < new_flags.size()) {
-            ++i;
-            continue;
-        }
-        cleaned.push_back(new_flags[i]);
-    }
-
-    cmd.resolved.flags = std::move(cleaned);
-    cmd.resolved.is_cc1 = ranges::contains(cmd.resolved.flags, llvm::StringRef("-cc1"));
-    return {};
+    auto resolved_id = synthesize(id, it->second);
+    synth_cache.try_emplace(synth_key, resolved_id);
+    return resolved_id;
 }
 
-void Toolchain::resolve_or_warn(CompileCommand& cmd) {
-    if(auto result = resolve(cmd); !result) {
-        LOG_WARN("Toolchain resolve failed for {}: {}", cmd.source_file, result.error());
-    }
-}
+void Toolchain::warm(llvm::ArrayRef<std::pair<ConfigID, InputKind>> pairs) {
+    struct Pending {
+        std::string key;
+        QuerySpec spec;
+    };
 
-bool Toolchain::has_cache() const {
-    return !cache.empty();
-}
-
-void Toolchain::warm(llvm::ArrayRef<CompileCommand> commands) {
     llvm::StringMap<bool> seen;
-    std::vector<PendingQuery> pending;
+    std::vector<Pending> pending;
 
-    for(auto& cmd: commands) {
-        if(cmd.resolved.flags.empty())
+    for(auto& [id, input]: pairs) {
+        auto pk = probe_key(id, input);
+        if(probes.contains(pk.key)) {
             continue;
-
-        auto extract = extract_flags(cmd.source_file, cmd.resolved.flags);
-        auto& key = extract.key;
-        if(cache.count(key))
-            continue;
-        if(auto failed_it = failed.find(key); failed_it != failed.end()) {
+        }
+        if(auto failed_it = failed.find(pk.key); failed_it != failed.end()) {
             // Same expiry as resolve(): a cooled-down failure retries
             // through this warm instead of being skipped forever.
-            if(std::chrono::steady_clock::now() - failed_it->second.second < failed_retry)
+            if(std::chrono::steady_clock::now() - failed_it->second.second < failed_retry) {
                 continue;
+            }
             failed.erase(failed_it);
         }
-        if(!seen.try_emplace(key, true).second)
+        if(!seen.try_emplace(pk.key, true).second) {
             continue;
+        }
 
-        pending.push_back({std::move(key), std::move(extract.query_args), cmd.source_file});
+        auto& config = db.config(id);
+        auto argv = probe_argv(config, pk.cwd_sensitive);
+        QuerySpec spec;
+        spec.argv = std::move(argv.argv);
+        spec.slot = argv.slot;
+        spec.kind = input.value;
+        spec.family = config.family;
+        spec.cwd = pk.cwd_sensitive ? config.directory : db.workspace_root;
+        pending.push_back({std::move(pk.key), std::move(spec)});
     }
 
-    if(pending.empty())
+    if(pending.empty()) {
         return;
+    }
 
     auto total = pending.size();
     LOG_INFO("Warming toolchain cache: {} unique queries", total);
@@ -908,9 +1187,9 @@ void Toolchain::warm(llvm::ArrayRef<CompileCommand> commands) {
 
     // The query is moved into the coroutine frame as a parameter, so the
     // argument references stay valid for the coroutine's whole lifetime.
-    auto make_task = [](PendingQuery q) -> kota::task<QueryOutcome> {
-        auto result = co_await query_one(q.query_args, q.file);
-        co_return QueryOutcome{std::move(q.key), std::move(result)};
+    auto make_task = [](Pending p) -> kota::task<QueryOutcome> {
+        auto result = co_await query_one(p.spec);
+        co_return QueryOutcome{std::move(p.key), std::move(result)};
     };
 
     kota::small_vector<QueryOutcome> outcomes;
@@ -919,8 +1198,9 @@ void Toolchain::warm(llvm::ArrayRef<CompileCommand> commands) {
     auto run = [&]() -> kota::task<> {
         std::vector<kota::task<QueryOutcome>> tasks;
         tasks.reserve(pending.size());
-        for(auto& q: pending)
-            tasks.push_back(make_task(std::move(q)));
+        for(auto& p: pending) {
+            tasks.push_back(make_task(std::move(p)));
+        }
 
         outcomes = co_await kota::when_all(std::move(tasks));
     };
@@ -937,11 +1217,12 @@ void Toolchain::warm(llvm::ArrayRef<CompileCommand> commands) {
             continue;
         }
 
-        std::vector<const char*> saved;
+        llvm::SmallVector<const char*, 64> saved;
         saved.reserve(o.result->size());
-        for(auto& arg: *o.result)
-            saved.push_back(strings.save(arg).data());
-        cache.try_emplace(std::move(o.key), std::move(saved));
+        for(auto& token: *o.result) {
+            saved.push_back(db.strings.save(token).data());
+        }
+        probes.try_emplace(std::move(o.key), std::move(saved));
         succeeded += 1;
     }
 

--- a/src/command/toolchain.h
+++ b/src/command/toolchain.h
@@ -3,86 +3,101 @@
 #include <chrono>
 #include <cstdint>
 #include <expected>
-#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "support/object_pool.h"
+#include "command/command.h"
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/Allocator.h"
 
 namespace clice {
 
-struct CompileCommand;
-
-enum class CompilerFamily : std::uint8_t {
-    Unknown,
-    GCC,      // Covers gcc, g++, cc, c++, and versioned/arch variants
-    Clang,    // Covers clang, clang++, and versioned variants (excluding clang-cl)
-    MSVC,     // Covers cl
-    ClangCL,  // Covers clang-cl explicitly
-    NVCC,     // Covers nvcc
-    Intel,    // Covers icc, icpc, icx, dpcpp
-    Zig,      // Covers zig cc / zig c++ (assumed GCC/Clang compatible for query)
-};
-
-/// Patches raw CDB commands into clang-acceptable cc1 arguments by querying
-/// the compiler driver. Results are cached by (driver, file extension,
-/// non-user-content flags); user-content flags (-I, -D, ...) don't affect
-/// the query and are re-appended from the original command after resolution.
+/// Resolves driver-level configs into full cc1-level configurations by
+/// probing the compiler driver, in two layers:
+///
+///   - Probe layer: keyed by (driver, input language, non-user-content
+///     args, and — only for cwd-sensitive configs — the directory). One
+///     driver spawn per unique key; results and failures (with a retry
+///     cooldown) are cached. User-content flags (-I, -D, ...) never affect
+///     the probe and are re-attached at synthesis.
+///
+///   - Synthesis layer: keyed by (config, input). Probe output parsed once
+///     into structured args, the config's own user-content re-attached,
+///     external resource dirs replaced with ours (except a matched
+///     LLVM-MinGW installation, which keeps its own tree).
 class Toolchain {
 public:
+    using ResolvedID = std::uint32_t;
+
+    /// A synthesized full compile configuration, self-contained: rendering
+    /// it needs no trip back to the source config.
+    struct Resolved {
+        /// The compiler binary the probe resolved.
+        const char* driver = nullptr;
+
+        /// Frontend-level args (cc1): render as `driver -cc1 <args>`.
+        /// False for driver-level results (cl mode).
+        bool is_cc1 = false;
+
+        llvm::ArrayRef<Arg> args;
+    };
+
     /// `failed_retry` bounds the negative cache: a failed key is retried
     /// once the cooldown passes (cf. CrashBudget), so a transient driver
     /// failure — an upgrade replacing the binary mid-stat, a full tmpfs —
     /// cannot poison the key for the rest of the session.
-    explicit Toolchain(std::chrono::steady_clock::duration failed_retry = std::chrono::seconds(30));
+    explicit Toolchain(CompilationDatabase& db,
+                       std::chrono::steady_clock::duration failed_retry = std::chrono::seconds(30));
     ~Toolchain();
 
-    Toolchain(Toolchain&&) = default;
-    Toolchain& operator=(Toolchain&&) = default;
+    /// Resolve a config for one input language. Blocks on a driver spawn on
+    /// probe miss; hits are lookups.
+    std::expected<ResolvedID, std::string> resolve(ConfigID id, InputKind input);
 
-    /// Batch pre-warm: deduplicate commands and query unique toolchains in
-    /// parallel internally. Blocks until all queries complete.
-    void warm(llvm::ArrayRef<CompileCommand> commands);
+    const Resolved& resolved(ResolvedID id) const {
+        return resolved_configs[id];
+    }
 
-    /// Resolve a driver-level command to cc1 level by querying the toolchain.
-    /// Modifies the command in-place.
-    [[nodiscard]] std::expected<void, std::string> resolve(CompileCommand& cmd);
+    /// Pre-probe in parallel, deduplicated by probe key. Blocks until all
+    /// unique probes complete.
+    void warm(llvm::ArrayRef<std::pair<ConfigID, InputKind>> pairs);
 
-    /// Like resolve(), but logs a warning on failure instead of returning it.
-    void resolve_or_warn(CompileCommand& cmd);
-
-    /// Single synchronous toolchain query. Returns cc1 arguments as owned strings.
-    /// `file` is used for temp file extension detection (optional if -x is set).
-    /// Unlike resolve(), this is uncached and forwards `arguments` as-is; prefer
-    /// resolve() for CDB commands so results are cached and per-file user-content
-    /// flags are re-appended.
-    static std::expected<std::vector<std::string>, std::string>
-        query(llvm::ArrayRef<const char*> arguments, llvm::StringRef file = {});
-
-    bool has_cache() const;
+    bool has_cache() const {
+        return !probes.empty();
+    }
 
     static CompilerFamily driver_family(llvm::StringRef driver);
 
+    /// Single synchronous toolchain query on a raw driver argv (no input
+    /// file among the arguments; a temp input with `file`'s extension is
+    /// appended). Uncached — prefer resolve() for CDB configs.
+    static std::expected<std::vector<std::string>, std::string>
+        query(llvm::ArrayRef<const char*> arguments, llvm::StringRef file = {});
+
 #ifdef CLICE_ENABLE_TEST
 
-    /// Compute the cache key for the given file and driver-level arguments.
-    std::string cache_key(llvm::StringRef file, llvm::ArrayRef<const char*> arguments) {
-        return extract_flags(file, arguments).key;
+    std::string probe_key_for(ConfigID id, InputKind input) {
+        return probe_key(id, input).key;
     }
 
-    /// Number of cached toolchain query results.
-    std::size_t cache_size() const {
-        return cache.size();
+    void set_failed_retry(std::chrono::steady_clock::duration retry) {
+        failed_retry = retry;
     }
 
-    /// Number of negatively cached (failed) toolchain queries.
-    std::size_t failed_size() const {
+    bool probe_cwd_sensitive_for(ConfigID id) {
+        return probe_key(id, {}).cwd_sensitive;
+    }
+
+    std::size_t probe_count() const {
+        return probes.size();
+    }
+
+    std::size_t failed_count() const {
         return failed.size();
     }
 
@@ -93,28 +108,43 @@ public:
 #endif
 
 private:
-    struct ToolchainExtract {
+    struct ProbeKey {
         std::string key;
-        std::vector<const char*> query_args;
-
-        /// The command targets windows-gnu (LLVM-MinGW): the injected
-        /// -resource-dir was dropped from the query, and resolve() keeps
-        /// an existing external resource tree instead of replacing it.
-        bool preserve_external_resource = false;
+        bool cwd_sensitive = false;
     };
 
-    ToolchainExtract extract_flags(llvm::StringRef file, llvm::ArrayRef<const char*> arguments);
+    ProbeKey probe_key(ConfigID id, InputKind input);
 
-    std::unique_ptr<llvm::BumpPtrAllocator> allocator;
-    StringSet strings;
-    llvm::StringMap<std::vector<const char*>> cache;
+    /// The probe argv: driver (+ subcommand) + non-user-content args, with
+    /// the input slot position recorded for the temp-file insertion.
+    /// Relative path-suspect values of cwd-sensitive configs absolutize
+    /// against the directory (the in-process driver cannot change cwd).
+    struct ProbeArgv {
+        std::vector<const char*> argv;
+        std::size_t slot = 0;
+    };
+
+    ProbeArgv probe_argv(const CompileConfig& config, bool cwd_sensitive);
+
+    /// Parse raw probe output into a Resolved entry for `id`, re-attaching
+    /// the config's user-content args and replacing external resource dirs.
+    ResolvedID synthesize(ConfigID id, llvm::ArrayRef<const char*> tokens);
+
+    CompilationDatabase& db;
+
+    /// Probe layer: key → raw probe output tokens (interned).
+    llvm::StringMap<llvm::SmallVector<const char*, 64>> probes;
 
     /// Negative cache: keys whose query failed, mapped to the error message
     /// and when it was recorded. Avoids re-spawning the same failing driver
     /// probe for every file that shares the key (see clangd's
-    /// SystemIncludeExtractor for precedent); expires after `failed_retry`
-    /// so a transient failure is not cached for the session's lifetime.
+    /// SystemIncludeExtractor for precedent); expires after `failed_retry`.
     llvm::StringMap<std::pair<std::string, std::chrono::steady_clock::time_point>> failed;
+
+    /// Synthesis layer: (config, input language) → resolved entry.
+    llvm::DenseMap<std::pair<std::uint32_t, const char*>, ResolvedID> synth_cache;
+
+    std::vector<Resolved> resolved_configs;
 
     std::chrono::steady_clock::duration failed_retry;
 };

--- a/src/compile/compilation.cpp
+++ b/src/compile/compilation.cpp
@@ -6,6 +6,7 @@
 #include "compile/diagnostic.h"
 #include "compile/implement.h"
 #include "semantic/decls.h"
+#include "support/filesystem.h"
 #include "support/logging.h"
 
 #include "kota/ipc/lsp/position.h"
@@ -86,10 +87,16 @@ std::unique_ptr<clang::CompilerInvocation>
 
     /// The entry's compilation directory governs relative paths in the
     /// compile (inputs, -include, header search), the same way clang's
-    /// -working-directory does — which wins when the command carries one.
-    auto& fs_opts = invocation->getFileSystemOpts();
-    if(fs_opts.WorkingDir.empty() && !params.directory.empty()) {
-        fs_opts.WorkingDir = params.directory;
+    /// -working-directory does. An explicit -working-directory wins, but
+    /// its own relative value resolves from the compile's directory, like
+    /// the real driver run from there.
+    if(!params.directory.empty()) {
+        auto& working_dir = invocation->getFileSystemOpts().WorkingDir;
+        if(working_dir.empty()) {
+            working_dir = params.directory;
+        } else if(!path::is_absolute(working_dir)) {
+            working_dir = path::join(params.directory, working_dir);
+        }
     }
 
     auto& pp_opts = invocation->getPreprocessorOpts();

--- a/src/compile/compilation.cpp
+++ b/src/compile/compilation.cpp
@@ -84,6 +84,14 @@ std::unique_ptr<clang::CompilerInvocation>
         }
     }
 
+    /// The entry's compilation directory governs relative paths in the
+    /// compile (inputs, -include, header search), the same way clang's
+    /// -working-directory does — which wins when the command carries one.
+    auto& fs_opts = invocation->getFileSystemOpts();
+    if(fs_opts.WorkingDir.empty() && !params.directory.empty()) {
+        fs_opts.WorkingDir = params.directory;
+    }
+
     auto& pp_opts = invocation->getPreprocessorOpts();
 
     // CompilerInstance does not deterministically clear RetainRemappedFileBuffers,

--- a/src/driver/inspect.cc
+++ b/src/driver/inspect.cc
@@ -429,8 +429,7 @@ std::optional<FileCommand> file_command(FileEntry& entry,
                                         const std::string& file,
                                         llvm::ArrayRef<std::string> flags,
                                         llvm::StringRef flags_directory,
-                                        CompilationDatabase* database,
-                                        Toolchain& toolchain) {
+                                        CompilationDatabase* database) {
     namespace types = clang::driver::types;
     auto type = file_type(file);
     bool is_header = is_header_type(type);
@@ -482,8 +481,8 @@ std::optional<FileCommand> file_command(FileEntry& entry,
     llvm::StringRef donor;
     if(is_header && database != nullptr && !database->has_entry(file)) {
         std::pair<int, std::size_t> best{-1, 0};
-        for(auto& candidate: database->get_entries()) {
-            llvm::StringRef donor_path = database->resolve_path(candidate.file);
+        for(auto& candidate: database->entries()) {
+            llvm::StringRef donor_path = database->paths().resolve(candidate.file);
             auto donor_ext = path::extension(donor_path);
             auto donor_type = donor_ext.empty()
                                   ? types::TY_INVALID
@@ -502,27 +501,24 @@ std::optional<FileCommand> file_command(FileEntry& entry,
         }
     }
 
-    // lookup() synthesizes a default command for unknown files, so an
-    // explicit entry check decides between the CDB and our fallback.
     if(database != nullptr && database->has_entry(file)) {
-        auto commands = database->lookup(file);
-        auto& cdb_command = commands.front();
-        toolchain.resolve_or_warn(cdb_command);
-        for(const char* arg: cdb_command.to_argv()) {
-            command.arguments.emplace_back(arg);
-        }
-        command.directory = cdb_command.resolved.directory.str();
+        auto& cdb_entry = database->candidate_entries(file).front();
+        CommandRef ref{cdb_entry.file,
+                       cdb_entry.config,
+                       database->input_kind(cdb_entry.config, file),
+                       CommandSource::CDBExact};
+        command.arguments = to_strings(database->render(ref));
+        command.directory = database->config(cdb_entry.config).directory;
     } else if(!donor.empty()) {
-        auto commands = database->lookup(donor);
-        auto& cdb_command = commands.front();
-        toolchain.resolve_or_warn(cdb_command);
-        // The donor's resolved flags (including its -x language) apply to
-        // the header itself; to_argv() re-derives -main-file-name from it.
-        cdb_command.source_file = file.c_str();
-        for(const char* arg: cdb_command.to_argv()) {
-            command.arguments.emplace_back(arg);
-        }
-        command.directory = cdb_command.resolved.directory.str();
+        auto& cdb_entry = database->candidate_entries(donor).front();
+        // The donor's language applies to the header itself — it compiles
+        // as a fragment of that TU's world, not by its own extension.
+        CommandRef ref{database->paths().intern(file),
+                       cdb_entry.config,
+                       database->input_kind(cdb_entry.config, donor),
+                       CommandSource::IncludeGraph};
+        command.arguments = to_strings(database->render(ref));
+        command.directory = database->config(cdb_entry.config).directory;
     } else {
         // No CDB entry for this file: query the toolchain with default
         // flags. Uncached, but this path only runs for files outside any
@@ -827,7 +823,6 @@ int run_inspect(const InspectOptions& opts) {
         return &it->second;
     };
 
-    Toolchain toolchain;
     llvm::StringRef unit_directory =
         is_dir ? llvm::StringRef(abs_path) : path::parent_path(abs_path);
     auto command_for = [&](FileEntry& entry, const SourceFile& file) {
@@ -835,8 +830,7 @@ int run_inspect(const InspectOptions& opts) {
                             file.abs,
                             flags,
                             unit_directory,
-                            flags.empty() ? database_for(file.abs) : nullptr,
-                            toolchain);
+                            flags.empty() ? database_for(file.abs) : nullptr);
     };
 
     // Serial module builder (directory mode): scan for module declarations

--- a/src/sched/batch.cpp
+++ b/src/sched/batch.cpp
@@ -186,7 +186,7 @@ kota::task<> run(BatchStack& stack, const BatchOptions& options, BatchResult& re
         co_await shutdown(stack);
         co_return;
     }
-    if(workspace.cdb.get_entries().empty()) {
+    if(workspace.cdb.entries().empty()) {
         LOG_ERROR("Nothing to index: no compile_commands.json found under {}", options.root);
         result.exit_code = 1;
         co_await shutdown(stack);
@@ -362,7 +362,7 @@ kota::task<> run_lint(BatchStack& stack,
                         options.root,
                         /*read_only_index=*/!options.with_index);
 
-    if(workspace.cdb.get_entries().empty()) {
+    if(workspace.cdb.entries().empty()) {
         LOG_ERROR("Nothing to lint: no compile_commands.json found under {}", options.root);
         result.exit_code = 2;
         co_await shutdown(stack);
@@ -380,10 +380,9 @@ kota::task<> run_lint(BatchStack& stack,
     // the command resolve_command picks — same as the indexing sweep.
     llvm::SmallVector<std::uint32_t> tus;
     llvm::DenseSet<std::uint32_t> seen;
-    for(auto& entry: workspace.cdb.get_entries()) {
-        auto id = workspace.path_pool.intern(workspace.cdb.resolve_path(entry.file));
-        if(seen.insert(id).second) {
-            tus.push_back(id);
+    for(auto& entry: workspace.cdb.entries()) {
+        if(seen.insert(entry.file).second) {
+            tus.push_back(entry.file);
         }
     }
 

--- a/src/sched/bootstrap.cpp
+++ b/src/sched/bootstrap.cpp
@@ -60,6 +60,7 @@ BootstrapReport bootstrap_workspace(Workspace& workspace,
         }
     }
 
+    workspace.cdb.set_workspace_root(root);
     report.cdb_path = discover_compile_commands(workspace.config, root);
     if(report.cdb_path.empty()) {
         // Persisted index shards are CDB-independent; load them so a
@@ -75,8 +76,6 @@ BootstrapReport bootstrap_workspace(Workspace& workspace,
     LOG_PERF("startup", "phase=cdb_load entries={} elapsed_ms={}", count, cdb_timer.ms());
 
     auto scan = scan_dependency_graph(workspace.cdb,
-                                      workspace.toolchain,
-                                      workspace.path_pool,
                                       workspace.dep_graph,
                                       /*cache=*/nullptr,
                                       [&workspace](llvm::StringRef path,
@@ -115,14 +114,12 @@ BootstrapReport bootstrap_workspace(Workspace& workspace,
     pump.claim_report(store.load(read_only_index).report);
 
     if(cfg.enable_indexing.value) {
-        for(auto& entry: workspace.cdb.get_entries()) {
-            auto file = workspace.cdb.resolve_path(entry.file);
-            auto server_id = workspace.path_pool.intern(file);
+        for(auto& entry: workspace.cdb.entries()) {
             // Bulk sweep of unknown staleness: the hash gate decides per
             // file. DepsOnly — a cold start with a warm index cache must
             // keep serving the loaded shards, not blank every query until
             // the sweep drains.
-            pump.enqueue(server_id, ReindexReason::DepsOnly);
+            pump.enqueue(entry.file, ReindexReason::DepsOnly);
         }
         pump.schedule();
     }

--- a/src/sched/context.cpp
+++ b/src/sched/context.cpp
@@ -44,28 +44,28 @@ static void log_command_decision(llvm::StringRef path,
 }
 
 /// Pick the host CDB entry matching the session's pinned command hash
-/// (multi-configuration hosts), defaulting to the first entry.
+/// (multi-configuration hosts), defaulting to the first candidate.
 ///
-/// Published hashes are computed against host-path rules, while `results`
-/// may carry header-path rules — match by index through a host-rules
-/// lookup of the same entry set instead of hashing `results` directly.
-static CompileCommand& pick_host_command(Workspace& workspace,
-                                         llvm::StringRef host_path,
-                                         llvm::SmallVector<CompileCommand>& results,
-                                         llvm::StringRef pinned_hash) {
+/// Published hashes are computed against host-path rules, while the caller
+/// will apply header-path rules — so the pin is validated in the host-rules
+/// context and the winning base config returned for the caller to re-derive.
+static ConfigID pick_host_config(Workspace& workspace,
+                                 llvm::StringRef host_path,
+                                 llvm::ArrayRef<CompilationEntry> candidates,
+                                 llvm::StringRef pinned_hash) {
     if(!pinned_hash.empty()) {
         std::vector<std::string> host_append, host_remove;
         workspace.config.match_rules(host_path, host_append, host_remove);
-        auto canonical =
-            workspace.cdb.lookup(host_path, {.remove = host_remove, .append = host_append});
-        for(std::size_t i = 0; i < canonical.size() && i < results.size(); ++i) {
-            if(canonical_command_hash(canonical[i].to_string_argv(),
-                                      canonical[i].resolved.directory) == pinned_hash) {
-                return results[i];
+        for(auto& entry: candidates) {
+            auto applied =
+                workspace.cdb.apply_rules(entry.config,
+                                          {.remove = host_remove, .append = host_append});
+            if(workspace.cdb.entry_hash_hex(applied) == pinned_hash) {
+                return entry.config;
             }
         }
     }
-    return results.front();
+    return candidates.front().config;
 }
 
 HeaderMode ContextResolver::header_mode(llvm::StringRef path, std::uint32_t path_id) const {
@@ -181,7 +181,8 @@ bool ContextResolver::fill_header_context_args(llvm::StringRef path,
                                                std::string& directory,
                                                std::vector<std::string>& arguments,
                                                ContextUse use,
-                                               std::uint32_t* host_path_id) {
+                                               std::uint32_t* host_path_id,
+                                               CommandRef* out_ref) {
     // Opening one of our own synthesized files (prefix/suffix/snapshot):
     // it is a fragment of the host TU it was synthesized for, so compile
     // it with that host's command, treated as self-contained. It must not
@@ -194,20 +195,27 @@ bool ContextResolver::fill_header_context_args(llvm::StringRef path,
             return false;
         }
         auto host_path = workspace.path_pool.resolve(it->second);
-        if(!workspace.cdb.has_entry(host_path)) {
+        auto candidates = workspace.cdb.candidate_entries(host_path);
+        if(candidates.empty()) {
             return false;
         }
         std::vector<std::string> rule_append, rule_remove;
         workspace.config.match_rules(path, rule_append, rule_remove);
-        auto host_results =
-            workspace.cdb.lookup(host_path, {.remove = rule_remove, .append = rule_append});
-        workspace.toolchain.resolve_or_warn(host_results.front());
-        CompileCommand artifact_cmd = host_results.front();
-        artifact_cmd.source_file = workspace.path_pool.resolve(path_id).data();
-        directory = artifact_cmd.resolved.directory.str();
-        arguments = artifact_cmd.to_string_argv();
+        auto applied = workspace.cdb.apply_rules(candidates.front().config,
+                                                 {.remove = rule_remove, .append = rule_append});
+        // The artifact is a fragment of the host TU: it compiles as the
+        // host's language, with the artifact path injected as the input.
+        CommandRef ref{path_id,
+                       applied,
+                       workspace.cdb.input_kind(applied, host_path),
+                       CommandSource::IncludeGraph};
+        directory = workspace.cdb.config(applied).directory;
+        arguments = to_strings(workspace.cdb.render(ref));
         if(host_path_id) {
             *host_path_id = it->second;
+        }
+        if(out_ref) {
+            *out_ref = ref;
         }
         return true;
     }
@@ -263,7 +271,8 @@ bool ContextResolver::fill_header_context_args(llvm::StringRef path,
     }
 
     auto host_path = workspace.path_pool.resolve(ctx_ptr->host_path_id);
-    if(!workspace.cdb.has_entry(host_path)) {
+    auto candidates = workspace.cdb.candidate_entries(host_path);
+    if(candidates.empty()) {
         LOG_WARN("fill_header_context_args: host {} has no CDB entry", host_path);
         return false;
     }
@@ -272,30 +281,27 @@ bool ContextResolver::fill_header_context_args(llvm::StringRef path,
     // the host's command — rules are expected to apply uniformly to every file.
     std::vector<std::string> rule_append, rule_remove;
     workspace.config.match_rules(path, rule_append, rule_remove);
-    auto host_results =
-        workspace.cdb.lookup(host_path, {.remove = rule_remove, .append = rule_append});
+    auto base = pick_host_config(workspace, host_path, candidates, ctx_ptr->host_command_hash);
+    auto applied = workspace.cdb.apply_rules(base, {.remove = rule_remove, .append = rule_append});
 
-    auto& host_cmd =
-        pick_host_command(workspace, host_path, host_results, ctx_ptr->host_command_hash);
-    workspace.toolchain.resolve_or_warn(host_cmd);
-    directory = host_cmd.resolved.directory.str();
-
-    // Replace source_file; inject -include <preamble> only when a prefix
-    // was synthesized (after "-cc1" for cc1, after the driver otherwise).
-    CompileCommand header_cmd = host_cmd;
-    header_cmd.source_file = workspace.path_pool.resolve(path_id).data();
-
+    // The header compiles as the host's language, with the header injected
+    // as the input; the synthesized preamble lands after the host's own
+    // user-content flags (its -include runs first).
+    CommandRef ref{path_id,
+                   applied,
+                   workspace.cdb.input_kind(applied, host_path),
+                   CommandSource::IncludeGraph};
+    RenderOptions opts;
     if(!ctx_ptr->preamble_path.empty()) {
-        std::size_t inject_pos = header_cmd.resolved.is_cc1 ? 2 : 1;
-        header_cmd.resolved.flags.insert(header_cmd.resolved.flags.begin() + inject_pos,
-                                         ctx_ptr->preamble_path.c_str());
-        header_cmd.resolved.flags.insert(header_cmd.resolved.flags.begin() + inject_pos,
-                                         "-include");
+        opts.preamble = ctx_ptr->preamble_path.c_str();
     }
-
-    arguments = header_cmd.to_string_argv();
+    directory = workspace.cdb.config(applied).directory;
+    arguments = to_strings(workspace.cdb.render(ref, opts));
     if(host_path_id) {
         *host_path_id = ctx_ptr->host_path_id;
+    }
+    if(out_ref) {
+        *out_ref = ref;
     }
 
     LOG_INFO("resolve_command: header context for {} (host={}, preamble={})",
@@ -311,37 +317,49 @@ CommandSource ContextResolver::resolve_command(llvm::StringRef path,
                                                ContextUse use,
                                                std::uint32_t* host_path_id,
                                                llvm::ArrayRef<std::string> extra_prepend,
-                                               llvm::ArrayRef<std::string> extra_append) {
+                                               llvm::ArrayRef<std::string> extra_append,
+                                               CommandRef* out_ref) {
     auto path_id = workspace.path_pool.intern(path);
     llvm::SmallVector<llvm::StringRef, 3> tried;
 
     // Fill from the CDB layer with config rules applied (append/remove flags
-    // based on file patterns). Also used for tier 4: lookup() synthesizes a
-    // default command for files without an entry.
-    auto fill_from_cdb = [&] {
+    // based on file patterns). Also used for tier 4 with the synthesized
+    // default config for files without an entry.
+    auto fill_from_cdb = [&](CommandSource source) {
         std::vector<std::string> rule_append, rule_remove;
         workspace.config.match_rules(path, rule_append, rule_remove);
-        auto results = workspace.cdb.lookup(path,
-                                            {.remove = rule_remove,
-                                             .append = rule_append,
-                                             .extra_prepend = extra_prepend,
-                                             .extra_append = extra_append});
-        auto* cmd = &results.front();
-        // Multi-config projects: honor the user's chosen CDB entry, matched
-        // by canonical command hash so the choice survives CDB reordering.
-        const SavedContext* choice = active_choice(use, path_id);
-        if(choice && choice->host_path_id == no_path_id && !choice->command_hash.empty()) {
-            for(auto& candidate: results) {
-                if(canonical_command_hash(candidate.to_string_argv(),
-                                          candidate.resolved.directory) == choice->command_hash) {
-                    cmd = &candidate;
-                    break;
+        CommandOptions options{.remove = rule_remove,
+                               .append = rule_append,
+                               .extra_prepend = extra_prepend,
+                               .extra_append = extra_append};
+
+        auto candidates = workspace.cdb.candidate_entries(path_id);
+        ConfigID base;
+        if(candidates.empty()) {
+            base = workspace.cdb.fallback_config(path);
+        } else {
+            base = candidates.front().config;
+            // Multi-config projects: honor the user's chosen CDB entry,
+            // matched by entry hash so the choice survives CDB reordering.
+            const SavedContext* choice = active_choice(use, path_id);
+            if(choice && choice->host_path_id == no_path_id && !choice->command_hash.empty()) {
+                for(auto& candidate: candidates) {
+                    auto applied = workspace.cdb.apply_rules(candidate.config, options);
+                    if(workspace.cdb.entry_hash_hex(applied) == choice->command_hash) {
+                        base = candidate.config;
+                        break;
+                    }
                 }
             }
         }
-        workspace.toolchain.resolve_or_warn(*cmd);
-        directory = cmd->resolved.directory.str();
-        arguments = cmd->to_string_argv();
+
+        auto applied = workspace.cdb.apply_rules(base, options);
+        CommandRef ref{path_id, applied, workspace.cdb.input_kind(applied, path), source};
+        directory = workspace.cdb.config(applied).directory;
+        arguments = to_strings(workspace.cdb.render(ref));
+        if(out_ref) {
+            *out_ref = ref;
+        }
     };
 
     const SavedContext* choice = active_choice(use, path_id);
@@ -351,17 +369,22 @@ CommandSource ContextResolver::resolve_command(llvm::StringRef path,
     //    host source's CDB entry with file path replaced and preamble injected.
     if(has_host_choice) {
         tried.push_back("switch_context");
-        if(fill_header_context_args(path, path_id, directory, arguments, use, host_path_id)) {
+        if(fill_header_context_args(path,
+                                    path_id,
+                                    directory,
+                                    arguments,
+                                    use,
+                                    host_path_id,
+                                    out_ref)) {
             log_command_decision(path, tried, CommandSource::IncludeGraph, arguments);
             return CommandSource::IncludeGraph;
         }
     }
 
-    // 2. Real CDB entry for the file itself (lookup() synthesizes a command
-    //    for unknown files, so a non-empty result alone proves nothing).
+    // 2. Real CDB entry for the file itself.
     tried.push_back("cdb");
-    if(workspace.cdb.has_entry(path)) {
-        fill_from_cdb();
+    if(!workspace.cdb.candidate_entries(path_id).empty()) {
+        fill_from_cdb(CommandSource::CDBExact);
         log_command_decision(path, tried, CommandSource::CDBExact, arguments);
         return CommandSource::CDBExact;
     }
@@ -369,17 +392,22 @@ CommandSource ContextResolver::resolve_command(llvm::StringRef path,
     // 3. No CDB entry — try automatic header context resolution.
     if(!has_host_choice) {
         tried.push_back("include_graph");
-        if(fill_header_context_args(path, path_id, directory, arguments, use, host_path_id)) {
+        if(fill_header_context_args(path,
+                                    path_id,
+                                    directory,
+                                    arguments,
+                                    use,
+                                    host_path_id,
+                                    out_ref)) {
             log_command_decision(path, tried, CommandSource::IncludeGraph, arguments);
             return CommandSource::IncludeGraph;
         }
     }
 
-    // 4. Nothing matched — use the default command the CDB layer synthesizes
-    //    for unknown files, so the file still compiles and produces
-    //    diagnostics instead of failing silently.
+    // 4. Nothing matched — use the synthesized default command, so the file
+    //    still compiles and produces diagnostics instead of failing silently.
     tried.push_back("fallback");
-    fill_from_cdb();
+    fill_from_cdb(CommandSource::Fallback);
     log_command_decision(path, tried, CommandSource::Fallback, arguments);
     return CommandSource::Fallback;
 }
@@ -479,18 +507,20 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
     // search configuration, so same-named headers in different directories
     // cannot be confused.
     auto host_path = workspace.path_pool.resolve(host_path_id);
-    std::vector<std::string> rule_append, rule_remove;
-    workspace.config.match_rules(host_path, rule_append, rule_remove);
-    auto host_results =
-        workspace.cdb.lookup(host_path, {.remove = rule_remove, .append = rule_append});
-    if(host_results.empty()) {
+    auto candidates = workspace.cdb.candidate_entries(host_path);
+    if(candidates.empty()) {
         return std::nullopt;
     }
-    auto& resolve_cmd = pick_host_command(workspace, host_path, host_results, host_command_hash);
-    workspace.toolchain.resolve_or_warn(resolve_cmd);
+    std::vector<std::string> rule_append, rule_remove;
+    workspace.config.match_rules(host_path, rule_append, rule_remove);
+    auto base = pick_host_config(workspace, host_path, candidates, host_command_hash);
+    auto applied = workspace.cdb.apply_rules(base, {.remove = rule_remove, .append = rule_append});
+    CommandRef host_ref{host_path_id,
+                        applied,
+                        workspace.cdb.input_kind(applied, host_path),
+                        CommandSource::CDBExact};
 
-    auto argv = resolve_cmd.to_argv();
-    auto search_config = extract_search_config(argv, resolve_cmd.resolved.directory);
+    auto search_config = workspace.cdb.search_config(host_ref);
     DirListingCache dir_cache;
     auto resolved_config = resolve_search_config(search_config, dir_cache);
 
@@ -674,9 +704,10 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
 bool ContextResolver::entry_has_hash(llvm::StringRef entry_path, llvm::StringRef hash) const {
     std::vector<std::string> rule_append, rule_remove;
     workspace.config.match_rules(entry_path, rule_append, rule_remove);
-    for(auto& cmd:
-        workspace.cdb.lookup(entry_path, {.remove = rule_remove, .append = rule_append})) {
-        if(canonical_command_hash(cmd.to_string_argv(), cmd.resolved.directory) == hash) {
+    for(auto& entry: workspace.cdb.candidate_entries(entry_path)) {
+        auto applied =
+            workspace.cdb.apply_rules(entry.config, {.remove = rule_remove, .append = rule_append});
+        if(workspace.cdb.entry_hash_hex(applied) == hash) {
             return true;
         }
     }

--- a/src/sched/context.cpp
+++ b/src/sched/context.cpp
@@ -52,7 +52,18 @@ static void log_command_decision(llvm::StringRef path,
 static ConfigID pick_host_config(Workspace& workspace,
                                  llvm::StringRef host_path,
                                  llvm::ArrayRef<CompilationEntry> candidates,
-                                 llvm::StringRef pinned_hash) {
+                                 llvm::StringRef pinned_hash,
+                                 llvm::StringRef pinned_base) {
+    // The base identity resolved at pin time is exact; the applied hash
+    // remains as the fallback for pins saved before the base was recorded
+    // (and cannot distinguish candidates the rules collapse together).
+    if(!pinned_base.empty()) {
+        for(auto& entry: candidates) {
+            if(workspace.cdb.entry_hash_hex(entry.config) == pinned_base) {
+                return entry.config;
+            }
+        }
+    }
     if(!pinned_hash.empty()) {
         std::vector<std::string> host_append, host_remove;
         workspace.config.match_rules(host_path, host_append, host_remove);
@@ -127,6 +138,7 @@ void ContextResolver::dump_cache_slices(
         entry.host = saved.host_path_id != no_path_id ? intern_id(saved.host_path_id) : ~0u;
         entry.occurrence = saved.occurrence.value_or(~0u);
         entry.command_hash = saved.command_hash;
+        entry.base_hash = saved.base_hash;
         contexts.push_back(std::move(entry));
     }
 }
@@ -164,6 +176,7 @@ void
             saved.occurrence = entry.occurrence;
         }
         saved.command_hash = entry.command_hash;
+        saved.base_hash = entry.base_hash;
         saved_contexts[workspace.path_pool.intern(file)] = std::move(saved);
     }
 
@@ -243,7 +256,8 @@ bool ContextResolver::fill_header_context_args(llvm::StringRef path,
             bool override_mismatch =
                 has_host_choice && (cached->host_path_id != choice->host_path_id ||
                                     cached->occurrence != choice->occurrence.value_or(0) ||
-                                    cached->host_command_hash != choice->command_hash);
+                                    cached->host_command_hash != choice->command_hash ||
+                                    cached->host_base_hash != choice->base_hash);
             bool mode_mismatch = cached->preamble_path.empty() == synthesize;
             if(override_mismatch || mode_mismatch ||
                deps_changed(workspace.path_pool, cached->deps)) {
@@ -281,7 +295,11 @@ bool ContextResolver::fill_header_context_args(llvm::StringRef path,
     // the host's command — rules are expected to apply uniformly to every file.
     std::vector<std::string> rule_append, rule_remove;
     workspace.config.match_rules(path, rule_append, rule_remove);
-    auto base = pick_host_config(workspace, host_path, candidates, ctx_ptr->host_command_hash);
+    auto base = pick_host_config(workspace,
+                                 host_path,
+                                 candidates,
+                                 ctx_ptr->host_command_hash,
+                                 ctx_ptr->host_base_hash);
     auto applied = workspace.cdb.apply_rules(base, {.remove = rule_remove, .append = rule_append});
 
     // The header compiles as the host's language, with the header injected
@@ -343,11 +361,23 @@ CommandSource ContextResolver::resolve_command(llvm::StringRef path,
             // matched by entry hash so the choice survives CDB reordering.
             const SavedContext* choice = active_choice(use, path_id);
             if(choice && choice->host_path_id == no_path_id && !choice->command_hash.empty()) {
-                for(auto& candidate: candidates) {
-                    auto applied = workspace.cdb.apply_rules(candidate.config, options);
-                    if(workspace.cdb.entry_hash_hex(applied) == choice->command_hash) {
-                        base = candidate.config;
-                        break;
+                bool base_matched = false;
+                if(!choice->base_hash.empty()) {
+                    for(auto& candidate: candidates) {
+                        if(workspace.cdb.entry_hash_hex(candidate.config) == choice->base_hash) {
+                            base = candidate.config;
+                            base_matched = true;
+                            break;
+                        }
+                    }
+                }
+                if(!base_matched) {
+                    for(auto& candidate: candidates) {
+                        auto applied = workspace.cdb.apply_rules(candidate.config, options);
+                        if(workspace.cdb.entry_hash_hex(applied) == choice->command_hash) {
+                            base = candidate.config;
+                            break;
+                        }
                     }
                 }
             }
@@ -487,8 +517,10 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
     // Self-contained route: borrow the host's command, no prefix needed.
     // The chain is kept so a didSave along it still invalidates the session.
     std::string host_command_hash;
+    std::string host_base_hash;
     if(has_host_choice) {
         host_command_hash = choice->command_hash;
+        host_base_hash = choice->base_hash;
     }
 
     if(!synthesize) {
@@ -499,6 +531,7 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
                              "",
                              occurrence.value_or(0),
                              std::move(host_command_hash),
+                             std::move(host_base_hash),
                              std::move(chain_ids),
                              {}};
     }
@@ -513,7 +546,8 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
     }
     std::vector<std::string> rule_append, rule_remove;
     workspace.config.match_rules(host_path, rule_append, rule_remove);
-    auto base = pick_host_config(workspace, host_path, candidates, host_command_hash);
+    auto base =
+        pick_host_config(workspace, host_path, candidates, host_command_hash, host_base_hash);
     auto applied = workspace.cdb.apply_rules(base, {.remove = rule_remove, .append = rule_append});
     CommandRef host_ref{host_path_id,
                         applied,
@@ -697,17 +731,22 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
                          std::move(suffix_path),
                          occurrence.value_or(0),
                          std::move(host_command_hash),
+                         std::move(host_base_hash),
                          std::move(chain_ids),
                          std::move(deps)};
 }
 
-bool ContextResolver::entry_has_hash(llvm::StringRef entry_path, llvm::StringRef hash) const {
+bool ContextResolver::pin_alive(llvm::StringRef entry_path, const SavedContext& saved) const {
     std::vector<std::string> rule_append, rule_remove;
     workspace.config.match_rules(entry_path, rule_append, rule_remove);
     for(auto& entry: workspace.cdb.candidate_entries(entry_path)) {
+        if(!saved.base_hash.empty() &&
+           workspace.cdb.entry_hash_hex(entry.config) == saved.base_hash) {
+            return true;
+        }
         auto applied =
             workspace.cdb.apply_rules(entry.config, {.remove = rule_remove, .append = rule_append});
-        if(workspace.cdb.entry_hash_hex(applied) == hash) {
+        if(workspace.cdb.entry_hash_hex(applied) == saved.command_hash) {
             return true;
         }
     }
@@ -730,9 +769,9 @@ void ContextResolver::validate_saved_context(std::uint32_t path_id) {
             auto host_path = ws.path_pool.resolve(saved.host_path_id);
             valid = ws.cdb.has_entry(host_path) &&
                     !ws.dep_graph.find_include_chain(saved.host_path_id, path_id).empty() &&
-                    (saved.command_hash.empty() || entry_has_hash(host_path, saved.command_hash));
+                    (saved.command_hash.empty() || pin_alive(host_path, saved));
         } else if(!saved.command_hash.empty()) {
-            valid = ws.cdb.has_entry(path) && entry_has_hash(path, saved.command_hash);
+            valid = ws.cdb.has_entry(path) && pin_alive(path, saved);
         }
         if(!valid) {
             LOG_INFO("didOpen: dropping stale saved context for {}", path);

--- a/src/sched/context.h
+++ b/src/sched/context.h
@@ -36,6 +36,7 @@ struct CacheContextEntry {
     std::uint32_t host;  // index into the cache path table; ~0u = none
     std::uint32_t occurrence;
     std::string command_hash;
+    std::string base_hash;
 };
 
 struct CacheArtifactEntry {
@@ -233,10 +234,13 @@ public:
         return it != saved_contexts.end() ? &it->second : nullptr;
     }
 
-    /// Whether the CDB still holds an entry for `entry_path` whose canonical
-    /// command hash equals `hash` — the validity test for a pinned context
-    /// choice, shared by didOpen validation and the server's orphan pass.
-    bool entry_has_hash(llvm::StringRef entry_path, llvm::StringRef hash) const;
+    /// Whether a pinned command choice still has a live basis among
+    /// `entry_path`'s CDB entries: its applied hash matches a candidate
+    /// under current rules, or its recorded base entry hash still names
+    /// one (a rule edit moves every applied hash; the base survives it).
+    /// The validity test shared by didOpen validation and the server's
+    /// orphan pass.
+    bool pin_alive(llvm::StringRef entry_path, const SavedContext& saved) const;
 
 private:
     std::optional<HeaderContext> resolve_header_context(std::uint32_t header_path_id,

--- a/src/sched/context.h
+++ b/src/sched/context.h
@@ -15,23 +15,6 @@
 
 namespace clice {
 
-/// Where the compile command for a file came from. Anything other than
-/// CDBExact means the command was guessed to some degree, which is why
-/// diagnostics produced with it may deserve a guidance note (see
-/// format_diagnostics).
-enum class CommandSource : std::uint8_t {
-    /// Direct compilation database entry for the file.
-    CDBExact,
-    /// Header compiled in the context of a host source found through the
-    /// include graph (automatic or via clice/switchContext).
-    IncludeGraph,
-    /// Reserved for command transfer heuristics (e.g. nearest CDB entry);
-    /// no producer yet.
-    Inferred,
-    /// Synthesized default command — no CDB entry and no usable host source.
-    Fallback,
-};
-
 /// Who a command resolution serves. User context choices steer
 /// editor-facing compiles of open files, never background indexing.
 enum class ContextUse : std::uint8_t {
@@ -204,13 +187,17 @@ public:
     /// before toolchain resolution so the driver interprets them. Unlike
     /// config rule appends they are never NVCC-translated; prepends land
     /// right after the binary name, appends win over rule appends.
+    /// @param out_ref  If non-null, receives the resolved command selection
+    /// (the ref behind `arguments`) for structured consumers — search
+    /// config, language queries.
     CommandSource resolve_command(llvm::StringRef path,
                                   std::string& directory,
                                   std::vector<std::string>& arguments,
                                   ContextUse use = ContextUse::Background,
                                   std::uint32_t* host_path_id = nullptr,
                                   llvm::ArrayRef<std::string> extra_prepend = {},
-                                  llvm::ArrayRef<std::string> extra_append = {});
+                                  llvm::ArrayRef<std::string> extra_append = {},
+                                  CommandRef* out_ref = nullptr);
 
     /// Append the header context's suffix as one trailing #include line: the
     /// suffix content (everything after the include position along the chain)
@@ -228,7 +215,8 @@ public:
                                   std::string& directory,
                                   std::vector<std::string>& arguments,
                                   ContextUse use,
-                                  std::uint32_t* host_path_id);
+                                  std::uint32_t* host_path_id,
+                                  CommandRef* out_ref = nullptr);
 
     /// Validate a context choice persisted from an earlier run against the
     /// current CDB and include graph, dropping it when stale. Called on

--- a/src/sched/families/pcm.cpp
+++ b/src/sched/families/pcm.cpp
@@ -32,16 +32,20 @@ void PCMFamily::register_runner() {
 
 PCMFamily::ModuleDeps PCMFamily::direct_deps(std::uint32_t path_id,
                                              std::optional<llvm::StringRef> content) {
+    // The same resolution the real build uses (run() below): a module unit
+    // scanned with a different command than it compiles with would edge
+    // against a different dependency set.
     auto file_path = workspace.path_pool.resolve(path_id);
-    std::vector<std::string> rule_append, rule_remove;
-    workspace.config.match_rules(file_path, rule_append, rule_remove);
-    auto results = workspace.cdb.lookup(file_path, {.remove = rule_remove, .append = rule_append});
-    if(results.empty())
-        return {};
-    workspace.toolchain.resolve_or_warn(results[0]);
+    std::string directory;
+    std::vector<std::string> arguments;
+    contexts.resolve_command(file_path, directory, arguments);
 
-    auto& cmd = results[0];
-    return direct_deps(path_id, cmd.to_argv(), cmd.resolved.directory, content);
+    std::vector<const char*> argv;
+    argv.reserve(arguments.size());
+    for(auto& arg: arguments) {
+        argv.push_back(arg.c_str());
+    }
+    return direct_deps(path_id, argv, directory, content);
 }
 
 PCMFamily::ModuleDeps PCMFamily::direct_deps(std::uint32_t path_id,

--- a/src/sched/index/store.cpp
+++ b/src/sched/index/store.cpp
@@ -53,12 +53,6 @@ struct CDBSnapshotEntry {
 
 struct CDBSnapshot {
     std::vector<CDBSnapshotEntry> entries;
-
-    /// Auto-discovered CDB origins (logical path + discovery anchor),
-    /// restored at startup so lazily discovered databases are re-loaded
-    /// before snapshot reconciliation. Explicitly configured origins are
-    /// never persisted — the current config is always authoritative.
-    std::vector<std::string> origins;
 };
 
 /// clice.toml append/remove rules change the effective indexing command

--- a/src/sched/index/store.cpp
+++ b/src/sched/index/store.cpp
@@ -41,12 +41,24 @@ std::string blob_key(llvm::StringRef path) {
 struct CDBSnapshotEntry {
     std::string file;
     std::vector<std::string> hashes;
+
+    /// Entry hash of the file's default selection (the candidate-order
+    /// winner). The hash multiset alone cannot see an offline flip of the
+    /// winner — candidates unchanged, selection changed.
+    std::string selected;
+
     std::string rules;
     std::string host;
 };
 
 struct CDBSnapshot {
     std::vector<CDBSnapshotEntry> entries;
+
+    /// Auto-discovered CDB origins (logical path + discovery anchor),
+    /// restored at startup so lazily discovered databases are re-loaded
+    /// before snapshot reconciliation. Explicitly configured origins are
+    /// never persisted — the current config is always authoritative.
+    std::vector<std::string> origins;
 };
 
 /// clice.toml append/remove rules change the effective indexing command
@@ -77,11 +89,12 @@ CDBSnapshot build_cdb_snapshot(Workspace& workspace,
                                llvm::ArrayRef<std::uint32_t> standalone_debt) {
     CDBSnapshot snapshot;
     for(auto& [path_id, hashes]: workspace.cdb.command_hash_snapshot()) {
-        auto file = workspace.cdb.resolve_path(path_id).str();
+        auto file = workspace.path_pool.resolve(path_id).str();
         auto rules = rules_hash(workspace.config, file);
         snapshot.entries.push_back({
             .file = std::move(file),
             .hashes = {hashes.begin(), hashes.end()},
+            .selected = workspace.cdb.selected_hash(path_id).value_or(std::string()),
             .rules = std::move(rules),
         });
     }
@@ -1055,8 +1068,11 @@ void IndexStore::reconcile_cdb_snapshot(Report& report) {
         auto server_id = workspace.path_pool.intern(entry.file);
         cdb_ids.insert(server_id);
         auto it = before.find(entry.file);
+        // `selected` guards the offline winner flip: the candidate multiset
+        // can survive a reload that still changes which entry is the
+        // default selection.
         if(it != before.end() && it->second->hashes == entry.hashes &&
-           it->second->rules == entry.rules) {
+           it->second->selected == entry.selected && it->second->rules == entry.rules) {
             continue;
         }
         changed_ids.push_back(server_id);

--- a/src/sched/workspace.cpp
+++ b/src/sched/workspace.cpp
@@ -106,7 +106,21 @@ void Workspace::rescan_includes(std::uint32_t path_id) {
 
         std::vector<std::string> rule_append, rule_remove;
         config.match_rules(cmd_path, rule_append, rule_remove);
-        auto cmds = cdb.lookup(cmd_path, {.remove = rule_remove, .append = rule_append});
+        auto candidates = cdb.candidate_entries(cmd_path);
+        llvm::SmallVector<CommandRef> refs;
+        for(auto& entry: candidates) {
+            auto applied =
+                cdb.apply_rules(entry.config, {.remove = rule_remove, .append = rule_append});
+            refs.push_back(
+                {entry.file, applied, cdb.input_kind(applied, cmd_path), CommandSource::CDBExact});
+        }
+        if(refs.empty()) {
+            auto fallback = cdb.fallback_config(cmd_path);
+            auto applied =
+                cdb.apply_rules(fallback, {.remove = rule_remove, .append = rule_append});
+            refs.push_back(
+                {path_id, applied, cdb.input_kind(applied, cmd_path), CommandSource::Fallback});
+        }
 
         // Resolve under every configuration: an include may only be
         // reachable through the -I set of a non-first CDB entry. The local
@@ -115,11 +129,8 @@ void Workspace::rescan_includes(std::uint32_t path_id) {
         auto includes = scan_quick((*buf)->getBuffer()).includes;
         DirListingCache dir_cache;
         auto dir = llvm::sys::path::parent_path(path);
-        for(std::uint32_t ci = 0; ci < cmds.size(); ++ci) {
-            auto& cmd = cmds[ci];
-            toolchain.resolve_or_warn(cmd);
-            auto argv = cmd.to_argv();
-            auto search_config = extract_search_config(argv, cmd.resolved.directory);
+        for(std::uint32_t ci = 0; ci < refs.size(); ++ci) {
+            auto search_config = cdb.search_config(refs[ci]);
             auto resolved_config = resolve_search_config(search_config, dir_cache);
             auto entries = resolve_dir(dir, dir_cache);
 
@@ -163,16 +174,19 @@ void Workspace::rescan_after_save(std::uint32_t path_id) {
         // or this save would drop a guarded interface from both provider
         // maps and leave its importers unresolved until a reload.
         if(result.need_preprocess) {
-            auto cmds = cdb.lookup(file_path);
-            if(!cmds.empty()) {
-                toolchain.resolve_or_warn(cmds[0]);
-                auto fallback = scan_module_decl(cmds[0].to_argv(),
-                                                 cmds[0].resolved.directory,
-                                                 (*buf)->getBuffer());
-                if(!fallback.module_name.empty()) {
-                    result.module_name = std::move(fallback.module_name);
-                    result.is_interface_unit = fallback.is_interface_unit;
-                }
+            auto candidates = cdb.candidate_entries(file_path);
+            bool has_entry = !candidates.empty();
+            auto config = has_entry ? candidates.front().config : cdb.fallback_config(file_path);
+            CommandRef ref{path_id,
+                           config,
+                           cdb.input_kind(config, file_path),
+                           has_entry ? CommandSource::CDBExact : CommandSource::Fallback};
+            auto fallback = scan_module_decl(cdb.render(ref),
+                                             cdb.config(ref.config).directory,
+                                             (*buf)->getBuffer());
+            if(!fallback.module_name.empty()) {
+                result.module_name = std::move(fallback.module_name);
+                result.is_interface_unit = fallback.is_interface_unit;
             }
         }
         // Both maps hold interface units only, mirroring the startup scan:

--- a/src/sched/workspace.cpp
+++ b/src/sched/workspace.cpp
@@ -176,10 +176,15 @@ void Workspace::rescan_after_save(std::uint32_t path_id) {
         if(result.need_preprocess) {
             auto candidates = cdb.candidate_entries(file_path);
             bool has_entry = !candidates.empty();
-            auto config = has_entry ? candidates.front().config : cdb.fallback_config(file_path);
+            auto base = has_entry ? candidates.front().config : cdb.fallback_config(file_path);
+            // Same rules-applied command as the startup scan: a rule-added
+            // define may be what unguards the module declaration.
+            std::vector<std::string> append, remove;
+            config.match_rules(file_path, append, remove);
+            auto applied = cdb.apply_rules(base, {.remove = remove, .append = append});
             CommandRef ref{path_id,
-                           config,
-                           cdb.input_kind(config, file_path),
+                           applied,
+                           cdb.input_kind(applied, file_path),
                            has_entry ? CommandSource::CDBExact : CommandSource::Fallback};
             auto fallback = scan_module_decl(cdb.render(ref),
                                              cdb.config(ref.config).directory,

--- a/src/sched/workspace.h
+++ b/src/sched/workspace.h
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "command/command.h"
-#include "command/toolchain.h"
 #include "compile/dep_file.h"
 #include "config/config.h"
 #include "index/database.h"
@@ -36,7 +35,7 @@ class ContextResolver;
 
 /// On-disk cache layout version (CacheStore root `cache/v{N}`).
 /// Bump to discard all cached artifacts after incompatible format changes.
-constexpr inline std::uint32_t cache_format_version = 7;
+constexpr inline std::uint32_t cache_format_version = 8;
 
 /// Sentinel for "no path": path pool ids start at 0, so 0 is a real file.
 constexpr inline std::uint32_t no_path_id = ~0u;
@@ -209,9 +208,10 @@ struct Workspace {
     /// overlay.
     Config config;
     CompilationDatabase cdb;
-    Toolchain toolchain;
 
-    PathPool path_pool;
+    /// The single path-id space: the CDB owns it, everything else shares
+    /// it — CDB entry file ids and workspace path ids are the same ids.
+    PathPool& path_pool = cdb.paths();
 
     /// Unified on-disk blob store for PCH/PCM/index artifacts.  Opened by
     /// load_workspace() when cache_dir is configured; absent means caching

--- a/src/sched/workspace.h
+++ b/src/sched/workspace.h
@@ -109,6 +109,10 @@ struct HeaderContext {
     /// hosts); empty = the first entry.
     std::string host_command_hash;
 
+    /// Base entry hash of that entry (before rules): stays unique when
+    /// rules collapse two candidates' applied hashes onto one value.
+    std::string host_base_hash;
+
     /// Include chain from host to the target's direct includer (excludes the
     /// target itself). The synthesized preamble embeds these files' content,
     /// so clang never opens them — staleness must be tracked here.
@@ -136,7 +140,12 @@ struct SavedContext {
     /// Pinned include occurrence; no value = automatic.
     std::optional<std::uint32_t> occurrence;
 
-    std::string command_hash;  ///< Pinned CDB entry; empty = none.
+    std::string command_hash;  ///< Pinned CDB entry (rules applied); empty = none.
+
+    /// Base entry hash of the pinned entry, resolved at pin time. The
+    /// applied hash is the protocol identity; the base disambiguates
+    /// candidates whose applied hashes collapse under the current rules.
+    std::string base_hash;
 };
 
 /// Cached PCH state.  Stored in Workspace.pch_cache keyed by the content

--- a/src/server/service/context_service.cpp
+++ b/src/server/service/context_service.cpp
@@ -233,27 +233,32 @@ ext::SwitchContextResult ContextService::switch_context(llvm::StringRef path,
         return result;
     }
 
-    // Validate that `hash` names a real CDB entry of `entry_path`.
-    auto has_command = [&](llvm::StringRef entry_path, llvm::StringRef hash) {
+    // Validate that `hash` names a real CDB entry of `entry_path` and
+    // resolve the matched candidate's base entry hash — the identity that
+    // stays unique when rules collapse two applied hashes onto one value.
+    auto find_command = [&](llvm::StringRef entry_path,
+                            llvm::StringRef hash) -> std::optional<std::string> {
         std::vector<std::string> rule_append, rule_remove;
         ws.config.match_rules(entry_path, rule_append, rule_remove);
         for(auto& entry: ws.cdb.candidate_entries(entry_path)) {
             auto applied =
                 ws.cdb.apply_rules(entry.config, {.remove = rule_remove, .append = rule_append});
             if(ws.cdb.entry_hash_hex(applied) == hash) {
-                return true;
+                return ws.cdb.entry_hash_hex(entry.config);
             }
         }
-        return false;
+        return std::nullopt;
     };
 
     SavedContext saved;
     if(context_path_id == path_id && params.command_hash.has_value()) {
         // Pin one of the file's own CDB entries.
-        if(!has_command(path, *params.command_hash)) {
+        auto base = find_command(path, *params.command_hash);
+        if(!base) {
             return result;
         }
         saved.command_hash = *params.command_hash;
+        saved.base_hash = std::move(*base);
     } else {
         // Pin a host source for a header: it must have a real CDB
         // entry, actually (transitively) include this header, and —
@@ -264,8 +269,12 @@ ext::SwitchContextResult ContextService::switch_context(llvm::StringRef path,
         if(ws.dep_graph.find_include_chain(context_path_id, path_id).empty()) {
             return result;
         }
-        if(params.command_hash.has_value() && !has_command(context_path, *params.command_hash)) {
-            return result;
+        std::optional<std::string> base;
+        if(params.command_hash.has_value()) {
+            base = find_command(context_path, *params.command_hash);
+            if(!base) {
+                return result;
+            }
         }
         if(params.occurrence.has_value() && *params.occurrence > 0) {
             auto count = ws.count_occurrences(context_path_id, path_id);
@@ -276,6 +285,7 @@ ext::SwitchContextResult ContextService::switch_context(llvm::StringRef path,
         saved.host_path_id = context_path_id;
         saved.occurrence = params.occurrence;
         saved.command_hash = params.command_hash.value_or("");
+        saved.base_hash = base.value_or("");
     }
 
     resolver.drop_header_context(path_id);
@@ -316,13 +326,11 @@ bool ContextService::drop_orphaned_choices(SessionStore& sessions) {
             // The pinned host command itself can vanish (a CDB reload
             // changed the entry's flags): same validation didOpen applies.
             if(!orphaned && !saved.command_hash.empty()) {
-                orphaned = !resolver.entry_has_hash(workspace.path_pool.resolve(host_id),
-                                                    saved.command_hash);
+                orphaned = !resolver.pin_alive(workspace.path_pool.resolve(host_id), saved);
             }
         } else if(!saved.command_hash.empty()) {
             // Own-entry pin: the pinned command must still exist in the CDB.
-            orphaned = !resolver.entry_has_hash(workspace.path_pool.resolve(session_id),
-                                                saved.command_hash);
+            orphaned = !resolver.pin_alive(workspace.path_pool.resolve(session_id), saved);
         }
         if(orphaned) {
             LOG_INFO("Dropping orphaned context choice for {}: its basis no longer exists",

--- a/src/server/service/context_service.cpp
+++ b/src/server/service/context_service.cpp
@@ -38,8 +38,8 @@ bool indicates_missing_context(llvm::ArrayRef<protocol::Diagnostic> diagnostics)
 }
 
 /// Human-readable summary of the distinguishing flags of a command.
-static std::string flags_label(const CompileCommand& cmd) {
-    auto argv = cmd.to_argv();
+static std::string flags_label(Workspace& ws, ConfigID config) {
+    auto argv = ws.cdb.render_full(config);
     std::string desc;
     for(std::size_t j = 0; j < argv.size(); ++j) {
         llvm::StringRef a(argv[j]);
@@ -89,18 +89,20 @@ ext::QueryContextResult ContextService::query_contexts(llvm::StringRef path,
         // different preprocessor state.
         std::vector<std::string> host_append, host_remove;
         ws.config.match_rules(host_path, host_append, host_remove);
-        auto cmds = ws.cdb.lookup(host_path, {.remove = host_remove, .append = host_append});
+        auto candidates = ws.cdb.candidate_entries(host_path);
         auto occurrences = ws.count_occurrences(host_id, path_id);
 
-        for(auto& cmd: cmds) {
-            auto hash = canonical_command_hash(cmd.to_string_argv(), cmd.resolved.directory);
+        for(auto& entry: candidates) {
+            auto applied =
+                ws.cdb.apply_rules(entry.config, {.remove = host_remove, .append = host_append});
+            auto hash = ws.cdb.entry_hash_hex(applied);
             if(dedup_hosts && !seen_configs.insert(hash).second)
                 continue;
 
             ext::ContextItem item;
             item.label = llvm::sys::path::filename(host_path).str();
-            if(cmds.size() > 1) {
-                auto desc = flags_label(cmd);
+            if(candidates.size() > 1) {
+                auto desc = flags_label(ws, applied);
                 if(!desc.empty()) {
                     item.label = std::format("{} [{}]", item.label, desc);
                 }
@@ -132,18 +134,19 @@ ext::QueryContextResult ContextService::query_contexts(llvm::StringRef path,
     if(ws.cdb.has_entry(path)) {
         std::vector<std::string> rule_append, rule_remove;
         ws.config.match_rules(path, rule_append, rule_remove);
-        auto entries = ws.cdb.lookup(path, {.remove = rule_remove, .append = rule_append});
+        auto entries = ws.cdb.candidate_entries(path);
         auto uri_opt = lsp::URI::from_file_path(std::string(path));
         for(std::size_t i = 0; uri_opt && i < entries.size(); ++i) {
-            auto& cmd = entries[i];
-            auto hash = canonical_command_hash(cmd.to_string_argv(), cmd.resolved.directory);
+            auto applied = ws.cdb.apply_rules(entries[i].config,
+                                              {.remove = rule_remove, .append = rule_append});
+            auto hash = ws.cdb.entry_hash_hex(applied);
             if(!seen_configs.insert(hash).second)
                 continue;
 
-            auto desc = flags_label(cmd);
+            auto desc = flags_label(ws, applied);
             ext::ContextItem item;
             item.label = desc.empty() ? std::format("config #{}", i) : desc;
-            item.description = cmd.resolved.directory.str();
+            item.description = ws.cdb.config(applied).directory;
             item.uri = uri_opt->str();
             item.command_hash = std::move(hash);
             all_items.push_back(std::move(item));
@@ -191,14 +194,15 @@ ext::CurrentContextResult ContextService::current_context(llvm::StringRef path,
         if(ws.cdb.has_entry(path)) {
             std::vector<std::string> rule_append, rule_remove;
             ws.config.match_rules(path, rule_append, rule_remove);
-            for(auto& cmd: ws.cdb.lookup(path, {.remove = rule_remove, .append = rule_append})) {
-                if(canonical_command_hash(cmd.to_string_argv(), cmd.resolved.directory) ==
-                   choice->command_hash) {
-                    auto desc = flags_label(cmd);
+            for(auto& entry: ws.cdb.candidate_entries(path)) {
+                auto applied = ws.cdb.apply_rules(entry.config,
+                                                  {.remove = rule_remove, .append = rule_append});
+                if(ws.cdb.entry_hash_hex(applied) == choice->command_hash) {
+                    auto desc = flags_label(ws, applied);
                     if(!desc.empty()) {
                         item.label = std::move(desc);
                     }
-                    item.description = cmd.resolved.directory.str();
+                    item.description = ws.cdb.config(applied).directory;
                     break;
                 }
             }
@@ -231,13 +235,12 @@ ext::SwitchContextResult ContextService::switch_context(llvm::StringRef path,
 
     // Validate that `hash` names a real CDB entry of `entry_path`.
     auto has_command = [&](llvm::StringRef entry_path, llvm::StringRef hash) {
-        if(!ws.cdb.has_entry(entry_path)) {
-            return false;
-        }
         std::vector<std::string> rule_append, rule_remove;
         ws.config.match_rules(entry_path, rule_append, rule_remove);
-        for(auto& cmd: ws.cdb.lookup(entry_path, {.remove = rule_remove, .append = rule_append})) {
-            if(canonical_command_hash(cmd.to_string_argv(), cmd.resolved.directory) == hash) {
+        for(auto& entry: ws.cdb.candidate_entries(entry_path)) {
+            auto applied =
+                ws.cdb.apply_rules(entry.config, {.remove = rule_remove, .append = rule_append});
+            if(ws.cdb.entry_hash_hex(applied) == hash) {
                 return true;
             }
         }

--- a/src/server/service/feature_router.cpp
+++ b/src/server/service/feature_router.cpp
@@ -135,32 +135,23 @@ struct CommandLang {
 };
 
 static std::optional<CommandLang> command_lang(Workspace& workspace, llvm::StringRef path) {
-    if(!workspace.cdb.has_entry(path)) {
+    auto candidates = workspace.cdb.candidate_entries(path);
+    if(candidates.empty()) {
         return std::nullopt;
     }
     std::vector<std::string> append, remove;
     workspace.config.match_rules(path, append, remove);
-    auto commands = workspace.cdb.lookup(path, {.remove = remove, .append = append});
+    auto applied =
+        workspace.cdb.apply_rules(candidates.front().config, {.remove = remove, .append = append});
 
     CommandLang result;
-    auto& flags = commands.front().resolved.flags;
-    for(std::size_t i = 0; i < flags.size(); i += 1) {
-        llvm::StringRef flag = flags[i];
-        llvm::StringRef language;
-        if(flag == "-x") {
-            if(i + 1 < flags.size()) {
-                language = flags[i + 1];
-            }
-        } else if(flag.starts_with("-x")) {
-            language = flag.drop_front(2);
-        } else if(flag.consume_front("-std=") || flag.consume_front("--std=")) {
-            result.standard = flag.str();
-            continue;
-        } else {
-            continue;
-        }
-        if(!language.empty()) {
-            result.forces_c = language == "c" || language == "c-header";
+    auto language = workspace.cdb.forced_language(applied);
+    if(!language.empty()) {
+        result.forces_c = language == "c" || language == "c-header";
+    }
+    for(auto& arg: workspace.cdb.config(applied).args) {
+        if(arg.opt_id == option::OPT_std_EQ && arg.values.size() == 1) {
+            result.standard = arg.values[0];
         }
     }
     return result;
@@ -769,14 +760,17 @@ FeatureRouter::RawResult FeatureRouter::completion(std::shared_ptr<Session> sess
             std::vector<std::string> arguments;
             // Editor use: candidates must come from the same command (host
             // choice, chosen CDB entry) the open buffer compiles under.
-            contexts.resolve_command(path, directory, arguments, ContextUse::Editor);
+            CommandRef ref;
+            contexts.resolve_command(path,
+                                     directory,
+                                     arguments,
+                                     ContextUse::Editor,
+                                     /*host_path_id=*/nullptr,
+                                     /*extra_prepend=*/{},
+                                     /*extra_append=*/{},
+                                     &ref);
 
-            std::vector<const char*> args_ptrs;
-            args_ptrs.reserve(arguments.size());
-            for(auto& arg: arguments)
-                args_ptrs.push_back(arg.c_str());
-
-            auto search_config = extract_search_config(args_ptrs, directory);
+            auto search_config = workspace.cdb.search_config(ref);
             DirListingCache dir_cache;
             auto resolved = resolve_search_config(search_config, dir_cache);
             bool angled = (pctx.kind == CompletionContext::IncludeAngled);

--- a/src/server/state/file_tracker.cpp
+++ b/src/server/state/file_tracker.cpp
@@ -99,18 +99,11 @@ llvm::SmallVector<FileEvent> FileTracker::tick_cdb(bool force) {
         return {};
     }
 
-    // The diff speaks in the CDB's own path ids; events speak in master
-    // path-pool ids.
+    // Diff ids and event ids share the single path pool.
     FileEvent::CDBDelta delta;
-    auto convert = [&](llvm::ArrayRef<std::uint32_t> cdb_ids,
-                       llvm::SmallVectorImpl<std::uint32_t>& out) {
-        for(auto id: cdb_ids) {
-            out.push_back(workspace.path_pool.intern(workspace.cdb.resolve_path(id)));
-        }
-    };
-    convert(diff->added, delta.added);
-    convert(diff->removed, delta.removed);
-    convert(diff->changed, delta.changed);
+    delta.added.assign(diff->added.begin(), diff->added.end());
+    delta.removed.assign(diff->removed.begin(), diff->removed.end());
+    delta.changed.assign(diff->changed.begin(), diff->changed.end());
 
     llvm::SmallVector<FileEvent> events;
     events.push_back(FileEvent::cdb_changed(std::move(delta)));

--- a/src/server/state/invalidator.cpp
+++ b/src/server/state/invalidator.cpp
@@ -414,8 +414,6 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
 
                 workspace.dep_graph = DependencyGraph();
                 scan_dependency_graph(workspace.cdb,
-                                      workspace.toolchain,
-                                      workspace.path_pool,
                                       workspace.dep_graph,
                                       /*cache=*/nullptr,
                                       [this](llvm::StringRef path,

--- a/src/server/transport/agent_client.cpp
+++ b/src/server/transport/agent_client.cpp
@@ -94,12 +94,12 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
         ProjectFilesResult result;
         llvm::DenseSet<std::uint32_t> seen;
 
-        for(auto& entry: ws.cdb.get_entries()) {
-            auto file_path = ws.cdb.resolve_path(entry.file);
+        for(auto& entry: ws.cdb.entries()) {
+            auto file_path = ws.path_pool.resolve(entry.file);
             if(file_path.empty())
                 continue;
 
-            auto path_id = ws.path_pool.intern(file_path);
+            auto path_id = entry.file;
             if(!seen.insert(path_id).second)
                 continue;
 

--- a/src/server/transport/agent_client.cpp
+++ b/src/server/transport/agent_client.cpp
@@ -76,7 +76,10 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
             srv.pool.foreground_pulse();
             std::string directory;
             std::vector<std::string> arguments;
-            srv.contexts.resolve_command(params.path, directory, arguments);
+            // Editor semantics: an agent asks what the user's file compiles
+            // as — pins and header context included, never the background
+            // tier ladder (which offers a header nothing but fallback).
+            srv.contexts.resolve_command(params.path, directory, arguments, ContextUse::Editor);
 
             co_return CompileCommandResult{
                 .file = params.path,

--- a/src/server/transport/agentic.cpp
+++ b/src/server/transport/agentic.cpp
@@ -5,11 +5,13 @@
 #include <string>
 
 #include "server/protocol/agentic.h"
+#include "support/filesystem.h"
 #include "support/logging.h"
 
 #include "kota/async/async.h"
 #include "kota/ipc/codec/json.h"
 #include "kota/ipc/transport.h"
+#include "llvm/ADT/SmallString.h"
 
 namespace clice {
 
@@ -30,6 +32,14 @@ static kota::task<> agentic_request(kota::ipc::JsonPeer& peer,
                                     const QueryOptions& opts) {
     auto method = opts.method.value_or("compileCommand");
     auto path = opts.path.value_or("");
+    // The server matches paths against its absolute path pool; resolve a
+    // relative --path against this CLI's working directory before it ships.
+    if(!path.empty() && !path::is_absolute(path)) {
+        llvm::SmallString<256> abs(path);
+        fs::make_absolute(abs);
+        path::remove_dots(abs, /*remove_dot_dot=*/true);
+        path = abs.str();
+    }
     auto name = opts.name.value_or("");
     auto query = opts.query.value_or("");
     auto line = opts.line.value_or(0);

--- a/src/support/object_pool.h
+++ b/src/support/object_pool.h
@@ -20,7 +20,9 @@ public:
     using ID = std::uint32_t;
 
     explicit StringSet(llvm::BumpPtrAllocator* allocator) : allocator(allocator) {
-        strings.emplace_back();
+        /// Slot 0 is the empty string; a real "" keeps data() non-null and
+        /// null-terminated for callers that treat results as C strings.
+        strings.emplace_back("");
     }
 
     StringSet(const StringSet&) = delete;

--- a/src/syntax/dependency_graph.cpp
+++ b/src/syntax/dependency_graph.cpp
@@ -4,7 +4,6 @@
 #include <chrono>
 
 #include "command/search_config.h"
-#include "command/toolchain.h"
 #include "support/logging.h"
 #include "syntax/include_resolver.h"
 #include "syntax/scan.h"
@@ -297,13 +296,12 @@ FileScanResult scan_file_worker(const char* path, std::uint32_t path_id, std::ui
 
 /// The async scan implementation that runs on a local event loop.
 kota::task<> scan_impl(CompilationDatabase& cdb,
-                       Toolchain& toolchain,
-                       PathPool& path_pool,
                        DependencyGraph& graph,
                        ScanReport& report,
                        ScanCache* ext_cache,
                        kota::event_loop& loop,
                        const RuleMatcher& rule_matcher) {
+    auto& path_pool = cdb.paths();
     auto start_time = std::chrono::steady_clock::now();
 
     // On warm runs (ext_cache populated from a previous scan), skip the expensive
@@ -318,56 +316,52 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
 
     auto config_start = std::chrono::steady_clock::now();
 
-    // Intermediate: one ConfigGroup per unique CompilationInfo in the CDB.
-    // Used to build configs, initial_wave, and pre-warm the toolchain cache.
-    // Not cached — rebuilt on cold runs from CDB state which is cheap.
-    llvm::SmallVector<CompilationDatabase::ConfigGroup> config_groups;
+    // One scan group per unique (rules-applied config, input language) —
+    // the SearchConfig granularity: different -I sets resolve differently,
+    // and the same flags compiled as C and C++ pull different implicit
+    // include sets. Not cached — rebuilt on cold runs from CDB state.
+    llvm::SmallVector<CommandRef> group_refs;
+    std::vector<WaveEntry> wave0;
 
     if(!have_config_cache) {
-        // Ask CDB for unique compilation configs. Each ConfigGroup bundles:
-        //   - file_ids:  all CDB path_ids sharing the same (dir, canonical, patch)
-        //   - command:   a representative CompileCommand (driver-level flags)
-        //
-        // This is the right granularity for SearchConfig: different -I paths
-        // produce different groups. For toolchain queries the granularity is
-        // coarser (user-content flags don't affect the key), so warm()
-        // further deduplicates internally.
-        config_groups = cdb.unique_configs();
-
-        // Pre-warm toolchain cache: warm() keys each command by its
-        // non-user-content flags. Commands differing only in -D/-I collapse
-        // to the same key, so N config groups often yield just 1-2 subprocess
-        // calls.
-        auto prewarm_start = std::chrono::steady_clock::now();
-        llvm::SmallVector<CompileCommand> representative_cmds;
-        representative_cmds.reserve(config_groups.size());
-        for(auto& group: config_groups) {
-            representative_cmds.push_back(group.command);
-        }
-
-        toolchain.warm(representative_cmds);
-        auto prewarm_end = std::chrono::steady_clock::now();
-        report.prewarm_ms =
-            std::chrono::duration_cast<std::chrono::milliseconds>(prewarm_end - prewarm_start)
-                .count();
-
-        // Extract SearchConfig for each unique config group.
-        // Toolchain is now warm, so resolve() hits cache.
-        std::int64_t lookup_us = 0;
-        for(std::uint32_t config_id = 0; config_id < config_groups.size(); ++config_id) {
-            auto& group = config_groups[config_id];
-            auto representative_path = llvm::StringRef(group.command.source_file);
+        llvm::DenseMap<std::pair<std::uint32_t, const char*>, std::uint32_t> group_ids;
+        for(auto& entry: cdb.entries()) {
+            auto file_path = path_pool.resolve(entry.file);
 
             // Apply per-file rules so that [[rules]]-modified -I/-isystem/-std
             // flags are reflected in the search config used by the scan.
             std::vector<std::string> rule_append, rule_remove;
             if(rule_matcher)
-                rule_matcher(representative_path, rule_append, rule_remove);
+                rule_matcher(file_path, rule_append, rule_remove);
 
+            auto applied =
+                cdb.apply_rules(entry.config, {.remove = rule_remove, .append = rule_append});
+            auto input = cdb.input_kind(applied, file_path);
+            auto [it, inserted] =
+                group_ids.try_emplace({static_cast<std::uint32_t>(applied), input.value},
+                                      static_cast<std::uint32_t>(group_refs.size()));
+            if(inserted) {
+                group_refs.push_back({entry.file, applied, input, CommandSource::CDBExact});
+            }
+            wave0.push_back({entry.file, it->second, /*found_dir_idx=*/0});
+        }
+
+        // Pre-warm the toolchain cache: probes key by non-user-content
+        // flags, so groups differing only in -D/-I collapse to the same
+        // probe — N groups often yield just 1-2 subprocess calls.
+        auto prewarm_start = std::chrono::steady_clock::now();
+        cdb.warm(group_refs);
+        auto prewarm_end = std::chrono::steady_clock::now();
+        report.prewarm_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(prewarm_end - prewarm_start)
+                .count();
+
+        // Extract SearchConfig for each group. The toolchain is warm, so
+        // resolution hits the cache.
+        std::int64_t lookup_us = 0;
+        for(std::uint32_t group_id = 0; group_id < group_refs.size(); ++group_id) {
             auto t0 = std::chrono::steady_clock::now();
-            auto cmd = cdb.group_command(group, {.remove = rule_remove, .append = rule_append});
-            toolchain.resolve_or_warn(cmd);
-            configs[config_id] = extract_search_config(cmd.to_argv(), cmd.resolved.directory);
+            configs[group_id] = cdb.search_config(group_refs[group_id]);
             auto t1 = std::chrono::steady_clock::now();
             lookup_us += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
         }
@@ -408,8 +402,8 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
             }
         }
         // Also prefetch parent directories of source files (for quoted include resolution).
-        for(auto& entry: cdb.get_entries()) {
-            auto file_path = cdb.resolve_path(entry.file);
+        for(auto& entry: cdb.entries()) {
+            auto file_path = path_pool.resolve(entry.file);
             auto dir = llvm::sys::path::parent_path(file_path);
             if(!dir.empty()) {
                 unique_dirs.insert(dir);
@@ -439,28 +433,19 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
     // Value: found_dir_idx needed for #include_next.
     llvm::DenseMap<std::uint32_t, unsigned> scanned_files;
 
-    // Wave 0: all source files from CDB.
-    // Re-use the cached initial_wave when available; otherwise build from
-    // config_groups, converting CDB path_ids → PathPool path_ids.
+    // Wave 0: all source files from CDB (entry file ids are pool ids).
+    // Re-use the cached initial_wave when available.
     std::vector<WaveEntry> current_wave;
     if(have_config_cache) {
         current_wave = ext_cache->initial_wave;
-        for(auto& entry: current_wave) {
-            scanned_files.try_emplace(entry.path_id, entry.found_dir_idx);
-        }
     } else {
-        current_wave.reserve(cdb.get_entries().size());
-        for(std::uint32_t config_id = 0; config_id < config_groups.size(); ++config_id) {
-            for(auto cdb_file_id: config_groups[config_id].file_ids) {
-                auto file_path = cdb.resolve_path(cdb_file_id);
-                auto pool_id = path_pool.intern(file_path);
-                scanned_files.try_emplace(pool_id, 0u);
-                current_wave.push_back({pool_id, config_id, /*found_dir_idx=*/0});
-            }
-        }
+        current_wave = std::move(wave0);
         if(ext_cache) {
             ext_cache->initial_wave = current_wave;
         }
+    }
+    for(auto& entry: current_wave) {
+        scanned_files.try_emplace(entry.path_id, entry.found_dir_idx);
     }
 
     report.source_files = current_wave.size();
@@ -628,12 +613,16 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
             // headers cannot contain module declarations.
             if(scan_result.scan_result.need_preprocess && wave_num == 0) {
                 auto file_path = llvm::StringRef(scan_result.path);
-                auto contexts = cdb.lookup(file_path);
-                if(!contexts.empty()) {
-                    toolchain.resolve_or_warn(contexts[0]);
-                    auto& cmd = contexts[0];
-                    auto fallback =
-                        scan_module_decl(cmd.to_argv(), cmd.resolved.directory, /*content=*/{});
+                auto candidates = cdb.candidate_entries(file_path);
+                if(!candidates.empty()) {
+                    auto& entry = candidates.front();
+                    CommandRef ref{entry.file,
+                                   entry.config,
+                                   cdb.input_kind(entry.config, file_path),
+                                   CommandSource::CDBExact};
+                    auto fallback = scan_module_decl(cdb.render(ref),
+                                                     cdb.config(ref.config).directory,
+                                                     /*content=*/{});
                     if(!fallback.module_name.empty()) {
                         scan_result.scan_result.module_name = std::move(fallback.module_name);
                         scan_result.scan_result.is_interface_unit = fallback.is_interface_unit;
@@ -829,18 +818,16 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
 // Public sync entry point
 
 ScanReport scan_dependency_graph(CompilationDatabase& cdb,
-                                 Toolchain& toolchain,
-                                 PathPool& path_pool,
                                  DependencyGraph& graph,
                                  ScanCache* cache,
                                  const RuleMatcher& rule_matcher) {
     ScanReport report;
-    if(cdb.get_entries().empty()) {
+    if(cdb.entries().empty()) {
         return report;
     }
 
     kota::event_loop loop;
-    loop.schedule(scan_impl(cdb, toolchain, path_pool, graph, report, cache, loop, rule_matcher));
+    loop.schedule(scan_impl(cdb, graph, report, cache, loop, rule_matcher));
     loop.run();
     return report;
 }

--- a/src/syntax/dependency_graph.cpp
+++ b/src/syntax/dependency_graph.cpp
@@ -319,11 +319,15 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
     // One scan group per unique (rules-applied config, input language) —
     // the SearchConfig granularity: different -I sets resolve differently,
     // and the same flags compiled as C and C++ pull different implicit
-    // include sets. Not cached — rebuilt on cold runs from CDB state.
+    // include sets. Groups are rebuilt on warm runs too: the preprocess
+    // fallback renders each unit's own group command, and the dense group
+    // ids assigned here line up with a warm cache's recorded ids because
+    // entry order is deterministic (apply_rules memoizes, so this pass is
+    // cheap next to the skipped probe and search-config work).
     llvm::SmallVector<CommandRef> group_refs;
     std::vector<WaveEntry> wave0;
 
-    if(!have_config_cache) {
+    {
         llvm::DenseMap<std::pair<std::uint32_t, const char*>, std::uint32_t> group_ids;
         for(auto& entry: cdb.entries()) {
             auto file_path = path_pool.resolve(entry.file);
@@ -343,9 +347,13 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
             if(inserted) {
                 group_refs.push_back({entry.file, applied, input, CommandSource::CDBExact});
             }
-            wave0.push_back({entry.file, it->second, /*found_dir_idx=*/0});
+            if(!have_config_cache) {
+                wave0.push_back({entry.file, it->second, /*found_dir_idx=*/0});
+            }
         }
+    }
 
+    if(!have_config_cache) {
         // Pre-warm the toolchain cache: probes key by non-user-content
         // flags, so groups differing only in -D/-I collapse to the same
         // probe — N groups often yield just 1-2 subprocess calls.
@@ -619,8 +627,9 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                     // Preprocess under the scan unit's own group command —
                     // only its flags (e.g. a define unguarding the
                     // declaration) can resolve this unit; a multi-entry
-                    // file has one group per candidate. Warm runs rebuild
-                    // no groups and re-derive from the first candidate.
+                    // file has one group per candidate. A cached unit whose
+                    // group id outlived the CDB it was recorded against
+                    // re-derives from the first candidate instead.
                     ConfigID applied;
                     InputKind input;
                     if(scan_result.config_id < group_refs.size()) {
@@ -642,8 +651,12 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                     if(!fallback.module_name.empty()) {
                         scan_result.scan_result.module_name = std::move(fallback.module_name);
                         scan_result.scan_result.is_interface_unit = fallback.is_interface_unit;
-                        // Update cache so warm runs don't re-trigger fallback.
-                        if(ext_cache) {
+                        // Update cache so warm runs don't re-trigger the
+                        // fallback — single-candidate files only: the cache
+                        // holds one result per path, and a multi-group
+                        // file's groups may resolve different names, so its
+                        // units must re-derive on every run.
+                        if(ext_cache && candidates.size() == 1) {
                             auto cache_it = ext_cache->scan_results.find(scan_result.path_id);
                             if(cache_it != ext_cache->scan_results.end()) {
                                 cache_it->second.module_name = scan_result.scan_result.module_name;

--- a/src/syntax/dependency_graph.cpp
+++ b/src/syntax/dependency_graph.cpp
@@ -616,18 +616,26 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                 auto candidates = cdb.candidate_entries(file_path);
                 if(!candidates.empty()) {
                     auto& entry = candidates.front();
-                    // Same rules-applied command as the main scan groups: a
-                    // rule-added define may be what unguards the module
-                    // declaration this pass is trying to see.
-                    std::vector<std::string> rule_append, rule_remove;
-                    if(rule_matcher)
-                        rule_matcher(file_path, rule_append, rule_remove);
-                    auto applied = cdb.apply_rules(entry.config,
-                                                   {.remove = rule_remove, .append = rule_append});
-                    CommandRef ref{entry.file,
-                                   applied,
-                                   cdb.input_kind(applied, file_path),
-                                   CommandSource::CDBExact};
+                    // Preprocess under the scan unit's own group command —
+                    // only its flags (e.g. a define unguarding the
+                    // declaration) can resolve this unit; a multi-entry
+                    // file has one group per candidate. Warm runs rebuild
+                    // no groups and re-derive from the first candidate.
+                    ConfigID applied;
+                    InputKind input;
+                    if(scan_result.config_id < group_refs.size()) {
+                        auto& group = group_refs[scan_result.config_id];
+                        applied = group.config;
+                        input = group.input;
+                    } else {
+                        std::vector<std::string> rule_append, rule_remove;
+                        if(rule_matcher)
+                            rule_matcher(file_path, rule_append, rule_remove);
+                        applied = cdb.apply_rules(entry.config,
+                                                  {.remove = rule_remove, .append = rule_append});
+                        input = cdb.input_kind(applied, file_path);
+                    }
+                    CommandRef ref{entry.file, applied, input, CommandSource::CDBExact};
                     auto fallback = scan_module_decl(cdb.render(ref),
                                                      cdb.config(ref.config).directory,
                                                      /*content=*/{});

--- a/src/syntax/dependency_graph.cpp
+++ b/src/syntax/dependency_graph.cpp
@@ -616,9 +616,17 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                 auto candidates = cdb.candidate_entries(file_path);
                 if(!candidates.empty()) {
                     auto& entry = candidates.front();
+                    // Same rules-applied command as the main scan groups: a
+                    // rule-added define may be what unguards the module
+                    // declaration this pass is trying to see.
+                    std::vector<std::string> rule_append, rule_remove;
+                    if(rule_matcher)
+                        rule_matcher(file_path, rule_append, rule_remove);
+                    auto applied = cdb.apply_rules(entry.config,
+                                                   {.remove = rule_remove, .append = rule_append});
                     CommandRef ref{entry.file,
-                                   entry.config,
-                                   cdb.input_kind(entry.config, file_path),
+                                   applied,
+                                   cdb.input_kind(applied, file_path),
                                    CommandSource::CDBExact};
                     auto fallback = scan_module_decl(cdb.render(ref),
                                                      cdb.config(ref.config).directory,

--- a/src/syntax/dependency_graph.h
+++ b/src/syntax/dependency_graph.h
@@ -19,8 +19,6 @@
 
 namespace clice {
 
-class Toolchain;
-
 class DependencyGraph {
 public:
     /// Conditional flag: bit 31 marks an include inside #ifdef/#if.
@@ -306,8 +304,6 @@ using RuleMatcher = std::function<
 ///               dependency graph (otherwise rule-affected files would have
 ///               stale resolution).
 ScanReport scan_dependency_graph(CompilationDatabase& cdb,
-                                 Toolchain& toolchain,
-                                 PathPool& path_pool,
                                  DependencyGraph& graph,
                                  ScanCache* cache = nullptr,
                                  const RuleMatcher& rule_matcher = {});

--- a/tests/integration/agentic/agentic.test.ts
+++ b/tests/integration/agentic/agentic.test.ts
@@ -84,11 +84,14 @@ test("compile command", async ({ session }) => {
 });
 
 test("compile command fallback", async ({ session }) => {
-    const { host, port } = await agenticServer(session, "hello_world");
-    const result = await runAgentic(cliceExecutable(), host, port, "/nonexistent/file.cpp");
+    const { host, port, workspace } = await agenticServer(session, "hello_world");
+    // Absolute on every platform; a relative path would be resolved
+    // against the CLI's cwd before it reaches the server.
+    const probe = posix(workspace.path("nonexistent/file.cpp"));
+    const result = await runAgentic(cliceExecutable(), host, port, probe);
     expect(result.status, `stderr: ${result.stderr}`).toBe(0);
     const data = JSON.parse(result.stdout) as { file: string };
-    expect(data.file).toBe("/nonexistent/file.cpp");
+    expect(data.file).toBe(probe);
 });
 
 test("multiple requests", async ({ session }) => {

--- a/tests/integration/extensions/context_switching.test.ts
+++ b/tests/integration/extensions/context_switching.test.ts
@@ -20,7 +20,8 @@ function snapshotMtimes(dir: string): Record<string, bigint> {
 }
 
 /// Switching between two CDB entries of one source must recompile it
-/// under the selected flags.
+/// under the selected flags. The unswitched default is content-decided
+/// (not CDB order), so the test drives both states explicitly.
 test("source command switch", async ({ session }) => {
     const { client, workspace } = session.tmp();
     workspace.write(
@@ -33,9 +34,7 @@ test("source command switch", async ({ session }) => {
     ]);
     await client.initialize(workspace);
 
-    // Default entry is the first one: EXPECTED defined, clean.
     const [mainUri] = await client.openAndWait("main.cpp");
-    client.assertCleanCompile(mainUri);
 
     const query = await client.queryContext(mainUri);
     expect(query.total).toBe(2);
@@ -47,8 +46,14 @@ test("source command switch", async ({ session }) => {
     const plainHash = contexts.find((c) => !c.label.includes("-DEXPECTED"))!.commandHash!;
     const definedHash = contexts.find((c) => c.label.includes("-DEXPECTED"))!.commandHash!;
 
+    // Pin the entry with the define: clean compile.
+    let switched = await client.switchContext(mainUri, mainUri, { commandHash: definedHash });
+    expect(switched.success).toBe(true);
+    await client.waitForRecompile(mainUri);
+    client.assertCleanCompile(mainUri);
+
     // Switch to the entry without the define: the #error must fire.
-    let switched = await client.switchContext(mainUri, mainUri, { commandHash: plainHash });
+    switched = await client.switchContext(mainUri, mainUri, { commandHash: plainHash });
     expect(switched.success).toBe(true);
     await client.waitForRecompile(mainUri);
     client.assertHasErrors(mainUri, "Expected #error without -DEXPECTED");
@@ -416,17 +421,24 @@ test("switched context survives reopen", async ({ session }) => {
     await client.initialize(workspace);
 
     const [uri] = await client.openAndWait("main.cpp");
-    client.assertCleanCompile(uri);
 
     const query = await client.queryContext(uri);
     const contexts = query.contexts;
     expect(query.total, `expected both entries: ${JSON.stringify(contexts)}`).toBe(2);
+    const cleanHash = contexts.find((c) => (c.label || "").includes("USE_A"))!.commandHash!;
     const targetHash = contexts.find((c) => (c.label || "").includes("USE_B"))!.commandHash!;
 
-    const switched = await client.switchContext(uri, uri, {
-        commandHash: targetHash,
+    // The unswitched default is content-decided; pin USE_A for a known
+    // starting state.
+    let switched = await client.switchContext(uri, uri, {
+        commandHash: cleanHash,
         epoch: query.epoch,
     });
+    expect(switched.success, `switch failed: ${JSON.stringify(switched)}`).toBe(true);
+    await client.waitForRecompile(uri);
+    client.assertCleanCompile(uri);
+
+    switched = await client.switchContext(uri, uri, { commandHash: targetHash });
     expect(switched.success, `switch failed: ${JSON.stringify(switched)}`).toBe(true);
 
     client.close(uri);

--- a/tests/unit/command/argument_parser_tests.cpp
+++ b/tests/unit/command/argument_parser_tests.cpp
@@ -82,6 +82,9 @@ TEST_CASE(CLVisibility) {
     ASSERT_EQ(parse_with_vis({"/DFOO"}, cl_vis), OPT_D);
     ASSERT_EQ(parse_with_vis({"-DFOO"}, gcc_vis), OPT_D);
     ASSERT_EQ(parse_with_vis({"-DFOO"}, cl_vis), OPT_D);
+    /// /D carries the DXC visibility bit besides CL; a Unix-driver mask must
+    /// exclude both or /Data-style paths misparse.
+    ASSERT_EQ(parse_with_vis({"/DFOO"}, gcc_vis), OPT_INPUT);
 };
 
 TEST_CASE(RenderRoundTrip) {

--- a/tests/unit/command/cdb_diff_tests.cpp
+++ b/tests/unit/command/cdb_diff_tests.cpp
@@ -16,7 +16,7 @@ namespace ranges = std::ranges;
 
 /// path_id that `cdb` assigns to a file under the temp root.
 std::uint32_t id_of(CompilationDatabase& cdb, TempDir& tmp, llvm::StringRef rel) {
-    return cdb.intern_path(path::join(tmp.root.str(), rel));
+    return cdb.paths().intern(path::join(tmp.root.str(), rel));
 }
 
 bool contains(llvm::ArrayRef<std::uint32_t> list, std::uint32_t id) {
@@ -258,9 +258,11 @@ TEST_CASE(CorruptKeepsEntries) {
     ASSERT_FALSE(diff.has_value());
     EXPECT_TRUE(cdb.has_entry(path::join(tmp.root.str(), "a.cpp")));
 
-    auto results = cdb.lookup(path::join(tmp.root.str(), "a.cpp"), {.inject_resource_dir = false});
-    ASSERT_EQ(results.size(), 1U);
-    EXPECT_TRUE(llvm::StringRef(print_argv(results.front().to_argv())).contains("-std=c++20"));
+    auto file = path::join(tmp.root.str(), "a.cpp");
+    auto candidates = cdb.candidate_entries(file);
+    ASSERT_EQ(candidates.size(), 1U);
+    EXPECT_TRUE(llvm::StringRef(print_argv(cdb.render_full(candidates.front().config)))
+                    .contains("-std=c++20"));
 };
 
 TEST_CASE(MissingFileFails) {

--- a/tests/unit/command/command_tests.cpp
+++ b/tests/unit/command/command_tests.cpp
@@ -563,19 +563,17 @@ std::size_t load_json(CompilationDatabase& database, llvm::StringRef json) {
 
 TEST_CASE(LoadMixedFormats) {
     /// "arguments" array and "command" string can coexist in the same CDB.
+    TempDir tmp;
+    auto dir = json_escape(tmp.root);
     CompilationDatabase database;
-    auto count = load_json(database, R"([
-        {"directory": "/build", "file": "a.cpp",
-         "arguments": ["clang++", "-std=c++20", "a.cpp"]},
-        {"directory": "/build", "file": "b.cpp",
-         "command": "clang++ -std=c++23 b.cpp"}
-    ])");
+    auto count = load_json(database, R"([{"directory": ")" + dir + R"(", "file": "a.cpp",
+          "arguments": ["clang++", "-std=c++20", "a.cpp"]},
+         {"directory": ")" + dir + R"(", "file": "b.cpp",
+          "command": "clang++ -std=c++23 b.cpp"}])");
 
     ASSERT_EQ(count, 2U);
-    EXPECT_CONTAINS(print_argv(render_entry(database, path::join("/build", "a.cpp"))),
-                    "-std=c++20");
-    EXPECT_CONTAINS(print_argv(render_entry(database, path::join("/build", "b.cpp"))),
-                    "-std=c++23");
+    EXPECT_CONTAINS(print_argv(render_entry(database, tmp.path("a.cpp"))), "-std=c++20");
+    EXPECT_CONTAINS(print_argv(render_entry(database, tmp.path("b.cpp"))), "-std=c++23");
 };
 
 TEST_CASE(RelativeDirectoryAnchored) {
@@ -621,74 +619,77 @@ TEST_CASE(RelativeLoadPathAnchored) {
 
 TEST_CASE(LoadErrorRecovery) {
     /// Bad entries should be skipped; good entries still load.
+    TempDir tmp;
+    auto dir = json_escape(tmp.root);
     CompilationDatabase database;
-    auto count = load_json(database, R"([
-        {"file": "no_dir.cpp",
-         "arguments": ["clang++", "no_dir.cpp"]},
-        {"directory": "/build",
-         "arguments": ["clang++", "no_file.cpp"]},
-        {"directory": "/build", "file": "no_args.cpp"},
-        {"directory": "/build", "file": "good.cpp",
-         "arguments": ["clang++", "-std=c++20", "good.cpp"]},
-        42,
-        {"directory": "/build", "file": "also_good.cpp",
-         "command": "clang++ -Wall also_good.cpp"}
-    ])");
+    auto count = load_json(database,
+                           R"([{"file": "no_dir.cpp",
+          "arguments": ["clang++", "no_dir.cpp"]},
+         {"directory": ")" + dir +
+                               R"(",
+          "arguments": ["clang++", "no_file.cpp"]},
+         {"directory": ")" + dir +
+                               R"(", "file": "no_args.cpp"},
+         {"directory": ")" + dir +
+                               R"(", "file": "good.cpp",
+          "arguments": ["clang++", "-std=c++20", "good.cpp"]},
+         42,
+         {"directory": ")" + dir +
+                               R"(", "file": "also_good.cpp",
+          "command": "clang++ -Wall also_good.cpp"}])");
 
     ASSERT_EQ(count, 2U);
-    EXPECT_CONTAINS(print_argv(render_entry(database, path::join("/build", "good.cpp"))),
-                    "-std=c++20");
-    EXPECT_CONTAINS(print_argv(render_entry(database, path::join("/build", "also_good.cpp"))),
-                    "-Wall");
+    EXPECT_CONTAINS(print_argv(render_entry(database, tmp.path("good.cpp"))), "-std=c++20");
+    EXPECT_CONTAINS(print_argv(render_entry(database, tmp.path("also_good.cpp"))), "-Wall");
 };
 
 TEST_CASE(LoadCudaHeader) {
     /// .cuh entries are C-family despite clang's extension table; non-C
     /// entries some build systems emit are skipped.
+    TempDir tmp;
+    auto dir = json_escape(tmp.root);
     CompilationDatabase database;
-    auto count = load_json(database, R"([
-        {"directory": "/build", "file": "kernels.cuh",
-         "command": "nvcc -c kernels.cuh -o kernels.o"},
-        {"directory": "/build", "file": "app.rc",
-         "command": "rc /fo app.res app.rc"}
-    ])");
+    auto count = load_json(database, R"([{"directory": ")" + dir + R"(", "file": "kernels.cuh",
+          "command": "nvcc -c kernels.cuh -o kernels.o"},
+         {"directory": ")" + dir + R"(", "file": "app.rc",
+          "command": "rc /fo app.res app.rc"}])");
 
     ASSERT_EQ(count, 1U);
-    EXPECT_TRUE(database.has_entry(path::join("/build", "kernels.cuh")));
+    EXPECT_TRUE(database.has_entry(tmp.path("kernels.cuh")));
 };
 
 TEST_CASE(LoadEmptyCommand) {
     /// Whitespace-only or empty "command" should not crash.
+    TempDir tmp;
+    auto dir = json_escape(tmp.root);
     CompilationDatabase database;
-    auto count = load_json(database, R"([
-        {"directory": "/build", "file": "empty.cpp", "command": ""},
-        {"directory": "/build", "file": "spaces.cpp", "command": "   "},
-        {"directory": "/build", "file": "ok.cpp",
-         "command": "clang++ -std=c++20 ok.cpp"}
-    ])");
+    auto count = load_json(database,
+                           R"([{"directory": ")" + dir + R"(", "file": "empty.cpp", "command": ""},
+         {"directory": ")" + dir +
+                               R"(", "file": "spaces.cpp", "command": "   "},
+         {"directory": ")" + dir +
+                               R"(", "file": "ok.cpp",
+          "command": "clang++ -std=c++20 ok.cpp"}])");
 
     ASSERT_EQ(count, 1U);
-    EXPECT_CONTAINS(print_argv(render_entry(database, path::join("/build", "ok.cpp"))),
-                    "-std=c++20");
+    EXPECT_CONTAINS(print_argv(render_entry(database, tmp.path("ok.cpp"))), "-std=c++20");
 };
 
 TEST_CASE(LoadReload) {
     /// Second load() replaces all entries from the first.
+    TempDir tmp;
+    auto dir = json_escape(tmp.root);
     CompilationDatabase database;
 
-    auto file_a = path::join("/build", "a.cpp");
-    auto file_b = path::join("/build", "b.cpp");
+    auto file_a = tmp.path("a.cpp");
+    auto file_b = tmp.path("b.cpp");
 
-    load_json(database, R"([
-        {"directory": "/build", "file": "a.cpp",
-         "arguments": ["clang++", "-std=c++17", "a.cpp"]}
-    ])");
+    load_json(database, R"([{"directory": ")" + dir + R"(", "file": "a.cpp",
+          "arguments": ["clang++", "-std=c++17", "a.cpp"]}])");
     EXPECT_CONTAINS(print_argv(render_entry(database, file_a)), "-std=c++17");
 
-    auto count = load_json(database, R"([
-        {"directory": "/build", "file": "b.cpp",
-         "arguments": ["clang++", "-std=c++23", "b.cpp"]}
-    ])");
+    auto count = load_json(database, R"([{"directory": ")" + dir + R"(", "file": "b.cpp",
+          "arguments": ["clang++", "-std=c++23", "b.cpp"]}])");
     ASSERT_EQ(count, 1U);
 
     EXPECT_TRUE(database.candidate_entries(file_a).empty());
@@ -697,34 +698,37 @@ TEST_CASE(LoadReload) {
 
 TEST_CASE(LoadCommandQuoting) {
     /// "command" string with spaces in paths and quoted defines.
+    TempDir tmp;
+    auto dir = json_escape(tmp.root);
     CompilationDatabase database;
-    auto count = load_json(database, R"([
-        {"directory": "/build", "file": "main.cpp",
-         "command": "clang++ -std=c++20 \"-DMSG=hello world\" -I\"/path with spaces\" main.cpp"}
-    ])");
+    auto count = load_json(database, R"([{"directory": ")" + dir + R"(", "file": "main.cpp",
+          "command": "clang++ -std=c++20 \"-DMSG=hello world\" -I\"/path with spaces\" main.cpp"}])");
 
     ASSERT_EQ(count, 1U);
-    auto argv = print_argv(render_entry(database, path::join("/build", "main.cpp")));
+    auto argv = print_argv(render_entry(database, tmp.path("main.cpp")));
     EXPECT_CONTAINS(argv, "hello world");
-    EXPECT_CONTAINS(argv, "/path with spaces");
+    EXPECT_CONTAINS(argv, "with spaces");
 };
 
 TEST_CASE(LoadRelativePath) {
     /// load() resolves relative file paths against the directory.
+    TempDir tmp;
+    auto project = tmp.path("project/build");
+    auto other = tmp.path("other/build");
     CompilationDatabase database;
-    auto count = load_json(database, R"([
-        {"directory": "/project/build", "file": "src/main.cpp",
-         "arguments": ["clang++", "-std=c++20", "src/main.cpp"]},
-        {"directory": "/other/build", "file": "src/main.cpp",
-         "arguments": ["clang++", "-std=c++17", "src/main.cpp"]}
-    ])");
+    auto count = load_json(database,
+                           R"([{"directory": ")" + json_escape(project) +
+                               R"(", "file": "src/main.cpp",
+          "arguments": ["clang++", "-std=c++20", "src/main.cpp"]},
+         {"directory": ")" + json_escape(other) +
+                               R"(", "file": "src/main.cpp",
+          "arguments": ["clang++", "-std=c++17", "src/main.cpp"]}])");
 
     ASSERT_EQ(count, 2U);
 
-    EXPECT_CONTAINS(
-        print_argv(render_entry(database, path::join("/project/build", "src/main.cpp"))),
-        "-std=c++20");
-    EXPECT_CONTAINS(print_argv(render_entry(database, path::join("/other/build", "src/main.cpp"))),
+    EXPECT_CONTAINS(print_argv(render_entry(database, path::join(project, "src", "main.cpp"))),
+                    "-std=c++20");
+    EXPECT_CONTAINS(print_argv(render_entry(database, path::join(other, "src", "main.cpp"))),
                     "-std=c++17");
 
     /// A relative spelling is a different path — no entry.
@@ -734,14 +738,16 @@ TEST_CASE(LoadRelativePath) {
 TEST_CASE(LoadDotSegments) {
     /// Entry paths intern without . and .. segments, so lookups against
     /// clang-reported (realpath'd) spellings match.
+    TempDir tmp;
+    auto build = tmp.path("project/build");
     CompilationDatabase database;
-    auto count = load_json(database, R"([
-        {"directory": "/project/build", "file": "../src/./main.cpp",
-         "arguments": ["clang++", "-std=c++20", "../src/./main.cpp"]}
-    ])");
+    auto count = load_json(database,
+                           R"([{"directory": ")" + json_escape(build) +
+                               R"(", "file": "../src/./main.cpp",
+          "arguments": ["clang++", "-std=c++20", "../src/./main.cpp"]}])");
 
     ASSERT_EQ(count, 1U);
-    EXPECT_TRUE(database.has_entry(path::join("/project", "src", "main.cpp")));
+    EXPECT_TRUE(database.has_entry(tmp.path("project/src/main.cpp")));
 };
 
 TEST_CASE(ResourceDir) {

--- a/tests/unit/command/command_tests.cpp
+++ b/tests/unit/command/command_tests.cpp
@@ -1,3 +1,5 @@
+#include "test/cdb_helper.h"
+#include "test/temp_dir.h"
 #include "test/test.h"
 #include "command/argument_parser.h"
 #include "command/command.h"
@@ -11,27 +13,41 @@ namespace {
 
 using namespace std::literals;
 
-CommandOptions quiet_options() {
-    CommandOptions options;
-    options.inject_resource_dir = false;
-    return options;
-}
-
 #define EXPECT_CONTAINS(haystack, needle) EXPECT_TRUE(llvm::StringRef(haystack).contains(needle))
 #define EXPECT_NOT_CONTAINS(haystack, needle)                                                      \
     EXPECT_FALSE(llvm::StringRef(haystack).contains(needle))
 
 TEST_SUITE(Command) {
 
+/// The synthesized fallback render for a file without an entry, resource
+/// dir stripped like render_entry.
+std::vector<const char*> render_fallback(CompilationDatabase& db,
+                                         llvm::StringRef file,
+                                         const CommandOptions& options = {}) {
+    auto applied = db.apply_rules(db.fallback_config(file), options);
+    CommandRef ref{db.paths().intern(file),
+                   applied,
+                   db.input_kind(applied, file),
+                   CommandSource::Fallback};
+    auto argv = db.render_driver(ref);
+    for(std::size_t i = 0; i + 1 < argv.size(); i += 1) {
+        if(llvm::StringRef(argv[i]) == "-resource-dir") {
+            argv.erase(argv.begin() + i, argv.begin() + i + 2);
+            break;
+        }
+    }
+    return argv;
+}
+
 void EXPECT_STRIP(llvm::StringRef argv, llvm::StringRef result) {
     CompilationDatabase database;
     llvm::StringRef file = "main.cpp";
     database.add_command("fake/", file, argv);
-    ASSERT_EQ(result, print_argv(database.lookup(file, quiet_options()).front().to_argv()));
+    ASSERT_EQ(result, print_argv(render_entry(database, file)));
 };
 
 TEST_CASE(DefaultFilters) {
-    /// Filter -c, -o and input file.
+    /// Filter -c, -o and keep the input in place.
     EXPECT_STRIP("g++ main.cpp", "g++ main.cpp");
     EXPECT_STRIP("clang++ -c main.cpp", "clang++ main.cpp");
     EXPECT_STRIP("clang++ -o main.o main.cpp", "clang++ main.cpp");
@@ -48,28 +64,27 @@ TEST_CASE(DefaultFilters) {
         "clang++ -Winvalid-pch -Xclang -include -Xclang cmake_pch.hxx main.cpp");
     EXPECT_STRIP("cl.exe /Yufoo.h /FIfoo.h /Fpfoo.h_v143.pch /c /Fomain.cpp.o main.cpp",
                  "cl.exe -include foo.h main.cpp");
-
-    /// TODO: Test more commands from other build system.
 };
 
-TEST_CASE(Reuse) {
+TEST_CASE(ConfigDedup) {
     CompilationDatabase database;
     database.add_command("fake", "test.cpp", "clang++ -std=c++23 test.cpp"sv);
     database.add_command("fake", "test2.cpp", "clang++ -std=c++23 test2.cpp"sv);
+    database.add_command("fake", "test3.cpp", "clang++ -std=c++23 -DA test3.cpp"sv);
 
-    auto options = quiet_options();
-    auto command1 = database.lookup("test.cpp", options).front().to_argv();
-    auto command2 = database.lookup("test2.cpp", options).front().to_argv();
-    ASSERT_EQ(command1.size(), 3U);
-    ASSERT_EQ(command2.size(), 3U);
+    /// Same flags dedupe to one config; a user-content difference splits.
+    auto config1 = database.candidate_entries("test.cpp").front().config;
+    auto config2 = database.candidate_entries("test2.cpp").front().config;
+    auto config3 = database.candidate_entries("test3.cpp").front().config;
+    EXPECT_EQ(config1, config2);
+    EXPECT_NE(config1, config3);
 
-    ASSERT_EQ(command1[0], "clang++"sv);
-    ASSERT_EQ(command1[1], "-std=c++23"sv);
-    ASSERT_EQ(command1[2], "test.cpp"sv);
-
-    ASSERT_EQ(command1[0], command2[0]);
-    ASSERT_EQ(command1[1], command2[1]);
-    ASSERT_EQ(command2[2], "test2.cpp"sv);
+    auto argv1 = render_entry(database, "test.cpp");
+    ASSERT_EQ(argv1.size(), 3U);
+    EXPECT_EQ(argv1[0], "clang++"sv);
+    EXPECT_EQ(argv1[1], "-std=c++23"sv);
+    EXPECT_EQ(argv1[2], "test.cpp"sv);
+    EXPECT_EQ(render_entry(database, "test2.cpp").back(), "test2.cpp"sv);
 };
 
 TEST_CASE(RemoveAppend) {
@@ -86,40 +101,172 @@ TEST_CASE(RemoveAppend) {
     CompilationDatabase database;
     database.add_command("/fake", "main.cpp", args);
 
-    auto options = quiet_options();
+    CommandOptions options;
 
     llvm::SmallVector<std::string> remove;
     llvm::SmallVector<std::string> append;
 
     remove = {"-DA"};
     options.remove = remove;
-    auto result = database.lookup("main.cpp", options).front().to_argv();
-    ASSERT_EQ(print_argv(result), "clang++ -D B=0 main.cpp");
+    EXPECT_EQ(print_argv(render_entry(database, "main.cpp", options)), "clang++ -D B=0 main.cpp");
 
     remove = {"-D", "A"};
     options.remove = remove;
-    result = database.lookup("main.cpp", options).front().to_argv();
-    ASSERT_EQ(print_argv(result), "clang++ -D B=0 main.cpp");
+    EXPECT_EQ(print_argv(render_entry(database, "main.cpp", options)), "clang++ -D B=0 main.cpp");
 
     remove = {"-DA", "-D", "B=0"};
     options.remove = remove;
-    result = database.lookup("main.cpp", options).front().to_argv();
-    ASSERT_EQ(print_argv(result), "clang++ main.cpp");
+    EXPECT_EQ(print_argv(render_entry(database, "main.cpp", options)), "clang++ main.cpp");
 
     remove = {"-D*"};
     options.remove = remove;
-    result = database.lookup("main.cpp", options).front().to_argv();
-    ASSERT_EQ(print_argv(result), "clang++ main.cpp");
+    EXPECT_EQ(print_argv(render_entry(database, "main.cpp", options)), "clang++ main.cpp");
 
     remove = {"-D", "*"};
     options.remove = remove;
-    result = database.lookup("main.cpp", options).front().to_argv();
-    ASSERT_EQ(print_argv(result), "clang++ main.cpp");
+    EXPECT_EQ(print_argv(render_entry(database, "main.cpp", options)), "clang++ main.cpp");
 
+    options.remove = {};
     append = {"-D", "C"};
     options.append = append;
-    result = database.lookup("main.cpp", options).front().to_argv();
-    ASSERT_EQ(print_argv(result), "clang++ -D C main.cpp");
+    EXPECT_EQ(print_argv(render_entry(database, "main.cpp", options)),
+              "clang++ -D A -D B=0 -D C main.cpp");
+};
+
+TEST_CASE(AppendBeforeSlot) {
+    /// Appends insert before the input slot, so they always govern the
+    /// compile — even when the CDB command carries flags after the input.
+    CompilationDatabase database;
+    database.add_command("/fake", "a.c", "clang -x c a.c -x none"sv);
+
+    CommandOptions options;
+    llvm::SmallVector<std::string> append = {"-x", "c++"};
+    options.append = append;
+
+    EXPECT_EQ(print_argv(render_entry(database, "a.c", options)), "clang -x c -x c++ a.c -x none");
+
+    auto applied = database.apply_rules(database.candidate_entries("a.c").front().config, options);
+    EXPECT_EQ(llvm::StringRef(database.input_kind(applied, "a.c").value), "c++");
+};
+
+TEST_CASE(SelectorHistoryRestored) {
+    /// Removing the later selector re-exposes the earlier one.
+    CompilationDatabase database;
+    database.add_command("/fake", "a.c", "clang -x cuda -x c++ a.c"sv);
+
+    auto base = database.candidate_entries("a.c").front().config;
+    EXPECT_EQ(llvm::StringRef(database.input_kind(base, "a.c").value), "c++");
+
+    CommandOptions options;
+    llvm::SmallVector<std::string> remove = {"-x", "c++"};
+    options.remove = remove;
+    auto applied = database.apply_rules(base, options);
+    EXPECT_EQ(llvm::StringRef(database.input_kind(applied, "a.c").value), "cuda");
+};
+
+TEST_CASE(SelectorPositional) {
+    /// -x only governs inputs after it: a trailing selector leaves the
+    /// input to its extension, and removing the leading one restores it.
+    CompilationDatabase database;
+    database.add_command("/fake", "a.cu", "clang -x c++ a.cu -x c"sv);
+
+    auto base = database.candidate_entries("a.cu").front().config;
+    EXPECT_EQ(llvm::StringRef(database.input_kind(base, "a.cu").value), "c++");
+
+    CommandOptions options;
+    llvm::SmallVector<std::string> remove = {"-x", "c++"};
+    options.remove = remove;
+    auto applied = database.apply_rules(base, options);
+    EXPECT_EQ(llvm::StringRef(database.input_kind(applied, "a.cu").value), "cuda");
+
+    /// -x none resets the state; the extension decides again.
+    database.add_command("/fake", "b.c", "clang -x c++ -x none b.c"sv);
+    auto reset = database.candidate_entries("b.c").front().config;
+    EXPECT_EQ(llvm::StringRef(database.input_kind(reset, "b.c").value), "c");
+};
+
+TEST_CASE(PerFileClSelectors) {
+    /// /Tc<file> and /Tp<file> pair a selector with one input: the entry's
+    /// own selector rewrites to the equivalent global form, the other
+    /// input vanishes with its selector.
+    CompilationDatabase database;
+    database.add_command("/fake", "/fake/alpha.c", "cl /Tc/fake/alpha.c /Tp/fake/beta.c /c"sv);
+    database.add_command("/fake", "/fake/beta.c", "cl /Tc/fake/alpha.c /Tp/fake/beta.c /c"sv);
+
+    auto alpha = database.candidate_entries("/fake/alpha.c").front().config;
+    auto beta = database.candidate_entries("/fake/beta.c").front().config;
+    EXPECT_NE(alpha, beta);
+
+    EXPECT_EQ(llvm::StringRef(database.input_kind(alpha, "/fake/alpha.c").value), "c");
+    EXPECT_EQ(llvm::StringRef(database.input_kind(beta, "/fake/beta.c").value), "c++");
+
+    auto beta_argv = print_argv(render_entry(database, "/fake/beta.c"));
+    EXPECT_CONTAINS(beta_argv, "/TP");
+    EXPECT_NOT_CONTAINS(beta_argv, "alpha.c");
+
+    auto alpha_argv = print_argv(render_entry(database, "/fake/alpha.c"));
+    EXPECT_CONTAINS(alpha_argv, "/TC");
+    EXPECT_NOT_CONTAINS(alpha_argv, "beta.c");
+};
+
+TEST_CASE(IdentityHashes) {
+    CompilationDatabase database;
+    database.add_command("/fake", "a.cpp", "clang++ -std=c++20 a.cpp"sv);
+    database.add_command("/fake", "b.cpp", "clang++ -std=c++20 b.cpp"sv);
+    database.add_command("/fake", "c.cpp", "clang++ -std=c++17 c.cpp"sv);
+    database.add_command("/fake", "x1.c", "clang -x c++ x1.c"sv);
+    database.add_command("/fake", "x2.c", "clang -x c x2.c"sv);
+    database.add_command("/fake", "g.cpp", "clang++ -std=c++20 -g a.cpp"sv);
+
+    auto hash_of = [&](llvm::StringRef file) {
+        return database.entry_hash(database.candidate_entries(file).front().config);
+    };
+
+    /// Same command, different file: one config, one identity.
+    EXPECT_EQ(hash_of("a.cpp"), hash_of("b.cpp"));
+    /// A semantic flag difference changes the identity.
+    EXPECT_NE(hash_of("a.cpp"), hash_of("c.cpp"));
+    /// A selector difference changes the identity (selectors live in args).
+    EXPECT_NE(hash_of("x1.c"), hash_of("x2.c"));
+    /// Codegen-only flags never enter the identity.
+    EXPECT_EQ(hash_of("a.cpp"), hash_of("g.cpp"));
+
+    /// The input slot's position is part of the identity.
+    database.add_command("/fake", "p1.cpp", "clang++ p1.cpp -Wall"sv);
+    database.add_command("/fake", "p2.cpp", "clang++ -Wall p2.cpp"sv);
+    EXPECT_NE(hash_of("p1.cpp"), hash_of("p2.cpp"));
+
+    EXPECT_EQ(database.entry_hash_hex(database.candidate_entries("a.cpp").front().config).size(),
+              16U);
+};
+
+TEST_CASE(WrapperStripped) {
+    CompilationDatabase database;
+    database.add_command("/fake", "a.cpp", "ccache clang++ -std=c++20 a.cpp"sv);
+    database.add_command("/fake", "b.cpp", "clang++ -std=c++20 b.cpp"sv);
+
+    /// The wrapper is entry provenance, not config identity.
+    auto& a = database.candidate_entries("a.cpp").front();
+    auto& b = database.candidate_entries("b.cpp").front();
+    EXPECT_EQ(a.config, b.config);
+    ASSERT_EQ(a.wrapper.size(), 1U);
+    EXPECT_EQ(llvm::StringRef(a.wrapper[0]), "ccache");
+    EXPECT_TRUE(b.wrapper.empty());
+
+    EXPECT_EQ(llvm::StringRef(database.config(a.config).driver), "clang++");
+    EXPECT_NOT_CONTAINS(print_argv(render_entry(database, "a.cpp")), "ccache");
+};
+
+TEST_CASE(ResponseFileExpansion) {
+    TempDir tmp;
+    tmp.touch("flags.rsp", "-std=c++23 -DFROM_RSP=1\n");
+    CompilationDatabase database;
+    database.add_command(tmp.root.str(), "main.cpp", "clang++ @flags.rsp main.cpp"sv);
+
+    auto argv = print_argv(render_entry(database, "main.cpp"));
+    EXPECT_CONTAINS(argv, "-std=c++23");
+    EXPECT_CONTAINS(argv, "FROM_RSP=1");
+    EXPECT_NOT_CONTAINS(argv, "@");
 };
 
 TEST_CASE(PrependAfterBinary) {
@@ -128,61 +275,47 @@ TEST_CASE(PrependAfterBinary) {
     CompilationDatabase database;
     database.add_command("/fake", "main.cpp", args);
 
-    auto options = quiet_options();
+    CommandOptions options;
     llvm::SmallVector<std::string> prepend = {"-std=c++17", "-DB"};
     options.extra_prepend = prepend;
-    auto result = database.lookup("main.cpp", options).front().to_argv();
     // Prepends sit ahead of the command's own flags, so the command wins
-    // on collision. (The base -DA renders canonicalized, as two tokens.)
-    ASSERT_EQ(print_argv(result), "clang++ -std=c++17 -DB -D A main.cpp");
+    // on collision. (Defines render canonicalized, as two tokens.)
+    EXPECT_EQ(print_argv(render_entry(database, "main.cpp", options)),
+              "clang++ -std=c++17 -D B -D A main.cpp");
 };
 
 TEST_CASE(DefaultFallback) {
-    /// Lookup for a file not in the CDB should synthesize a default command.
     CompilationDatabase database;
-    auto options = quiet_options();
 
     /// C++ files get "clang++ -std=c++20 <file>".
-    auto cpp_results = database.lookup("unknown.cpp", options);
-    ASSERT_EQ(cpp_results.size(), 1U);
-    auto cpp_argv = cpp_results.front().to_argv();
+    auto cpp_argv = render_fallback(database, "unknown.cpp");
     ASSERT_EQ(cpp_argv.size(), 3U);
-    ASSERT_EQ(cpp_argv[0], "clang++"sv);
-    ASSERT_EQ(cpp_argv[1], "-std=c++20"sv);
-    ASSERT_EQ(cpp_argv[2], "unknown.cpp"sv);
+    EXPECT_EQ(cpp_argv[0], "clang++"sv);
+    EXPECT_EQ(cpp_argv[1], "-std=c++20"sv);
+    EXPECT_EQ(cpp_argv[2], "unknown.cpp"sv);
 
-    /// .hpp files also get C++ default.
-    auto hpp_results = database.lookup("header.hpp", options);
-    ASSERT_EQ(hpp_results.front().to_argv().size(), 3U);
-    ASSERT_EQ(hpp_results.front().to_argv()[0], "clang++"sv);
-
-    /// .cc files also get C++ default.
-    auto cc_results = database.lookup("file.cc", options);
-    ASSERT_EQ(cc_results.front().to_argv().size(), 3U);
-    ASSERT_EQ(cc_results.front().to_argv()[0], "clang++"sv);
+    /// .hpp and .cc also get the C++ default.
+    EXPECT_EQ(render_fallback(database, "header.hpp")[0], "clang++"sv);
+    EXPECT_EQ(render_fallback(database, "file.cc")[0], "clang++"sv);
 
     /// C files get "clang <file>".
-    auto c_results = database.lookup("unknown.c", options);
-    ASSERT_EQ(c_results.size(), 1U);
-    auto c_argv = c_results.front().to_argv();
+    auto c_argv = render_fallback(database, "unknown.c");
     ASSERT_EQ(c_argv.size(), 2U);
-    ASSERT_EQ(c_argv[0], "clang"sv);
-    ASSERT_EQ(c_argv[1], "unknown.c"sv);
+    EXPECT_EQ(c_argv[0], "clang"sv);
+    EXPECT_EQ(c_argv[1], "unknown.c"sv);
 
     /// Other extensions also get plain clang.
-    auto h_results = database.lookup("foo.h", options);
-    ASSERT_EQ(h_results.front().to_argv().size(), 2U);
-    ASSERT_EQ(h_results.front().to_argv()[0], "clang"sv);
+    EXPECT_EQ(render_fallback(database, "foo.h")[0], "clang"sv);
 
     /// CUDA files pin cuda mode and the device-side view NVCC-backed
-    /// commands default to.
+    /// commands default to (the render spells the unaliased form).
     for(llvm::StringRef cuda_file: {"kern.cu", "kernels.cuh"}) {
-        auto cu_argv = database.lookup(cuda_file, options).front().to_argv();
+        auto cu_argv = render_fallback(database, cuda_file);
         ASSERT_EQ(cu_argv.size(), 6U);
-        ASSERT_EQ(cu_argv[0], "clang++"sv);
-        ASSERT_EQ(cu_argv[2], "-x"sv);
-        ASSERT_EQ(cu_argv[3], "cuda"sv);
-        ASSERT_EQ(cu_argv[4], "--cuda-device-only"sv);
+        EXPECT_EQ(cu_argv[0], "clang++"sv);
+        EXPECT_EQ(cu_argv[2], "-x"sv);
+        EXPECT_EQ(cu_argv[3], "cuda"sv);
+        EXPECT_EQ(cu_argv[4], "--offload-device-only"sv);
     }
 };
 
@@ -190,22 +323,16 @@ TEST_CASE(FallbackAppliesAppend) {
     /// Config rule appends must reach the synthesized fallback command:
     /// users without a CDB rely on them to supply include paths.
     CompilationDatabase database;
-    auto options = quiet_options();
+    CommandOptions options;
     std::vector<std::string> append = {"-I/opt/include"};
     options.append = append;
 
-    auto results = database.lookup("unknown.cpp", options);
-    auto argv = results.front().to_argv();
-    ASSERT_EQ(argv.size(), 4U);
-    ASSERT_EQ(argv[0], "clang++"sv);
-    ASSERT_EQ(argv[1], "-std=c++20"sv);
-    ASSERT_EQ(argv[2], "-I/opt/include"sv);
+    auto argv = print_argv(render_fallback(database, "unknown.cpp", options));
+    EXPECT_CONTAINS(argv, "-std=c++20");
+    EXPECT_CONTAINS(argv, "/opt/include");
 
     /// The plain-clang branch applies them too.
-    auto c_argv = database.lookup("unknown.c", options).front().to_argv();
-    ASSERT_EQ(c_argv.size(), 3U);
-    ASSERT_EQ(c_argv[0], "clang"sv);
-    ASSERT_EQ(c_argv[1], "-I/opt/include"sv);
+    EXPECT_CONTAINS(print_argv(render_fallback(database, "unknown.c", options)), "/opt/include");
 };
 
 TEST_CASE(MultiCommand) {
@@ -215,15 +342,13 @@ TEST_CASE(MultiCommand) {
     database.add_command("fake", "main.cpp", "clang++ -std=c++20 main.cpp"sv);
     database.add_command("fake", "other.cpp", "clang++ -std=c++23 other.cpp"sv);
 
-    auto options = quiet_options();
+    auto candidates = database.candidate_entries("main.cpp");
+    ASSERT_EQ(candidates.size(), 2U);
 
-    auto results = database.lookup("main.cpp", options);
-    ASSERT_EQ(results.size(), 2U);
-
-    /// Both commands are present (order depends on insert position).
+    /// Both commands are present, in a stable content-based order.
     bool has_17 = false, has_20 = false;
-    for(auto& cmd: results) {
-        auto argv = print_argv(cmd.to_argv());
+    for(auto& entry: candidates) {
+        auto argv = print_argv(database.render_full(entry.config));
         if(llvm::StringRef(argv).contains("-std=c++17"))
             has_17 = true;
         if(llvm::StringRef(argv).contains("-std=c++20"))
@@ -232,95 +357,28 @@ TEST_CASE(MultiCommand) {
     EXPECT_TRUE(has_17);
     EXPECT_TRUE(has_20);
 
-    /// other.cpp has only one.
-    auto other = database.lookup("other.cpp", options);
-    ASSERT_EQ(other.size(), 1U);
+    ASSERT_EQ(database.candidate_entries("other.cpp").size(), 1U);
 };
 
-TEST_CASE(UniqueConfigsSameFile) {
-    CompilationDatabase database;
-    database.add_command("fake", "main.cpp", "clang++ -std=c++17 main.cpp"sv);
-    database.add_command("fake", "main.cpp", "clang++ -std=c++20 main.cpp"sv);
-    database.add_command("fake", "main.cpp", "clang++ -std=c++20 main.cpp"sv);
+TEST_CASE(CandidateOrderStable) {
+    /// The default selection is content-decided: loading the same entries
+    /// in a different order picks the same winner.
+    CompilationDatabase first;
+    first.add_command("fake", "main.cpp", "clang++ -std=c++17 main.cpp"sv);
+    first.add_command("fake", "main.cpp", "clang++ -std=c++20 main.cpp"sv);
 
-    auto groups = database.unique_configs(quiet_options());
-    ASSERT_EQ(groups.size(), 2U);
+    CompilationDatabase second;
+    second.add_command("fake", "main.cpp", "clang++ -std=c++20 main.cpp"sv);
+    second.add_command("fake", "main.cpp", "clang++ -std=c++17 main.cpp"sv);
 
-    bool has_17 = false;
-    bool has_20 = false;
-    for(auto& group: groups) {
-        ASSERT_EQ(group.file_ids.size(), 1U);
-        ASSERT_EQ(llvm::StringRef(group.command.source_file), "main.cpp"sv);
-
-        auto argv = print_argv(group.command.to_argv());
-        if(llvm::StringRef(argv).contains("-std=c++17")) {
-            has_17 = true;
-        }
-        if(llvm::StringRef(argv).contains("-std=c++20")) {
-            has_20 = true;
-        }
-    }
-
-    EXPECT_TRUE(has_17);
-    EXPECT_TRUE(has_20);
-};
-
-TEST_CASE(UniqueConfigsMultiFile) {
-    CompilationDatabase database;
-    database.add_command("fake", "a.cpp", "clang++ -std=c++20 -Wall a.cpp"sv);
-    database.add_command("fake", "b.cpp", "clang++ -std=c++20 -Wall b.cpp"sv);
-    database.add_command("fake", "c.cpp", "clang++ -std=c++17 c.cpp"sv);
-    database.add_command("fake", "d.cpp", "clang++ -std=c++20 -Wall -DA d.cpp"sv);
-
-    auto groups = database.unique_configs(quiet_options());
-
-    // a.cpp and b.cpp share canonical (-std=c++20 -Wall, no user-content diff).
-    // c.cpp has different canonical (-std=c++17).
-    // d.cpp has same canonical as a/b but different patch (-DA).
-    ASSERT_EQ(groups.size(), 3U);
-
-    for(auto& group: groups) {
-        auto argv = print_argv(group.command.to_argv());
-        if(llvm::StringRef(argv).contains("-std=c++17")) {
-            ASSERT_EQ(group.file_ids.size(), 1U);
-        } else if(llvm::StringRef(argv).contains("-D")) {
-            ASSERT_EQ(group.file_ids.size(), 1U);
-        } else {
-            ASSERT_EQ(group.file_ids.size(), 2U);
-        }
-    }
-};
-
-TEST_CASE(GroupCommandRebuild) {
-    CompilationDatabase database;
-    database.add_command("fake", "main.cpp", "clang++ -std=c++17 main.cpp"sv);
-    database.add_command("fake", "main.cpp", "clang++ -std=c++20 main.cpp"sv);
-
-    auto groups = database.unique_configs(quiet_options());
-    ASSERT_EQ(groups.size(), 2U);
-
-    llvm::SmallVector<std::string> append = {"-fms-extensions"};
-    auto options = quiet_options();
-    options.append = append;
-
-    // Both groups share the same source file; group_command must rebuild from
-    // each group's own info, not from a path lookup that always returns the
-    // first entry for the file.
-    bool has_17 = false, has_20 = false;
-    for(auto& group: groups) {
-        auto argv = print_argv(database.group_command(group, options).to_argv());
-        EXPECT_CONTAINS(argv, "-fms-extensions");
-        if(llvm::StringRef(argv).contains("-std=c++17"))
-            has_17 = true;
-        if(llvm::StringRef(argv).contains("-std=c++20"))
-            has_20 = true;
-    }
-    EXPECT_TRUE(has_17);
-    EXPECT_TRUE(has_20);
+    EXPECT_EQ(first.selected_hash(first.paths().intern("main.cpp")),
+              second.selected_hash(second.paths().intern("main.cpp")));
+    EXPECT_EQ(print_argv(render_entry(first, "main.cpp")),
+              print_argv(render_entry(second, "main.cpp")));
 };
 
 TEST_CASE(CodegenFilter) {
-    /// Codegen-only options should be stripped from the canonical command.
+    /// Codegen-only options never reach the compile render.
     CompilationDatabase database;
     database.add_command(
         "fake",
@@ -328,13 +386,10 @@ TEST_CASE(CodegenFilter) {
         "clang++ -std=c++20 -fPIC -fno-omit-frame-pointer -fstack-protector-strong "
         "-fdata-sections -ffunction-sections -flto -fcolor-diagnostics -g main.cpp"sv);
 
-    auto result = database.lookup("main.cpp", quiet_options()).front().to_argv();
-    auto argv = print_argv(result);
+    auto argv = print_argv(render_entry(database, "main.cpp"));
 
-    /// -std=c++20 must survive (semantic).
     EXPECT_CONTAINS(argv, "-std=c++20");
 
-    /// All codegen flags must be stripped.
     EXPECT_NOT_CONTAINS(argv, "-fPIC");
     EXPECT_NOT_CONTAINS(argv, "-fno-omit-frame-pointer");
     EXPECT_NOT_CONTAINS(argv, "-fstack-protector");
@@ -343,17 +398,21 @@ TEST_CASE(CodegenFilter) {
     EXPECT_NOT_CONTAINS(argv, "-flto");
     EXPECT_NOT_CONTAINS(argv, "-fcolor-diagnostics");
     EXPECT_NOT_CONTAINS(argv, "-g");
+
+    /// They survive in the full view.
+    auto full =
+        print_argv(database.render_full(database.candidate_entries("main.cpp").front().config));
+    EXPECT_CONTAINS(full, "-fPIC");
+    EXPECT_CONTAINS(full, "-flto");
 };
 
 TEST_CASE(DependencyScanFilter) {
-    /// Dependency scan options should be stripped.
     CompilationDatabase database;
     database.add_command("fake",
                          "main.cpp",
                          "clang++ -std=c++20 -MD -MF main.d -MT main.o main.cpp"sv);
 
-    auto result = database.lookup("main.cpp", quiet_options()).front().to_argv();
-    auto argv = print_argv(result);
+    auto argv = print_argv(render_entry(database, "main.cpp"));
 
     EXPECT_CONTAINS(argv, "-std=c++20");
     EXPECT_NOT_CONTAINS(argv, "-MD");
@@ -363,53 +422,45 @@ TEST_CASE(DependencyScanFilter) {
 };
 
 TEST_CASE(ModuleFilter) {
-    /// Module-related options should be stripped.
-    EXPECT_STRIP("clang++ -std=c++20 -fmodule-file=mod.pcm main.cpp",
+    /// A named module mapping is discarded (clice builds its own PCMs);
+    /// the bare header-unit form stays part of the frontend semantics.
+    EXPECT_STRIP("clang++ -std=c++20 -fmodule-file=m=mod.pcm main.cpp",
                  "clang++ -std=c++20 main.cpp");
+    EXPECT_STRIP("clang++ -std=c++20 -fmodule-file=mod.pcm main.cpp",
+                 "clang++ -std=c++20 -fmodule-file=mod.pcm main.cpp");
     EXPECT_STRIP("clang++ -std=c++20 -fprebuilt-module-path=/tmp main.cpp",
                  "clang++ -std=c++20 main.cpp");
 };
 
 TEST_CASE(UserContentClassification) {
-    /// -D, -U, -include go to per-file patch; -std=, -W go to canonical.
-    /// Files with different -D but same -std/-W share canonical.
     CompilationDatabase database;
     database.add_command("fake", "a.cpp", "clang++ -std=c++20 -Wall -DA=1 -DFOO a.cpp"sv);
     database.add_command("fake", "b.cpp", "clang++ -std=c++20 -Wall -DB=2 b.cpp"sv);
 
-    auto options = quiet_options();
+    auto a_argv = print_argv(render_entry(database, "a.cpp"));
+    auto b_argv = print_argv(render_entry(database, "b.cpp"));
 
-    auto a_argv = print_argv(database.lookup("a.cpp", options).front().to_argv());
-    auto b_argv = print_argv(database.lookup("b.cpp", options).front().to_argv());
-
-    /// Both must contain canonical flags.
     EXPECT_CONTAINS(a_argv, "-std=c++20");
     EXPECT_CONTAINS(a_argv, "-Wall");
     EXPECT_CONTAINS(b_argv, "-std=c++20");
     EXPECT_CONTAINS(b_argv, "-Wall");
 
-    /// a.cpp has its own defines.
-    EXPECT_CONTAINS(a_argv, "-D");
     EXPECT_CONTAINS(a_argv, "A=1");
     EXPECT_CONTAINS(a_argv, "FOO");
-
-    /// b.cpp has its own defines.
-    EXPECT_CONTAINS(b_argv, "-D");
     EXPECT_CONTAINS(b_argv, "B=2");
 
-    /// Cross check: a.cpp should not have B=2, b.cpp should not have A=1.
     EXPECT_NOT_CONTAINS(a_argv, "B=2");
     EXPECT_NOT_CONTAINS(b_argv, "A=1");
 };
 
 TEST_CASE(IncludePathAbsolutize) {
-    /// Relative include paths should be absolutized against the directory.
+    /// Relative include paths absolutize against the entry directory.
     CompilationDatabase database;
     database.add_command("/project/build",
                          "main.cpp",
                          "clang++ -Iinclude -isystem sys/inc -iquote ../src main.cpp"sv);
 
-    auto result = database.lookup("main.cpp", quiet_options()).front().to_argv();
+    auto result = render_entry(database, "main.cpp");
 
     /// Check each argument individually with separator normalization
     /// (print_argv escapes backslashes, breaking convert_to_slash on Windows).
@@ -421,56 +472,31 @@ TEST_CASE(IncludePathAbsolutize) {
         return false;
     };
 
-    /// Relative paths must be resolved against /project/build.
     EXPECT_TRUE(has_path(result, "/project/build/include"));
     EXPECT_TRUE(has_path(result, "/project/build/sys/inc"));
-    /// ../src relative to /project/build → /project/src (or /project/build/../src)
     EXPECT_TRUE(has_path(result, "/project/"));
 
-    /// Absolute paths should be kept as-is.
+    /// Absolute paths are kept as-is.
     CompilationDatabase database2;
     database2.add_command("/project/build", "main.cpp", "clang++ -I/usr/include main.cpp"sv);
-
-    auto result2 = database2.lookup("main.cpp", quiet_options()).front().to_argv();
-    EXPECT_TRUE(has_path(result2, "/usr/include"));
+    EXPECT_TRUE(has_path(render_entry(database2, "main.cpp"), "/usr/include"));
 };
 
 TEST_CASE(SemanticOptionsPreserved) {
-    /// Flags that affect semantics must survive.
     EXPECT_STRIP("clang++ -std=c++20 -fno-exceptions -fno-rtti -pedantic main.cpp",
                  "clang++ -std=c++20 -fno-exceptions -fno-rtti -pedantic main.cpp");
     EXPECT_STRIP("clang++ -std=c++20 -Wall -Werror main.cpp",
                  "clang++ -std=c++20 -Wall -Werror main.cpp");
 };
 
-TEST_CASE(ResolvePath) {
+TEST_CASE(ForcedLanguage) {
     CompilationDatabase database;
-    database.add_command("fake", "test/main.cpp", "clang++ test/main.cpp"sv);
+    database.add_command("fake", "a.h", "clang++ -x c++ a.h"sv);
+    database.add_command("fake", "b.cpp", "clang++ b.cpp"sv);
 
-    /// After add_command, lookup should work and resolve_path via the file in arguments.
-    auto result = database.lookup("test/main.cpp", quiet_options()).front().to_argv();
-    /// The last argument is the file, resolved from PathPool.
-    ASSERT_EQ(result.back(), "test/main.cpp"sv);
-};
-
-TEST_CASE(MoveSemantics) {
-    CompilationDatabase db1;
-    db1.add_command("fake", "main.cpp", "clang++ -std=c++23 main.cpp"sv);
-
-    /// Move construct.
-    CompilationDatabase db2 = std::move(db1);
-
-    auto options = quiet_options();
-    auto result = db2.lookup("main.cpp", options).front().to_argv();
-    ASSERT_EQ(result.size(), 3U);
-    ASSERT_EQ(result[1], "-std=c++23"sv);
-
-    /// Move assign.
-    CompilationDatabase db3;
-    db3 = std::move(db2);
-    result = db3.lookup("main.cpp", options).front().to_argv();
-    ASSERT_EQ(result.size(), 3U);
-    ASSERT_EQ(result[1], "-std=c++23"sv);
+    EXPECT_EQ(database.forced_language(database.candidate_entries("a.h").front().config), "c++");
+    EXPECT_TRUE(
+        database.forced_language(database.candidate_entries("b.cpp").front().config).empty());
 };
 
 /// Write JSON to a temp file, load into a CDB, remove the file.
@@ -493,8 +519,6 @@ std::size_t load_json(CompilationDatabase& database, llvm::StringRef json) {
 
 TEST_CASE(LoadMixedFormats) {
     /// "arguments" array and "command" string can coexist in the same CDB.
-    /// Use relative file paths so that the test works on both Linux and Windows
-    /// (paths like "/src/a.cpp" are not absolute on Windows — no drive letter).
     CompilationDatabase database;
     auto count = load_json(database, R"([
         {"directory": "/build", "file": "a.cpp",
@@ -504,16 +528,10 @@ TEST_CASE(LoadMixedFormats) {
     ])");
 
     ASSERT_EQ(count, 2U);
-
-    auto options = quiet_options();
-
-    auto a = database.lookup(path::join("/build", "a.cpp"), options);
-    ASSERT_EQ(a.size(), 1U);
-    EXPECT_CONTAINS(print_argv(a.front().to_argv()), "-std=c++20");
-
-    auto b = database.lookup(path::join("/build", "b.cpp"), options);
-    ASSERT_EQ(b.size(), 1U);
-    EXPECT_CONTAINS(print_argv(b.front().to_argv()), "-std=c++23");
+    EXPECT_CONTAINS(print_argv(render_entry(database, path::join("/build", "a.cpp"))),
+                    "-std=c++20");
+    EXPECT_CONTAINS(print_argv(render_entry(database, path::join("/build", "b.cpp"))),
+                    "-std=c++23");
 };
 
 TEST_CASE(LoadErrorRecovery) {
@@ -532,18 +550,11 @@ TEST_CASE(LoadErrorRecovery) {
          "command": "clang++ -Wall also_good.cpp"}
     ])");
 
-    /// Only the two valid entries should survive.
     ASSERT_EQ(count, 2U);
-
-    auto options = quiet_options();
-
-    auto good = database.lookup(path::join("/build", "good.cpp"), options);
-    ASSERT_EQ(good.size(), 1U);
-    EXPECT_CONTAINS(print_argv(good.front().to_argv()), "-std=c++20");
-
-    auto also = database.lookup(path::join("/build", "also_good.cpp"), options);
-    ASSERT_EQ(also.size(), 1U);
-    EXPECT_CONTAINS(print_argv(also.front().to_argv()), "-Wall");
+    EXPECT_CONTAINS(print_argv(render_entry(database, path::join("/build", "good.cpp"))),
+                    "-std=c++20");
+    EXPECT_CONTAINS(print_argv(render_entry(database, path::join("/build", "also_good.cpp"))),
+                    "-Wall");
 };
 
 TEST_CASE(LoadCudaHeader) {
@@ -571,12 +582,9 @@ TEST_CASE(LoadEmptyCommand) {
          "command": "clang++ -std=c++20 ok.cpp"}
     ])");
 
-    /// Only the valid entry survives.
     ASSERT_EQ(count, 1U);
-
-    auto ok = database.lookup(path::join("/build", "ok.cpp"), quiet_options());
-    ASSERT_EQ(ok.size(), 1U);
-    EXPECT_CONTAINS(print_argv(ok.front().to_argv()), "-std=c++20");
+    EXPECT_CONTAINS(print_argv(render_entry(database, path::join("/build", "ok.cpp"))),
+                    "-std=c++20");
 };
 
 TEST_CASE(LoadReload) {
@@ -590,30 +598,16 @@ TEST_CASE(LoadReload) {
         {"directory": "/build", "file": "a.cpp",
          "arguments": ["clang++", "-std=c++17", "a.cpp"]}
     ])");
+    EXPECT_CONTAINS(print_argv(render_entry(database, file_a)), "-std=c++17");
 
-    auto options = quiet_options();
-
-    auto a = database.lookup(file_a, options);
-    ASSERT_EQ(a.size(), 1U);
-    EXPECT_CONTAINS(print_argv(a.front().to_argv()), "-std=c++17");
-
-    /// Reload with different content.
     auto count = load_json(database, R"([
         {"directory": "/build", "file": "b.cpp",
          "arguments": ["clang++", "-std=c++23", "b.cpp"]}
     ])");
-
     ASSERT_EQ(count, 1U);
 
-    /// Old entry gone (falls back to default).
-    auto a2 = database.lookup(file_a, options);
-    ASSERT_EQ(a2.size(), 1U);
-    EXPECT_NOT_CONTAINS(print_argv(a2.front().to_argv()), "-std=c++17");
-
-    /// New entry present.
-    auto b = database.lookup(file_b, options);
-    ASSERT_EQ(b.size(), 1U);
-    EXPECT_CONTAINS(print_argv(b.front().to_argv()), "-std=c++23");
+    EXPECT_TRUE(database.candidate_entries(file_a).empty());
+    EXPECT_CONTAINS(print_argv(render_entry(database, file_b)), "-std=c++23");
 };
 
 TEST_CASE(LoadCommandQuoting) {
@@ -625,18 +619,13 @@ TEST_CASE(LoadCommandQuoting) {
     ])");
 
     ASSERT_EQ(count, 1U);
-
-    auto result = database.lookup(path::join("/build", "main.cpp"), quiet_options());
-    ASSERT_EQ(result.size(), 1U);
-    auto argv = print_argv(result.front().to_argv());
-
-    /// The define and include path should be present after shell tokenization.
+    auto argv = print_argv(render_entry(database, path::join("/build", "main.cpp")));
     EXPECT_CONTAINS(argv, "hello world");
     EXPECT_CONTAINS(argv, "/path with spaces");
 };
 
 TEST_CASE(LoadRelativePath) {
-    /// load() should resolve relative file paths against directory.
+    /// load() resolves relative file paths against the directory.
     CompilationDatabase database;
     auto count = load_json(database, R"([
         {"directory": "/project/build", "file": "src/main.cpp",
@@ -647,54 +636,66 @@ TEST_CASE(LoadRelativePath) {
 
     ASSERT_EQ(count, 2U);
 
-    auto options = quiet_options();
+    EXPECT_CONTAINS(
+        print_argv(render_entry(database, path::join("/project/build", "src/main.cpp"))),
+        "-std=c++20");
+    EXPECT_CONTAINS(print_argv(render_entry(database, path::join("/other/build", "src/main.cpp"))),
+                    "-std=c++17");
 
-    /// Lookup by the resolved absolute path (use path::join for correct separator).
-    auto results = database.lookup(path::join("/project/build", "src/main.cpp"), options);
-    ASSERT_EQ(results.size(), 1U);
-    EXPECT_CONTAINS(print_argv(results.front().to_argv()), "-std=c++20");
-
-    auto results2 = database.lookup(path::join("/other/build", "src/main.cpp"), options);
-    ASSERT_EQ(results2.size(), 1U);
-    EXPECT_CONTAINS(print_argv(results2.front().to_argv()), "-std=c++17");
-
-    /// Relative path lookup should not match (different path_id).
-    auto results3 = database.lookup("src/main.cpp", options);
-    ASSERT_EQ(results3.size(), 1U);
-    /// Falls back to default command since no match.
-    EXPECT_CONTAINS(print_argv(results3.front().to_argv()), "clang");
+    /// A relative spelling is a different path — no entry.
+    EXPECT_TRUE(database.candidate_entries("src/main.cpp").empty());
 };
 
-TEST_CASE(Module) {
-    // TODO: revisit module command handling.
-}
+TEST_CASE(LoadDotSegments) {
+    /// Entry paths intern without . and .. segments, so lookups against
+    /// clang-reported (realpath'd) spellings match.
+    CompilationDatabase database;
+    auto count = load_json(database, R"([
+        {"directory": "/project/build", "file": "../src/./main.cpp",
+         "arguments": ["clang++", "-std=c++20", "../src/./main.cpp"]}
+    ])");
+
+    ASSERT_EQ(count, 1U);
+    EXPECT_TRUE(database.has_entry(path::join("/project", "src", "main.cpp")));
+};
 
 TEST_CASE(ResourceDir) {
     CompilationDatabase database;
     database.add_command("/fake", "main.cpp", "clang++ -std=c++23 test.cpp"sv);
 
-    // With inject_resource_dir disabled, no resource dir in result.
-    auto args_no_rd = database.lookup("main.cpp", {.inject_resource_dir = false}).front().to_argv();
-    ASSERT_EQ(args_no_rd.size(), 3U);
-    ASSERT_EQ(args_no_rd[0], "clang++"sv);
-    ASSERT_EQ(args_no_rd[1], "-std=c++23"sv);
-    ASSERT_EQ(args_no_rd[2], "main.cpp"sv);
+    auto& entry = database.candidate_entries("main.cpp").front();
+    CommandRef ref{entry.file,
+                   entry.config,
+                   database.input_kind(entry.config, "main.cpp"),
+                   CommandSource::CDBExact};
+    auto argv = database.render_driver(ref);
 
-    // With inject_resource_dir enabled (default), resource dir is present.
-    auto args_tc = database.lookup("main.cpp").front().to_argv();
     bool has_resource_dir = false;
-    for(size_t i = 0; i + 1 < args_tc.size(); ++i) {
-        if(args_tc[i] == "-resource-dir"sv) {
-            EXPECT_EQ(llvm::StringRef(args_tc[i + 1]), resource_dir());
+    for(std::size_t i = 0; i + 1 < argv.size(); i += 1) {
+        if(argv[i] == "-resource-dir"sv) {
+            EXPECT_EQ(llvm::StringRef(argv[i + 1]), resource_dir());
             has_resource_dir = true;
             break;
         }
     }
-    if(resource_dir().empty()) {
-        EXPECT_FALSE(has_resource_dir);
-    } else {
-        EXPECT_TRUE(has_resource_dir);
+    EXPECT_EQ(has_resource_dir, !resource_dir().empty());
+
+    /// A command carrying its own resource dir is not double-injected.
+    CompilationDatabase database2;
+    database2.add_command("/fake", "main.cpp", "clang++ -resource-dir /custom main.cpp"sv);
+    auto& entry2 = database2.candidate_entries("main.cpp").front();
+    CommandRef ref2{entry2.file,
+                    entry2.config,
+                    database2.input_kind(entry2.config, "main.cpp"),
+                    CommandSource::CDBExact};
+    auto argv2 = database2.render_driver(ref2);
+    int count = 0;
+    for(auto* arg: argv2) {
+        if(arg == "-resource-dir"sv) {
+            count += 1;
+        }
     }
+    EXPECT_EQ(count, 1);
 };
 
 };  // TEST_SUITE(Command)

--- a/tests/unit/command/command_tests.cpp
+++ b/tests/unit/command/command_tests.cpp
@@ -257,6 +257,22 @@ TEST_CASE(WrapperStripped) {
     EXPECT_NOT_CONTAINS(print_argv(render_entry(database, "a.cpp")), "ccache");
 };
 
+TEST_CASE(WrapperValueOptions) {
+    /// A wrapper option's separate KEY=VAL value must not be mistaken for
+    /// the compiler.
+    CompilationDatabase database;
+    database.add_command("/fake",
+                         "a.cpp",
+                         "ccache --set-config cache_dir=/tmp/cc clang++ -std=c++20 a.cpp"sv);
+    database.add_command("/fake", "b.cpp", "clang++ -std=c++20 b.cpp"sv);
+
+    auto& a = database.candidate_entries("a.cpp").front();
+    auto& b = database.candidate_entries("b.cpp").front();
+    EXPECT_EQ(a.config, b.config);
+    EXPECT_EQ(llvm::StringRef(database.config(a.config).driver), "clang++");
+    ASSERT_EQ(a.wrapper.size(), 3U);
+};
+
 TEST_CASE(ResponseFileExpansion) {
     TempDir tmp;
     tmp.touch("flags.rsp", "-std=c++23 -DFROM_RSP=1\n");
@@ -532,6 +548,25 @@ TEST_CASE(LoadMixedFormats) {
                     "-std=c++20");
     EXPECT_CONTAINS(print_argv(render_entry(database, path::join("/build", "b.cpp"))),
                     "-std=c++23");
+};
+
+TEST_CASE(RelativeDirectoryAnchored) {
+    /// A relative CDB `directory` anchors to the workspace root, both for
+    /// resolving the entry's file and as the config's directory.
+    TempDir tmp;
+    CompilationDatabase database;
+    database.set_workspace_root(tmp.root);
+    auto count = load_json(database, R"([
+        {"directory": "build", "file": "main.cpp",
+         "arguments": ["clang++", "-std=c++20", "main.cpp"]}
+    ])");
+
+    ASSERT_EQ(count, 1U);
+    auto file = path::join(tmp.root, "build", "main.cpp");
+    auto candidates = database.candidate_entries(file);
+    ASSERT_EQ(candidates.size(), 1U);
+    EXPECT_EQ(llvm::StringRef(database.config(candidates.front().config).directory),
+              path::join(tmp.root, "build"));
 };
 
 TEST_CASE(LoadErrorRecovery) {

--- a/tests/unit/command/command_tests.cpp
+++ b/tests/unit/command/command_tests.cpp
@@ -290,6 +290,29 @@ TEST_CASE(WrapperValueOptions) {
     ASSERT_EQ(a.wrapper.size(), 3U);
 };
 
+TEST_CASE(WrapperCaseInsensitive) {
+    /// Windows tools emit launcher spellings like CCACHE.EXE.
+    CompilationDatabase database;
+    database.add_command("/fake", "a.cpp", "CCACHE.EXE clang++ -std=c++20 a.cpp"sv);
+
+    auto& a = database.candidate_entries("a.cpp").front();
+    EXPECT_EQ(llvm::StringRef(database.config(a.config).driver), "clang++");
+    ASSERT_EQ(a.wrapper.size(), 1U);
+    EXPECT_EQ(llvm::StringRef(a.wrapper[0]), "CCACHE.EXE");
+};
+
+TEST_CASE(InputKindNoExtension) {
+    /// An extensionless file must yield a real (non-null) empty kind, not
+    /// a null C string.
+    CompilationDatabase database;
+    database.add_command("/fake", "noext", "clang++ -std=c++20 noext"sv);
+
+    auto& entry = database.candidate_entries("noext").front();
+    auto kind = database.input_kind(entry.config, "noext");
+    ASSERT_TRUE(kind.value != nullptr);
+    EXPECT_TRUE(llvm::StringRef(kind.value).empty());
+};
+
 TEST_CASE(ResponseFileExpansion) {
     TempDir tmp;
     tmp.touch("flags.rsp", "-std=c++23 -DFROM_RSP=1\n");

--- a/tests/unit/command/command_tests.cpp
+++ b/tests/unit/command/command_tests.cpp
@@ -5,6 +5,7 @@
 #include "command/command.h"
 #include "support/filesystem.h"
 
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace clice::testing {
@@ -563,6 +564,29 @@ TEST_CASE(RelativeDirectoryAnchored) {
 
     auto file = path::join(tmp.root, "build", "main.cpp");
     auto candidates = database.candidate_entries(file);
+    ASSERT_EQ(candidates.size(), 1U);
+    EXPECT_EQ(llvm::StringRef(database.config(candidates.front().config).directory),
+              path::join(tmp.root, "build"));
+};
+
+TEST_CASE(RelativeLoadPathAnchored) {
+    /// A relative CDB path given to load() must not leak relative entry
+    /// identities: the anchor base is absolutized first.
+    TempDir tmp;
+    tmp.touch("compile_commands.json", R"([
+        {"directory": "build", "file": "main.cpp",
+         "arguments": ["clang++", "-std=c++20", "main.cpp"]}
+    ])");
+
+    llvm::SmallString<256> saved_cwd;
+    ASSERT_FALSE(bool(llvm::sys::fs::current_path(saved_cwd)));
+    ASSERT_FALSE(bool(llvm::sys::fs::set_current_path(tmp.root)));
+    auto restore = llvm::make_scope_exit([&] { llvm::sys::fs::set_current_path(saved_cwd); });
+
+    CompilationDatabase database;
+    ASSERT_EQ(database.load("compile_commands.json").value_or(0), 1U);
+
+    auto candidates = database.candidate_entries(path::join(tmp.root, "build", "main.cpp"));
     ASSERT_EQ(candidates.size(), 1U);
     EXPECT_EQ(llvm::StringRef(database.config(candidates.front().config).directory),
               path::join(tmp.root, "build"));

--- a/tests/unit/command/command_tests.cpp
+++ b/tests/unit/command/command_tests.cpp
@@ -54,6 +54,8 @@ TEST_CASE(DefaultFilters) {
     EXPECT_STRIP("clang++ -o main.o main.cpp", "clang++ main.cpp");
     EXPECT_STRIP("clang++ -c -o main.o main.cpp", "clang++ main.cpp");
     EXPECT_STRIP("cl.exe /c /Fomain.cpp.o main.cpp", "cl.exe main.cpp");
+    /// CL options stay visible under Windows's free-form driver casing.
+    EXPECT_STRIP("CL.exe /FIfoo.h /c main.cpp", "CL.exe -include foo.h main.cpp");
 
     /// Filter PCH related.
 
@@ -132,6 +134,20 @@ TEST_CASE(RemoveAppend) {
     options.append = append;
     EXPECT_EQ(print_argv(render_entry(database, "main.cpp", options)),
               "clang++ -D A -D B=0 -D C main.cpp");
+};
+
+TEST_CASE(AppendUnknownValue) {
+    /// An appended option the table does not know keeps its separate value:
+    /// an edit cannot name the entry input, so an input-classified token is
+    /// really the option's value.
+    CompilationDatabase database;
+    database.add_command("/fake", "main.cpp", "clang++ main.cpp"sv);
+
+    CommandOptions options;
+    llvm::SmallVector<std::string> append = {"-fnot-a-real-flag", "value"};
+    options.append = append;
+    EXPECT_EQ(print_argv(render_entry(database, "main.cpp", options)),
+              "clang++ -fnot-a-real-flag value main.cpp");
 };
 
 TEST_CASE(AppendBeforeSlot) {
@@ -284,6 +300,17 @@ TEST_CASE(ResponseFileExpansion) {
     EXPECT_CONTAINS(argv, "-std=c++23");
     EXPECT_CONTAINS(argv, "FROM_RSP=1");
     EXPECT_NOT_CONTAINS(argv, "@");
+};
+
+TEST_CASE(DriverModeFromRsp) {
+    /// --driver-mode=cl inside a response file still switches on CL option
+    /// visibility (clang interprets the mode after expansion).
+    TempDir tmp;
+    tmp.touch("flags.rsp", "--driver-mode=cl /TP\n");
+    CompilationDatabase database;
+    database.add_command(tmp.root.str(), "main.cpp", "clang++ @flags.rsp main.cpp"sv);
+
+    EXPECT_CONTAINS(print_argv(render_entry(database, "main.cpp")), "/TP");
 };
 
 TEST_CASE(PrependAfterBinary) {

--- a/tests/unit/command/command_tests.cpp
+++ b/tests/unit/command/command_tests.cpp
@@ -551,17 +551,16 @@ TEST_CASE(LoadMixedFormats) {
 };
 
 TEST_CASE(RelativeDirectoryAnchored) {
-    /// A relative CDB `directory` anchors to the workspace root, both for
-    /// resolving the entry's file and as the config's directory.
+    /// A relative CDB `directory` anchors to the CDB file's own location,
+    /// both for resolving the entry's file and as the config's directory.
     TempDir tmp;
     CompilationDatabase database;
-    database.set_workspace_root(tmp.root);
-    auto count = load_json(database, R"([
+    tmp.touch("compile_commands.json", R"([
         {"directory": "build", "file": "main.cpp",
          "arguments": ["clang++", "-std=c++20", "main.cpp"]}
     ])");
+    ASSERT_EQ(database.load(tmp.path("compile_commands.json")).value_or(0), 1U);
 
-    ASSERT_EQ(count, 1U);
     auto file = path::join(tmp.root, "build", "main.cpp");
     auto candidates = database.candidate_entries(file);
     ASSERT_EQ(candidates.size(), 1U);

--- a/tests/unit/command/nvcc_tests.cpp
+++ b/tests/unit/command/nvcc_tests.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 
+#include "test/cdb_helper.h"
 #include "test/test.h"
 #include "command/command.h"
 #include "command/nvcc.h"
@@ -504,11 +505,18 @@ TEST_CASE(DryrunTopFallback) {
 }
 
 TEST_CASE(CcbinAffectsKey) {
-    Toolchain tc;
-    std::vector<const char*> a = {"nvcc", "-ccbin=/usr/bin/g++-12"};
-    std::vector<const char*> b = {"nvcc", "-ccbin=/usr/bin/g++-13"};
-    EXPECT_NE(tc.cache_key("/tmp/a.cu", a), tc.cache_key("/tmp/a.cu", b));
-    EXPECT_EQ(tc.cache_key("/tmp/a.cu", a), tc.cache_key("/tmp/a.cu", a));
+    /// -ccbin persists as an unknown probe token; two commands differing
+    /// only in host compiler must not share a probe.
+    CompilationDatabase db;
+    db.add_command("/tmp", "/tmp/a.cu", "nvcc -ccbin=/usr/bin/g++-12 -c /tmp/a.cu"sv);
+    db.add_command("/tmp", "/tmp/b.cu", "nvcc -ccbin=/usr/bin/g++-13 -c /tmp/b.cu"sv);
+
+    auto key_of = [&](llvm::StringRef file) {
+        auto& entry = db.candidate_entries(file).front();
+        return db.toolchain().probe_key_for(entry.config, db.input_kind(entry.config, file));
+    };
+    EXPECT_NE(key_of("/tmp/a.cu"), key_of("/tmp/b.cu"));
+    EXPECT_EQ(key_of("/tmp/a.cu"), key_of("/tmp/a.cu"));
 }
 
 TEST_CASE(DatabaseTranslatesNVCC) {
@@ -527,10 +535,9 @@ TEST_CASE(DatabaseTranslatesNVCC) {
                                           "kern.cu.o"};
     db.add_command("/tmp", "/tmp/kern.cu", arguments);
 
-    auto commands = db.lookup("/tmp/kern.cu");
-    ASSERT_EQ(commands.size(), std::size_t(1));
-
-    auto& flags = commands[0].resolved.flags;
+    // Probe tokens (-ccbin, ...) are unknown-class: visible in the full
+    // view and the probe, never in the compile render.
+    auto flags = db.render_full(db.candidate_entries("/tmp/kern.cu").front().config);
     auto has = [&](llvm::StringRef flag) {
         return std::ranges::contains(flags, flag);
     };
@@ -541,7 +548,10 @@ TEST_CASE(DatabaseTranslatesNVCC) {
     EXPECT_TRUE(has("-x"));
     EXPECT_TRUE(has("cuda"));
     EXPECT_TRUE(has("MY_FLAG=1"));
-    EXPECT_FALSE(has("-forward-unknown-to-host-compiler"));
+    /// nvcc-only leftovers are unknown-class: full view keeps them for
+    /// identity, the compile render must not pass them to clang.
+    EXPECT_FALSE(std::ranges::contains(render_entry(db, "/tmp/kern.cu"),
+                                       llvm::StringRef("-forward-unknown-to-host-compiler")));
     for(llvm::StringRef flag: flags) {
         EXPECT_FALSE(flag.starts_with("--generate-code"));
     }
@@ -566,16 +576,14 @@ TEST_CASE(RuleFlagsTranslated) {
                                              "--generate-code=arch=compute_90a,code=sm_90a"};
     options.append = append;
 
-    auto commands = db.lookup("/tmp/kern.cu", options);
-    ASSERT_EQ(commands.size(), std::size_t(1));
-
-    auto& flags = commands[0].resolved.flags;
+    auto flags = db.render_full(
+        db.apply_rules(db.candidate_entries("/tmp/kern.cu").front().config, options));
     auto has = [&](llvm::StringRef flag) {
         return std::ranges::contains(flags, flag);
     };
     EXPECT_FALSE(has("--offload-arch=sm_75"));
-    EXPECT_TRUE(has("--cuda-gpu-arch=sm_90a"));
-    EXPECT_TRUE(has("-D__CUDACC_EXTENDED_LAMBDA__"));
+    EXPECT_TRUE(has("--offload-arch=sm_90a"));
+    EXPECT_TRUE(has("__CUDACC_EXTENDED_LAMBDA__"));
     for(llvm::StringRef flag: flags) {
         EXPECT_FALSE(flag.starts_with("--generate-code"));
         EXPECT_FALSE(flag.starts_with("--extended-lambda"));
@@ -596,35 +604,43 @@ TEST_CASE(AppendOverridesBase) {
                                              "-arch=sm_80"};
     options.append = append;
 
-    auto commands = db.lookup("/tmp/kern.cu", options);
-    ASSERT_EQ(commands.size(), std::size_t(1));
-
-    auto& flags = commands[0].resolved.flags;
+    auto flags = render_entry(db, "/tmp/kern.cu", options);
+    auto count = std::ptrdiff_t(flags.size());
     auto index_of = [&](llvm::StringRef flag) {
         return std::ranges::find(flags,
                                  flag,
                                  [](const char* arg) { return llvm::StringRef(arg); }) -
                flags.begin();
     };
-    auto count = std::ptrdiff_t(flags.size());
+    /// Defines and undefs render as two tokens; locate the value preceded
+    /// by the given option token.
+    auto pair_index = [&](llvm::StringRef option_token, llvm::StringRef value) {
+        for(std::ptrdiff_t i = 0; i + 1 < count; i += 1) {
+            if(llvm::StringRef(flags[i]) == option_token &&
+               llvm::StringRef(flags[i + 1]) == value) {
+                return i;
+            }
+        }
+        return count;
+    };
 
     // rdc: the appended negation follows the base's enable, so clang's own
     // last-wins turns it off and undefines the macro the base defined.
     EXPECT_TRUE(index_of("-fgpu-rdc") < index_of("-fno-gpu-rdc"));
     EXPECT_TRUE(index_of("-fno-gpu-rdc") < count);
-    EXPECT_TRUE(index_of("__CUDACC_RDC__") < index_of("-U__CUDACC_RDC__"));
-    EXPECT_TRUE(index_of("-U__CUDACC_RDC__") < count);
+    EXPECT_TRUE(pair_index("-D", "__CUDACC_RDC__") < pair_index("-U", "__CUDACC_RDC__"));
+    EXPECT_TRUE(pair_index("-U", "__CUDACC_RDC__") < count);
 
     // stream: undef after the base's define.
-    EXPECT_TRUE(index_of("CUDA_API_PER_THREAD_DEFAULT_STREAM=1") <
-                index_of("-UCUDA_API_PER_THREAD_DEFAULT_STREAM"));
-    EXPECT_TRUE(index_of("-UCUDA_API_PER_THREAD_DEFAULT_STREAM") < count);
+    EXPECT_TRUE(pair_index("-D", "CUDA_API_PER_THREAD_DEFAULT_STREAM=1") <
+                pair_index("-U", "CUDA_API_PER_THREAD_DEFAULT_STREAM"));
+    EXPECT_TRUE(pair_index("-U", "CUDA_API_PER_THREAD_DEFAULT_STREAM") < count);
 
     // arch: the base's architecture is cleared before the appended one, not
     // accumulated into a second device pass.
     EXPECT_TRUE(index_of("--offload-arch=sm_75") < index_of("--no-offload-arch=all"));
-    EXPECT_TRUE(index_of("--no-offload-arch=all") < index_of("--cuda-gpu-arch=sm_80"));
-    EXPECT_TRUE(index_of("--cuda-gpu-arch=sm_80") < count);
+    EXPECT_TRUE(index_of("--no-offload-arch=all") < index_of("--offload-arch=sm_80"));
+    EXPECT_TRUE(index_of("--offload-arch=sm_80") < count);
 }
 
 TEST_CASE(ExtrasStayClangDialect) {
@@ -641,12 +657,10 @@ TEST_CASE(ExtrasStayClangDialect) {
     options.extra_prepend = prepend;
     options.extra_append = append;
 
-    auto commands = db.lookup("/tmp/kern.cu", options);
-    ASSERT_EQ(commands.size(), std::size_t(1));
-
-    auto& flags = commands[0].resolved.flags;
+    auto flags = render_entry(db, "/tmp/kern.cu", options);
     EXPECT_EQ(llvm::StringRef(flags[1]), "-fno-gpu-rdc");
-    EXPECT_EQ(llvm::StringRef(flags.back()), "-fgpu-rdc");
+    /// The input sits at its slot after the extra append.
+    EXPECT_EQ(llvm::StringRef(flags[flags.size() - 2]), "-fgpu-rdc");
 }
 
 TEST_CASE(GencodeAppendAccumulates) {
@@ -660,9 +674,8 @@ TEST_CASE(GencodeAppendAccumulates) {
     auto arch_flags = [&](llvm::ArrayRef<std::string> append) {
         CommandOptions options;
         options.append = append;
-        auto commands = db.lookup("/tmp/kern.cu", options);
         std::vector<std::string> result;
-        for(llvm::StringRef flag: commands[0].resolved.flags) {
+        for(llvm::StringRef flag: render_entry(db, "/tmp/kern.cu", options)) {
             if(flag.contains("arch")) {
                 result.push_back(flag.str());
             }
@@ -676,51 +689,55 @@ TEST_CASE(GencodeAppendAccumulates) {
     llvm::SmallVector<std::string> older = {"-gencode=arch=compute_75,code=sm_75"};
     auto kept = arch_flags(older);
     EXPECT_TRUE(std::ranges::contains(kept, "--offload-arch=sm_90"));
-    EXPECT_FALSE(std::ranges::contains(kept, "--cuda-gpu-arch=sm_75"));
+    EXPECT_FALSE(std::ranges::contains(kept, "--offload-arch=sm_75"));
     EXPECT_FALSE(std::ranges::contains(kept, "--no-offload-arch=all"));
 
     // A newer append takes over — by numeric rank, not string order, which
     // would sort sm_100a below sm_90.
     llvm::SmallVector<std::string> newer = {"-gencode=arch=compute_100a,code=sm_100a"};
     auto switched = arch_flags(newer);
-    EXPECT_TRUE(std::ranges::contains(switched, "--cuda-gpu-arch=sm_100a"));
+    EXPECT_TRUE(std::ranges::contains(switched, "--offload-arch=sm_100a"));
     EXPECT_FALSE(std::ranges::contains(switched, "--offload-arch=sm_90"));
 }
 
 TEST_CASE(CollapseHonorsNegatives) {
+    using K = ArchFlagKind;
+
     // A specific --no-offload-arch erases only its matches from the ranking;
     // the negated flag pair stays for clang to consume, and the newest of
-    // the survivors wins.
-    std::vector<const char*> flags = {"clang",
-                                      "--cuda-gpu-arch=sm_90",
-                                      "--no-offload-arch=sm_90",
-                                      "--cuda-gpu-arch=sm_75",
-                                      "--cuda-gpu-arch=sm_86"};
-    collapse_gpu_arch_flags(flags);
-    std::vector<std::string> collapsed(flags.begin(), flags.end());
-    std::vector<std::string> expected = {"clang",
-                                         "--cuda-gpu-arch=sm_90",
-                                         "--no-offload-arch=sm_90",
-                                         "--cuda-gpu-arch=sm_86"};
-    EXPECT_EQ(collapsed, expected);
+    // the survivors wins (dropping the rest).
+    auto dropped = collapse_gpu_archs({
+        {
+         {K::GpuArch, "sm_90"},
+         {K::NoOffloadArch, "sm_90"},
+         {K::GpuArch, "sm_75"},
+         {K::GpuArch, "sm_86"},
+         }
+    });
+    ASSERT_TRUE(dropped.has_value());
+    ASSERT_EQ(dropped->size(), 1U);
+    EXPECT_EQ((*dropped)[0], 2U);
 
     // A single survivor leaves nothing to collapse.
-    std::vector<const char*> single = {"clang",
-                                       "--cuda-gpu-arch=sm_90",
-                                       "--no-offload-arch=sm_90",
-                                       "--cuda-gpu-arch=sm_75"};
-    auto kept = single;
-    collapse_gpu_arch_flags(single);
-    EXPECT_EQ(single, kept);
+    auto single = collapse_gpu_archs({
+        {
+         {K::GpuArch, "sm_90"},
+         {K::NoOffloadArch, "sm_90"},
+         {K::GpuArch, "sm_75"},
+         }
+    });
+    ASSERT_TRUE(single.has_value());
+    EXPECT_TRUE(single->empty());
 
     // An unrankable negative leaves the whole command to clang.
-    std::vector<const char*> native = {"clang",
-                                       "--cuda-gpu-arch=sm_90",
-                                       "--no-offload-arch=native",
-                                       "--cuda-gpu-arch=sm_75"};
-    auto untouched = native;
-    collapse_gpu_arch_flags(native);
-    EXPECT_EQ(native, untouched);
+    auto native = collapse_gpu_archs({
+        {
+         {K::GpuArch, "sm_90"},
+         {K::NoOffloadArch, "native"},
+         {K::GpuArch, "sm_75"},
+         }
+    });
+    EXPECT_FALSE(native.has_value());
 }
 
 TEST_CASE(WildcardRemoveClearsArch) {
@@ -736,9 +753,9 @@ TEST_CASE(WildcardRemoveClearsArch) {
     db.add_command("/tmp", "/tmp/native.cu", native);
 
     auto arch_flags = [&](llvm::StringRef file, const CommandOptions& options) {
-        auto commands = db.lookup(file, options);
+        auto applied = db.apply_rules(db.candidate_entries(file).front().config, options);
         std::vector<std::string> result;
-        for(llvm::StringRef flag: commands[0].resolved.flags) {
+        for(llvm::StringRef flag: db.render_full(applied)) {
             if(flag.contains("arch")) {
                 result.push_back(flag.str());
             }
@@ -768,7 +785,7 @@ TEST_CASE(WildcardRemoveClearsArch) {
     options.append = append;
     auto replaced = arch_flags("/tmp/other.cu", options);
     EXPECT_FALSE(std::ranges::contains(replaced, "--offload-arch=sm_80"));
-    EXPECT_TRUE(std::ranges::contains(replaced, "--cuda-gpu-arch=sm_90a"));
+    EXPECT_TRUE(std::ranges::contains(replaced, "--offload-arch=sm_90a"));
 }
 
 TEST_CASE(RemoveMatchesUnknownSpelling) {
@@ -786,12 +803,10 @@ TEST_CASE(RemoveMatchesUnknownSpelling) {
     llvm::SmallVector<std::string> remove = {"--allow-unsupported-compiler"};
     options.remove = remove;
 
-    auto commands = db.lookup("/tmp/kern.cu", options);
-    ASSERT_EQ(commands.size(), std::size_t(1));
-
     // Probe flags all parse as the shared unknown id; removal keys on the
     // spelling, so the other probe tokens survive.
-    auto& flags = commands[0].resolved.flags;
+    auto flags = db.render_full(
+        db.apply_rules(db.candidate_entries("/tmp/kern.cu").front().config, options));
     auto has = [&](llvm::StringRef flag) {
         return std::ranges::contains(flags, flag);
     };
@@ -819,10 +834,8 @@ TEST_CASE(RemoveListAlternatives) {
                                              "--default-stream=per-thread"};
     options.remove = remove;
 
-    auto commands = db.lookup("/tmp/kern.cu", options);
-    ASSERT_EQ(commands.size(), std::size_t(1));
-
-    auto& flags = commands[0].resolved.flags;
+    auto flags = db.render_full(
+        db.apply_rules(db.candidate_entries("/tmp/kern.cu").front().config, options));
     auto has = [&](llvm::StringRef flag) {
         return std::ranges::contains(flags, flag);
     };
@@ -839,9 +852,9 @@ TEST_CASE(WildcardRemovesProbeValue) {
     auto probe_flags = [&](llvm::ArrayRef<std::string> remove) {
         CommandOptions options;
         options.remove = remove;
-        auto commands = db.lookup("/tmp/kern.cu", options);
+        auto applied = db.apply_rules(db.candidate_entries("/tmp/kern.cu").front().config, options);
         std::vector<std::string> result;
-        for(llvm::StringRef flag: commands[0].resolved.flags) {
+        for(llvm::StringRef flag: db.render_full(applied)) {
             if(is_nvcc_probe_flag(flag)) {
                 result.push_back(flag.str());
             }

--- a/tests/unit/command/search_config_tests.cpp
+++ b/tests/unit/command/search_config_tests.cpp
@@ -1,5 +1,6 @@
 #include "test/temp_dir.h"
 #include "test/test.h"
+#include "command/command.h"
 #include "command/search_config.h"
 
 namespace clice::testing {
@@ -7,6 +8,15 @@ namespace clice::testing {
 namespace {
 
 TEST_SUITE(ExtractSearchConfig) {
+
+/// Normalize a raw argv through the database and extract from the
+/// structured command (the only extraction path).
+SearchConfig extract(llvm::ArrayRef<const char*> args, llvm::StringRef directory) {
+    CompilationDatabase db;
+    db.add_command(directory, "main.cpp", args);
+    auto& entry = db.candidate_entries("main.cpp").front();
+    return extract_search_config(db.config(entry.config).args, directory);
+}
 
 TEST_CASE(ReordersDirectoryGroups) {
     // TempDir gives cross-platform absolute paths (drive letter on Windows).
@@ -23,7 +33,7 @@ TEST_CASE(ReordersDirectoryGroups) {
                                      "-iquote",
                                      tmp.c_path("quoted"),
                                      "main.cpp"};
-    auto config = extract_search_config(args, tmp.root.str());
+    auto config = extract(args, tmp.root.str());
 
     // Expected order: [quoted | user | stdlib, clang, sysroot]
     ASSERT_EQ(config.dirs.size(), 5u);
@@ -49,7 +59,7 @@ TEST_CASE(PreservesWithinGroupOrder) {
                                      "-isystem",
                                      tmp.c_path("s1"),
                                      "main.cpp"};
-    auto config = extract_search_config(args, tmp.root.str());
+    auto config = extract(args, tmp.root.str());
 
     ASSERT_EQ(config.dirs.size(), 4u);
     EXPECT_EQ(config.angled_start_idx, 0u);
@@ -70,7 +80,7 @@ TEST_CASE(DeduplicatesAngledSystem) {
                                      "-internal-isystem",
                                      tmp.c_path("only_sys"),
                                      "main.cpp"};
-    auto config = extract_search_config(args, tmp.root.str());
+    auto config = extract(args, tmp.root.str());
 
     // /shared in both Angled and System → keep Angled copy.
     ASSERT_EQ(config.dirs.size(), 2u);
@@ -93,7 +103,7 @@ TEST_CASE(QuotedAngledSamePathKeptInBoth) {
                                      "-I",
                                      tmp.c_path("other"),
                                      "main.cpp"};
-    auto config = extract_search_config(args, tmp.root.str());
+    auto config = extract(args, tmp.root.str());
 
     // "shared" must appear in both Quoted and Angled segments.
     ASSERT_EQ(config.dirs.size(), 3u);
@@ -117,7 +127,7 @@ TEST_CASE(DeduplicateAdjustsIndices) {
                                      "-isystem",
                                      tmp.c_path("s"),
                                      "main.cpp"};
-    auto config = extract_search_config(args, tmp.root.str());
+    auto config = extract(args, tmp.root.str());
 
     // Before dedup: [q | dup, a2 | dup, s] angled=1, system=3
     // dup in system removed. system_start_idx stays 3.
@@ -148,7 +158,7 @@ TEST_CASE(PrefixIncludeOptions) {
                                      "-iwithprefix",
                                      "include",
                                      "main.cpp"};
-    auto config = extract_search_config(args, tmp.root.str());
+    auto config = extract(args, tmp.root.str());
 
     // -iwithprefixbefore → Angled, -iwithprefix → After
     ASSERT_EQ(config.dirs.size(), 3u);
@@ -170,7 +180,7 @@ TEST_CASE(DirafterGroup) {
                                      "-idirafter",
                                      tmp.c_path("fallback"),
                                      "main.cpp"};
-    auto config = extract_search_config(args, tmp.root.str());
+    auto config = extract(args, tmp.root.str());
 
     ASSERT_EQ(config.dirs.size(), 3u);
     EXPECT_EQ(config.angled_start_idx, 0u);
@@ -191,7 +201,7 @@ TEST_CASE(DirafterDeduplication) {
                                      "-idirafter",
                                      tmp.c_path("extra"),
                                      "main.cpp"};
-    auto config = extract_search_config(args, tmp.root.str());
+    auto config = extract(args, tmp.root.str());
 
     ASSERT_EQ(config.dirs.size(), 2u);
     EXPECT_EQ(config.angled_start_idx, 0u);

--- a/tests/unit/command/toolchain_tests.cpp
+++ b/tests/unit/command/toolchain_tests.cpp
@@ -326,6 +326,20 @@ TEST_CASE(KeyTracksSemantics) {
     EXPECT_NE(f.key(base), f.key(semantic));
 }
 
+TEST_CASE(KeyTracksConfigFile) {
+    /// A relative --config resolves against the compilation directory, so
+    /// identical commands in different directories must not share a probe.
+    Fixture f;
+    auto a = f.add("/fake/a", "/tmp/a.cpp", {"clang++", "--config", "clang.cfg", "/tmp/a.cpp"});
+    auto b = f.add("/fake/b", "/tmp/b.cpp", {"clang++", "--config", "clang.cfg", "/tmp/b.cpp"});
+    EXPECT_NE(f.key(a), f.key(b));
+
+    /// An absolute config file is directory-independent.
+    auto c = f.add("/fake/a", "/tmp/c.cpp", {"clang++", "--config=/etc/clang.cfg", "/tmp/c.cpp"});
+    auto d = f.add("/fake/b", "/tmp/d.cpp", {"clang++", "--config=/etc/clang.cfg", "/tmp/d.cpp"});
+    EXPECT_EQ(f.key(c), f.key(d));
+}
+
 TEST_CASE(QueryEmptyArgs) {
     EXPECT_FALSE(Toolchain::query({}).has_value());
 }

--- a/tests/unit/command/toolchain_tests.cpp
+++ b/tests/unit/command/toolchain_tests.cpp
@@ -257,52 +257,73 @@ TEST_CASE(NVCCHostInput, skip = !(CIEnvironment && Linux)) {
     ASSERT_TRUE(unit.diagnostics().empty());
 };
 
+/// A database wrapping test entries — the unit tests' handle on the two
+/// toolchain layers.
+struct Fixture {
+    CompilationDatabase db;
+
+    CommandRef add(llvm::StringRef directory,
+                   llvm::StringRef file,
+                   llvm::ArrayRef<const char*> arguments) {
+        db.add_command(directory, file, arguments);
+        auto& entry = db.candidate_entries(file).front();
+        return {entry.file,
+                entry.config,
+                db.input_kind(entry.config, file),
+                CommandSource::CDBExact};
+    }
+
+    std::string key(const CommandRef& ref) {
+        return db.toolchain().probe_key_for(ref.config, ref.input);
+    }
+};
+
 TEST_CASE(InitiallyEmpty) {
-    Toolchain tc;
-    EXPECT_FALSE(tc.has_cache());
+    CompilationDatabase db;
+    EXPECT_FALSE(db.toolchain().has_cache());
 }
 
 TEST_CASE(KeyIgnoresUserContent) {
-    Toolchain tc;
-    std::vector<const char*> base = {"clang++", "-std=c++23"};
-    std::vector<const char*> with_user = {"clang++",
-                                          "-std=c++23",
-                                          "-I/usr/include",
-                                          "-DFOO=1",
-                                          "-include",
-                                          "foo.h",
-                                          "-isystem",
-                                          "/opt/include"};
-    EXPECT_EQ(tc.cache_key("/tmp/a.cpp", base), tc.cache_key("/tmp/a.cpp", with_user));
+    Fixture f;
+    auto base = f.add("/fake", "/tmp/a.cpp", {"clang++", "-std=c++23", "/tmp/a.cpp"});
+    auto user = f.add("/fake",
+                      "/tmp/b.cpp",
+                      {"clang++",
+                       "-std=c++23",
+                       "-I/usr/include",
+                       "-DFOO=1",
+                       "-include",
+                       "foo.h",
+                       "-isystem",
+                       "/opt/include",
+                       "/tmp/b.cpp"});
+    EXPECT_EQ(f.key(base), f.key(user));
 }
 
 TEST_CASE(KeyTracksSemantics) {
-    Toolchain tc;
-    std::vector<const char*> base = {"clang++", "-std=c++23"};
-    auto key = tc.cache_key("/tmp/a.cpp", base);
+    Fixture f;
+    auto base = f.add("/fake", "/tmp/a.cpp", {"clang++", "-std=c++23", "/tmp/a.cpp"});
 
-    std::vector<const char*> driver = {"g++", "-std=c++23"};
-    EXPECT_NE(key, tc.cache_key("/tmp/a.cpp", driver));
+    auto driver = f.add("/fake", "/tmp/b.cpp", {"g++", "-std=c++23", "/tmp/b.cpp"});
+    EXPECT_NE(f.key(base), f.key(driver));
 
-    std::vector<const char*> target = {"clang++", "-std=c++23", "--target=aarch64-linux-gnu"};
-    EXPECT_NE(key, tc.cache_key("/tmp/a.cpp", target));
+    auto target = f.add("/fake",
+                        "/tmp/c.cpp",
+                        {"clang++", "-std=c++23", "--target=aarch64-linux-gnu", "/tmp/c.cpp"});
+    EXPECT_NE(f.key(base), f.key(target));
 
-    std::vector<const char*> lang = {"clang++", "-std=c++23", "-x", "c"};
-    EXPECT_NE(key, tc.cache_key("/tmp/a.cpp", lang));
+    /// The language dimension: an -x selector and a C extension both
+    /// change the key.
+    auto lang = f.add("/fake", "/tmp/d.cpp", {"clang++", "-std=c++23", "-x", "c", "/tmp/d.cpp"});
+    EXPECT_NE(f.key(base), f.key(lang));
 
-    EXPECT_NE(key, tc.cache_key("/tmp/a.c", base));
+    auto ext = f.add("/fake", "/tmp/e.c", {"clang++", "-std=c++23", "/tmp/e.c"});
+    EXPECT_NE(f.key(base), f.key(ext));
 
     // Any non-user-content flag affects the key, not just toolchain options.
-    std::vector<const char*> semantic = {"clang++", "-std=c++23", "-fno-exceptions"};
-    EXPECT_NE(key, tc.cache_key("/tmp/a.cpp", semantic));
-}
-
-TEST_CASE(ResolveEmptyFlags) {
-    Toolchain tc;
-    CompileCommand cmd;
-    cmd.source_file = "main.cpp";
-    EXPECT_FALSE(tc.resolve(cmd).has_value());
-    EXPECT_FALSE(tc.has_cache());
+    auto semantic =
+        f.add("/fake", "/tmp/g.cpp", {"clang++", "-std=c++23", "-fno-exceptions", "/tmp/g.cpp"});
+    EXPECT_NE(f.key(base), f.key(semantic));
 }
 
 TEST_CASE(QueryEmptyArgs) {
@@ -311,16 +332,6 @@ TEST_CASE(QueryEmptyArgs) {
 
 TEST_CASE(QueryMissingDriver) {
     EXPECT_FALSE(Toolchain::query({"clice-nonexistent-driver"}).has_value());
-}
-
-TEST_CASE(WarmSkipsEmptyFlags) {
-    Toolchain tc;
-    CompileCommand cmd;
-    cmd.source_file = "main.cpp";
-    llvm::SmallVector<CompileCommand> cmds = {cmd};
-    tc.warm(cmds);
-    EXPECT_FALSE(tc.has_cache());
-    EXPECT_EQ(tc.cache_size(), std::size_t(0));
 }
 
 TEST_CASE(ParseCC1FirstLine) {
@@ -404,35 +415,32 @@ TEST_CASE(FailedQueryRetries, skip = Windows) {
     auto src = tmp.path("a.cpp");
     auto script = "#!/bin/sh\necho '" + std::string(fake_cc1_line) + "' >&2\n";
 
-    Toolchain eager(std::chrono::seconds(0));
-    CompileCommand cmd;
-    cmd.source_file = src.c_str();
-    cmd.resolved.flags = {driver.c_str(), "-std=c++23"};
+    Fixture eager;
+    eager.db.toolchain().set_failed_retry(std::chrono::seconds(0));
+    auto ref = eager.add(tmp.root.str(), src, {driver.c_str(), "-std=c++23", src.c_str()});
 
-    ASSERT_FALSE(eager.resolve(cmd).has_value());
-    EXPECT_EQ(eager.failed_size(), std::size_t(1));
+    ASSERT_FALSE(eager.db.toolchain().resolve(ref.config, ref.input).has_value());
+    EXPECT_EQ(eager.db.toolchain().failed_count(), std::size_t(1));
 
     // The driver appears; the expired entry re-queries and succeeds.
     ASSERT_TRUE(fs::write(driver, script));
     ASSERT_TRUE(!fs::setPermissions(driver, fs::all_read | fs::all_exe));
-    ASSERT_TRUE(eager.resolve(cmd).has_value());
-    EXPECT_EQ(eager.failed_size(), std::size_t(0));
-    EXPECT_TRUE(eager.has_cache());
+    ASSERT_TRUE(eager.db.toolchain().resolve(ref.config, ref.input).has_value());
+    EXPECT_EQ(eager.db.toolchain().failed_count(), std::size_t(0));
+    EXPECT_TRUE(eager.db.toolchain().has_cache());
 
     // Control: within the cooldown the cached failure replays untouched
     // even after the driver appears.
     auto late = tmp.path("cc2.clang");
-    Toolchain patient;
-    CompileCommand cmd2;
-    cmd2.source_file = src.c_str();
-    cmd2.resolved.flags = {late.c_str(), "-std=c++23"};
+    Fixture patient;
+    auto ref2 = patient.add(tmp.root.str(), src, {late.c_str(), "-std=c++23", src.c_str()});
 
-    ASSERT_FALSE(patient.resolve(cmd2).has_value());
+    ASSERT_FALSE(patient.db.toolchain().resolve(ref2.config, ref2.input).has_value());
     ASSERT_TRUE(fs::write(late, script));
     ASSERT_TRUE(!fs::setPermissions(late, fs::all_read | fs::all_exe));
-    ASSERT_FALSE(patient.resolve(cmd2).has_value());
-    EXPECT_EQ(patient.failed_size(), std::size_t(1));
-    EXPECT_FALSE(patient.has_cache());
+    ASSERT_FALSE(patient.db.toolchain().resolve(ref2.config, ref2.input).has_value());
+    EXPECT_EQ(patient.db.toolchain().failed_count(), std::size_t(1));
+    EXPECT_FALSE(patient.db.toolchain().has_cache());
 }
 
 TEST_CASE(WarmRetriesExpired, skip = Windows) {
@@ -442,50 +450,46 @@ TEST_CASE(WarmRetriesExpired, skip = Windows) {
     auto driver = tmp.path("cc.clang");
     auto src = tmp.path("a.cpp");
 
-    Toolchain tc(std::chrono::seconds(0));
-    CompileCommand cmd;
-    cmd.source_file = src.c_str();
-    cmd.resolved.flags = {driver.c_str(), "-std=c++23"};
-    llvm::SmallVector<CompileCommand> cmds = {cmd};
+    Fixture f;
+    f.db.toolchain().set_failed_retry(std::chrono::seconds(0));
+    auto ref = f.add(tmp.root.str(), src, {driver.c_str(), "-std=c++23", src.c_str()});
+    llvm::SmallVector<CommandRef> refs = {ref};
 
-    tc.warm(cmds);
-    EXPECT_EQ(tc.failed_size(), std::size_t(1));
-    EXPECT_FALSE(tc.has_cache());
+    f.db.warm(refs);
+    EXPECT_EQ(f.db.toolchain().failed_count(), std::size_t(1));
+    EXPECT_FALSE(f.db.toolchain().has_cache());
 
     auto script = "#!/bin/sh\necho '" + std::string(fake_cc1_line) + "' >&2\n";
     ASSERT_TRUE(fs::write(driver, script));
     ASSERT_TRUE(!fs::setPermissions(driver, fs::all_read | fs::all_exe));
 
-    tc.warm(cmds);
-    EXPECT_EQ(tc.failed_size(), std::size_t(0));
-    EXPECT_TRUE(tc.has_cache());
+    f.db.warm(refs);
+    EXPECT_EQ(f.db.toolchain().failed_count(), std::size_t(0));
+    EXPECT_TRUE(f.db.toolchain().has_cache());
 }
 
 TEST_CASE(WarmPartialFailure, skip = Windows) {
     auto driver = create_fake_clang(fake_cc1_line);
     ASSERT_TRUE(driver.has_value());
 
-    CompileCommand good;
-    good.resolved.flags = {driver->c_str(), "-std=c++23"};
-    good.source_file = "/tmp/a.cpp";
+    Fixture f;
+    auto good = f.add("/tmp", "/tmp/a.cpp", {driver->c_str(), "-std=c++23", "/tmp/a.cpp"});
+    auto bad =
+        f.add("/tmp", "/tmp/b.cpp", {"clice-nonexistent-driver", "-std=c++23", "/tmp/b.cpp"});
 
-    CompileCommand bad;
-    bad.resolved.flags = {"clice-nonexistent-driver", "-std=c++23"};
-    bad.source_file = "/tmp/b.cpp";
-
-    Toolchain tc;
-    llvm::SmallVector<CompileCommand> cmds = {good, bad};
-    tc.warm(cmds);
+    llvm::SmallVector<CommandRef> refs = {good, bad};
+    f.db.warm(refs);
 
     // The successful query is cached; the failed one is negatively cached
     // so later resolve() calls fail fast without re-probing the driver.
-    EXPECT_EQ(tc.cache_size(), std::size_t(1));
-    EXPECT_EQ(tc.failed_size(), std::size_t(1));
+    EXPECT_EQ(f.db.toolchain().probe_count(), std::size_t(1));
+    EXPECT_EQ(f.db.toolchain().failed_count(), std::size_t(1));
 
-    ASSERT_TRUE(tc.resolve(good).has_value());
-    EXPECT_TRUE(good.resolved.is_cc1);
-    EXPECT_FALSE(tc.resolve(bad).has_value());
-    EXPECT_EQ(tc.failed_size(), std::size_t(1));
+    auto resolved = f.db.toolchain().resolve(good.config, good.input);
+    ASSERT_TRUE(resolved.has_value());
+    EXPECT_TRUE(f.db.toolchain().resolved(*resolved).is_cc1);
+    EXPECT_FALSE(f.db.toolchain().resolve(bad.config, bad.input).has_value());
+    EXPECT_EQ(f.db.toolchain().failed_count(), std::size_t(1));
 }
 
 TEST_CASE(ResolveFailNegativeCache, skip = Windows) {
@@ -493,24 +497,22 @@ TEST_CASE(ResolveFailNegativeCache, skip = Windows) {
     auto driver = create_fake_clang("this is not a cc1 line");
     ASSERT_TRUE(driver.has_value());
 
-    CompileCommand cmd;
-    cmd.resolved.flags = {driver->c_str(), "-std=c++23"};
-    cmd.source_file = "/tmp/a.cpp";
+    Fixture f;
+    auto ref = f.add("/tmp", "/tmp/a.cpp", {driver->c_str(), "-std=c++23", "/tmp/a.cpp"});
 
-    Toolchain tc;
-    auto first = tc.resolve(cmd);
+    auto first = f.db.toolchain().resolve(ref.config, ref.input);
     ASSERT_FALSE(first.has_value());
-    EXPECT_EQ(tc.cache_size(), std::size_t(0));
-    EXPECT_EQ(tc.failed_size(), std::size_t(1));
+    EXPECT_EQ(f.db.toolchain().probe_count(), std::size_t(0));
+    EXPECT_EQ(f.db.toolchain().failed_count(), std::size_t(1));
 
     // Remove the driver: a re-probe would now fail differently ("not found or
     // not executable"), so getting the original error back proves the second
     // resolve() hit the negative cache without spawning the driver again.
     ASSERT_TRUE(!fs::remove(*driver));
-    auto second = tc.resolve(cmd);
+    auto second = f.db.toolchain().resolve(ref.config, ref.input);
     ASSERT_FALSE(second.has_value());
     EXPECT_EQ(second.error(), first.error());
-    EXPECT_EQ(tc.failed_size(), std::size_t(1));
+    EXPECT_EQ(f.db.toolchain().failed_count(), std::size_t(1));
 }
 
 TEST_CASE(ResolveReplacesResourceDir, skip = Windows) {
@@ -519,19 +521,17 @@ TEST_CASE(ResolveReplacesResourceDir, skip = Windows) {
     auto driver = create_fake_clang(line);
     ASSERT_TRUE(driver.has_value());
 
-    CompileCommand cmd;
-    cmd.resolved.flags = {driver->c_str(), "-std=c++23"};
-    cmd.source_file = "/tmp/a.cpp";
-
-    Toolchain tc;
-    ASSERT_TRUE(tc.resolve(cmd).has_value());
+    Fixture f;
+    auto ref = f.add("/tmp", "/tmp/a.cpp", {driver->c_str(), "-std=c++23", "/tmp/a.cpp"});
+    ASSERT_TRUE(f.db.toolchain().resolve(ref.config, ref.input).has_value());
 
     // The external driver's resource dir is rewritten to ours, including
     // derived paths sharing the prefix.
+    auto argv = f.db.render(ref);
     auto expected_include = resource_dir().str() + "/include";
-    EXPECT_TRUE(std::ranges::contains(cmd.resolved.flags, resource_dir()));
-    EXPECT_TRUE(std::ranges::contains(cmd.resolved.flags, llvm::StringRef(expected_include)));
-    for(llvm::StringRef arg: cmd.resolved.flags) {
+    EXPECT_TRUE(std::ranges::contains(argv, resource_dir()));
+    EXPECT_TRUE(std::ranges::contains(argv, llvm::StringRef(expected_include)));
+    for(llvm::StringRef arg: argv) {
         EXPECT_FALSE(arg.starts_with("/clice-fake"));
     }
 }
@@ -576,8 +576,9 @@ echo " \"/usr/bin/clang-22\" \"-cc1\" \"-resource-dir\" \"$rd\" \"-internal-isys
 }
 
 /// The MinGW preservation tests share one shape: an external resource tree,
-/// an echoing driver, and the expectation that the resolved flags keep the
-/// external tree and never mention clice's own.
+/// an echoing driver (deriving that tree when no -resource-dir is forced),
+/// and the expectation that the resolved config keeps the external tree and
+/// never mentions clice's own.
 void EXPECT_KEEPS_EXTERNAL(llvm::StringRef driver_name,
                            llvm::ArrayRef<const char*> extra_flags,
                            bool warm_first = false) {
@@ -589,23 +590,23 @@ void EXPECT_KEEPS_EXTERNAL(llvm::StringRef driver_name,
     auto driver = create_echo_clang(external_dir, driver_name);
     ASSERT_TRUE(driver.has_value());
 
-    CompileCommand cmd;
-    cmd.resolved.flags = {driver->c_str(), "-std=c++23"};
-    cmd.resolved.flags.insert(cmd.resolved.flags.end(), extra_flags.begin(), extra_flags.end());
-    cmd.resolved.flags.push_back("-resource-dir");
-    cmd.resolved.flags.push_back(resource_dir().data());
-    cmd.source_file = "/tmp/a.cpp";
+    Fixture f;
+    std::vector<const char*> arguments = {driver->c_str(), "-std=c++23"};
+    arguments.insert(arguments.end(), extra_flags.begin(), extra_flags.end());
+    arguments.push_back("/tmp/a.cpp");
+    auto ref = f.add("/tmp", "/tmp/a.cpp", arguments);
 
-    Toolchain tc;
     if(warm_first) {
-        tc.warm({cmd});
+        llvm::SmallVector<CommandRef> refs = {ref};
+        f.db.warm(refs);
         // The driver disappears after warming: the resolve below can only
         // succeed from the warmed cache entry, never from a fresh query.
         fs::remove(*driver);
     }
-    ASSERT_TRUE(tc.resolve(cmd).has_value());
-    EXPECT_TRUE(std::ranges::contains(cmd.resolved.flags, llvm::StringRef(external_dir)));
-    EXPECT_FALSE(std::ranges::contains(cmd.resolved.flags, resource_dir()));
+    ASSERT_TRUE(f.db.toolchain().resolve(ref.config, ref.input).has_value());
+    auto argv = f.db.render(ref);
+    EXPECT_TRUE(std::ranges::contains(argv, llvm::StringRef(external_dir)));
+    EXPECT_FALSE(std::ranges::contains(argv, resource_dir()));
 
     fs::remove(*driver);
     if(!driver_name.empty()) {
@@ -640,15 +641,14 @@ TEST_CASE(ResolveReplacesNonMingwResource, skip = Windows) {
     auto driver = create_echo_clang(external_dir, "");
     ASSERT_TRUE(driver.has_value());
 
-    CompileCommand cmd;
-    cmd.resolved.flags = {driver->c_str(), "-std=c++23"};
-    cmd.source_file = "/tmp/a.cpp";
+    Fixture f;
+    auto ref = f.add("/tmp", "/tmp/a.cpp", {driver->c_str(), "-std=c++23", "/tmp/a.cpp"});
+    ASSERT_TRUE(f.db.toolchain().resolve(ref.config, ref.input).has_value());
 
-    Toolchain tc;
-    ASSERT_TRUE(tc.resolve(cmd).has_value());
+    auto argv = f.db.render(ref);
     auto expected_include = resource_dir().str() + "/include";
-    EXPECT_TRUE(std::ranges::contains(cmd.resolved.flags, resource_dir()));
-    EXPECT_TRUE(std::ranges::contains(cmd.resolved.flags, llvm::StringRef(expected_include)));
+    EXPECT_TRUE(std::ranges::contains(argv, resource_dir()));
+    EXPECT_TRUE(std::ranges::contains(argv, llvm::StringRef(expected_include)));
 
     fs::remove(*driver);
     llvm::sys::fs::remove(external_dir_buf);
@@ -660,25 +660,21 @@ TEST_CASE(ResolveMainFileName, skip = Windows) {
     auto driver = create_fake_clang(line);
     ASSERT_TRUE(driver.has_value());
 
-    CompileCommand cmd;
-    cmd.resolved.flags = {driver->c_str(), "-std=c++23"};
-    cmd.source_file = "/tmp/dir/a.cpp";
+    Fixture f;
+    auto ref = f.add("/tmp", "/tmp/dir/a.cpp", {driver->c_str(), "-std=c++23", "/tmp/dir/a.cpp"});
+    ASSERT_TRUE(f.db.toolchain().resolve(ref.config, ref.input).has_value());
 
-    Toolchain tc;
-    ASSERT_TRUE(tc.resolve(cmd).has_value());
-    EXPECT_TRUE(cmd.resolved.is_cc1);
-
-    // The probe file's -main-file-name is stripped from the cached result...
-    EXPECT_FALSE(std::ranges::contains(cmd.resolved.flags, llvm::StringRef("-main-file-name")));
-
-    // ...and to_argv() re-injects it with the real file's basename.
-    auto argv = cmd.to_argv();
-    bool reinjected = false;
-    for(std::size_t i = 0; i + 1 < argv.size(); ++i) {
-        if(argv[i] == "-main-file-name"sv && argv[i + 1] == "a.cpp"sv)
-            reinjected = true;
+    // The probe file's -main-file-name is stripped; the render re-injects
+    // it with the real file's basename, exactly once.
+    auto argv = f.db.render(ref);
+    int injected = 0;
+    for(std::size_t i = 0; i + 1 < argv.size(); i += 1) {
+        if(argv[i] == "-main-file-name"sv) {
+            EXPECT_EQ(llvm::StringRef(argv[i + 1]), "a.cpp");
+            injected += 1;
+        }
     }
-    EXPECT_TRUE(reinjected);
+    EXPECT_EQ(injected, 1);
 }
 
 TEST_CASE(ResolveKeepsSemanticFlags, skip = !CIEnvironment) {
@@ -687,19 +683,19 @@ TEST_CASE(ResolveKeepsSemanticFlags, skip = !CIEnvironment) {
         LOG_ERROR_RET(void(), "{}", file.error());
     }
 
-    CompileCommand cmd;
-    cmd.resolved.flags = {"clang++", "-std=c++23", "-fms-extensions", "-Wno-everything"};
-    cmd.source_file = file->c_str();
-
-    Toolchain tc;
-    ASSERT_TRUE(tc.resolve(cmd).has_value());
-    EXPECT_TRUE(cmd.resolved.is_cc1);
+    Fixture f;
+    auto ref =
+        f.add("/tmp",
+              *file,
+              {"clang++", "-std=c++23", "-fms-extensions", "-Wno-everything", file->c_str()});
+    ASSERT_TRUE(f.db.toolchain().resolve(ref.config, ref.input).has_value());
 
     // Semantic flags must survive resolution to cc1 (they were dropped when
     // the query only forwarded toolchain options).
+    auto argv = f.db.render(ref);
     bool has_ms_extensions = false;
     bool has_wno_everything = false;
-    for(auto* arg: cmd.to_argv()) {
+    for(auto* arg: argv) {
         if(arg == "-fms-extensions"sv)
             has_ms_extensions = true;
         if(arg == "-Wno-everything"sv)
@@ -715,18 +711,15 @@ TEST_CASE(Resolve, skip = !CIEnvironment) {
         LOG_ERROR_RET(void(), "{}", file.error());
     }
 
-    CompileCommand cmd;
-    std::vector<const char*> flags = {"clang++", "-std=c++23", "-I/usr/include", "-DFOO=1"};
-    cmd.resolved.flags = std::move(flags);
-    cmd.source_file = file->c_str();
+    Fixture f;
+    auto ref =
+        f.add("/tmp", *file, {"clang++", "-std=c++23", "-I/usr/include", "-DFOO=1", file->c_str()});
+    auto resolved = f.db.toolchain().resolve(ref.config, ref.input);
+    ASSERT_TRUE(resolved.has_value());
+    EXPECT_TRUE(f.db.toolchain().has_cache());
+    EXPECT_TRUE(f.db.toolchain().resolved(*resolved).is_cc1);
 
-    Toolchain tc;
-    auto ok = tc.resolve(cmd);
-    ASSERT_TRUE(ok.has_value());
-    EXPECT_TRUE(tc.has_cache());
-    EXPECT_TRUE(cmd.resolved.is_cc1);
-
-    auto argv = cmd.to_argv();
+    auto argv = f.db.render(ref);
     bool has_cc1 = false;
     bool has_include = false;
     bool has_define = false;
@@ -750,31 +743,24 @@ TEST_CASE(Resolve, skip = !CIEnvironment) {
 TEST_CASE(Warm, skip = !CIEnvironment) {
     auto file1 = fs::createTemporaryFile("clice", "cpp");
     auto file2 = fs::createTemporaryFile("clice", "cpp");
-    if(!file1 || !file2) {
+    auto file3 = fs::createTemporaryFile("clice", "cpp");
+    if(!file1 || !file2 || !file3) {
         LOG_ERROR_RET(void(), "failed to create temp files");
     }
 
-    CompileCommand cmd1;
-    cmd1.resolved.flags = {"clang++", "-std=c++23"};
-    cmd1.source_file = file1->c_str();
+    Fixture f;
+    auto ref1 = f.add("/tmp", *file1, {"clang++", "-std=c++23", file1->c_str()});
+    auto ref2 = f.add("/tmp", *file2, {"clang++", "-std=c++23", file2->c_str()});
+    auto ref3 = f.add("/tmp", *file3, {"clang++", "-std=c++17", file3->c_str()});
 
-    CompileCommand cmd2;
-    cmd2.resolved.flags = {"clang++", "-std=c++23"};
-    cmd2.source_file = file2->c_str();
+    llvm::SmallVector<CommandRef> refs = {ref1, ref2, ref3};
+    f.db.warm(refs);
+    EXPECT_TRUE(f.db.toolchain().has_cache());
 
-    CompileCommand cmd3;
-    cmd3.resolved.flags = {"clang++", "-std=c++17"};
-    cmd3.source_file = file1->c_str();
-
-    Toolchain tc;
-    llvm::SmallVector<CompileCommand> cmds = {cmd1, cmd2, cmd3};
-    tc.warm(cmds);
-    EXPECT_TRUE(tc.has_cache());
-
-    // After warm, resolve should hit cache (no subprocess).
-    auto ok = tc.resolve(cmd1);
-    ASSERT_TRUE(ok.has_value());
-    EXPECT_TRUE(cmd1.resolved.is_cc1);
+    // After warm, resolve should hit the probe cache (no subprocess).
+    auto resolved = f.db.toolchain().resolve(ref1.config, ref1.input);
+    ASSERT_TRUE(resolved.has_value());
+    EXPECT_TRUE(f.db.toolchain().resolved(*resolved).is_cc1);
 }
 
 };  // TEST_SUITE(ToolchainTests)

--- a/tests/unit/command/toolchain_tests.cpp
+++ b/tests/unit/command/toolchain_tests.cpp
@@ -45,6 +45,10 @@ TEST_CASE(Family) {
     EXPECT_FAMILY("clang-cl-20.exe", ClangCL);
 
     EXPECT_FAMILY("cl.exe", MSVC);
+    /// Windows casing is free-form: CL.exe is how msbuild spells it.
+    EXPECT_FAMILY("CL.exe", MSVC);
+    EXPECT_FAMILY("CL.EXE", MSVC);
+    EXPECT_FAMILY("Clang-Cl.exe", ClangCL);
     EXPECT_FAMILY("nvcc", NVCC);
     EXPECT_FAMILY("icx", Intel);
     EXPECT_FAMILY("icc", Intel);
@@ -334,9 +338,12 @@ TEST_CASE(KeyTracksConfigFile) {
     auto b = f.add("/fake/b", "/tmp/b.cpp", {"clang++", "--config", "clang.cfg", "/tmp/b.cpp"});
     EXPECT_NE(f.key(a), f.key(b));
 
-    /// An absolute config file is directory-independent.
-    auto c = f.add("/fake/a", "/tmp/c.cpp", {"clang++", "--config=/etc/clang.cfg", "/tmp/c.cpp"});
-    auto d = f.add("/fake/b", "/tmp/d.cpp", {"clang++", "--config=/etc/clang.cfg", "/tmp/d.cpp"});
+    /// An absolute config file is directory-independent (a platform-native
+    /// absolute path: POSIX spellings are not absolute on Windows).
+    TempDir tmp;
+    auto cfg = "--config=" + tmp.path("clang.cfg");
+    auto c = f.add("/fake/a", "/tmp/c.cpp", {"clang++", cfg.c_str(), "/tmp/c.cpp"});
+    auto d = f.add("/fake/b", "/tmp/d.cpp", {"clang++", cfg.c_str(), "/tmp/d.cpp"});
     EXPECT_EQ(f.key(c), f.key(d));
 }
 

--- a/tests/unit/command/toolchain_tests.cpp
+++ b/tests/unit/command/toolchain_tests.cpp
@@ -338,12 +338,16 @@ TEST_CASE(KeyTracksConfigFile) {
     auto b = f.add("/fake/b", "/tmp/b.cpp", {"clang++", "--config", "clang.cfg", "/tmp/b.cpp"});
     EXPECT_NE(f.key(a), f.key(b));
 
-    /// An absolute config file is directory-independent (a platform-native
-    /// absolute path: POSIX spellings are not absolute on Windows).
+    /// An absolute config file is directory-independent. Both paths are
+    /// platform-native absolute (POSIX spellings are not absolute on
+    /// Windows), and the driver is absolute too: a bare driver name is
+    /// never cwd-exempt on Windows and would tie the key to the directory
+    /// on its own.
     TempDir tmp;
     auto cfg = "--config=" + tmp.path("clang.cfg");
-    auto c = f.add("/fake/a", "/tmp/c.cpp", {"clang++", cfg.c_str(), "/tmp/c.cpp"});
-    auto d = f.add("/fake/b", "/tmp/d.cpp", {"clang++", cfg.c_str(), "/tmp/d.cpp"});
+    auto driver = tmp.path("clang++");
+    auto c = f.add("/fake/a", "/tmp/c.cpp", {driver.c_str(), cfg.c_str(), "/tmp/c.cpp"});
+    auto d = f.add("/fake/b", "/tmp/d.cpp", {driver.c_str(), cfg.c_str(), "/tmp/d.cpp"});
     EXPECT_EQ(f.key(c), f.key(d));
 }
 
@@ -732,9 +736,15 @@ TEST_CASE(Resolve, skip = !CIEnvironment) {
         LOG_ERROR_RET(void(), "{}", file.error());
     }
 
+    /// A platform-native absolute include dir: a POSIX spelling would be
+    /// re-anchored (and separator-normalized) on Windows.
+    TempDir tmp;
+    auto inc = tmp.path("inc");
+    auto inc_flag = "-I" + inc;
+
     Fixture f;
     auto ref =
-        f.add("/tmp", *file, {"clang++", "-std=c++23", "-I/usr/include", "-DFOO=1", file->c_str()});
+        f.add("/tmp", *file, {"clang++", "-std=c++23", inc_flag.c_str(), "-DFOO=1", file->c_str()});
     auto resolved = f.db.toolchain().resolve(ref.config, ref.input);
     ASSERT_TRUE(resolved.has_value());
     EXPECT_TRUE(f.db.toolchain().has_cache());
@@ -748,7 +758,7 @@ TEST_CASE(Resolve, skip = !CIEnvironment) {
     for(std::size_t i = 0; i < argv.size(); ++i) {
         if(argv[i] == "-cc1"sv)
             has_cc1 = true;
-        if(argv[i] == "-I"sv && i + 1 < argv.size() && argv[i + 1] == "/usr/include"sv)
+        if(argv[i] == "-I"sv && i + 1 < argv.size() && llvm::StringRef(argv[i + 1]) == inc)
             has_include = true;
         if(argv[i] == "-D"sv && i + 1 < argv.size() && argv[i + 1] == "FOO=1"sv)
             has_define = true;

--- a/tests/unit/compile/compilation_tests.cpp
+++ b/tests/unit/compile/compilation_tests.cpp
@@ -47,6 +47,27 @@ struct Bar {
     ASSERT_EQ(unit->top_level_decls().size(), 4U);
 }
 
+TEST_CASE(DirectoryAnchorsIncludes) {
+    /// The entry's `directory` governs relative search paths in the
+    /// compile: -Igen must resolve against it, not the process cwd.
+    TempDir tmp;
+    tmp.touch("gen/config.h", "#define FROM_GEN 1\n");
+    tmp.touch("main.cpp", R"(
+#include <config.h>
+int x = FROM_GEN;
+)");
+
+    std::vector<std::string> owned = {"clang++", "-std=c++20", "-Igen", tmp.path("main.cpp")};
+    for(auto& arg: owned) {
+        params.arguments.push_back(arg.c_str());
+    }
+    params.directory = tmp.root.str().str();
+
+    auto built = clice::compile(params);
+    ASSERT_TRUE(built.completed());
+    ASSERT_TRUE(built.diagnostics().empty());
+}
+
 TEST_CASE(StopCompilation) {
     std::shared_ptr<std::atomic_bool> stop = std::make_shared<std::atomic_bool>(false);
 

--- a/tests/unit/compile/compilation_tests.cpp
+++ b/tests/unit/compile/compilation_tests.cpp
@@ -283,18 +283,25 @@ export int a_value() { return b_value() + 1; }
 )");
 
     CompilationDatabase cdb;
-    Toolchain tc;
+
+    auto render_entry = [&](llvm::StringRef file) {
+        auto& entry = cdb.candidate_entries(file).front();
+        CommandRef ref{entry.file,
+                       entry.config,
+                       cdb.input_kind(entry.config, file),
+                       CommandSource::CDBExact};
+        EXPECT_TRUE(cdb.toolchain().resolve(ref.config, ref.input).has_value());
+        return cdb.render(ref);
+    };
 
     // Build PCM for mod_b.
     cdb.add_command(tmp.root.str(),
                     tmp.path("mod_b.cppm"),
                     std::format("clang++ -std=c++20 {}", tmp.path("mod_b.cppm")));
 
-    auto cmds_b = cdb.lookup(tmp.path("mod_b.cppm"));
-    ASSERT_TRUE(tc.resolve(cmds_b.front()).has_value());
     CompilationParams params_b;
     params_b.kind = CompilationKind::ModuleInterface;
-    params_b.arguments = cmds_b.front().to_argv();
+    params_b.arguments = render_entry(tmp.path("mod_b.cppm"));
 
     auto pcm_b_path = fs::createTemporaryFile("mod_b", "pcm");
     ASSERT_TRUE(pcm_b_path.operator bool());
@@ -310,11 +317,9 @@ export int a_value() { return b_value() + 1; }
                     tmp.path("mod_a.cppm"),
                     std::format("clang++ -std=c++20 {}", tmp.path("mod_a.cppm")));
 
-    auto cmds_a = cdb.lookup(tmp.path("mod_a.cppm"));
-    ASSERT_TRUE(tc.resolve(cmds_a.front()).has_value());
     CompilationParams params_a;
     params_a.kind = CompilationKind::ModuleInterface;
-    params_a.arguments = cmds_a.front().to_argv();
+    params_a.arguments = render_entry(tmp.path("mod_a.cppm"));
     params_a.pcms.try_emplace("mod_b", info_b.path);
 
     auto pcm_a_path = fs::createTemporaryFile("mod_a", "pcm");

--- a/tests/unit/sched/pcm_graph_integration_tests.cpp
+++ b/tests/unit/sched/pcm_graph_integration_tests.cpp
@@ -3,7 +3,6 @@
 #include "test/temp_dir.h"
 #include "test/test.h"
 #include "command/command.h"
-#include "command/toolchain.h"
 #include "compile/compilation.h"
 #include "sched/graph.h"
 #include "support/path_pool.h"
@@ -84,22 +83,24 @@ struct GraphShim {
 /// Clang requires ALL transitive PCM deps (not just direct imports)
 /// in PrebuiltModuleFiles, so we pass every available PCM.
 DispatchFn make_dispatch(CompilationDatabase& cdb,
-                         Toolchain& toolchain,
-                         PathPool& pool,
                          DependencyGraph& graph,
                          llvm::DenseMap<std::uint32_t, std::string>& pcm_paths) {
     return [&](std::uint32_t path_id, bool) -> kota::task<RoundOutcome> {
-        auto file_path = pool.resolve(path_id);
-        auto results = cdb.lookup(file_path);
-        if(results.empty()) {
+        auto file_path = cdb.paths().resolve(path_id);
+        auto candidates = cdb.candidate_entries(file_path);
+        if(candidates.empty()) {
             co_return RoundOutcome::Failed;
         }
-        toolchain.resolve_or_warn(results[0]);
+        auto& entry = candidates.front();
+        CommandRef ref{entry.file,
+                       entry.config,
+                       cdb.input_kind(entry.config, file_path),
+                       CommandSource::CDBExact};
 
         CompilationParams cp;
         cp.kind = CompilationKind::ModuleInterface;
-        cp.directory = results[0].resolved.directory.str();
-        cp.arguments = results[0].to_argv();
+        cp.directory = cdb.config(entry.config).directory;
+        cp.arguments = cdb.render(ref);
 
         // Fill ALL available PCM paths (clang needs transitive deps too).
         for(auto& [pid, pcm_path]: pcm_paths) {
@@ -129,19 +130,20 @@ DispatchFn make_dispatch(CompilationDatabase& cdb,
 }
 
 /// Build a resolve_fn that lazily scans module files for imports.
-ResolveFn make_resolver(CompilationDatabase& cdb,
-                        Toolchain& toolchain,
-                        PathPool& pool,
-                        DependencyGraph& graph) {
+ResolveFn make_resolver(CompilationDatabase& cdb, DependencyGraph& graph) {
     return [&](std::uint32_t path_id) -> llvm::SmallVector<std::uint32_t> {
-        auto file_path = pool.resolve(path_id);
-        auto results = cdb.lookup(file_path);
-        if(results.empty()) {
+        auto file_path = cdb.paths().resolve(path_id);
+        auto candidates = cdb.candidate_entries(file_path);
+        if(candidates.empty()) {
             return {};
         }
-        toolchain.resolve_or_warn(results[0]);
+        auto& entry = candidates.front();
+        CommandRef ref{entry.file,
+                       entry.config,
+                       cdb.input_kind(entry.config, file_path),
+                       CommandSource::CDBExact};
 
-        auto scan_result = scan_precise(results[0].to_argv(), results[0].resolved.directory);
+        auto scan_result = scan_precise(cdb.render(ref), cdb.config(entry.config).directory);
 
         llvm::SmallVector<std::uint32_t> deps;
         for(auto& mod_name: scan_result.modules) {
@@ -158,14 +160,12 @@ ResolveFn make_resolver(CompilationDatabase& cdb,
 struct ModuleTestEnv {
     TempDir tmp;
     CompilationDatabase cdb;
-    Toolchain toolchain;
-    PathPool pool;
     DependencyGraph graph;
     llvm::DenseMap<std::uint32_t, std::string> pcm_paths;
 
     void setup(llvm::ArrayRef<CDBEntry> entries, llvm::StringRef json) {
         write_cdb(tmp, cdb, json);
-        scan_dependency_graph(cdb, toolchain, pool, graph);
+        scan_dependency_graph(cdb, graph);
     }
 
     std::uint32_t lookup(llvm::StringRef mod_name) {
@@ -181,11 +181,11 @@ std::optional<kota::event_loop> loop;
 std::optional<GraphShim> cg;
 
 DispatchFn default_dispatch() {
-    return make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths);
+    return make_dispatch(env.cdb, env.graph, env.pcm_paths);
 }
 
 ResolveFn default_resolver() {
-    return make_resolver(env.cdb, env.toolchain, env.pool, env.graph);
+    return make_resolver(env.cdb, env.graph);
 }
 
 void make_graph(DispatchFn dispatch, ResolveFn resolve) {
@@ -1115,14 +1115,18 @@ TEST_CASE(module_implementation_unit) {
 
         // Now compile the implementation unit as Content (like a stateful worker would).
         auto impl_path = env.tmp.path("impl.cpp");
-        auto results = env.cdb.lookup(impl_path);
-        CO_ASSERT_FALSE(results.empty());
-        env.toolchain.resolve_or_warn(results[0]);
+        auto candidates = env.cdb.candidate_entries(impl_path);
+        CO_ASSERT_FALSE(candidates.empty());
+        auto& impl_entry = candidates.front();
+        CommandRef impl_ref{impl_entry.file,
+                            impl_entry.config,
+                            env.cdb.input_kind(impl_entry.config, impl_path),
+                            CommandSource::CDBExact};
 
         CompilationParams cp;
         cp.kind = CompilationKind::Content;
-        cp.directory = results[0].resolved.directory.str();
-        cp.arguments = results[0].to_argv();
+        cp.directory = env.cdb.config(impl_entry.config).directory;
+        cp.arguments = env.cdb.render(impl_ref);
         // Pass the built PCM so clang can resolve `module Greeter;`.
         for(auto& [pid, pcm_path]: env.pcm_paths) {
             for(auto& [mod_name, mod_ids]: env.graph.modules()) {

--- a/tests/unit/server/ast_family_tests.cpp
+++ b/tests/unit/server/ast_family_tests.cpp
@@ -430,10 +430,7 @@ TEST_CASE(BufferImportBuildsPCM) {
                   {tmp.root, tmp.path("m.cppm"), {}},
                   {tmp.root, src,                {}},
     }));
-    scan_dependency_graph(stack.workspace.cdb,
-                          stack.workspace.toolchain,
-                          stack.workspace.path_pool,
-                          stack.workspace.dep_graph);
+    scan_dependency_graph(stack.workspace.cdb, stack.workspace.dep_graph);
     stack.workspace.dep_graph.build_reverse_map();
     stack.workspace.build_module_map();
 

--- a/tests/unit/server/context_resolver_tests.cpp
+++ b/tests/unit/server/context_resolver_tests.cpp
@@ -50,6 +50,48 @@ TEST_CASE(ChoiceNeedsSession) {
     ASSERT_TRUE(llvm::is_contained(arguments, define_of(candidates.front().config)));
 }
 
+TEST_CASE(PinBaseSurvivesRules) {
+    TempDir tmp;
+    Workspace workspace;
+    SessionStore store;
+    ContextResolver resolver(workspace);
+    tmp.touch("main.cpp");
+    auto path = tmp.path("main.cpp");
+    write_cdb(tmp,
+              workspace.cdb,
+              build_cdb_json({
+                  {tmp.root, path, {"-DFIRST"} },
+                  {tmp.root, path, {"-DSECOND"}}
+    }));
+
+    auto file = workspace.path_pool.intern(path);
+    auto candidates = workspace.cdb.candidate_entries(path);
+    ASSERT_EQ(candidates.size(), 2u);
+    auto define_of = [&](ConfigID config) -> llvm::StringRef {
+        auto argv = print_argv(workspace.cdb.render_full(config));
+        return llvm::StringRef(argv).contains("SECOND") ? "SECOND" : "FIRST";
+    };
+    auto pinned = candidates.back().config;
+
+    // A pin whose applied hash went stale (a rule edit since it was saved)
+    // but whose base identity is recorded still selects its candidate...
+    resolver.saved_contexts[file] = SavedContext{no_path_id,
+                                                 std::nullopt,
+                                                 "0123456789abcdef",
+                                                 workspace.cdb.entry_hash_hex(pinned)};
+    auto session = store.open(file);
+    std::string directory;
+    std::vector<std::string> arguments;
+    resolver.resolve_command(path, directory, arguments, ContextUse::Editor);
+    ASSERT_TRUE(llvm::is_contained(arguments, define_of(pinned)));
+
+    // ...while the same stale hash without a base falls back to the default.
+    resolver.saved_contexts[file] = SavedContext{no_path_id, std::nullopt, "0123456789abcdef", ""};
+    arguments.clear();
+    resolver.resolve_command(path, directory, arguments, ContextUse::Editor);
+    ASSERT_TRUE(llvm::is_contained(arguments, define_of(candidates.front().config)));
+}
+
 TEST_CASE(ValidateKeepsValidChoice) {
     TempDir tmp;
     Workspace workspace;

--- a/tests/unit/server/context_resolver_tests.cpp
+++ b/tests/unit/server/context_resolver_tests.cpp
@@ -25,24 +25,29 @@ TEST_CASE(ChoiceNeedsSession) {
     }));
 
     auto file = workspace.path_pool.intern(path);
-    auto results = workspace.cdb.lookup(path, {});
-    ASSERT_EQ(results.size(), 2u);
-    resolver.saved_contexts[file] = SavedContext{
-        no_path_id,
-        std::nullopt,
-        canonical_command_hash(results[1].to_string_argv(), results[1].resolved.directory)};
+    auto candidates = workspace.cdb.candidate_entries(path);
+    ASSERT_EQ(candidates.size(), 2u);
+    // Pin the non-default candidate (candidate order is content-decided,
+    // so the defines are read back rather than assumed).
+    auto define_of = [&](ConfigID config) -> llvm::StringRef {
+        auto argv = print_argv(workspace.cdb.render_full(config));
+        return llvm::StringRef(argv).contains("SECOND") ? "SECOND" : "FIRST";
+    };
+    auto pinned = candidates.back().config;
+    resolver.saved_contexts[file] =
+        SavedContext{no_path_id, std::nullopt, workspace.cdb.entry_hash_hex(pinned)};
 
     // An open session honors the pinned CDB entry...
     auto session = store.open(file);
     std::string directory;
     std::vector<std::string> arguments;
     resolver.resolve_command(path, directory, arguments, ContextUse::Editor);
-    ASSERT_TRUE(llvm::is_contained(arguments, "SECOND"));
+    ASSERT_TRUE(llvm::is_contained(arguments, define_of(pinned)));
 
     // ...but background indexing (no session) must never see user choices.
     arguments.clear();
     resolver.resolve_command(path, directory, arguments, ContextUse::Background);
-    ASSERT_TRUE(llvm::is_contained(arguments, "FIRST"));
+    ASSERT_TRUE(llvm::is_contained(arguments, define_of(candidates.front().config)));
 }
 
 TEST_CASE(ValidateKeepsValidChoice) {

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -3027,10 +3027,7 @@ TEST_CASE(ModuleLintScanParity) {
                   {tmp.root, tmp.path("m.cppm"), {}},
                   {tmp.root, tmp.path("n.cppm"), {}},
     }));
-    scan_dependency_graph(f.workspace.cdb,
-                          f.workspace.toolchain,
-                          f.workspace.path_pool,
-                          f.workspace.dep_graph);
+    scan_dependency_graph(f.workspace.cdb, f.workspace.dep_graph);
     f.workspace.dep_graph.build_reverse_map();
     f.workspace.build_module_map();
 

--- a/tests/unit/syntax/dependency_graph_tests.cpp
+++ b/tests/unit/syntax/dependency_graph_tests.cpp
@@ -249,6 +249,31 @@ export module m;
     EXPECT_EQ(graph.lookup_module("m").size(), 1u);
 }
 
+TEST_CASE(GuardedModulePerCandidate) {
+    /// Two candidates whose defines select different module names: each
+    /// scan unit must preprocess under its own group's command, not
+    /// whichever candidate sorts first.
+    TempDir tmp;
+    tmp.touch("src/m.cppm", R"(#ifdef V2
+export module m2;
+#else
+export module m1;
+#endif
+)");
+
+    CompilationDatabase cdb;
+    DependencyGraph graph;
+    auto json = build_cdb_json({
+        {tmp.root, tmp.path("src/m.cppm"), {}      },
+        {tmp.root, tmp.path("src/m.cppm"), {"-DV2"}},
+    });
+    write_cdb(tmp, cdb, json);
+    scan_dependency_graph(cdb, graph);
+
+    EXPECT_EQ(graph.lookup_module("m1").size(), 1u);
+    EXPECT_EQ(graph.lookup_module("m2").size(), 1u);
+}
+
 TEST_CASE(SingleFileNoIncludes) {
     TempDir tmp;
     tmp.touch("src/main.cpp", R"(int main() { return 0; })");

--- a/tests/unit/syntax/dependency_graph_tests.cpp
+++ b/tests/unit/syntax/dependency_graph_tests.cpp
@@ -263,15 +263,24 @@ export module m1;
 
     CompilationDatabase cdb;
     DependencyGraph graph;
+    ScanCache cache;
     auto json = build_cdb_json({
         {tmp.root, tmp.path("src/m.cppm"), {}      },
         {tmp.root, tmp.path("src/m.cppm"), {"-DV2"}},
     });
     write_cdb(tmp, cdb, json);
-    scan_dependency_graph(cdb, graph);
+    scan_dependency_graph(cdb, graph, &cache);
 
     EXPECT_EQ(graph.lookup_module("m1").size(), 1u);
     EXPECT_EQ(graph.lookup_module("m2").size(), 1u);
+
+    // A warm run must reproduce both: the shared per-path cache cannot
+    // hold two names, so multi-group units re-derive under their own
+    // group command every run.
+    DependencyGraph graph2;
+    scan_dependency_graph(cdb, graph2, &cache);
+    EXPECT_EQ(graph2.lookup_module("m1").size(), 1u);
+    EXPECT_EQ(graph2.lookup_module("m2").size(), 1u);
 }
 
 TEST_CASE(SingleFileNoIncludes) {

--- a/tests/unit/syntax/dependency_graph_tests.cpp
+++ b/tests/unit/syntax/dependency_graph_tests.cpp
@@ -222,6 +222,33 @@ TEST_CASE(EmptyCDB) {
     EXPECT_EQ(graph.edge_count(), 0u);
 }
 
+TEST_CASE(GuardedModuleRuleDefine) {
+    /// A module declaration unguarded only by a rule-added define: the
+    /// preprocess fallback must scan with the rules-applied command, like
+    /// the main scan groups.
+    TempDir tmp;
+    tmp.touch("src/m.cppm", R"(#ifdef ENABLE_M
+export module m;
+#endif
+)");
+
+    CompilationDatabase cdb;
+    DependencyGraph graph;
+    auto json = build_cdb_json({
+        {tmp.root, tmp.path("src/m.cppm"), {}}
+    });
+    write_cdb(tmp, cdb, json);
+    scan_dependency_graph(cdb,
+                          graph,
+                          /*cache=*/nullptr,
+                          [](llvm::StringRef,
+                             std::vector<std::string>& append,
+                             std::vector<std::string>&) { append.push_back("-DENABLE_M"); });
+
+    EXPECT_EQ(graph.module_count(), 1u);
+    EXPECT_EQ(graph.lookup_module("m").size(), 1u);
+}
+
 TEST_CASE(SingleFileNoIncludes) {
     TempDir tmp;
     tmp.touch("src/main.cpp", R"(int main() { return 0; })");

--- a/tests/unit/syntax/dependency_graph_tests.cpp
+++ b/tests/unit/syntax/dependency_graph_tests.cpp
@@ -2,7 +2,6 @@
 #include "test/temp_dir.h"
 #include "test/test.h"
 #include "command/command.h"
-#include "command/toolchain.h"
 #include "support/path_pool.h"
 #include "syntax/dependency_graph.h"
 
@@ -214,11 +213,9 @@ TEST_SUITE(ScanDependencyGraph) {
 
 TEST_CASE(EmptyCDB) {
     CompilationDatabase cdb;
-    PathPool pool;
     DependencyGraph graph;
 
-    Toolchain tc;
-    scan_dependency_graph(cdb, tc, pool, graph);
+    scan_dependency_graph(cdb, graph);
 
     EXPECT_EQ(graph.file_count(), 0u);
     EXPECT_EQ(graph.module_count(), 0u);
@@ -230,15 +227,13 @@ TEST_CASE(SingleFileNoIncludes) {
     tmp.touch("src/main.cpp", R"(int main() { return 0; })");
 
     CompilationDatabase cdb;
-    PathPool pool;
     DependencyGraph graph;
 
     auto json = build_cdb_json({
         {tmp.root, tmp.path("src/main.cpp"), {}}
     });
     write_cdb(tmp, cdb, json);
-    Toolchain tc;
-    scan_dependency_graph(cdb, tc, pool, graph);
+    scan_dependency_graph(cdb, graph);
 
     EXPECT_EQ(graph.file_count(), 1u);
     EXPECT_EQ(graph.edge_count(), 0u);
@@ -254,15 +249,13 @@ int main() { return x; }
 )");
 
     CompilationDatabase cdb;
-    PathPool pool;
     DependencyGraph graph;
 
     auto json = build_cdb_json({
         {tmp.root, tmp.path("src/main.cpp"), {"-I", tmp.path("include")}}
     });
     write_cdb(tmp, cdb, json);
-    Toolchain tc;
-    scan_dependency_graph(cdb, tc, pool, graph);
+    scan_dependency_graph(cdb, graph);
 
     EXPECT_GE(graph.file_count(), 1u);
     EXPECT_GE(graph.edge_count(), 1u);
@@ -279,15 +272,13 @@ int main() {}
 )");
 
     CompilationDatabase cdb;
-    PathPool pool;
     DependencyGraph graph;
 
     auto json = build_cdb_json({
         {tmp.root, tmp.path("src/main.cpp"), {"-I", tmp.path("inc")}}
     });
     write_cdb(tmp, cdb, json);
-    Toolchain tc;
-    scan_dependency_graph(cdb, tc, pool, graph);
+    scan_dependency_graph(cdb, graph);
 
     // main->a, a->b, b->c across 4 waves.
     EXPECT_GE(graph.file_count(), 3u);
@@ -307,7 +298,6 @@ void b() {}
 )");
 
     CompilationDatabase cdb;
-    PathPool pool;
     DependencyGraph graph;
 
     std::vector<std::string> inc = {"-I", tmp.path("inc")};
@@ -316,8 +306,7 @@ void b() {}
         {tmp.root, tmp.path("src/b.cpp"), inc},
     });
     write_cdb(tmp, cdb, json);
-    Toolchain tc;
-    scan_dependency_graph(cdb, tc, pool, graph);
+    scan_dependency_graph(cdb, graph);
 
     EXPECT_GE(graph.file_count(), 2u);
     EXPECT_GE(graph.edge_count(), 2u);
@@ -335,15 +324,13 @@ TEST_CASE(ConditionalIncludes) {
 )");
 
     CompilationDatabase cdb;
-    PathPool pool;
     DependencyGraph graph;
 
     auto json = build_cdb_json({
         {tmp.root, tmp.path("src/main.cpp"), {"-I", tmp.path("inc")}}
     });
     write_cdb(tmp, cdb, json);
-    Toolchain tc;
-    scan_dependency_graph(cdb, tc, pool, graph);
+    scan_dependency_graph(cdb, graph);
 
     // Both headers discovered (over-approximate).
     EXPECT_GE(graph.edge_count(), 2u);
@@ -351,7 +338,7 @@ TEST_CASE(ConditionalIncludes) {
     // Verify conditional flag.
     bool found_unconditional = false;
     bool found_conditional = false;
-    auto includes = graph.get_includes(pool.cache[tmp.path("src/main.cpp")], 0);
+    auto includes = graph.get_includes(cdb.paths().intern(tmp.path("src/main.cpp")), 0);
     for(auto id: includes) {
         if(id & DependencyGraph::CONDITIONAL_FLAG) {
             found_conditional = true;
@@ -371,20 +358,18 @@ export int foo() { return 42; }
 )");
 
     CompilationDatabase cdb;
-    PathPool pool;
     DependencyGraph graph;
 
     auto json = build_cdb_json({
         {tmp.root, tmp.path("src/mymod.cpp"), {}}
     });
     write_cdb(tmp, cdb, json);
-    Toolchain tc;
-    scan_dependency_graph(cdb, tc, pool, graph);
+    scan_dependency_graph(cdb, graph);
 
     auto result = graph.lookup_module("my.module");
     ASSERT_EQ(result.size(), 1u);
 
-    auto path = pool.resolve(result[0]);
+    auto path = cdb.paths().resolve(result[0]);
     EXPECT_TRUE(llvm::sys::fs::equivalent(path, tmp.path("src/mymod.cpp")));
 }
 
@@ -396,15 +381,13 @@ void impl() {}
 )");
 
     CompilationDatabase cdb;
-    PathPool pool;
     DependencyGraph graph;
 
     auto json = build_cdb_json({
         {tmp.root, tmp.path("src/mod.cpp"), {}}
     });
     write_cdb(tmp, cdb, json);
-    Toolchain tc;
-    scan_dependency_graph(cdb, tc, pool, graph);
+    scan_dependency_graph(cdb, graph);
 
     ASSERT_EQ(graph.lookup_module("my.mod:part").size(), 1u);
 }
@@ -427,15 +410,13 @@ int main() {}
 )");
 
     CompilationDatabase cdb;
-    PathPool pool;
     DependencyGraph graph;
 
     auto json = build_cdb_json({
         {tmp.root, tmp.path("src/main.cpp"), {"-I", tmp.path("inc")}}
     });
     write_cdb(tmp, cdb, json);
-    Toolchain tc;
-    scan_dependency_graph(cdb, tc, pool, graph);
+    scan_dependency_graph(cdb, graph);
 
     // main->a, main->b, a->common, b->common.
     EXPECT_GE(graph.edge_count(), 4u);
@@ -453,7 +434,6 @@ int main() {}
 )");
 
     CompilationDatabase cdb;
-    PathPool pool;
     DependencyGraph graph;
 
     auto json = build_cdb_json({
@@ -462,8 +442,7 @@ int main() {}
          {"-iquote", tmp.path("quoted"), "-I", tmp.path("angled")}}
     });
     write_cdb(tmp, cdb, json);
-    Toolchain tc;
-    scan_dependency_graph(cdb, tc, pool, graph);
+    scan_dependency_graph(cdb, graph);
 
     EXPECT_GE(graph.edge_count(), 2u);
 }
@@ -476,15 +455,13 @@ int main() {}
 )");
 
     CompilationDatabase cdb;
-    PathPool pool;
     DependencyGraph graph;
 
     auto json = build_cdb_json({
         {tmp.root, tmp.path("src/main.cpp"), {}}
     });
     write_cdb(tmp, cdb, json);
-    Toolchain tc;
-    scan_dependency_graph(cdb, tc, pool, graph);
+    scan_dependency_graph(cdb, graph);
 
     EXPECT_EQ(graph.file_count(), 1u);
     EXPECT_EQ(graph.edge_count(), 0u);
@@ -506,7 +483,6 @@ void a_impl() {}
 )");
 
     CompilationDatabase cdb;
-    PathPool pool;
     DependencyGraph graph;
 
     auto json = build_cdb_json({
@@ -515,8 +491,7 @@ void a_impl() {}
         {tmp.root, tmp.path("src/impl.cpp"),  {}},
     });
     write_cdb(tmp, cdb, json);
-    Toolchain tc;
-    scan_dependency_graph(cdb, tc, pool, graph);
+    scan_dependency_graph(cdb, graph);
 
     EXPECT_EQ(graph.module_count(), 2u);
     ASSERT_FALSE(graph.lookup_module("mod.a").empty());
@@ -536,15 +511,13 @@ int main() {}
 )");
 
     CompilationDatabase cdb;
-    PathPool pool;
     DependencyGraph graph;
 
     auto json = build_cdb_json({
         {tmp.root, tmp.path("src/main.cpp"), {"-I", tmp.path("inc")}}
     });
     write_cdb(tmp, cdb, json);
-    Toolchain tc;
-    scan_dependency_graph(cdb, tc, pool, graph);
+    scan_dependency_graph(cdb, graph);
 
     // main->h0->h1->h2->h3->h4 across 5 waves.
     EXPECT_GE(graph.edge_count(), 5u);
@@ -562,15 +535,13 @@ export int value() { return util; }
 )");
 
     CompilationDatabase cdb;
-    PathPool pool;
     DependencyGraph graph;
 
     auto json = build_cdb_json({
         {tmp.root, tmp.path("src/mymod.cpp"), {"-I", tmp.path("inc")}}
     });
     write_cdb(tmp, cdb, json);
-    Toolchain tc;
-    scan_dependency_graph(cdb, tc, pool, graph);
+    scan_dependency_graph(cdb, graph);
 
     ASSERT_FALSE(graph.lookup_module("my.lib").empty());
     EXPECT_GE(graph.edge_count(), 1u);
@@ -585,9 +556,7 @@ int main() {}
 )");
 
     CompilationDatabase cdb;
-    PathPool pool;
     ScanCache cache;
-    Toolchain tc;
 
     auto json = build_cdb_json({
         {tmp.root, tmp.path("src/main.cpp"), {"-I", tmp.path("inc")}}
@@ -595,13 +564,13 @@ int main() {}
     write_cdb(tmp, cdb, json);
 
     DependencyGraph graph;
-    auto cold = scan_dependency_graph(cdb, tc, pool, graph, &cache);
+    auto cold = scan_dependency_graph(cdb, graph, &cache);
     EXPECT_GE(graph.edge_count(), 1u);
 
     // Warm run with the same cache and pool reproduces the same graph
     // and hits the scan result cache instead of re-reading files.
     DependencyGraph graph2;
-    auto warm = scan_dependency_graph(cdb, tc, pool, graph2, &cache);
+    auto warm = scan_dependency_graph(cdb, graph2, &cache);
     EXPECT_GT(warm.scan_cache_hits, std::size_t(0));
     EXPECT_EQ(graph2.edge_count(), graph.edge_count());
     EXPECT_EQ(graph2.file_count(), graph.file_count());

--- a/tests/unit/test/cdb_helper.h
+++ b/tests/unit/test/cdb_helper.h
@@ -66,10 +66,16 @@ inline void write_cdb(TempDir& tmp, CompilationDatabase& cdb, llvm::StringRef js
 
 /// Rules-applied driver-level render of a file's default candidate, with
 /// the injected resource dir stripped so tests can assert exact argv.
+/// A file without candidates renders empty — the caller's assertion then
+/// fails readably instead of the front() of an empty list crashing.
 inline std::vector<const char*> render_entry(CompilationDatabase& cdb,
                                              llvm::StringRef file,
                                              const CommandOptions& options = {}) {
-    auto& entry = cdb.candidate_entries(file).front();
+    auto candidates = cdb.candidate_entries(file);
+    if(candidates.empty()) {
+        return {};
+    }
+    auto& entry = candidates.front();
     auto applied = cdb.apply_rules(entry.config, options);
     CommandRef ref{entry.file, applied, cdb.input_kind(applied, file), CommandSource::CDBExact};
     auto argv = cdb.render_driver(ref);

--- a/tests/unit/test/cdb_helper.h
+++ b/tests/unit/test/cdb_helper.h
@@ -64,4 +64,22 @@ inline void write_cdb(TempDir& tmp, CompilationDatabase& cdb, llvm::StringRef js
     cdb.load(tmp.path("compile_commands.json"));
 }
 
+/// Rules-applied driver-level render of a file's default candidate, with
+/// the injected resource dir stripped so tests can assert exact argv.
+inline std::vector<const char*> render_entry(CompilationDatabase& cdb,
+                                             llvm::StringRef file,
+                                             const CommandOptions& options = {}) {
+    auto& entry = cdb.candidate_entries(file).front();
+    auto applied = cdb.apply_rules(entry.config, options);
+    CommandRef ref{entry.file, applied, cdb.input_kind(applied, file), CommandSource::CDBExact};
+    auto argv = cdb.render_driver(ref);
+    for(std::size_t i = 0; i + 1 < argv.size(); i += 1) {
+        if(llvm::StringRef(argv[i]) == "-resource-dir") {
+            argv.erase(argv.begin() + i, argv.begin() + i + 2);
+            break;
+        }
+    }
+    return argv;
+}
+
 }  // namespace clice::testing

--- a/tests/unit/test/tester.cpp
+++ b/tests/unit/test/tester.cpp
@@ -310,14 +310,11 @@ void Tester::prepare_driver(llvm::StringRef standard) {
     }
 
     auto command = std::format("clang++ {} {} -fms-extensions", standard, src_path);
-    database.add_command("fake", src_path, command);
-
-    auto candidates = database.candidate_entries(src_path);
-    assert(!candidates.empty() && "no entry after add_command");
-    auto& entry = candidates.front();
-    CommandRef ref{entry.file,
-                   entry.config,
-                   database.input_kind(entry.config, src_path),
+    auto entry = database.add_command("fake", src_path, command);
+    assert(entry && "no entry after add_command");
+    CommandRef ref{entry->file,
+                   entry->config,
+                   database.input_kind(entry->config, src_path),
                    CommandSource::CDBExact};
     params.arguments = database.render(ref);
 

--- a/tests/unit/test/tester.cpp
+++ b/tests/unit/test/tester.cpp
@@ -312,10 +312,14 @@ void Tester::prepare_driver(llvm::StringRef standard) {
     auto command = std::format("clang++ {} {} -fms-extensions", standard, src_path);
     database.add_command("fake", src_path, command);
 
-    auto commands = database.lookup(src_path);
-    assert(!commands.empty() && "lookup failed after add_command");
-    toolchain.resolve_or_warn(commands.front());
-    params.arguments = commands.front().to_argv();
+    auto candidates = database.candidate_entries(src_path);
+    assert(!candidates.empty() && "no entry after add_command");
+    auto& entry = candidates.front();
+    CommandRef ref{entry.file,
+                   entry.config,
+                   database.input_kind(entry.config, src_path),
+                   CommandSource::CDBExact};
+    params.arguments = database.render(ref);
 
     params.kind = CompilationKind::Content;
 
@@ -341,8 +345,6 @@ bool Tester::compile_driver(llvm::StringRef standard) {
 
 void Tester::clear() {
     params = CompilationParams();
-    database = CompilationDatabase();
-    toolchain = Toolchain();
     unit.reset();
     sources.all_files.clear();
     src_path.clear();

--- a/tests/unit/test/tester.h
+++ b/tests/unit/test/tester.h
@@ -7,7 +7,6 @@
 
 #include "test/test.h"
 #include "command/command.h"
-#include "command/toolchain.h"
 #include "compile/compilation.h"
 #include "syntax/annotation.h"
 
@@ -16,7 +15,6 @@ namespace clice::testing {
 struct Tester {
     CompilationParams params;
     CompilationDatabase database;
-    Toolchain toolchain;
     std::optional<CompilationUnit> unit;
     std::string src_path;
 
@@ -87,6 +85,8 @@ struct Tester {
 
     LocalSourceRange range(llvm::StringRef name = "", llvm::StringRef file = "");
 
+    /// Reset per-compile state so one case can compile several sources.
+    /// The database persists — entries are append-only and harmless.
     void clear();
 };
 

--- a/tools/client/workspace.ts
+++ b/tools/client/workspace.ts
@@ -10,7 +10,7 @@ import { buildCDBEntry, generateCDB } from "../compile_commands.ts";
 
 /// Versioned root of the unified cache store; bump together with
 /// cache_format_version in src/server/state/workspace.h.
-const CACHE_ROOT = path.join(".clice", "cache", "v7");
+const CACHE_ROOT = path.join(".clice", "cache", "v8");
 
 /// The harness-wide canonical URI spelling: percent-decoded. vscode-uri
 /// encodes the drive colon (file:///c%3A/...) while the server emits it


### PR DESCRIPTION
## Related issue

Fixes #638, fixes #548, fixes #544, fixes #284.

Also moves #98 and #18 forward: `zig cc` / `zig c++` subcommand drivers now probe through the standard toolchain path, and files without a CDB entry get a synthesized fallback command with rule edits applied. Both stay open — the former pending verification against a real zig toolchain, the latter for the remaining inference tier.

## What changed

The command layer previously re-parsed and re-filtered raw argv at every consumer. This PR rewrites it around a parse-once model:

- **Structured commands.** Every CDB entry is normalized once at load (wrapper strip → driver/subcommand split → response-file expansion → NVCC translation → parse → classification → path normalization) into a `CompileConfig` deduplicated by `ConfigID`. Downstream consumers hold ids and decode on demand; flat argv only appears at compiler invocations, IPC and logs.
- **Command identity.** `EntryHash` (frontend-semantic view + input slot + directory) is the single identity used by CDB diffing, index snapshots and context pins. Codegen-only flag changes no longer count as command changes.
- **Structured rule editing.** `clice.toml` append/remove rules edit the parsed sequence — appends insert before the input slot so they always govern the compile, removes cancel structurally — memoized per (config, rule set). Rule flags for NVCC entries are translated the same way the base command was.
- **Toolchain rework.** Two-layer probe/synthesis cache keyed by the frontend profile. Probes run in the entry's directory, relative drivers resolve against it, and cwd-sensitive flags (`--sysroot`, `--config`, ...) tie the probe key to the directory. Pre-warming dedupes probes across configs.
- **`directory` end-to-end.** A relative CDB `directory` anchors to the CDB file's own location (identical semantics for server, batch and inspect). The worker compile sets the invocation working directory from the entry — an explicit `-working-directory` wins, its own relative value anchoring to the entry directory — so relative `-I`/`-include` finally resolve per the CDB contract. Dependency scanning and probing use the same base.
- **Deterministic candidate order.** A file with several entries gets a content-decided total order; the first candidate is the default selection everywhere. Pinned selections additionally record the pinned entry's base hash, so a pin survives rule edits that shift every applied hash.
- **Module scan correctness.** `#ifdef`-guarded module declarations are re-scanned under the same rules-applied, per-candidate group command as the main scan, on cold and warm runs alike.
- **Cache format v8.** The persisted snapshot records each file's sorted command hashes plus the selected winner, so offline command edits and winner flips are detected at startup.

Known limitations, deliberately out of scope:

- Response files are expanded at load; a change to an `@file`'s content alone is not watched yet.
- The protocol identifies a pinned command by its rules-applied hash; two candidates that collapse to one applied hash under the current rules cannot be distinguished at pin time.
- Toolchain memoization is append-only for the server lifetime; a CDB regenerating with fresh flags on every configure accumulates entries until restart.

## Tests

All four suites pass locally: unit 1370 (command/toolchain suites rewritten, plus new coverage for wrapper value options, relative `directory` and relative CDB-path anchoring, `--config` probe keys, compile working directory, per-candidate guarded-module scanning including warm cache runs, and pin base-identity survival), integration 379, smoke 3/3, snap 630. `npm run check` is green.
