### PR TITLE
fix(command): treat driver-ignored flags as discarded

### DIFF
--- a/src/command/argument_parser.cpp
+++ b/src/command/argument_parser.cpp
@@ -54,8 +54,8 @@ constexpr std::string_view str_at(unsigned offset) {
     return {ref.data(), ref.size()};
 }
 
-}  // namespace detail
-
+/// Plain enum: Options.inc combines these with bitwise-or, which needs the
+/// implicit conversion an enum class forbids.
 enum ClangDriverFlag : unsigned {
     HelpHidden = eo::HelpHidden,
     RenderAsInput = eo::RenderAsInput,
@@ -69,8 +69,11 @@ enum ClangDriverFlag : unsigned {
     Unsupported = 1u << 10,
 };
 
+}  // namespace detail
+
 const eo::OptTable& table() {
     using enum eo::Kind;
+    using enum detail::ClangDriverFlag;
     using detail::prefixes;
     using detail::str_at;
 
@@ -124,7 +127,7 @@ bool is_discarded_option(unsigned id) {
     /// Options the driver accepts and ignores (gcc compat knobs, e.g. the
     /// per-file -frandom-seed=<output> bazel stamps on every command): a
     /// per-file value here must not fracture probe and identity keys.
-    if(auto opt = option::table().option(id); opt && opt->has_flag(ClangDriverFlag::Ignored)) {
+    if(auto opt = option::table().option(id); opt && opt->has_flag(option::detail::Ignored)) {
         return true;
     }
 

--- a/src/command/argument_parser.cpp
+++ b/src/command/argument_parser.cpp
@@ -56,23 +56,23 @@ constexpr std::string_view str_at(unsigned offset) {
 
 }  // namespace detail
 
+enum ClangDriverFlag : unsigned {
+    HelpHidden = eo::HelpHidden,
+    RenderAsInput = eo::RenderAsInput,
+    RenderJoined = eo::RenderJoined,
+    Ignored = 1u << 4,
+    LinkOption = 1u << 5,
+    LinkerInput = 1u << 6,
+    NoArgumentUnused = 1u << 7,
+    NoXarchOption = 1u << 8,
+    TargetSpecific = 1u << 9,
+    Unsupported = 1u << 10,
+};
+
 const eo::OptTable& table() {
     using enum eo::Kind;
     using detail::prefixes;
     using detail::str_at;
-
-    enum ClangDriverFlag : unsigned {
-        HelpHidden = eo::HelpHidden,
-        RenderAsInput = eo::RenderAsInput,
-        RenderJoined = eo::RenderJoined,
-        Ignored = 1u << 4,
-        LinkOption = 1u << 5,
-        LinkerInput = 1u << 6,
-        NoArgumentUnused = 1u << 7,
-        NoXarchOption = 1u << 8,
-        TargetSpecific = 1u << 9,
-        Unsupported = 1u << 10,
-    };
 
     constexpr static eo::Option option_infos[] = {
 #define OPTION(PREFIXES_OFFSET,                                                                    \
@@ -121,6 +121,13 @@ const eo::OptTable& table() {
 using namespace option;
 
 bool is_discarded_option(unsigned id) {
+    /// Options the driver accepts and ignores (gcc compat knobs, e.g. the
+    /// per-file -frandom-seed=<output> bazel stamps on every command): a
+    /// per-file value here must not fracture probe and identity keys.
+    if(auto opt = option::table().option(id); opt && opt->has_flag(ClangDriverFlag::Ignored)) {
+        return true;
+    }
+
     switch(id) {
         /// Input file, unknown args, and output — we manage these ourselves.
         /// -main-file-name is per-file input identity injected by to_argv()

--- a/src/command/argument_parser.cpp
+++ b/src/command/argument_parser.cpp
@@ -127,6 +127,8 @@ bool is_discarded_option(unsigned id) {
     /// Options the driver accepts and ignores (gcc compat knobs, e.g. the
     /// per-file -frandom-seed=<output> bazel stamps on every command): a
     /// per-file value here must not fracture probe and identity keys.
+    /// Deliberately also drops clang's -Wignored-optimization-argument
+    /// compat warnings for them — under -Werror those abort the analysis.
     if(auto opt = option::table().option(id); opt && opt->has_flag(option::detail::Ignored)) {
         return true;
     }

--- a/src/command/argument_parser.h
+++ b/src/command/argument_parser.h
@@ -60,7 +60,8 @@ const kota::option::OptTable& table();
 bool is_codegen_option(unsigned id);
 
 /// Options that are completely irrelevant to an LSP and should be discarded
-/// (input/output, PCH building, dependency scan, C++ modules).
+/// (input/output, PCH building, dependency scan, C++ modules, and anything
+/// the driver itself accepts and ignores).
 bool is_discarded_option(unsigned id);
 
 /// User-content options that go into the per-file patch rather than the

--- a/tests/integration/extensions/header_context.test.ts
+++ b/tests/integration/extensions/header_context.test.ts
@@ -9,7 +9,7 @@
 /// server cannot compile utils.h at all.
 
 import * as proto from "vscode-languageserver-protocol";
-import { withTimeout } from "@clice/tools/client";
+import { waitUntil, withTimeout } from "@clice/tools/client";
 import { expect, test } from "../fixtures.ts";
 
 /// clice/queryContext on a header should return source files that include it.
@@ -210,20 +210,25 @@ test("switch between two hosts", async ({ session }) => {
     const [bUri] = await client.openAndWait("b.cpp");
     const [sharedUri] = client.open("shared.h");
 
-    const hoverGetValueContains = async (text: string): Promise<boolean> => {
-        const hover = await client.hoverAt(sharedUri, 0, 12); // 'get_value'
-        expect(hover, "Hover on get_value should work").not.toBeNull();
-        return JSON.stringify(hover!.contents).includes(text);
-    };
+    /// switchContext only flips server state; the recompile under the new
+    /// host is asynchronous (pull model), so the hover polls until it lands.
+    const hoverGetValueShows = (text: string, host: string) =>
+        waitUntil(
+            async () => {
+                const hover = await client.hoverAt(sharedUri, 0, 12); // 'get_value'
+                return hover !== null && JSON.stringify(hover.contents).includes(text);
+            },
+            { timeout: 10_000, interval: 500, description: `${text} under host ${host}` },
+        );
 
     // Host a.cpp: VALUE_TYPE is int.
     let switched = await client.switchContext(sharedUri, aUri);
     expect(switched.success).toBe(true);
-    expect(await hoverGetValueContains("int"), "Expected int under host a.cpp").toBe(true);
+    await hoverGetValueShows("int", "a.cpp");
 
     // Host b.cpp: VALUE_TYPE is float. This exercises the cached-context
     // invalidation branch (active context differs from cached host).
     switched = await client.switchContext(sharedUri, bUri);
     expect(switched.success).toBe(true);
-    expect(await hoverGetValueContains("float"), "Expected float under host b.cpp").toBe(true);
+    await hoverGetValueShows("float", "b.cpp");
 });

--- a/tests/unit/command/canonicalize_tests.cpp
+++ b/tests/unit/command/canonicalize_tests.cpp
@@ -29,6 +29,10 @@ TEST_CASE(CodegenFlagsIgnored) {
     ASSERT_EQ(base, canon({"clang++", "-std=c++20", "-fPIC", "-DFOO", "main.cpp"}));
     ASSERT_EQ(base, canon({"clang++", "-std=c++20", "-DFOO", "-flto", "main.cpp"}));
     ASSERT_EQ(base, canon({"clang++", "-std=c++20", "-ffunction-sections", "-DFOO", "main.cpp"}));
+    // Driver-ignored flags: bazel stamps a per-file -frandom-seed=<output>.
+    ASSERT_EQ(base,
+              canon({"clang++", "-frandom-seed=out/main.o", "-std=c++20", "-DFOO", "main.cpp"}));
+    ASSERT_EQ(base, canon({"clang++", "-std=c++20", "-fgcse", "-DFOO", "main.cpp"}));
 }
 
 TEST_CASE(SemanticFlagsChangeKey) {

--- a/tests/unit/command/command_tests.cpp
+++ b/tests/unit/command/command_tests.cpp
@@ -247,6 +247,9 @@ TEST_CASE(IdentityHashes) {
     EXPECT_NE(hash_of("x1.c"), hash_of("x2.c"));
     /// Codegen-only flags never enter the identity.
     EXPECT_EQ(hash_of("a.cpp"), hash_of("g.cpp"));
+    /// Driver-ignored flags never enter the identity.
+    database.add_command("/fake", "r.cpp", "clang++ -std=c++20 -frandom-seed=r.o r.cpp"sv);
+    EXPECT_EQ(hash_of("a.cpp"), hash_of("r.cpp"));
 
     /// The input slot's position is part of the identity.
     database.add_command("/fake", "p1.cpp", "clang++ p1.cpp -Wall"sv);

--- a/tests/unit/command/toolchain_tests.cpp
+++ b/tests/unit/command/toolchain_tests.cpp
@@ -304,6 +304,22 @@ TEST_CASE(KeyIgnoresUserContent) {
     EXPECT_EQ(f.key(base), f.key(user));
 }
 
+TEST_CASE(KeyIgnoresDriverIgnored) {
+    /// Driver-ignored flags carry per-file values in the wild (bazel's GCC
+    /// toolchain stamps -frandom-seed=<output> on every command); keying on
+    /// them would spawn one probe per file instead of one per toolchain.
+    Fixture f;
+    auto base = f.add("/fake", "/tmp/a.cpp", {"g++", "-std=c++23", "/tmp/a.cpp"});
+    auto seed_a = f.add("/fake",
+                        "/tmp/b.cpp",
+                        {"g++", "-std=c++23", "-frandom-seed=bazel-out/b.o", "/tmp/b.cpp"});
+    auto seed_b = f.add("/fake",
+                        "/tmp/c.cpp",
+                        {"g++", "-std=c++23", "-frandom-seed=bazel-out/c.o", "/tmp/c.cpp"});
+    EXPECT_EQ(f.key(base), f.key(seed_a));
+    EXPECT_EQ(f.key(base), f.key(seed_b));
+}
+
 TEST_CASE(KeyTracksSemantics) {
     Fixture f;
     auto base = f.add("/fake", "/tmp/a.cpp", {"clang++", "-std=c++23", "/tmp/a.cpp"});


### PR DESCRIPTION
## Related issue

Fixes the startup stall in #648.

## What changed

Options carrying clang's `Ignored` driver flag (the `clang_ignored_*` groups — 188 gcc-compatibility knobs the driver accepts and discards) fell through every classification predicate into the default `Semantic` class, so their values entered toolchain probe keys, entry identity hashes, and canonicalization keys.

Bazel's GCC toolchain stamps a per-file `-frandom-seed=<output path>` on every compile action. On the reporter's 28k-entry CDB this fractured the probe cache into 16590 "unique" toolchain queries — one `g++` spawn each, serially on the event loop — stalling startup for minutes with the LSP loop blocked. The same fracture silently defeated identity-hash dedup and preamble sharing on such projects.

`is_discarded_option()` now classifies any option carrying the `Ignored` driver flag as `Discarded`, the same treatment `-o` already gets. One probe per real toolchain again; identity and canonicalize keys stop varying per file. The flag check covers all ignored options at once and automatically picks up ones future clang versions add, rather than whitelisting flags one by one.

Two deliberate behavior notes:

- Ignored-flagged options no longer reach the embedded clang driver, which also suppresses clang's `-Wignored-optimization-argument` compat warning for them — previously, a CDB command with `-Werror -fgcse` failed toolchain resolution outright. A comment at the predicate pins this policy.
- Fortran/DXC options that also carry the flag are unreachable for C/C++ commands (visibility-gated at parse), so the check cannot misfire there.

## Tests

All four suites pass locally (unit 1375, integration 379, snap 630, smoke 3/3), plus `npm run check`. New coverage at each consumer layer:

- `Toolchain.KeyIgnoresDriverIgnored`: commands differing only in `-frandom-seed=<value>` share one probe key.
- `Command.IdentityHashes`: `-frandom-seed` never enters the entry identity.
- `Canonicalize.CodegenFlagsIgnored`: `-frandom-seed=`/`-fgcse` don't change the Frontend key.
