### PR TITLE
refactor(vfs): unify file state into a master-side FileTable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ add_custom_target(generate_version_header
 # see an LSP or server header.
 file(GLOB_RECURSE CLICE_CORE_SOURCES CONFIGURE_DEPENDS
     "${PROJECT_SOURCE_DIR}/src/support/*.cpp"
+    "${PROJECT_SOURCE_DIR}/src/vfs/*.cpp"
     "${PROJECT_SOURCE_DIR}/src/syntax/*.cpp"
     "${PROJECT_SOURCE_DIR}/src/command/*.cpp"
     "${PROJECT_SOURCE_DIR}/src/compile/*.cpp"

--- a/benchmarks/index_stats_benchmark.cpp
+++ b/benchmarks/index_stats_benchmark.cpp
@@ -1067,7 +1067,8 @@ int main(int argc, const char** argv) {
     clice::logging::options.level = spdlog::level::from_str(*opts.log_level);
     clice::logging::stderr_logger("index_stats_benchmark", clice::logging::options);
 
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     auto count = cdb.load(*opts.cdb_path);
     if(!count) {
         std::println(stderr, "Error: failed to load {}", *opts.cdb_path);
@@ -1080,7 +1081,7 @@ int main(int argc, const char** argv) {
     std::vector<llvm::StringRef> files;
     llvm::StringSet<> seen_files;
     for(auto& entry: cdb.entries()) {
-        auto path = cdb.paths().resolve(entry.file);
+        auto path = cdb.files().resolve(entry.file);
         if(opts.filter.has_value() && !path.contains(*opts.filter)) {
             continue;
         }

--- a/benchmarks/pipeline_benchmark.cpp
+++ b/benchmarks/pipeline_benchmark.cpp
@@ -447,7 +447,8 @@ int main(int argc, const char** argv) {
         }
     }
 
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     auto count = cdb.load(*opts.cdb_path);
     if(!count) {
         std::println(stderr, "Error: failed to load {}", *opts.cdb_path);
@@ -460,7 +461,7 @@ int main(int argc, const char** argv) {
     // like the server picks.
     std::vector<llvm::StringRef> files;
     for(auto& entry: cdb.entries()) {
-        auto path = cdb.paths().resolve(entry.file);
+        auto path = cdb.files().resolve(entry.file);
         if(opts.filter.has_value() && !path.contains(*opts.filter)) {
             continue;
         }

--- a/benchmarks/scan_benchmark.cpp
+++ b/benchmarks/scan_benchmark.cpp
@@ -23,8 +23,8 @@
 #include "command/command.h"
 #include "support/filesystem.h"
 #include "support/logging.h"
-#include "support/path_pool.h"
 #include "syntax/dependency_graph.h"
+#include "vfs/file_table.h"
 
 #include "kota/codec/json/json.h"
 #include "kota/deco/deco.h"
@@ -61,7 +61,7 @@ struct GraphExport {
     std::vector<FileNode> files;
 };
 
-void export_graph_json(const PathPool& path_pool,
+void export_graph_json(const FileTable& file_table,
                        const DependencyGraph& graph,
                        llvm::StringRef output_path) {
     // Build reverse module map: path_id -> module_name.
@@ -73,14 +73,14 @@ void export_graph_json(const PathPool& path_pool,
     }
 
     GraphExport export_data;
-    for(std::uint32_t id = 0; id < path_pool.paths.size(); id += 1) {
+    for(std::uint32_t id = 0; id < file_table.spellings.size(); id += 1) {
         auto inc_ids = graph.get_all_includes(id);
         if(inc_ids.empty()) {
             continue;
         }
 
         FileNode node;
-        node.path = path_pool.paths[id].str();
+        node.path = file_table.resolve(id).str();
 
         auto mod_it = path_to_module.find(id);
         if(mod_it != path_to_module.end()) {
@@ -89,7 +89,7 @@ void export_graph_json(const PathPool& path_pool,
 
         for(auto flagged_id: inc_ids) {
             auto raw_id = flagged_id & DependencyGraph::PATH_ID_MASK;
-            node.includes.push_back(path_pool.paths[raw_id].str());
+            node.includes.push_back(file_table.resolve(raw_id).str());
         }
 
         export_data.files.push_back(std::move(node));
@@ -268,8 +268,10 @@ int main(int argc, const char** argv) {
     // Load compilation database.
     auto t0 = std::chrono::steady_clock::now();
 
+    std::optional<FileTable> table_storage;
     std::optional<CompilationDatabase> cdb_storage;
-    cdb_storage.emplace();
+    table_storage.emplace();
+    cdb_storage.emplace(*table_storage);
     auto& cdb = *cdb_storage;
     auto loaded = cdb.load(cdb_path);
     if(!loaded) {
@@ -311,7 +313,9 @@ int main(int argc, const char** argv) {
     for(int i = 0; i < runs; i += 1) {
         // True cold start: rebuild CDB (clears toolchain & config caches)
         // and the DependencyGraph.
-        cdb_storage.emplace();
+        cdb_storage.reset();
+        table_storage.emplace();
+        cdb_storage.emplace(*table_storage);
         cdb_storage->load(cdb_path);
         graph = DependencyGraph{};
 
@@ -358,7 +362,7 @@ int main(int argc, const char** argv) {
 
     // Export dependency graph as JSON if requested.
     if(opts.export_path.has_value()) {
-        export_graph_json(cdb_storage->paths(), graph, *opts.export_path);
+        export_graph_json(cdb_storage->files(), graph, *opts.export_path);
     }
 
     return 0;

--- a/benchmarks/scan_benchmark.cpp
+++ b/benchmarks/scan_benchmark.cpp
@@ -65,7 +65,7 @@ void export_graph_json(const FileTable& file_table,
                        const DependencyGraph& graph,
                        llvm::StringRef output_path) {
     // Build reverse module map: path_id -> module_name.
-    llvm::DenseMap<std::uint32_t, llvm::StringRef> path_to_module;
+    llvm::DenseMap<Fid, llvm::StringRef> path_to_module;
     for(auto& [name, path_ids]: graph.modules()) {
         for(auto path_id: path_ids) {
             path_to_module[path_id] = name;
@@ -73,7 +73,8 @@ void export_graph_json(const FileTable& file_table,
     }
 
     GraphExport export_data;
-    for(std::uint32_t id = 0; id < file_table.spellings.size(); id += 1) {
+    for(std::uint32_t i = 0; i < file_table.spellings.size(); i += 1) {
+        auto id = Fid{i};
         auto inc_ids = graph.get_all_includes(id);
         if(inc_ids.empty()) {
             continue;
@@ -87,9 +88,8 @@ void export_graph_json(const FileTable& file_table,
             node.module_name = mod_it->second.str();
         }
 
-        for(auto flagged_id: inc_ids) {
-            auto raw_id = flagged_id & DependencyGraph::PATH_ID_MASK;
-            node.includes.push_back(file_table.resolve(raw_id).str());
+        for(auto inc: inc_ids) {
+            node.includes.push_back(file_table.resolve(inc).str());
         }
 
         export_data.files.push_back(std::move(node));

--- a/docs/en/design/incremental-parse.md
+++ b/docs/en/design/incremental-parse.md
@@ -86,7 +86,7 @@ The benefit of this model is avoiding wasteful compilations during rapid success
 PCH files on disk are named by a hash of the preamble content together with the frontend-relevant compile flags, directories, and clang version (e.g., `a3f7e8c1d2b4f6e9.pch`), implementing content-addressed storage. This provides two benefits:
 
 - **Disk sharing**: Different files whose preamble content and compile configuration agree naturally share the same PCH file on disk, with no additional deduplication logic needed.
-- **Cross-session persistence**: PCH cache metadata (path, hash, boundary, dependency snapshot) is serialized to a `cache.json` file on disk. On server restart, this metadata is loaded and each PCH's validity is verified through two-layer invalidation detection, avoiding the need to rebuild all PCHs on a cold start.
+- **Cross-session persistence**: PCH cache metadata (path, hash, boundary, dependency snapshot) is persisted into the index database alongside the symbol index. On server restart, this metadata is loaded and each PCH's validity is verified through two-layer invalidation detection, avoiding the need to rebuild all PCHs on a cold start.
 
 When preamble content changes, the new PCH uses a different hash for its filename and the old file becomes orphaned. A cleanup mechanism periodically reclaims orphaned PCH files that have not been used beyond a certain age.
 
@@ -172,7 +172,7 @@ For non-self-contained headers, the compilation context system synthesizes a pre
 
 ### Cache Persistence
 
-PCH and PCM cache metadata are persisted to disk via a `cache.json` file. This file is updated after each successful build and loaded on server startup. Writes use a write-to-temp-then-atomic-rename pattern to prevent file corruption from mid-write crashes.
+PCH and PCM cache metadata are persisted as a metadata blob in the index database. The blob is flushed shortly after each successful build and loaded on server startup; blob writes are atomic, and each record additionally pins the exact artifact file it describes (size, mtime, filesystem identity, content hash), so a crash between publishing an artifact and flushing its metadata is detected and the artifact re-verified instead of trusted.
 
 After loading the cache on startup, all PCH entries are validated through two-layer invalidation detection. Stale entries are automatically rebuilt on the next compilation, requiring no special cache consistency recovery logic.
 

--- a/docs/en/design/module-graph.md
+++ b/docs/en/design/module-graph.md
@@ -139,7 +139,7 @@ All compilation tasks are managed through kota::task_group, providing structured
 
 PCM files use content-addressed path naming — the filename is determined by the module name and a hash of the compilation arguments, stored in a dedicated cache directory. This is fully isolated from build system artifacts, avoiding file-locking conflicts.
 
-PCM cache uses two-layer staleness detection: first comparing dependency files' modification times (mtime), then re-hashing content when times have changed. Recompilation only occurs when dependency content has actually changed, avoiding unnecessary rebuilds caused by "touch without modification." Cache metadata is persisted to `cache.json` on disk and can be restored on server restart.
+PCM cache uses two-layer staleness detection: first comparing dependency files' modification times (mtime), then re-hashing content when times have changed. Recompilation only occurs when dependency content has actually changed, avoiding unnecessary rebuilds caused by "touch without modification." Cache metadata is persisted into the index database and restored on server restart.
 
 ### Integration with the Compilation Pipeline
 

--- a/docs/en/design/overview.md
+++ b/docs/en/design/overview.md
@@ -20,7 +20,7 @@ clice is a brand-new C++ language server, redesigned from the architecture level
 
 General-purpose utilities and infrastructure shared by all other modules.
 
-- `PathPool`: Internalizes file paths as `uint32_t` identifiers, used as stable file identifiers throughout the system
+- `FileTable` (in `src/vfs/`): Internalizes file paths as `uint32_t` identifiers used as stable file identifiers throughout the system, and holds the shared per-file facts derived from them — disk state, content versions, scan results, directory listings
 - `FuzzyMatcher`: Token-aware fuzzy matching for code completion and symbol search
 - Markup / Doxygen: Parsing and formatting of documentation comments
 - Logging, filesystem abstractions, string utilities, etc.
@@ -87,7 +87,7 @@ The language server's core runtime, responsible for assembling all the layers ab
 
 **`state/`** — Project and document state, plus the invalidation machinery.
 
-- `Workspace`: Project-level global state — the compilation database, toolchain, path pool, dependency graph, cache store, and project index. Core invariant: unsaved buffer contents of open files never modify the `Workspace` -- it only reflects the state on disk
+- `Workspace`: Project-level global state — the compilation database, toolchain, file table, dependency graph, cache store, and project index. Core invariant: unsaved buffer contents of open files never modify the `Workspace` -- it only reflects the state on disk
 - `Session` / `SessionStore`: The editing state for each open file (buffer contents, document version, in-memory index, PCH reference, etc.), created on didOpen and destroyed on didClose; `SessionStore` owns the table of open sessions and the buffer-synchronization logic
 - `Invalidator`: The invalidation engine — folds file events (buffer opens/saves, on-disk changes, compilation-database reloads, worker crashes) into a deduplicated set of invalidation effects
 - `FileTracker`: Stat-polling discovery of changes that happen outside the editor (a regenerated `compile_commands.json`, `git checkout`), feeding events to the `Invalidator`

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -50,14 +50,6 @@ Paths searched for compile_commands.json — file paths, or directories to look 
 
 Build the background index that serves cross-TU features (find references, workspace symbols, ...).
 
-### `project.index_db`
-
-| Type     | Default  |
-| -------- | -------- |
-| `string` | `"lmdb"` |
-
-Index persistence backend: "lmdb" (single database file) or "files" (one file per blob).
-
 ### `project.readonly`
 
 | Type     | Default |

--- a/docs/public/clice-config.schema.json
+++ b/docs/public/clice-config.schema.json
@@ -10,7 +10,6 @@
                 "logging_dir": "",
                 "compile_commands_paths": [],
                 "enable_indexing": true,
-                "index_db": "lmdb",
                 "readonly": "off",
                 "idle_timeout_ms": 3000,
                 "test_hooks": false,
@@ -95,15 +94,6 @@
                     "type": "boolean",
                     "description": "Build the background index that serves cross-TU features (find references, workspace symbols, ...).",
                     "default": true
-                },
-                "index_db": {
-                    "type": "string",
-                    "description": "Index persistence backend: \"lmdb\" (single database file) or \"files\" (one file per blob).",
-                    "default": "lmdb",
-                    "enum": [
-                        "lmdb",
-                        "files"
-                    ]
                 },
                 "readonly": {
                     "type": "string",

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -254,7 +254,7 @@ ConfigID CompilationDatabase::save_config(CompileConfig config, llvm::ArrayRef<A
 
 std::optional<CompilationDatabase::NormalizeResult>
     CompilationDatabase::normalize(llvm::StringRef directory,
-                                   std::uint32_t file,
+                                   Fid file,
                                    llvm::ArrayRef<const char*> arguments) {
     if(arguments.empty()) {
         return std::nullopt;
@@ -350,7 +350,7 @@ std::optional<CompilationDatabase::NormalizeResult>
     /// against the entry directory — and as spelled, for entries interned
     /// under a relative spelling (tests, hand-built databases).
     auto matches_entry = [&](llvm::StringRef token) {
-        if(file == ~0u || token.empty()) {
+        if(!file.valid() || token.empty()) {
             return false;
         }
         llvm::SmallString<256> abs;
@@ -508,9 +508,7 @@ std::optional<CompilationDatabase::NormalizeResult>
 }
 
 std::optional<CompilationDatabase::NormalizeResult>
-    CompilationDatabase::normalize(llvm::StringRef directory,
-                                   std::uint32_t file,
-                                   llvm::StringRef command) {
+    CompilationDatabase::normalize(llvm::StringRef directory, Fid file, llvm::StringRef command) {
     llvm::BumpPtrAllocator local;
     llvm::StringSaver saver(local);
 
@@ -839,9 +837,9 @@ std::optional<std::size_t> CompilationDatabase::load(llvm::StringRef path) {
     return entry_list.size();
 }
 
-llvm::DenseMap<std::uint32_t, llvm::SmallVector<std::string, 1>>
+llvm::DenseMap<Fid, llvm::SmallVector<std::string, 1>>
     CompilationDatabase::command_hash_snapshot() {
-    llvm::DenseMap<std::uint32_t, llvm::SmallVector<std::string, 1>> snapshot;
+    llvm::DenseMap<Fid, llvm::SmallVector<std::string, 1>> snapshot;
     for(auto& entry: entry_list) {
         snapshot[entry.file].push_back(entry_hash_hex(entry.config));
     }
@@ -853,7 +851,7 @@ llvm::DenseMap<std::uint32_t, llvm::SmallVector<std::string, 1>>
     return snapshot;
 }
 
-std::optional<std::string> CompilationDatabase::selected_hash(std::uint32_t path_id) {
+std::optional<std::string> CompilationDatabase::selected_hash(Fid path_id) {
     auto candidates = candidate_entries(path_id);
     if(candidates.empty()) {
         return std::nullopt;
@@ -895,8 +893,7 @@ std::optional<CDBDiff> CompilationDatabase::reload_and_diff(llvm::StringRef path
     return diff;
 }
 
-llvm::ArrayRef<CompilationEntry>
-    CompilationDatabase::candidate_entries(std::uint32_t path_id) const {
+llvm::ArrayRef<CompilationEntry> CompilationDatabase::candidate_entries(Fid path_id) const {
     auto [first, last] = ranges::equal_range(entry_list, path_id, {}, &CompilationEntry::file);
     if(first == last) {
         return {};
@@ -1206,7 +1203,7 @@ ConfigID CompilationDatabase::fallback_config(llvm::StringRef file) {
 
     auto [it, inserted] = fallback_configs.try_emplace(variant, invalid_config);
     if(inserted) {
-        auto normalized = normalize("", ~0u, arguments);
+        auto normalized = normalize("", Fid{}, arguments);
         assert(normalized && "fallback synthesis cannot fail");
         it->second = normalized->config;
     }

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -209,7 +209,8 @@ std::vector<std::string> to_strings(llvm::ArrayRef<const char*> argv) {
     return result;
 }
 
-CompilationDatabase::CompilationDatabase() : chain(std::make_unique<Toolchain>(*this)) {}
+CompilationDatabase::CompilationDatabase(FileTable& files) :
+    file_table(files), chain(std::make_unique<Toolchain>(*this)) {}
 
 CompilationDatabase::~CompilationDatabase() = default;
 
@@ -344,8 +345,8 @@ std::optional<CompilationDatabase::NormalizeResult>
         staged.push_back(parsed);
     }
 
-    /// Does this token name the entry's file? Compared through the path
-    /// pool (canonical spelling + dot removal), relative tokens resolved
+    /// Does this token name the entry's file? Compared through the file
+    /// table (canonical spelling + dot removal), relative tokens resolved
     /// against the entry directory — and as spelled, for entries interned
     /// under a relative spelling (tests, hand-built databases).
     auto matches_entry = [&](llvm::StringRef token) {
@@ -360,7 +361,7 @@ std::optional<CompilationDatabase::NormalizeResult>
             path::append(abs, token);
         }
         path::remove_dots(abs, /*remove_dot_dot=*/true);
-        return pool.intern(abs) == file || pool.intern(token) == file;
+        return file_table.intern(abs) == file || file_table.intern(token) == file;
     };
 
     /// A per-file selector naming the entry file forces its language and
@@ -792,7 +793,7 @@ std::optional<std::size_t> CompilationDatabase::load(llvm::StringRef path) {
             path::append(file_abs, file_ref);
         }
         path::remove_dots(file_abs, /*remove_dot_dot=*/true);
-        auto path_id = pool.intern(file_abs);
+        auto path_id = file_table.intern(file_abs);
 
         std::optional<NormalizeResult> normalized;
 
@@ -904,7 +905,7 @@ llvm::ArrayRef<CompilationEntry>
 }
 
 llvm::ArrayRef<CompilationEntry> CompilationDatabase::candidate_entries(llvm::StringRef file) {
-    return candidate_entries(pool.intern(file));
+    return candidate_entries(file_table.intern(file));
 }
 
 bool CompilationDatabase::has_entry(llvm::StringRef file) {
@@ -1215,7 +1216,7 @@ ConfigID CompilationDatabase::fallback_config(llvm::StringRef file) {
 std::vector<const char*> CompilationDatabase::render_driver(const CommandRef& ref,
                                                             const RenderOptions& opts) {
     auto& cfg = config(ref.config);
-    auto source = pool.resolve(ref.file);
+    auto source = file_table.resolve(ref.file);
 
     std::vector<const char*> argv;
     argv.reserve(cfg.args.size() + 8);
@@ -1296,12 +1297,12 @@ std::vector<const char*> CompilationDatabase::render(const CommandRef& ref,
                                                      const RenderOptions& opts) {
     auto resolved = chain->resolve(ref.config, ref.input);
     if(!resolved) {
-        LOG_WARN("Toolchain resolve failed for {}: {}", pool.resolve(ref.file), resolved.error());
+        LOG_WARN("Toolchain resolve failed for {}: {}", file_table.resolve(ref.file), resolved.error());
         return render_driver(ref, opts);
     }
 
     auto& rc = chain->resolved(*resolved);
-    auto source = pool.resolve(ref.file);
+    auto source = file_table.resolve(ref.file);
 
     std::vector<const char*> argv;
     argv.reserve(rc.args.size() + 8);
@@ -1382,7 +1383,7 @@ std::optional<CompilationEntry>
     CompilationDatabase::add_command(llvm::StringRef directory,
                                      llvm::StringRef file,
                                      llvm::ArrayRef<const char*> arguments) {
-    auto path_id = pool.intern(file);
+    auto path_id = file_table.intern(file);
     auto normalized = normalize(directory, path_id, arguments);
     if(!normalized) {
         return std::nullopt;
@@ -1396,7 +1397,7 @@ std::optional<CompilationEntry>
 std::optional<CompilationEntry> CompilationDatabase::add_command(llvm::StringRef directory,
                                                                  llvm::StringRef file,
                                                                  llvm::StringRef command) {
-    auto path_id = pool.intern(file);
+    auto path_id = file_table.intern(file);
     auto normalized = normalize(directory, path_id, command);
     if(!normalized) {
         return std::nullopt;

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -1297,7 +1297,9 @@ std::vector<const char*> CompilationDatabase::render(const CommandRef& ref,
                                                      const RenderOptions& opts) {
     auto resolved = chain->resolve(ref.config, ref.input);
     if(!resolved) {
-        LOG_WARN("Toolchain resolve failed for {}: {}", file_table.resolve(ref.file), resolved.error());
+        LOG_WARN("Toolchain resolve failed for {}: {}",
+                 file_table.resolve(ref.file),
+                 resolved.error());
         return render_driver(ref, opts);
     }
 

--- a/src/command/command.h
+++ b/src/command/command.h
@@ -152,7 +152,7 @@ enum class CommandSource : std::uint8_t {
 /// config plus the language the toolchain layer probes with. For a header
 /// borrowing a host command, `input` is the host's.
 struct CommandRef {
-    std::uint32_t file = ~0u;
+    Fid file;
     ConfigID config = invalid_config;
     InputKind input;
     CommandSource source = CommandSource::Fallback;
@@ -188,7 +188,7 @@ struct RenderOptions {
 /// A single entry in the compilation database.
 struct CompilationEntry {
     /// Fid of the source file (shared FileTable).
-    std::uint32_t file = ~0u;
+    Fid file;
 
     ConfigID config = invalid_config;
 
@@ -216,13 +216,13 @@ std::vector<std::string> to_strings(llvm::ArrayRef<const char*> argv);
 /// file table's fids (stable across reloads).
 struct CDBDiff {
     /// Files present only after the reload (gained their first entry).
-    llvm::SmallVector<std::uint32_t> added;
+    llvm::SmallVector<Fid> added;
 
     /// Files present only before the reload (lost all their entries).
-    llvm::SmallVector<std::uint32_t> removed;
+    llvm::SmallVector<Fid> removed;
 
     /// Files present on both sides whose set of command hashes differs.
-    llvm::SmallVector<std::uint32_t> changed;
+    llvm::SmallVector<Fid> changed;
 
     bool empty() const {
         return added.empty() && removed.empty() && changed.empty();
@@ -278,7 +278,7 @@ public:
 
     /// All entries for a file, in deterministic candidate order (the first
     /// is the default selection). Empty when the file has none.
-    llvm::ArrayRef<CompilationEntry> candidate_entries(std::uint32_t path_id) const;
+    llvm::ArrayRef<CompilationEntry> candidate_entries(Fid path_id) const;
     llvm::ArrayRef<CompilationEntry> candidate_entries(llvm::StringRef file);
 
     bool has_entry(llvm::StringRef file);
@@ -324,12 +324,12 @@ public:
     /// file may own several entries with different flags) — the identity
     /// reload_and_diff() diffs on and the indexer persists to catch command
     /// changes across sessions.
-    llvm::DenseMap<std::uint32_t, llvm::SmallVector<std::string, 1>> command_hash_snapshot();
+    llvm::DenseMap<Fid, llvm::SmallVector<std::string, 1>> command_hash_snapshot();
 
     /// The entry hash of a file's default selection (its first candidate);
     /// nullopt when the file has no entry. Persisted so an offline change
     /// of the winning candidate is detected at startup.
-    std::optional<std::string> selected_hash(std::uint32_t path_id);
+    std::optional<std::string> selected_hash(Fid path_id);
 
     /// Render the full compile argv for a ref: resolve the config through
     /// the toolchain (probe cached; may spawn the driver once per unique
@@ -385,13 +385,14 @@ private:
     /// The normalization pipeline (§ wrapper strip → driver info → @rsp
     /// expansion → nvcc translation → parse → classify → path normalize →
     /// dedup). `file` is the entry's normalized path used to pick the input
-    /// slot among the command's inputs; ~0u synthesizes the slot at the end.
+    /// slot among the command's inputs; invalid synthesizes the slot at the
+    /// end.
     std::optional<NormalizeResult> normalize(llvm::StringRef directory,
-                                             std::uint32_t file,
+                                             Fid file,
                                              llvm::ArrayRef<const char*> arguments);
 
     std::optional<NormalizeResult> normalize(llvm::StringRef directory,
-                                             std::uint32_t file,
+                                             Fid file,
                                              llvm::StringRef command);
 
     /// Expand @file tokens in place, driver-mode aware (CL commands

--- a/src/command/command.h
+++ b/src/command/command.h
@@ -9,7 +9,7 @@
 #include "command/argument_parser.h"
 #include "command/search_config.h"
 #include "support/object_pool.h"
-#include "support/path_pool.h"
+#include "vfs/file_table.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
@@ -187,7 +187,7 @@ struct RenderOptions {
 
 /// A single entry in the compilation database.
 struct CompilationEntry {
-    /// Path id of the source file (shared PathPool).
+    /// Fid of the source file (shared FileTable).
     std::uint32_t file = ~0u;
 
     ConfigID config = invalid_config;
@@ -213,7 +213,7 @@ unsigned family_visibility(CompilerFamily family);
 std::vector<std::string> to_strings(llvm::ArrayRef<const char*> argv);
 
 /// Per-file delta of a compilation database reload. Path ids are the shared
-/// pool's ids (stable across reloads).
+/// file table's fids (stable across reloads).
 struct CDBDiff {
     /// Files present only after the reload (gained their first entry).
     llvm::SmallVector<std::uint32_t> added;
@@ -231,7 +231,10 @@ struct CDBDiff {
 
 class CompilationDatabase {
 public:
-    CompilationDatabase();
+    /// The database interns entry files into the workspace-wide table it
+    /// is constructed over; entry file ids and workspace fids are the
+    /// same ids.
+    explicit CompilationDatabase(FileTable& files);
     ~CompilationDatabase();
 
     CompilationDatabase(const CompilationDatabase&) = delete;
@@ -241,9 +244,8 @@ public:
     /// means the process working directory.
     void set_workspace_root(llvm::StringRef root);
 
-    /// The single path-id space, shared with the whole workspace.
-    PathPool& paths() {
-        return pool;
+    FileTable& files() {
+        return file_table;
     }
 
     /// Load (or reload) the compilation database from the given file.
@@ -419,8 +421,9 @@ private:
 
     ObjectSet<CompileConfig> configs{allocator.get()};
 
-    /// The workspace's single path-id space (Workspace::path_pool aliases it).
-    PathPool pool;
+    /// The workspace-wide file table (owned by Workspace, or by the
+    /// driver in multi-CDB tools — nested databases share one id space).
+    FileTable& file_table;
 
     /// All compilation entries, sorted by (file, candidate order).
     std::vector<CompilationEntry> entry_list;

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -274,8 +274,8 @@ static kota::codec::dyn::Object* field_schema(kota::codec::dyn::Object& properti
 /// dropped — a committed schema must be byte-identical on every host, so
 /// the affected fields' descriptions state the derivation instead — the
 /// zero-invalid fields carry the lower bound finalize() enforces, and
-/// `index_db` names the backends open_database() accepts, so editors
-/// flag a typo that would silently fall back to LMDB.
+/// the enum fields name their accepted values so editors flag a typo
+/// that would silently fall back to the default.
 static void patch_field_schemas(kota::codec::dyn::Value& value) {
     if(auto* object = value.get_object()) {
         for(auto& [key, child]: *object) {
@@ -290,9 +290,6 @@ static void patch_field_schemas(kota::codec::dyn::Value& value) {
                         if(auto* schema = field_schema(*properties, field)) {
                             schema->assign("minimum", std::uint64_t{1});
                         }
-                    }
-                    if(auto* schema = field_schema(*properties, "index_db")) {
-                        schema->assign("enum", kota::codec::dyn::Array{"lmdb", "files"});
                     }
                     if(auto* schema = field_schema(*properties, "readonly")) {
                         schema->assign("enum", kota::codec::dyn::Array{"off", "on", "auto"});

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -92,12 +92,6 @@ struct ProjectConfig {
 
     KOTATSU_ANNOTATE(defaulted = true,
                      description =
-                         "Index persistence backend: \"lmdb\" (single database "
-                         "file) or \"files\" (one file per blob).")
-    <std::string> index_db = "lmdb";
-
-    KOTATSU_ANNOTATE(defaulted = true,
-                     description =
                          "Read-only serving for open files: \"off\" targets a "
                          "full AST for every open file — builds are pulled by "
                          "the first request that needs them, with the index "

--- a/src/driver/index.cc
+++ b/src/driver/index.cc
@@ -262,7 +262,7 @@ int run_stats_once(llvm::StringRef root, std::uint32_t top, bool allow_retry) {
                  total_relations);
     std::println("Global symbols: {}, file versions: {}",
                  project.symbols.size(),
-                 project.file_versions.size());
+                 workspace.file_table.versions.size());
 
     auto payload = columns.content + columns.variants + columns.symbols + columns.local_names +
                    columns.occ_rows + columns.occ_masks + columns.rel_rows + columns.rel_masks;

--- a/src/driver/index.cc
+++ b/src/driver/index.cc
@@ -213,7 +213,7 @@ int run_stats_once(llvm::StringRef root, std::uint32_t top, bool allow_retry) {
     files.reserve(workspace.shards.size());
     std::uint64_t total_bytes = 0, total_occurrences = 0, total_relations = 0;
     for(auto& [path_id, shard]: workspace.shards) {
-        ShardStat stat{.path = workspace.path_pool.resolve(path_id),
+        ShardStat stat{.path = workspace.file_table.resolve(path_id),
                        .bytes = shard.bytes().size(),
                        .variants = shard.variants().size()};
         shard.for_each_occurrence([&](const index::Occurrence&) {

--- a/src/driver/index.cc
+++ b/src/driver/index.cc
@@ -8,6 +8,7 @@
 #include "index/database.h"
 #include "index/serialization.h"
 #include "sched/batch.h"
+#include "sched/context.h"
 #include "sched/index/store.h"
 #include "sched/workspace.h"
 #include "support/cache_store.h"
@@ -138,7 +139,8 @@ int run_stats_once(llvm::StringRef root, std::uint32_t top, bool allow_retry) {
                   ec.message());
         return 1;
     }
-    IndexStore index_store(loop, workspace);
+    ContextResolver contexts(workspace);
+    IndexStore index_store(loop, workspace, contexts);
     auto loaded = index_store.load(/*read_only=*/true);
     if(!loaded.decoded) {
         LOG_ERROR("Index cache at {} is in an old or corrupt format; run `clice index` to rebuild",

--- a/src/driver/index.cc
+++ b/src/driver/index.cc
@@ -131,14 +131,6 @@ int run_stats_once(llvm::StringRef root, std::uint32_t top, bool allow_retry) {
     workspace.config = std::move(config);
     workspace.store.emplace(std::move(*store));
     workspace.index_db = index::open_database(*workspace.store);
-    // A namespace whose directory scan failed looks empty while its blobs
-    // exist — reporting "Index is empty" with exit code 0 would be a lie.
-    if(auto ec = workspace.store->scan_error()) {
-        LOG_ERROR("Failed to read the index cache at {}: {}",
-                  std::string_view(workspace.config.project.cache_dir),
-                  ec.message());
-        return 1;
-    }
     ContextResolver contexts(workspace);
     IndexStore index_store(loop, workspace, contexts);
     auto loaded = index_store.load(/*read_only=*/true);

--- a/src/driver/index.cc
+++ b/src/driver/index.cc
@@ -130,7 +130,7 @@ int run_stats_once(llvm::StringRef root, std::uint32_t top, bool allow_retry) {
     Workspace workspace;
     workspace.config = std::move(config);
     workspace.store.emplace(std::move(*store));
-    workspace.index_db = index::open_database(*workspace.store, workspace.config.project.index_db);
+    workspace.index_db = index::open_database(*workspace.store);
     // A namespace whose directory scan failed looks empty while its blobs
     // exist — reporting "Index is empty" with exit code 0 would be a lie.
     if(auto ec = workspace.store->scan_error()) {

--- a/src/driver/inspect.cc
+++ b/src/driver/inspect.cc
@@ -482,7 +482,7 @@ std::optional<FileCommand> file_command(FileEntry& entry,
     if(is_header && database != nullptr && !database->has_entry(file)) {
         std::pair<int, std::size_t> best{-1, 0};
         for(auto& candidate: database->entries()) {
-            llvm::StringRef donor_path = database->paths().resolve(candidate.file);
+            llvm::StringRef donor_path = database->files().resolve(candidate.file);
             auto donor_ext = path::extension(donor_path);
             auto donor_type = donor_ext.empty()
                                   ? types::TY_INVALID
@@ -513,7 +513,7 @@ std::optional<FileCommand> file_command(FileEntry& entry,
         auto& cdb_entry = database->candidate_entries(donor).front();
         // The donor's language applies to the header itself — it compiles
         // as a fragment of that TU's world, not by its own extension.
-        CommandRef ref{database->paths().intern(file),
+        CommandRef ref{database->files().intern(file),
                        cdb_entry.config,
                        database->input_kind(cdb_entry.config, donor),
                        CommandSource::IncludeGraph};
@@ -807,14 +807,16 @@ int run_inspect(const InspectOptions& opts) {
     // Each file resolves against the compile_commands.json nearest to it,
     // so a directory spanning nested projects picks up every inner
     // database. Files without a CDB entry fall back to a per-file
-    // toolchain query in file_command.
+    // toolchain query in file_command. All databases share one file
+    // table: nested projects live in a single fid space.
+    FileTable file_table;
     std::map<std::string, CompilationDatabase> databases;
     auto database_for = [&](llvm::StringRef file) -> CompilationDatabase* {
         auto cdb = find_cdb(path::parent_path(file));
         if(!cdb) {
             return nullptr;
         }
-        auto [it, inserted] = databases.try_emplace(*cdb);
+        auto [it, inserted] = databases.try_emplace(*cdb, file_table);
         if(inserted && !it->second.load(*cdb)) {
             // Keep the empty entry so the failure is logged once; its files
             // take the default-flags fallback.

--- a/src/index/database.cpp
+++ b/src/index/database.cpp
@@ -578,10 +578,8 @@ MetaCheck check_meta(MDB_env* env, MDB_dbi dbi, MDB_txn* txn, bool read_only) {
     return mdb_txn_commit(wtxn) == 0 ? MetaCheck::Ok : MetaCheck::Transient;
 }
 
-std::unique_ptr<LmdbDatabase> open_lmdb_env(CacheStore& store,
-                                            int lock_fd,
-                                            std::size_t initial_mapsize,
-                                            bool read_only) {
+std::unique_ptr<LmdbDatabase>
+    open_lmdb_env(CacheStore& store, int lock_fd, std::size_t initial_mapsize, bool read_only) {
     auto path = path::join(store.base_dir(), lmdb_file_name);
 
     auto mapsize = initial_mapsize != 0 ? initial_mapsize : lmdb_default_mapsize;

--- a/src/index/database.cpp
+++ b/src/index/database.cpp
@@ -75,17 +75,22 @@ llvm::StringRef namespace_of(IndexBlobKind kind) {
         case IndexBlobKind::Manifest: return "index-manifest";
         case IndexBlobKind::Global: return "index-global";
         case IndexBlobKind::CDB: return "index-cdb";
+        case IndexBlobKind::Artifacts: return "index-artifacts";
+        case IndexBlobKind::Contexts: return "index-contexts";
     }
     std::unreachable();
 }
 
 class FsDatabase final : public BlobDatabase {
 public:
-    FsDatabase(CacheStore& store, int lock_fd) : store(store), lock_fd(lock_fd) {
+    FsDatabase(CacheStore& store, int lock_fd, bool read_only) :
+        store(store), lock_fd(lock_fd), read_only_(read_only) {
         for(auto kind: {IndexBlobKind::Shard,
                         IndexBlobKind::Manifest,
                         IndexBlobKind::Global,
-                        IndexBlobKind::CDB}) {
+                        IndexBlobKind::CDB,
+                        IndexBlobKind::Artifacts,
+                        IndexBlobKind::Contexts}) {
             store.register_namespace({
                 .name = std::string(namespace_of(kind)),
                 .extension = ".idx",
@@ -133,6 +138,10 @@ public:
 
     void for_each_key(IndexBlobKind kind, llvm::function_ref<void(llvm::StringRef)> fn) override {
         store.for_each_key(namespace_of(kind), fn);
+    }
+
+    bool read_only() const override {
+        return read_only_;
     }
 
     std::expected<std::uint64_t, std::string> advance_read_snapshot() override {
@@ -194,6 +203,7 @@ private:
 
     CacheStore& store;
     int lock_fd;
+    bool read_only_ = false;
 };
 
 // ── LMDB backend ────────────────────────────────────────────────────
@@ -220,6 +230,8 @@ char kind_prefix(IndexBlobKind kind) {
         case IndexBlobKind::Manifest: return 'M';
         case IndexBlobKind::Global: return 'G';
         case IndexBlobKind::CDB: return 'C';
+        case IndexBlobKind::Artifacts: return 'A';
+        case IndexBlobKind::Contexts: return 'X';
     }
     std::unreachable();
 }
@@ -266,8 +278,18 @@ void remove_database_files(llvm::StringRef path) {
 
 class LmdbDatabase final : public BlobDatabase {
 public:
-    LmdbDatabase(MDB_env* env, MDB_dbi dbi, MDB_txn* txn, std::string path, int lock_fd) :
-        env(env), dbi(dbi), txn(txn), path(std::move(path)), lock_fd(lock_fd) {}
+    LmdbDatabase(MDB_env* env,
+                 MDB_dbi dbi,
+                 MDB_txn* txn,
+                 std::string path,
+                 int lock_fd,
+                 bool read_only) :
+        env(env), dbi(dbi), txn(txn), path(std::move(path)), lock_fd(lock_fd),
+        read_only_(read_only) {}
+
+    bool read_only() const override {
+        return read_only_;
+    }
 
     ~LmdbDatabase() override {
         retire_old_snapshot();
@@ -483,6 +505,7 @@ private:
     std::atomic<bool> poisoned = false;
     bool condemned = false;
     int lock_fd;
+    bool read_only_ = false;
 };
 
 #ifdef _WIN32
@@ -557,9 +580,9 @@ MetaCheck check_meta(MDB_env* env, MDB_dbi dbi, MDB_txn* txn, bool read_only) {
 
 std::unique_ptr<LmdbDatabase> open_lmdb_env(CacheStore& store,
                                             int lock_fd,
-                                            std::size_t initial_mapsize) {
+                                            std::size_t initial_mapsize,
+                                            bool read_only) {
     auto path = path::join(store.base_dir(), lmdb_file_name);
-    bool read_only = store.read_only();
 
     auto mapsize = initial_mapsize != 0 ? initial_mapsize : lmdb_default_mapsize;
 
@@ -670,7 +693,7 @@ std::unique_ptr<LmdbDatabase> open_lmdb_env(CacheStore& store,
                 return nullptr;
             }
         }
-        return std::make_unique<LmdbDatabase>(env, dbi, txn, std::move(path), lock_fd);
+        return std::make_unique<LmdbDatabase>(env, dbi, txn, std::move(path), lock_fd, read_only);
     }
     return nullptr;
 }
@@ -719,37 +742,43 @@ FsLocality filesystem_locality(llvm::StringRef dir) {
 
 }  // namespace
 
-std::unique_ptr<BlobDatabase> open_fs_database(CacheStore& store) {
+std::unique_ptr<BlobDatabase> open_fs_database(CacheStore& store, bool read_only) {
+    read_only = read_only || store.read_only();
     int lock_fd = -1;
-    if(!store.read_only()) {
+    if(!read_only) {
         auto locked = acquire_writer_lock(store);
         if(!locked) {
             return nullptr;
         }
         lock_fd = *locked;
     }
-    return std::make_unique<FsDatabase>(store, lock_fd);
+    return std::make_unique<FsDatabase>(store, lock_fd, read_only);
 }
 
-std::unique_ptr<BlobDatabase> open_lmdb_database(CacheStore& store, std::size_t initial_mapsize) {
+std::unique_ptr<BlobDatabase> open_lmdb_database(CacheStore& store,
+                                                 std::size_t initial_mapsize,
+                                                 bool read_only) {
+    read_only = read_only || store.read_only();
     int lock_fd = -1;
-    if(!store.read_only()) {
+    if(!read_only) {
         auto locked = acquire_writer_lock(store);
         if(!locked) {
             return nullptr;
         }
         lock_fd = *locked;
     }
-    auto db = open_lmdb_env(store, lock_fd, initial_mapsize);
+    auto db = open_lmdb_env(store, lock_fd, initial_mapsize, read_only);
     if(!db) {
         release_writer_lock(lock_fd);
     }
     return db;
 }
 
-std::unique_ptr<BlobDatabase> open_database(CacheStore& store, llvm::StringRef backend) {
+std::unique_ptr<BlobDatabase> open_database(CacheStore& store,
+                                            llvm::StringRef backend,
+                                            bool read_only) {
     if(backend == "files") {
-        return open_fs_database(store);
+        return open_fs_database(store, read_only);
     }
     if(backend != "lmdb") {
         LOG_WARN("Unknown index_db backend '{}'; using lmdb", backend);
@@ -761,7 +790,7 @@ std::unique_ptr<BlobDatabase> open_database(CacheStore& store, llvm::StringRef b
                 "{} is on a remote filesystem, which LMDB does not support; "
                 "using per-file index storage",
                 store.base_dir());
-            return open_fs_database(store);
+            return open_fs_database(store, read_only);
         }
         case FsLocality::Unknown: {
             LOG_WARN(
@@ -773,10 +802,11 @@ std::unique_ptr<BlobDatabase> open_database(CacheStore& store, llvm::StringRef b
     }
     // A reader before any LMDB writer ever ran (or after "files" runs)
     // reads whatever the per-file backend left behind — including nothing.
-    if(store.read_only() && !llvm::sys::fs::exists(path::join(store.base_dir(), lmdb_file_name))) {
-        return open_fs_database(store);
+    if((read_only || store.read_only()) &&
+       !llvm::sys::fs::exists(path::join(store.base_dir(), lmdb_file_name))) {
+        return open_fs_database(store, read_only);
     }
-    return open_lmdb_database(store);
+    return open_lmdb_database(store, 0, read_only);
 }
 
 }  // namespace clice::index

--- a/src/index/database.cpp
+++ b/src/index/database.cpp
@@ -17,7 +17,6 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Process.h"
-#include "llvm/Support/raw_ostream.h"
 
 #ifdef _WIN32
 #include <io.h>
@@ -66,147 +65,6 @@ void release_writer_lock(int lock_fd) {
         llvm::sys::Process::SafelyCloseFileDescriptor(lock_fd);
     }
 }
-
-// ── Filesystem backend ──────────────────────────────────────────────
-
-llvm::StringRef namespace_of(IndexBlobKind kind) {
-    switch(kind) {
-        case IndexBlobKind::Shard: return "index";
-        case IndexBlobKind::Manifest: return "index-manifest";
-        case IndexBlobKind::Global: return "index-global";
-        case IndexBlobKind::CDB: return "index-cdb";
-        case IndexBlobKind::Artifacts: return "index-artifacts";
-        case IndexBlobKind::Contexts: return "index-contexts";
-    }
-    std::unreachable();
-}
-
-class FsDatabase final : public BlobDatabase {
-public:
-    FsDatabase(CacheStore& store, int lock_fd, bool read_only) :
-        store(store), lock_fd(lock_fd), read_only_(read_only) {
-        for(auto kind: {IndexBlobKind::Shard,
-                        IndexBlobKind::Manifest,
-                        IndexBlobKind::Global,
-                        IndexBlobKind::CDB,
-                        IndexBlobKind::Artifacts,
-                        IndexBlobKind::Contexts}) {
-            store.register_namespace({
-                .name = std::string(namespace_of(kind)),
-                .extension = ".idx",
-                .policy = CachePolicy::Persistent,
-            });
-        }
-    }
-
-    ~FsDatabase() override {
-        release_writer_lock(lock_fd);
-    }
-
-    ReadBlob read(IndexBlobKind kind, llvm::StringRef key) override {
-        auto path = store.lookup(namespace_of(kind), key);
-        if(!path) {
-            return {};
-        }
-        auto buffer = llvm::MemoryBuffer::getFile(*path);
-        if(!buffer) {
-            return {};
-        }
-        return {.buffer = std::move(*buffer)};
-    }
-
-    bool contains(IndexBlobKind kind, llvm::StringRef key) override {
-        return store.lookup(namespace_of(kind), key).has_value();
-    }
-
-    llvm::SmallVector<std::size_t> write(llvm::ArrayRef<Blob> puts,
-                                         llvm::ArrayRef<BlobKey> removes) override {
-        // A failed batch keeps its removals too, mirroring the LMDB
-        // backend's all-or-nothing commit: a removal landing without the
-        // puts it was batched behind can delete a blob the surviving
-        // on-disk state still references. load() re-sweeps whatever the
-        // skip leaves behind.
-        auto failed = write_puts(puts);
-        if(!failed.empty()) {
-            return failed;
-        }
-        for(auto& [kind, key]: removes) {
-            store.invalidate(namespace_of(kind), key);
-        }
-        return {};
-    }
-
-    void for_each_key(IndexBlobKind kind, llvm::function_ref<void(llvm::StringRef)> fn) override {
-        store.for_each_key(namespace_of(kind), fn);
-    }
-
-    bool read_only() const override {
-        return read_only_;
-    }
-
-    std::expected<std::uint64_t, std::string> advance_read_snapshot() override {
-        return 0;
-    }
-
-    void retire_old_snapshot() override {}
-
-    std::expected<bool, std::string> grow() override {
-        return false;
-    }
-
-private:
-    llvm::SmallVector<std::size_t> write_puts(llvm::ArrayRef<Blob> puts) {
-        // Batch order encodes dependency (shards → manifests → global →
-        // CDB snapshot), so the first failure fails the rest of the batch:
-        // continuing would publish an entry whose prerequisites never
-        // landed — e.g. a CDB snapshot vouching for a global that failed —
-        // and load paths only tolerate a committed prefix, the crash shape.
-        auto fail_from = [&](std::size_t i) {
-            llvm::SmallVector<std::size_t> failed;
-            for(; i < puts.size(); i += 1) {
-                failed.push_back(i);
-            }
-            return failed;
-        };
-        for(std::size_t i = 0; i < puts.size(); i += 1) {
-            auto& blob = puts[i];
-            auto ns = namespace_of(blob.kind);
-            auto pending = store.begin_store(ns, blob.key);
-            std::error_code ec;
-            llvm::raw_fd_ostream os(pending.tmp_path, ec);
-            if(ec) {
-                LOG_WARN("Failed to write index blob {}/{}: {}", ns, blob.key, ec.message());
-                return fail_from(i);
-            }
-            os.write(blob.bytes.data(), blob.bytes.size());
-            os.close();
-            // A truncated blob (disk full) must never be committed: the
-            // namespaces are Persistent, so it would be served forever.
-            if(os.has_error()) {
-                LOG_WARN("Failed to write index blob {}/{}: {}",
-                         ns,
-                         blob.key,
-                         os.error().message());
-                os.clear_error();
-                return fail_from(i);
-            }
-            if(auto committed = store.commit(std::move(pending)); !committed) {
-                LOG_WARN("Failed to commit index blob {}/{}: {}",
-                         ns,
-                         blob.key,
-                         committed.error().message());
-                return fail_from(i);
-            }
-        }
-        return {};
-    }
-
-    CacheStore& store;
-    int lock_fd;
-    bool read_only_ = false;
-};
-
-// ── LMDB backend ────────────────────────────────────────────────────
 
 constexpr llvm::StringLiteral lmdb_file_name = "index.mdb";
 
@@ -592,9 +450,9 @@ std::unique_ptr<LmdbDatabase>
     // same discipline the loader applies to an unreadable global blob.
     for(int attempt = 0; attempt < 2; attempt += 1) {
         // Giving up must not leave behind a file this attempt created
-        // (make_sparse and mdb_env_open both create on demand): read-only
-        // opens select the LMDB backend on bare existence, so an abandoned
-        // uninitialized placeholder would shadow the per-file blobs.
+        // (make_sparse and mdb_env_open both create on demand): a later
+        // session would misread the abandoned uninitialized placeholder as
+        // corruption and log a spurious rebuild.
         bool created = !read_only && !llvm::sys::fs::exists(path);
         auto discard_created = [&] {
             if(created) {
@@ -740,19 +598,6 @@ FsLocality filesystem_locality(llvm::StringRef dir) {
 
 }  // namespace
 
-std::unique_ptr<BlobDatabase> open_fs_database(CacheStore& store, bool read_only) {
-    read_only = read_only || store.read_only();
-    int lock_fd = -1;
-    if(!read_only) {
-        auto locked = acquire_writer_lock(store);
-        if(!locked) {
-            return nullptr;
-        }
-        lock_fd = *locked;
-    }
-    return std::make_unique<FsDatabase>(store, lock_fd, read_only);
-}
-
 std::unique_ptr<BlobDatabase> open_lmdb_database(CacheStore& store,
                                                  std::size_t initial_mapsize,
                                                  bool read_only) {
@@ -772,37 +617,34 @@ std::unique_ptr<BlobDatabase> open_lmdb_database(CacheStore& store,
     return db;
 }
 
-std::unique_ptr<BlobDatabase> open_database(CacheStore& store,
-                                            llvm::StringRef backend,
-                                            bool read_only) {
-    if(backend == "files") {
-        return open_fs_database(store, read_only);
-    }
-    if(backend != "lmdb") {
-        LOG_WARN("Unknown index_db backend '{}'; using lmdb", backend);
-    }
+std::unique_ptr<BlobDatabase> open_database(CacheStore& store, bool read_only) {
+    // FIXME: no index persistence on remote filesystems. A per-file blob
+    // backend used to fill this gap (one CacheStore-namespace file per
+    // blob, removed in PR #650 — see its history to resurrect it), but it
+    // duplicated everything the database gives for free — atomic batches,
+    // read snapshots, corruption detection — while the remote scenarios
+    // it claimed to serve (NFS home directories, SMB project shares,
+    // WSL drvfs checkouts) differ enough in locking and cache-coherence
+    // behavior that one untested fallback cannot honestly cover them.
+    // What remote workspaces actually need is an open design question;
+    // until it is answered, such sessions run with an in-memory index
+    // and this warning.
     switch(filesystem_locality(store.base_dir())) {
         case FsLocality::Local: break;
         case FsLocality::Remote: {
             LOG_WARN(
-                "{} is on a remote filesystem, which LMDB does not support; "
-                "using per-file index storage",
+                "{} is on a remote filesystem, which the index database does not "
+                "support; index persistence is disabled for this session",
                 store.base_dir());
-            return open_fs_database(store, read_only);
+            return nullptr;
         }
         case FsLocality::Unknown: {
             LOG_WARN(
-                "{} is on a FUSE filesystem; LMDB needs local-filesystem semantics — "
-                "set index_db = \"files\" if the index database misbehaves",
+                "{} is on a FUSE filesystem; the index database needs "
+                "local-filesystem semantics and may misbehave there",
                 store.base_dir());
             break;
         }
-    }
-    // A reader before any LMDB writer ever ran (or after "files" runs)
-    // reads whatever the per-file backend left behind — including nothing.
-    if((read_only || store.read_only()) &&
-       !llvm::sys::fs::exists(path::join(store.base_dir(), lmdb_file_name))) {
-        return open_fs_database(store, read_only);
     }
     return open_lmdb_database(store, 0, read_only);
 }

--- a/src/index/database.h
+++ b/src/index/database.h
@@ -32,8 +32,8 @@ enum class IndexBlobKind : std::uint8_t {
     /// against, key "cdb" — how a cold start detects compile-command
     /// changes that happened while no server was running.
     CDB,
-    /// The single artifact-validity blob (PCH/PCM records with their deps
-    /// and blob bindings, header-mode verdicts), key "artifacts".
+    /// The single artifact-validity blob (PCH/PCM records with their deps,
+    /// header-mode verdicts), key "artifacts".
     Artifacts,
     /// The single user-context blob (saved context choices, synthesized
     /// artifact hosts), key "contexts" — sovereignty records, never

--- a/src/index/database.h
+++ b/src/index/database.h
@@ -32,6 +32,13 @@ enum class IndexBlobKind : std::uint8_t {
     /// against, key "cdb" — how a cold start detects compile-command
     /// changes that happened while no server was running.
     CDB,
+    /// The single artifact-validity blob (PCH/PCM records with their deps
+    /// and blob bindings, header-mode verdicts), key "artifacts".
+    Artifacts,
+    /// The single user-context blob (saved context choices, synthesized
+    /// artifact hosts), key "contexts" — sovereignty records, never
+    /// garbage-collected by content.
+    Contexts,
 };
 
 /// One blob read out of the database. The bytes' lifetime is
@@ -143,6 +150,13 @@ public:
     /// corruption observed at read time. The files go away under the
     /// writer lock, so the next open starts from an empty database.
     virtual void condemn() {}
+
+    /// Whether this handle was opened read-only (a session that must not
+    /// take the writer lock — batch lint, `clice index --stats`). Writes
+    /// are a caller bug then; persistence-side callers skip them.
+    virtual bool read_only() const {
+        return false;
+    }
 };
 
 /// Filesystem backend over the cache store; registers the index
@@ -151,7 +165,7 @@ public:
 /// returns nullptr when another clice process already holds it — the
 /// global/manifest blobs form one mutable lineage that tolerates no second
 /// writer. Read-only stores skip the lock.
-std::unique_ptr<BlobDatabase> open_fs_database(CacheStore& store);
+std::unique_ptr<BlobDatabase> open_fs_database(CacheStore& store, bool read_only = false);
 
 /// LMDB backend: a single `index.mdb` (plus its `-lock` file) in the
 /// store's version directory. Takes the same writer lock as the
@@ -166,7 +180,8 @@ std::unique_ptr<BlobDatabase> open_fs_database(CacheStore& store);
 /// reservation (tests exercise the growth path with a tiny map); 0 keeps
 /// the default.
 std::unique_ptr<BlobDatabase> open_lmdb_database(CacheStore& store,
-                                                 std::size_t initial_mapsize = 0);
+                                                 std::size_t initial_mapsize = 0,
+                                                 bool read_only = false);
 
 /// Backend selection: `backend` is the `project.index_db` config value
 /// ("lmdb" or "files"). Remote filesystems (which LMDB cannot run on) fall
@@ -174,6 +189,8 @@ std::unique_ptr<BlobDatabase> open_lmdb_database(CacheStore& store,
 /// cannot be opened safely disables persistence (nullptr) rather than
 /// falling back — a second lineage of filesystem blobs next to a live
 /// index.mdb would split the index's history.
-std::unique_ptr<BlobDatabase> open_database(CacheStore& store, llvm::StringRef backend);
+std::unique_ptr<BlobDatabase> open_database(CacheStore& store,
+                                            llvm::StringRef backend,
+                                            bool read_only = false);
 
 }  // namespace clice::index

--- a/src/index/database.h
+++ b/src/index/database.h
@@ -41,11 +41,11 @@ enum class IndexBlobKind : std::uint8_t {
     Contexts,
 };
 
-/// One blob read out of the database. The bytes' lifetime is
-/// backend-defined, and `generation` says which contract applies:
+/// One blob read out of the database. `generation` says which lifetime
+/// contract applies:
 ///
-/// - 0: the buffer owns its bytes (filesystem backend, and small LMDB
-///   values copied out for alignment) — valid for the buffer's lifetime.
+/// - 0: the buffer owns its bytes (small LMDB values copied out for
+///   alignment) — valid for the buffer's lifetime.
 /// - nonzero: the bytes are borrowed from the backend's read snapshot of
 ///   that generation and die when it is retired (advance_read_snapshot()
 ///   followed by retire_old_snapshot(), or grow()). A caller keeping such
@@ -70,9 +70,9 @@ struct BlobKey {
 /// Boundary with CacheStore: CacheStore manages the versioned cache
 /// directory and file-shaped artifacts (PCH/PCM/header contexts — clang
 /// consumes those by path, so they must be real files); BlobDatabase is
-/// the index's keyed blob store living inside that directory. The
-/// filesystem backend materializes each blob as one CacheStore-namespace
-/// file; the LMDB backend keeps them all in a single `index.mdb`.
+/// the index's keyed blob store living inside that directory, a single
+/// LMDB `index.mdb`. The interface stays virtual for test doubles (spies,
+/// failure injection).
 ///
 /// `write` does the heavy IO and belongs off the event loop; every other
 /// method is cheap and event-loop-only (read snapshots are owned by the
@@ -115,8 +115,7 @@ public:
     /// read out of it — stays valid until retire_old_snapshot(), so the
     /// caller can migrate long-lived borrowers incrementally, yielding
     /// between batches. On failure the current snapshot keeps serving and
-    /// nothing is invalidated. No-op on backends without snapshots
-    /// (filesystem): returns the current generation, 0.
+    /// nothing is invalidated.
     virtual std::expected<std::uint64_t, std::string> advance_read_snapshot() = 0;
 
     /// Retire every snapshot advance_read_snapshot() has replaced,
@@ -130,12 +129,11 @@ public:
     /// read snapshot first — all borrowed buffers die immediately — and
     /// opening a fresh one. Returns true when the map was resized: the
     /// caller must then rebind every borrower before yielding the event
-    /// loop. False when no growth was pending (including the filesystem
-    /// backend, where this is a no-op). An error return also means growth
-    /// was attempted, so every snapshot has already been retired: borrowed
-    /// buffers are dead and must be shed or re-read, and a replacement
-    /// snapshot may not have opened — reads then miss until a later grow()
-    /// succeeds.
+    /// loop. False when no growth was pending. An error return also means
+    /// growth was attempted, so every snapshot has already been retired:
+    /// borrowed buffers are dead and must be shed or re-read, and a
+    /// replacement snapshot may not have opened — reads then miss until a
+    /// later grow() succeeds.
     virtual std::expected<bool, std::string> grow() = 0;
 
     /// Whether the backend observed page-level corruption after open
@@ -159,18 +157,12 @@ public:
     }
 };
 
-/// Filesystem backend over the cache store; registers the index
-/// namespaces on construction. On a writable store this takes an exclusive
+/// A single `index.mdb` (plus its `-lock` file) in the store's version
+/// directory. On a writable store this first takes an exclusive
 /// cross-process writer lock for the index (held until destruction) and
 /// returns nullptr when another clice process already holds it — the
-/// global/manifest blobs form one mutable lineage that tolerates no second
-/// writer. Read-only stores skip the lock.
-std::unique_ptr<BlobDatabase> open_fs_database(CacheStore& store, bool read_only = false);
-
-/// LMDB backend: a single `index.mdb` (plus its `-lock` file) in the
-/// store's version directory. Takes the same writer lock as the
-/// filesystem backend before touching the environment. Returns nullptr
-/// when the lock is held elsewhere or the environment cannot be opened
+/// global/manifest blobs form one mutable lineage that tolerates no
+/// second writer. Also nullptr when the environment cannot be opened
 /// safely — only confirmed corruption (or a meta mismatch) is repaired by
 /// deleting and rebuilding the database; transient errors disable index
 /// persistence for the session and touch nothing. A read-only open uses
@@ -183,14 +175,11 @@ std::unique_ptr<BlobDatabase> open_lmdb_database(CacheStore& store,
                                                  std::size_t initial_mapsize = 0,
                                                  bool read_only = false);
 
-/// Backend selection: `backend` is the `project.index_db` config value
-/// ("lmdb" or "files"). Remote filesystems (which LMDB cannot run on) fall
-/// back to the filesystem backend with a warning; an LMDB environment that
-/// cannot be opened safely disables persistence (nullptr) rather than
-/// falling back — a second lineage of filesystem blobs next to a live
-/// index.mdb would split the index's history.
-std::unique_ptr<BlobDatabase> open_database(CacheStore& store,
-                                            llvm::StringRef backend,
-                                            bool read_only = false);
+/// The production entry: open_lmdb_database gated on the store living on
+/// a local filesystem. On a remote filesystem (NFS/SMB/9p — where LMDB is
+/// documented to break) index persistence is disabled with a warning; a
+/// FUSE mount gets the warning but proceeds, since FUSE fronts anything
+/// from a local overlay to sshfs.
+std::unique_ptr<BlobDatabase> open_database(CacheStore& store, bool read_only = false);
 
 }  // namespace clice::index

--- a/src/index/manifest.cpp
+++ b/src/index/manifest.cpp
@@ -71,12 +71,12 @@ void serialize_manifest(const TUManifest& manifest, llvm::raw_ostream& os) {
     blob.format_version = index_format_version;
     blob.global_gen = manifest.global_gen;
     blob.built_at = manifest.built_at;
-    blob.tu_fv = manifest.tu_fv;
+    blob.tu_fv = manifest.tu_fv.raw;
 
     blob.node_count = static_cast<std::uint32_t>(manifest.nodes.size());
     blob.nodes.reserve(manifest.nodes.size() * 6);
     for(auto& node: manifest.nodes) {
-        write_varint(blob.nodes, node.fv);
+        write_varint(blob.nodes, node.fv.raw);
         write_varint(blob.nodes, node.parent + 1);
         write_varint(blob.nodes, node.line);
     }
@@ -84,7 +84,7 @@ void serialize_manifest(const TUManifest& manifest, llvm::raw_ostream& os) {
     blob.contribution_count = static_cast<std::uint32_t>(manifest.contributions.size());
     blob.contributions.reserve(manifest.contributions.size() * 10);
     for(auto& [fv, hash]: manifest.contributions) {
-        write_varint(blob.contributions, fv);
+        write_varint(blob.contributions, fv.raw);
         std::uint8_t bytes[8];
         std::memcpy(bytes, &hash, sizeof(hash));
         blob.contributions.insert(blob.contributions.end(), bytes, bytes + sizeof(bytes));
@@ -111,7 +111,7 @@ std::optional<TUManifest> deserialize_manifest(llvm::StringRef data) {
     TUManifest manifest;
     manifest.global_gen = blob.global_gen;
     manifest.built_at = blob.built_at;
-    manifest.tu_fv = blob.tu_fv;
+    manifest.tu_fv = VersionID{blob.tu_fv};
 
     constexpr std::uint64_t id_max = std::numeric_limits<std::uint32_t>::max();
     std::span<const std::uint8_t> nodes(blob.nodes);
@@ -135,7 +135,7 @@ std::optional<TUManifest> deserialize_manifest(llvm::StringRef data) {
         if(parent > blob.node_count) {
             return std::nullopt;
         }
-        manifest.nodes.push_back({static_cast<std::uint32_t>(fv),
+        manifest.nodes.push_back({VersionID{static_cast<std::uint32_t>(fv)},
                                   static_cast<std::uint32_t>(parent) - 1,
                                   static_cast<std::uint32_t>(line)});
     }
@@ -157,7 +157,7 @@ std::optional<TUManifest> deserialize_manifest(llvm::StringRef data) {
         std::uint64_t hash = 0;
         std::memcpy(&hash, contributions.data() + pos, sizeof(hash));
         pos += 8;
-        manifest.contributions.emplace_back(static_cast<std::uint32_t>(fv), hash);
+        manifest.contributions.emplace_back(VersionID{static_cast<std::uint32_t>(fv)}, hash);
     }
     if(pos != contributions.size()) {
         return std::nullopt;

--- a/src/index/manifest.h
+++ b/src/index/manifest.h
@@ -15,7 +15,7 @@ namespace clice::index {
 /// where. Multiple entries of one file (headers without guards) are
 /// distinct nodes.
 struct ManifestNode {
-    /// FileVersion id (ProjectIndex::file_versions).
+    /// FileVersion id (FileTable::versions).
     std::uint32_t fv = 0;
 
     /// Index of the including node, ~0 when the directive sits in the TU's

--- a/src/index/manifest.h
+++ b/src/index/manifest.h
@@ -5,6 +5,8 @@
 #include <utility>
 #include <vector>
 
+#include "vfs/file_table.h"
+
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -16,7 +18,7 @@ namespace clice::index {
 /// distinct nodes.
 struct ManifestNode {
     /// FileVersion id (FileTable::versions).
-    std::uint32_t fv = 0;
+    VersionID fv;
 
     /// Index of the including node, ~0 when the directive sits in the TU's
     /// own file (the TU root is not itself a node).
@@ -47,14 +49,14 @@ struct TUManifest {
     std::uint64_t built_at = 0;
 
     /// The TU's own file version.
-    std::uint32_t tu_fv = 0;
+    VersionID tu_fv;
 
     std::vector<ManifestNode> nodes;
 
     /// FileVersion -> rows hash for every file this TU contributed rows to,
     /// the TU's own file included. Deduplicated: one entry per file version
     /// even when the file was entered several times.
-    std::vector<std::pair<std::uint32_t, std::uint64_t>> contributions;
+    std::vector<std::pair<VersionID, std::uint64_t>> contributions;
 
     friend bool operator==(const TUManifest&, const TUManifest&) = default;
 };

--- a/src/index/project_index.cpp
+++ b/src/index/project_index.cpp
@@ -219,7 +219,7 @@ llvm::SmallVector<std::uint64_t> ProjectIndex::live_variants(this const ProjectI
 
 void ProjectIndex::serialize_global(this ProjectIndex& self,
                                     llvm::raw_ostream& os,
-                                    const clice::PathPool& pool) {
+                                    const clice::FileTable& pool) {
     // Garbage-collect the FileVersion table down to what some manifest
     // still references — in memory too, so ids of dead versions stop
     // accumulating across the session (they are never reused either way).
@@ -303,7 +303,7 @@ void ProjectIndex::serialize_global(this ProjectIndex& self,
 
 bool ProjectIndex::load_global(this ProjectIndex& self,
                                llvm::StringRef data,
-                               clice::PathPool& pool,
+                               clice::FileTable& pool,
                                llvm::DenseMap<std::uint32_t, std::uint64_t>& manifest_pins) {
     GlobalBlob blob;
     if(!deserialize_blob(data, blob) || blob.format_version != index_format_version) {

--- a/src/index/project_index.cpp
+++ b/src/index/project_index.cpp
@@ -24,6 +24,15 @@ bool reserved_key(T value) {
            value == llvm::DenseMapInfo<T>::getTombstoneKey();
 }
 
+/// Adopting a blob's id space resizes the version table to its counter
+/// before any other rejection can run, so a structurally valid blob
+/// carrying a garbage high-water mark would OOM the load instead of
+/// failing it. The cap is far beyond any table a writer accumulates
+/// (ids grow only with newly seen (file, content-hash) pairs), and a
+/// table that ever drifts there is better compacted by the rebuild the
+/// rejection triggers.
+constexpr inline std::uint32_t max_persisted_versions = 1u << 24;
+
 /// The global layer's persisted form: the FileVersion table as parallel
 /// columns plus the symbol table with a self-contained path table for its
 /// reference bitmaps.
@@ -32,6 +41,9 @@ struct GlobalBlob {
 
     /// See ProjectIndex::global_generation.
     std::uint64_t generation = 0;
+
+    /// See FileTable::revocation_generation.
+    std::uint64_t revocation_generation = 0;
 
     std::uint32_t next_fv_id = 0;
 
@@ -229,6 +241,7 @@ void ProjectIndex::serialize_global(this ProjectIndex& self,
     GlobalBlob blob;
     blob.format_version = index_format_version;
     blob.generation = self.global_generation;
+    blob.revocation_generation = files.revocation_generation;
     blob.next_fv_id = static_cast<std::uint32_t>(files.versions.size());
 
     llvm::SmallVector<VersionID> ids(referenced.begin(), referenced.end());
@@ -326,7 +339,7 @@ bool ProjectIndex::load_global(this ProjectIndex& self,
     // itself, and the writer hands ids out from it, so ids must sit below
     // it — a bound that (with the sentinels at the top of the id space)
     // also keeps every id non-reserved.
-    if(reserved_key(blob.next_fv_id)) {
+    if(reserved_key(blob.next_fv_id) || blob.next_fv_id > max_persisted_versions) {
         return false;
     }
     for(auto id: blob.fv_ids) {
@@ -412,6 +425,7 @@ bool ProjectIndex::load_global(this ProjectIndex& self,
     assert(files.versions.empty() && "the global blob must load before any version interning");
 
     self.global_generation = blob.generation;
+    files.revocation_generation = blob.revocation_generation;
     files.versions.resize(blob.next_fv_id);
     for(std::size_t i = 0; i < count; i += 1) {
         auto path_id = files.intern(blob.fv_paths[i]);

--- a/src/index/project_index.cpp
+++ b/src/index/project_index.cpp
@@ -128,30 +128,19 @@ bool ProjectIndex::merge(this ProjectIndex& self,
     return true;
 }
 
-std::uint32_t ProjectIndex::intern_file_version(this ProjectIndex& self,
-                                                std::uint32_t path_id,
-                                                std::uint64_t content_hash) {
-    auto [it, inserted] = self.fv_ids.try_emplace({path_id, content_hash}, self.next_fv_id);
-    if(inserted) {
-        self.file_versions.try_emplace(
-            self.next_fv_id,
-            FileVersionRecord{.path_id = path_id, .content_hash = content_hash});
-        self.next_fv_id += 1;
-    }
-    return it->second;
-}
-
-bool ProjectIndex::knows_file_versions(this const ProjectIndex& self, const TUManifest& manifest) {
-    if(!self.file_versions.contains(manifest.tu_fv)) {
+bool ProjectIndex::knows_file_versions(this const ProjectIndex& self,
+                                       const clice::FileTable& files,
+                                       const TUManifest& manifest) {
+    if(!files.versions.contains(manifest.tu_fv)) {
         return false;
     }
     for(auto& node: manifest.nodes) {
-        if(!self.file_versions.contains(node.fv)) {
+        if(!files.versions.contains(node.fv)) {
             return false;
         }
     }
     for(auto& [fv, hash]: manifest.contributions) {
-        if(!self.file_versions.contains(fv)) {
+        if(!files.versions.contains(fv)) {
             return false;
         }
     }
@@ -159,12 +148,13 @@ bool ProjectIndex::knows_file_versions(this const ProjectIndex& self, const TUMa
 }
 
 llvm::SmallVector<std::uint32_t> ProjectIndex::apply_manifest(this ProjectIndex& self,
+                                                              const clice::FileTable& files,
                                                               std::uint32_t tu_path_id,
                                                               TUManifest manifest) {
-    llvm::SmallVector<std::uint32_t> affected = self.remove_manifest(tu_path_id);
+    llvm::SmallVector<std::uint32_t> affected = self.remove_manifest(files, tu_path_id);
 
     for(auto& [fv, hash]: manifest.contributions) {
-        auto path_id = self.file_versions.at(fv).path_id;
+        auto path_id = files.version(fv).fid;
         self.contributions[path_id][tu_path_id] = hash;
         affected.push_back(path_id);
     }
@@ -176,6 +166,7 @@ llvm::SmallVector<std::uint32_t> ProjectIndex::apply_manifest(this ProjectIndex&
 }
 
 llvm::SmallVector<std::uint32_t> ProjectIndex::remove_manifest(this ProjectIndex& self,
+                                                               const clice::FileTable& files,
                                                                std::uint32_t tu_path_id) {
     llvm::SmallVector<std::uint32_t> affected;
     auto it = self.manifests.find(tu_path_id);
@@ -184,7 +175,7 @@ llvm::SmallVector<std::uint32_t> ProjectIndex::remove_manifest(this ProjectIndex
     }
 
     for(auto& [fv, hash]: it->second.contributions) {
-        auto path_id = self.file_versions.at(fv).path_id;
+        auto path_id = files.version(fv).fid;
         auto contribution_it = self.contributions.find(path_id);
         if(contribution_it == self.contributions.end()) {
             continue;
@@ -219,10 +210,11 @@ llvm::SmallVector<std::uint64_t> ProjectIndex::live_variants(this const ProjectI
 
 void ProjectIndex::serialize_global(this ProjectIndex& self,
                                     llvm::raw_ostream& os,
-                                    const clice::FileTable& pool) {
-    // Garbage-collect the FileVersion table down to what some manifest
-    // still references — in memory too, so ids of dead versions stop
-    // accumulating across the session (they are never reused either way).
+                                    const clice::FileTable& files) {
+    // The blob carries only the versions some manifest still references —
+    // the persisted form's garbage collection. The shared table itself is
+    // left alone: other consumers may still anchor checks on a version the
+    // index dropped, and ids are never reused either way.
     llvm::DenseSet<std::uint32_t> referenced;
     for(auto& manifest: llvm::make_second_range(self.manifests)) {
         referenced.insert(manifest.tu_fv);
@@ -234,33 +226,17 @@ void ProjectIndex::serialize_global(this ProjectIndex& self,
         }
     }
 
-    llvm::SmallVector<std::uint32_t> dead;
-    for(auto id: llvm::make_first_range(self.file_versions)) {
-        if(!referenced.contains(id)) {
-            dead.push_back(id);
-        }
-    }
-    for(auto id: dead) {
-        auto& record = self.file_versions.at(id);
-        self.fv_ids.erase({record.path_id, record.content_hash});
-        self.file_versions.erase(id);
-    }
-
     GlobalBlob blob;
     blob.format_version = index_format_version;
     blob.generation = self.global_generation;
-    blob.next_fv_id = self.next_fv_id;
+    blob.next_fv_id = files.next_version_id;
 
-    llvm::SmallVector<std::uint32_t> ids;
-    ids.reserve(self.file_versions.size());
-    for(auto id: llvm::make_first_range(self.file_versions)) {
-        ids.push_back(id);
-    }
+    llvm::SmallVector<std::uint32_t> ids(referenced.begin(), referenced.end());
     llvm::sort(ids);
     for(auto id: ids) {
-        auto& record = self.file_versions.at(id);
+        auto& record = files.version(id);
         blob.fv_ids.push_back(id);
-        blob.fv_paths.emplace_back(pool.resolve(record.path_id));
+        blob.fv_paths.emplace_back(files.resolve(record.fid));
         blob.fv_hashes.push_back(record.content_hash);
         blob.fv_sizes.push_back(record.size);
         blob.fv_mtimes.push_back(record.mtime_ns);
@@ -289,7 +265,7 @@ void ProjectIndex::serialize_global(this ProjectIndex& self,
     }
     blob.sym_paths.reserve(bitmap_referenced.cardinality());
     for(auto id: bitmap_referenced) {
-        blob.sym_paths.emplace_back(id, pool.resolve(id).str());
+        blob.sym_paths.emplace_back(id, files.resolve(id).str());
     }
 
     serialize_blob(blob, os);
@@ -303,7 +279,7 @@ void ProjectIndex::serialize_global(this ProjectIndex& self,
 
 bool ProjectIndex::load_global(this ProjectIndex& self,
                                llvm::StringRef data,
-                               clice::FileTable& pool,
+                               clice::FileTable& files,
                                llvm::DenseMap<std::uint32_t, std::uint64_t>& manifest_pins) {
     GlobalBlob blob;
     if(!deserialize_blob(data, blob) || blob.format_version != index_format_version) {
@@ -429,13 +405,18 @@ bool ProjectIndex::load_global(this ProjectIndex& self,
         bitmaps.push_back(std::move(*decoded));
     }
 
+    // Adopting the blob's version ids verbatim is what keeps persisted
+    // manifests resolvable; it requires an untouched table — ids already
+    // handed out by this session could collide with the blob's.
+    assert(files.versions.empty() && "the global blob must load before any version interning");
+
     self.global_generation = blob.generation;
-    self.next_fv_id = blob.next_fv_id;
+    files.next_version_id = blob.next_fv_id;
     for(std::size_t i = 0; i < count; i += 1) {
-        auto path_id = pool.intern(blob.fv_paths[i]);
+        auto path_id = files.intern(blob.fv_paths[i]);
         auto id = blob.fv_ids[i];
-        self.file_versions[id] = {path_id, blob.fv_hashes[i], blob.fv_sizes[i], blob.fv_mtimes[i]};
-        self.fv_ids[{path_id, blob.fv_hashes[i]}] = id;
+        files.versions[id] = {path_id, blob.fv_hashes[i], blob.fv_sizes[i], blob.fv_mtimes[i]};
+        files.version_ids[{path_id, blob.fv_hashes[i]}] = id;
     }
 
     for(std::size_t k = 0; k < blob.manifest_fvs.size(); k += 1) {
@@ -448,7 +429,7 @@ bool ProjectIndex::load_global(this ProjectIndex& self,
     llvm::DenseMap<std::uint32_t, std::uint32_t> remap;
     remap.reserve(blob.sym_paths.size());
     for(auto& [id, path]: blob.sym_paths) {
-        remap.try_emplace(id, pool.intern(path));
+        remap.try_emplace(id, files.intern(path));
     }
 
     self.symbols.reserve(sym_count);

--- a/src/index/project_index.cpp
+++ b/src/index/project_index.cpp
@@ -68,7 +68,7 @@ struct GlobalBlob {
 
 bool ProjectIndex::merge(this ProjectIndex& self,
                          const TUIndex& index,
-                         llvm::ArrayRef<std::uint32_t> file_ids_map) {
+                         llvm::ArrayRef<Fid> file_ids_map) {
     // Decode and bound every reference bitmap before touching the table:
     // merged bits persist in the global blob while the result's recorded
     // versions all match the disk, so a malformed image normalized to
@@ -121,7 +121,7 @@ bool ProjectIndex::merge(this ProjectIndex& self,
             target.kind = identity.kind;
         }
         for(auto ref: references) {
-            target.reference_files.add(file_ids_map[ref]);
+            target.reference_files.add(file_ids_map[ref].raw);
         }
     }
 
@@ -131,27 +131,27 @@ bool ProjectIndex::merge(this ProjectIndex& self,
 bool ProjectIndex::knows_file_versions(this const ProjectIndex& self,
                                        const clice::FileTable& files,
                                        const TUManifest& manifest) {
-    if(!files.versions.contains(manifest.tu_fv)) {
+    if(!files.knows_version(manifest.tu_fv)) {
         return false;
     }
     for(auto& node: manifest.nodes) {
-        if(!files.versions.contains(node.fv)) {
+        if(!files.knows_version(node.fv)) {
             return false;
         }
     }
     for(auto& [fv, hash]: manifest.contributions) {
-        if(!files.versions.contains(fv)) {
+        if(!files.knows_version(fv)) {
             return false;
         }
     }
     return true;
 }
 
-llvm::SmallVector<std::uint32_t> ProjectIndex::apply_manifest(this ProjectIndex& self,
-                                                              const clice::FileTable& files,
-                                                              std::uint32_t tu_path_id,
-                                                              TUManifest manifest) {
-    llvm::SmallVector<std::uint32_t> affected = self.remove_manifest(files, tu_path_id);
+llvm::SmallVector<Fid> ProjectIndex::apply_manifest(this ProjectIndex& self,
+                                                    const clice::FileTable& files,
+                                                    Fid tu_path_id,
+                                                    TUManifest manifest) {
+    llvm::SmallVector<Fid> affected = self.remove_manifest(files, tu_path_id);
 
     for(auto& [fv, hash]: manifest.contributions) {
         auto path_id = files.version(fv).fid;
@@ -165,10 +165,10 @@ llvm::SmallVector<std::uint32_t> ProjectIndex::apply_manifest(this ProjectIndex&
     return affected;
 }
 
-llvm::SmallVector<std::uint32_t> ProjectIndex::remove_manifest(this ProjectIndex& self,
-                                                               const clice::FileTable& files,
-                                                               std::uint32_t tu_path_id) {
-    llvm::SmallVector<std::uint32_t> affected;
+llvm::SmallVector<Fid> ProjectIndex::remove_manifest(this ProjectIndex& self,
+                                                     const clice::FileTable& files,
+                                                     Fid tu_path_id) {
+    llvm::SmallVector<Fid> affected;
     auto it = self.manifests.find(tu_path_id);
     if(it == self.manifests.end()) {
         return affected;
@@ -194,7 +194,7 @@ llvm::SmallVector<std::uint32_t> ProjectIndex::remove_manifest(this ProjectIndex
 }
 
 llvm::SmallVector<std::uint64_t> ProjectIndex::live_variants(this const ProjectIndex& self,
-                                                             std::uint32_t path_id) {
+                                                             Fid path_id) {
     llvm::SmallVector<std::uint64_t> variants;
     auto it = self.contributions.find(path_id);
     if(it == self.contributions.end()) {
@@ -215,7 +215,7 @@ void ProjectIndex::serialize_global(this ProjectIndex& self,
     // the persisted form's garbage collection. The shared table itself is
     // left alone: other consumers may still anchor checks on a version the
     // index dropped, and ids are never reused either way.
-    llvm::DenseSet<std::uint32_t> referenced;
+    llvm::DenseSet<VersionID> referenced;
     for(auto& manifest: llvm::make_second_range(self.manifests)) {
         referenced.insert(manifest.tu_fv);
         for(auto& node: manifest.nodes) {
@@ -229,13 +229,13 @@ void ProjectIndex::serialize_global(this ProjectIndex& self,
     GlobalBlob blob;
     blob.format_version = index_format_version;
     blob.generation = self.global_generation;
-    blob.next_fv_id = files.next_version_id;
+    blob.next_fv_id = static_cast<std::uint32_t>(files.versions.size());
 
-    llvm::SmallVector<std::uint32_t> ids(referenced.begin(), referenced.end());
+    llvm::SmallVector<VersionID> ids(referenced.begin(), referenced.end());
     llvm::sort(ids);
     for(auto id: ids) {
         auto& record = files.version(id);
-        blob.fv_ids.push_back(id);
+        blob.fv_ids.push_back(id.raw);
         blob.fv_paths.emplace_back(files.resolve(record.fid));
         blob.fv_hashes.push_back(record.content_hash);
         blob.fv_sizes.push_back(record.size);
@@ -245,7 +245,7 @@ void ProjectIndex::serialize_global(this ProjectIndex& self,
     blob.manifest_fvs.reserve(self.manifests.size());
     blob.manifest_gens.reserve(self.manifests.size());
     for(auto& manifest: llvm::make_second_range(self.manifests)) {
-        blob.manifest_fvs.push_back(manifest.tu_fv);
+        blob.manifest_fvs.push_back(manifest.tu_fv.raw);
         blob.manifest_gens.push_back(manifest.global_gen);
     }
 
@@ -265,7 +265,7 @@ void ProjectIndex::serialize_global(this ProjectIndex& self,
     }
     blob.sym_paths.reserve(bitmap_referenced.cardinality());
     for(auto id: bitmap_referenced) {
-        blob.sym_paths.emplace_back(id, files.resolve(id).str());
+        blob.sym_paths.emplace_back(id, files.resolve(Fid{id}).str());
     }
 
     serialize_blob(blob, os);
@@ -280,7 +280,7 @@ void ProjectIndex::serialize_global(this ProjectIndex& self,
 bool ProjectIndex::load_global(this ProjectIndex& self,
                                llvm::StringRef data,
                                clice::FileTable& files,
-                               llvm::DenseMap<std::uint32_t, std::uint64_t>& manifest_pins) {
+                               llvm::DenseMap<VersionID, std::uint64_t>& manifest_pins) {
     GlobalBlob blob;
     if(!deserialize_blob(data, blob) || blob.format_version != index_format_version) {
         return false;
@@ -407,26 +407,28 @@ bool ProjectIndex::load_global(this ProjectIndex& self,
 
     // Adopting the blob's version ids verbatim is what keeps persisted
     // manifests resolvable; it requires an untouched table — ids already
-    // handed out by this session could collide with the blob's.
+    // handed out by this session could collide with the blob's. Ids the
+    // writer garbage-collected stay behind as holes (see knows_version).
     assert(files.versions.empty() && "the global blob must load before any version interning");
 
     self.global_generation = blob.generation;
-    files.next_version_id = blob.next_fv_id;
+    files.versions.resize(blob.next_fv_id);
     for(std::size_t i = 0; i < count; i += 1) {
         auto path_id = files.intern(blob.fv_paths[i]);
-        auto id = blob.fv_ids[i];
-        files.versions[id] = {path_id, blob.fv_hashes[i], blob.fv_sizes[i], blob.fv_mtimes[i]};
+        auto id = VersionID{blob.fv_ids[i]};
+        files.versions[id.raw] =
+            FileTable::FileVersion{path_id, blob.fv_hashes[i], blob.fv_sizes[i], blob.fv_mtimes[i]};
         files.version_ids[{path_id, blob.fv_hashes[i]}] = id;
     }
 
     for(std::size_t k = 0; k < blob.manifest_fvs.size(); k += 1) {
-        manifest_pins[blob.manifest_fvs[k]] = blob.manifest_gens[k];
+        manifest_pins[VersionID{blob.manifest_fvs[k]}] = blob.manifest_gens[k];
     }
 
     // The blob's bitmap ids are the writing session's pool ids: intern its
     // path table and remap every decoded id into this session's pool. Every
     // id was proven covered by the table above.
-    llvm::DenseMap<std::uint32_t, std::uint32_t> remap;
+    llvm::DenseMap<std::uint32_t, Fid> remap;
     remap.reserve(blob.sym_paths.size());
     for(auto& [id, path]: blob.sym_paths) {
         remap.try_emplace(id, files.intern(path));
@@ -436,7 +438,7 @@ bool ProjectIndex::load_global(this ProjectIndex& self,
     for(std::size_t k = 0; k < sym_count; k += 1) {
         Bitmap remapped;
         for(auto id: bitmaps[k]) {
-            remapped.add(remap.find(id)->second);
+            remapped.add(remap.find(id)->second.raw);
         }
         auto& symbol = self.symbols[blob.sym_hashes[k]];
         symbol.name = std::move(blob.sym_names[k]);

--- a/src/index/project_index.h
+++ b/src/index/project_index.h
@@ -5,7 +5,7 @@
 
 #include "index/manifest.h"
 #include "index/tu_index.h"
-#include "support/path_pool.h"
+#include "vfs/file_table.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
@@ -47,7 +47,7 @@ struct FileVersionRecord {
 ///   the file's live variants — the mask Shard queries filter by — and its
 ///   emptiness is what retires a shard blob.
 ///
-/// There is a single path-id space at runtime (clice::PathPool); persisted
+/// There is a single path-id space at runtime (clice::FileTable); persisted
 /// blobs are self-contained through path tables and remap on load.
 struct ProjectIndex {
     SymbolTable symbols;
@@ -122,7 +122,7 @@ struct ProjectIndex {
     /// of every manifest's generation stamp.
     void serialize_global(this ProjectIndex& self,
                           llvm::raw_ostream& os,
-                          const clice::PathPool& pool);
+                          const clice::FileTable& pool);
 
     /// Restore the global blob, interning its paths into `pool`. Returns
     /// false for an unreadable or old-format blob, leaving the index (and
@@ -133,7 +133,7 @@ struct ProjectIndex {
     /// adopted.
     bool load_global(this ProjectIndex& self,
                      llvm::StringRef data,
-                     clice::PathPool& pool,
+                     clice::FileTable& pool,
                      llvm::DenseMap<std::uint32_t, std::uint64_t>& manifest_pins);
 };
 

--- a/src/index/project_index.h
+++ b/src/index/project_index.h
@@ -43,12 +43,11 @@ struct ProjectIndex {
     /// leave an older on-disk manifest serving as current.
     std::uint64_t global_generation = 0;
 
-    /// TU path_id -> its manifest.
-    llvm::DenseMap<std::uint32_t, TUManifest> manifests;
+    /// TU fid -> its manifest.
+    llvm::DenseMap<Fid, TUManifest> manifests;
 
-    /// Derived from `manifests`: file path_id -> (TU path_id -> rows hash).
-    llvm::DenseMap<std::uint32_t, llvm::SmallDenseMap<std::uint32_t, std::uint64_t, 2>>
-        contributions;
+    /// Derived from `manifests`: file fid -> (TU fid -> rows hash).
+    llvm::DenseMap<Fid, llvm::SmallDenseMap<Fid, std::uint64_t, 2>> contributions;
 
     /// Merge a TU's external symbols straight off the wire; `file_ids_map`
     /// maps the TU-local ids of `index`'s path table to pool ids. Symbol
@@ -59,9 +58,7 @@ struct ProjectIndex {
     /// caller rejects the whole result, because merged bits persist while
     /// the result's recorded versions match the disk, so lost bits would
     /// never be rebuilt.
-    bool merge(this ProjectIndex& self,
-               const TUIndex& index,
-               llvm::ArrayRef<std::uint32_t> file_ids_map);
+    bool merge(this ProjectIndex& self, const TUIndex& index, llvm::ArrayRef<Fid> file_ids_map);
 
     /// Whether every FileVersion id the manifest references is known —
     /// the loader's staleness gate for manifests read from disk.
@@ -72,21 +69,20 @@ struct ProjectIndex {
     /// Install (or replace) a TU's manifest and rederive the affected
     /// contribution entries. Returns the file path_ids whose contribution
     /// set changed — the caller refreshes those shards' live-variant masks.
-    llvm::SmallVector<std::uint32_t> apply_manifest(this ProjectIndex& self,
-                                                    const clice::FileTable& files,
-                                                    std::uint32_t tu_path_id,
-                                                    TUManifest manifest);
+    llvm::SmallVector<Fid> apply_manifest(this ProjectIndex& self,
+                                          const clice::FileTable& files,
+                                          Fid tu_path_id,
+                                          TUManifest manifest);
 
     /// Drop a TU's manifest and its contribution entries. Returns the
     /// affected file path_ids, like apply_manifest.
-    llvm::SmallVector<std::uint32_t> remove_manifest(this ProjectIndex& self,
-                                                     const clice::FileTable& files,
-                                                     std::uint32_t tu_path_id);
+    llvm::SmallVector<Fid> remove_manifest(this ProjectIndex& self,
+                                           const clice::FileTable& files,
+                                           Fid tu_path_id);
 
     /// The distinct rows hashes contributed to `path_id` — the file's live
     /// variant set.
-    llvm::SmallVector<std::uint64_t> live_variants(this const ProjectIndex& self,
-                                                   std::uint32_t path_id);
+    llvm::SmallVector<std::uint64_t> live_variants(this const ProjectIndex& self, Fid path_id);
 
     /// Serialize the global blob: the versions some manifest still
     /// references (the shared table is not touched — a version the index
@@ -109,7 +105,7 @@ struct ProjectIndex {
     bool load_global(this ProjectIndex& self,
                      llvm::StringRef data,
                      clice::FileTable& files,
-                     llvm::DenseMap<std::uint32_t, std::uint64_t>& manifest_pins);
+                     llvm::DenseMap<VersionID, std::uint64_t>& manifest_pins);
 };
 
 }  // namespace clice::index

--- a/src/index/project_index.h
+++ b/src/index/project_index.h
@@ -14,52 +14,26 @@
 
 namespace clice::index {
 
-/// One observed version of a file on disk: the identity every manifest
-/// dependency points at, and the single place its freshness baseline
-/// lives — the consumed-content hash plus a stat fast path, shared by
-/// every TU that consumed this version instead of being copied per TU.
-///
-/// `size`/`mtime_ns` are recorded only when the file provably did not
-/// change since before the indexed build started; mtime_ns == 0 means "no
-/// fast path" and the check falls through to the hash comparison, which
-/// repairs the fast path in place on a match — once, for all consumers.
-struct FileVersionRecord {
-    /// Runtime path pool id; persisted as the path string.
-    std::uint32_t path_id = 0;
-
-    /// xxh3 of the bytes the indexing compile consumed (0 = the worker had
-    /// no buffer to hash; freshness stays conservative for this version).
-    std::uint64_t content_hash = 0;
-
-    std::uint64_t size = 0;
-    std::int64_t mtime_ns = 0;
-};
-
 /// The index's global layer: everything mutable, everything shared across
 /// files.
 ///
 /// - the project-wide external symbol table with per-symbol reference-file
 ///   bitmaps (the cross-file query fan-out),
-/// - the FileVersion table anchoring freshness and content identity,
 /// - one manifest per indexed TU (replaced wholesale by its reindex),
 /// - `contributions`, derived from the manifests at load: per file, which
 ///   TU contributed which rows variant. Its distinct hashes per file are
 ///   the file's live variants — the mask Shard queries filter by — and its
 ///   emptiness is what retires a shard blob.
 ///
+/// The FileVersion table manifests reference lives in clice::FileTable,
+/// shared with every other freshness consumer; the global blob persists
+/// the versions some manifest references, and load_global restores them
+/// id-for-id — so it must run before anything interns a version.
+///
 /// There is a single path-id space at runtime (clice::FileTable); persisted
 /// blobs are self-contained through path tables and remap on load.
 struct ProjectIndex {
     SymbolTable symbols;
-
-    llvm::DenseMap<std::uint32_t, FileVersionRecord> file_versions;
-
-    /// (path_id, content_hash) -> FileVersion id.
-    llvm::DenseMap<std::pair<std::uint32_t, std::uint64_t>, std::uint32_t> fv_ids;
-
-    /// Ids are monotonic and never reused, so a manifest on disk stays
-    /// resolvable against any later global blob (or is detected as stale).
-    std::uint32_t next_fv_id = 0;
 
     /// Generation of the persisted global blob, bumped once per save that
     /// writes it. Manifests are stamped with the generation they were
@@ -89,26 +63,24 @@ struct ProjectIndex {
                const TUIndex& index,
                llvm::ArrayRef<std::uint32_t> file_ids_map);
 
-    /// The FileVersion id for (path, content hash), interning a new record
-    /// on first sight.
-    std::uint32_t intern_file_version(this ProjectIndex& self,
-                                      std::uint32_t path_id,
-                                      std::uint64_t content_hash);
-
     /// Whether every FileVersion id the manifest references is known —
     /// the loader's staleness gate for manifests read from disk.
-    bool knows_file_versions(this const ProjectIndex& self, const TUManifest& manifest);
+    bool knows_file_versions(this const ProjectIndex& self,
+                             const clice::FileTable& files,
+                             const TUManifest& manifest);
 
     /// Install (or replace) a TU's manifest and rederive the affected
     /// contribution entries. Returns the file path_ids whose contribution
     /// set changed — the caller refreshes those shards' live-variant masks.
     llvm::SmallVector<std::uint32_t> apply_manifest(this ProjectIndex& self,
+                                                    const clice::FileTable& files,
                                                     std::uint32_t tu_path_id,
                                                     TUManifest manifest);
 
     /// Drop a TU's manifest and its contribution entries. Returns the
     /// affected file path_ids, like apply_manifest.
     llvm::SmallVector<std::uint32_t> remove_manifest(this ProjectIndex& self,
+                                                     const clice::FileTable& files,
                                                      std::uint32_t tu_path_id);
 
     /// The distinct rows hashes contributed to `path_id` — the file's live
@@ -116,24 +88,27 @@ struct ProjectIndex {
     llvm::SmallVector<std::uint64_t> live_variants(this const ProjectIndex& self,
                                                    std::uint32_t path_id);
 
-    /// Serialize the global blob: the FileVersion table (garbage-collected
-    /// down to the versions some manifest still references, in memory too),
-    /// the symbol table with a self-contained path table, and a per-TU pin
-    /// of every manifest's generation stamp.
+    /// Serialize the global blob: the versions some manifest still
+    /// references (the shared table is not touched — a version the index
+    /// stops referencing can still anchor another consumer's check; ids
+    /// are never reused either way), the symbol table with a
+    /// self-contained path table, and a per-TU pin of every manifest's
+    /// generation stamp.
     void serialize_global(this ProjectIndex& self,
                           llvm::raw_ostream& os,
-                          const clice::FileTable& pool);
+                          const clice::FileTable& files);
 
-    /// Restore the global blob, interning its paths into `pool`. Returns
-    /// false for an unreadable or old-format blob, leaving the index (and
-    /// `pool`) untouched — the caller treats that as "no index on disk"
-    /// and rebuilds in the background. Manifests are loaded separately
-    /// (apply_manifest per blob); `manifest_pins` maps each pinned TU's
-    /// tu_fv to the generation stamp its manifest must carry to be
-    /// adopted.
+    /// Restore the global blob, interning its paths and file versions
+    /// (id-for-id, which is why it must run before anything else interns a
+    /// version) into `files`. Returns false for an unreadable or
+    /// old-format blob, leaving the index (and `files`) untouched — the
+    /// caller treats that as "no index on disk" and rebuilds in the
+    /// background. Manifests are loaded separately (apply_manifest per
+    /// blob); `manifest_pins` maps each pinned TU's tu_fv to the
+    /// generation stamp its manifest must carry to be adopted.
     bool load_global(this ProjectIndex& self,
                      llvm::StringRef data,
-                     clice::FileTable& pool,
+                     clice::FileTable& files,
                      llvm::DenseMap<std::uint32_t, std::uint64_t>& manifest_pins);
 };
 

--- a/src/index/serialization.h
+++ b/src/index/serialization.h
@@ -105,7 +105,9 @@ namespace clice::index {
 /// silently stop matching newly computed ones), or when the meaning of
 /// stored data changes (v9: preamble document links are document-ordered;
 /// v10: an include location's `include` names the directive's containing
-/// file, not that file's includer).
+/// file, not that file's includer; v11: file-version stamps are the file
+/// table's corroborated shared stamps, adopted verbatim at load, and the
+/// artifact metadata blobs joined the database).
 constexpr inline std::uint32_t index_format_version = 11;
 
 /// Serialize a reflected index blob to `os` as a verified-readable

--- a/src/index/serialization.h
+++ b/src/index/serialization.h
@@ -106,7 +106,7 @@ namespace clice::index {
 /// stored data changes (v9: preamble document links are document-ordered;
 /// v10: an include location's `include` names the directive's containing
 /// file, not that file's includer).
-constexpr inline std::uint32_t index_format_version = 10;
+constexpr inline std::uint32_t index_format_version = 11;
 
 /// Serialize a reflected index blob to `os` as a verified-readable
 /// flatbuffer. Encoding only fails on structural impossibilities (e.g. more

--- a/src/index/shard.cpp
+++ b/src/index/shard.cpp
@@ -603,7 +603,11 @@ bool Shard::ascii() const {
 }
 
 bool Shard::matches_content(llvm::StringRef text) const {
-    return loaded() && text.size() == content_size() && llvm::xxh3_64bits(text) == content_hash();
+    return matches_content(text.size(), llvm::xxh3_64bits(text));
+}
+
+bool Shard::matches_content(std::uint64_t size, std::uint64_t hash) const {
+    return loaded() && size == content_size() && hash == content_hash();
 }
 
 std::vector<RowsHash> Shard::variants() const {

--- a/src/index/shard.h
+++ b/src/index/shard.h
@@ -87,6 +87,10 @@ public:
     /// hash, so it works for ASCII blobs, whose text is not stored.
     bool matches_content(llvm::StringRef text) const;
 
+    /// The same comparison for a caller that already holds the disk
+    /// content's size and hash (a FileTable observation) — no read.
+    bool matches_content(std::uint64_t size, std::uint64_t hash) const;
+
     /// All variant identities stored in the blob, in mask-bit order. A
     /// worker-emitted blob holds one anonymous variant identified by its
     /// own byte hash.

--- a/src/sched/batch.cpp
+++ b/src/sched/batch.cpp
@@ -39,7 +39,7 @@ struct BatchStack {
     ContextResolver contexts{workspace};
     TaskGraph graph;
     PCMFamily pcm{graph, workspace, contexts, pool};
-    IndexStore store{loop, workspace};
+    IndexStore store{loop, workspace, contexts};
     TURunFamily turun{graph, workspace, contexts, pcm, store, pool};
     IndexPump pump{loop, workspace, turun, store, pool};
 
@@ -103,7 +103,6 @@ kota::task<> shutdown(BatchStack& stack) {
     if(report.snapshot_stale) {
         stack.pump.claim_report(co_await stack.store.save(stack.pump.save_debt()));
     }
-    stack.workspace.save_cache(stack.contexts);
     co_await stack.pool.stop();
     if(stack.workspace.store) {
         stack.workspace.store->shutdown();

--- a/src/sched/batch.cpp
+++ b/src/sched/batch.cpp
@@ -244,7 +244,7 @@ using FindingsSink =
 
 kota::task<> lint_one(BatchStack& stack,
                       bool with_index,
-                      std::uint32_t path_id,
+                      Fid path_id,
                       LintSweep& sweep,
                       FindingsSink on_findings) {
     auto file = stack.workspace.file_table.resolve(path_id);
@@ -304,7 +304,7 @@ kota::task<> lint_one(BatchStack& stack,
 
 kota::task<> run_lint_sweep(BatchStack& stack,
                             const BatchLintOptions& options,
-                            llvm::ArrayRef<std::uint32_t> tus,
+                            llvm::ArrayRef<Fid> tus,
                             LintSweep& sweep,
                             FindingsSink on_findings) {
     kota::task_group<> workers(stack.loop);
@@ -314,7 +314,7 @@ kota::task<> run_lint_sweep(BatchStack& stack,
     // task unwinds before the group is destroyed.
     auto feeder = [](BatchStack& stack,
                      const BatchLintOptions& options,
-                     llvm::ArrayRef<std::uint32_t> tus,
+                     llvm::ArrayRef<Fid> tus,
                      LintSweep& sweep,
                      FindingsSink on_findings,
                      kota::task_group<>& workers) -> kota::task<> {
@@ -377,8 +377,8 @@ kota::task<> run_lint(BatchStack& stack,
 
     // One run per file: a file with several CDB entries lints once, under
     // the command resolve_command picks — same as the indexing sweep.
-    llvm::SmallVector<std::uint32_t> tus;
-    llvm::DenseSet<std::uint32_t> seen;
+    llvm::SmallVector<Fid> tus;
+    llvm::DenseSet<Fid> seen;
     for(auto& entry: workspace.cdb.entries()) {
         if(seen.insert(entry.file).second) {
             tus.push_back(entry.file);

--- a/src/sched/batch.cpp
+++ b/src/sched/batch.cpp
@@ -248,7 +248,7 @@ kota::task<> lint_one(BatchStack& stack,
                       std::uint32_t path_id,
                       LintSweep& sweep,
                       FindingsSink on_findings) {
-    auto file = stack.workspace.path_pool.resolve(path_id);
+    auto file = stack.workspace.file_table.resolve(path_id);
     TURunFamily::Plan plan;
     plan.tidy = true;
     plan.index = with_index;

--- a/src/sched/batch.cpp
+++ b/src/sched/batch.cpp
@@ -214,7 +214,7 @@ kota::task<> run(BatchStack& stack, const BatchOptions& options, BatchResult& re
     }
 
     result.completed = true;
-    result.indexed_tus = workspace.project_index.manifests.size();
+    result.indexed_tus = stack.pump.indexed_files();
     result.shard_count = workspace.shards.size();
     for(auto& shard: llvm::make_second_range(workspace.shards)) {
         result.shard_bytes += shard.bytes().size();

--- a/src/sched/bootstrap.cpp
+++ b/src/sched/bootstrap.cpp
@@ -46,13 +46,13 @@ BootstrapReport bootstrap_workspace(Workspace& workspace,
             cache->register_namespace(
                 {.name = "header_context", .extension = ".h", .policy = CachePolicy::Scratch});
             workspace.store.emplace(std::move(*cache));
-            // A read-only bootstrap never opens the index database: it
-            // would hold the writer lock for the process lifetime while
-            // committing nothing, starving a concurrent server or index
-            // run. The store's entry points all tolerate its absence.
-            if(!read_only_index) {
-                workspace.index_db = index::open_database(*workspace.store, cfg.index_db);
-            }
+            // A read-only bootstrap opens the index database read-only:
+            // no writer lock (a concurrent server or index run keeps
+            // owning it), while the persisted version stamps and artifact
+            // metadata still seed this session's fast paths. Its own
+            // metadata stays in memory and exits with it.
+            workspace.index_db =
+                index::open_database(*workspace.store, cfg.index_db, read_only_index);
             LOG_INFO("Cache store: {}", workspace.store->base_dir());
             report.opened_store = true;
         }
@@ -65,9 +65,6 @@ BootstrapReport bootstrap_workspace(Workspace& workspace,
         // database generated later (picked up by the CDB poll) starts from
         // the previous session's index.
         pump.claim_report(store.load(read_only_index).report);
-        // After the index load: the global blob restores file versions
-        // id-for-id, so it must run before cache.json interns any.
-        workspace.load_cache(contexts);
         return report;
     }
 
@@ -113,9 +110,6 @@ BootstrapReport bootstrap_workspace(Workspace& workspace,
 
     workspace.build_module_map();
     pump.claim_report(store.load(read_only_index).report);
-    // After the index load: the global blob restores file versions
-    // id-for-id, so it must run before cache.json interns any.
-    workspace.load_cache(contexts);
 
     if(cfg.enable_indexing.value) {
         for(auto& entry: workspace.cdb.entries()) {

--- a/src/sched/bootstrap.cpp
+++ b/src/sched/bootstrap.cpp
@@ -54,8 +54,6 @@ BootstrapReport bootstrap_workspace(Workspace& workspace,
                 workspace.index_db = index::open_database(*workspace.store, cfg.index_db);
             }
             LOG_INFO("Cache store: {}", workspace.store->base_dir());
-
-            workspace.load_cache(contexts);
             report.opened_store = true;
         }
     }
@@ -67,6 +65,9 @@ BootstrapReport bootstrap_workspace(Workspace& workspace,
         // database generated later (picked up by the CDB poll) starts from
         // the previous session's index.
         pump.claim_report(store.load(read_only_index).report);
+        // After the index load: the global blob restores file versions
+        // id-for-id, so it must run before cache.json interns any.
+        workspace.load_cache(contexts);
         return report;
     }
 
@@ -112,6 +113,9 @@ BootstrapReport bootstrap_workspace(Workspace& workspace,
 
     workspace.build_module_map();
     pump.claim_report(store.load(read_only_index).report);
+    // After the index load: the global blob restores file versions
+    // id-for-id, so it must run before cache.json interns any.
+    workspace.load_cache(contexts);
 
     if(cfg.enable_indexing.value) {
         for(auto& entry: workspace.cdb.entries()) {

--- a/src/sched/bootstrap.cpp
+++ b/src/sched/bootstrap.cpp
@@ -9,6 +9,7 @@
 #include "sched/index/store.h"
 #include "sched/workspace.h"
 #include "support/cache_store.h"
+#include "support/filesystem.h"
 #include "support/logging.h"
 #include "support/timer.h"
 #include "syntax/dependency_graph.h"
@@ -38,11 +39,13 @@ BootstrapReport bootstrap_workspace(Workspace& workspace,
                                        .extension = ".pch",
                                        .aux_extension = ".pch.idx",
                                        .policy = CachePolicy::LRU,
-                                       .max_bytes = 8 * GiB});
+                                       .max_bytes = 8 * GiB,
+                                       .deferred_metadata = true});
             cache->register_namespace({.name = "pcm",
                                        .extension = ".pcm",
                                        .policy = CachePolicy::LRU,
-                                       .max_bytes = 8 * GiB});
+                                       .max_bytes = 8 * GiB,
+                                       .deferred_metadata = true});
             cache->register_namespace(
                 {.name = "header_context", .extension = ".h", .policy = CachePolicy::Scratch});
             workspace.store.emplace(std::move(*cache));
@@ -53,6 +56,12 @@ BootstrapReport bootstrap_workspace(Workspace& workspace,
             // metadata stays in memory and exits with it.
             workspace.index_db =
                 index::open_database(*workspace.store, cfg.index_db, read_only_index);
+            if(!read_only_index) {
+                // The artifact metadata moved into the index database; a
+                // cache.json left in the store by an older clice would sit
+                // there forever.
+                fs::remove(path::join(workspace.store->base_dir(), "cache.json"));
+            }
             LOG_INFO("Cache store: {}", workspace.store->base_dir());
             report.opened_store = true;
         }

--- a/src/sched/bootstrap.cpp
+++ b/src/sched/bootstrap.cpp
@@ -75,7 +75,6 @@ BootstrapReport bootstrap_workspace(Workspace& workspace,
 
     auto scan = scan_dependency_graph(workspace.cdb,
                                       workspace.dep_graph,
-                                      /*cache=*/nullptr,
                                       [&workspace](llvm::StringRef path,
                                                    std::vector<std::string>& append,
                                                    std::vector<std::string>& remove) {

--- a/src/sched/bootstrap.cpp
+++ b/src/sched/bootstrap.cpp
@@ -26,10 +26,7 @@ BootstrapReport bootstrap_workspace(Workspace& workspace,
     auto& cfg = workspace.config.project;
 
     if(!workspace.store && !cfg.cache_dir.empty()) {
-        auto cache = CacheStore::open(cfg.cache_dir,
-                                      cache_format_version,
-                                      /*read_only=*/false,
-                                      /*adopt_writer_debt=*/!read_only_index);
+        auto cache = CacheStore::open(cfg.cache_dir, cache_format_version);
         if(!cache) {
             LOG_WARN("Failed to open cache store at {}: {}",
                      std::string_view(cfg.cache_dir),
@@ -42,13 +39,11 @@ BootstrapReport bootstrap_workspace(Workspace& workspace,
                                        .extension = ".pch",
                                        .aux_extension = ".pch.idx",
                                        .policy = CachePolicy::LRU,
-                                       .max_bytes = 8 * GiB,
-                                       .deferred_metadata = true});
+                                       .max_bytes = 8 * GiB});
             cache->register_namespace({.name = "pcm",
                                        .extension = ".pcm",
                                        .policy = CachePolicy::LRU,
-                                       .max_bytes = 8 * GiB,
-                                       .deferred_metadata = true});
+                                       .max_bytes = 8 * GiB});
             cache->register_namespace(
                 {.name = "header_context", .extension = ".h", .policy = CachePolicy::Scratch});
             workspace.store.emplace(std::move(*cache));

--- a/src/sched/bootstrap.cpp
+++ b/src/sched/bootstrap.cpp
@@ -26,7 +26,10 @@ BootstrapReport bootstrap_workspace(Workspace& workspace,
     auto& cfg = workspace.config.project;
 
     if(!workspace.store && !cfg.cache_dir.empty()) {
-        auto cache = CacheStore::open(cfg.cache_dir, cache_format_version);
+        auto cache = CacheStore::open(cfg.cache_dir,
+                                      cache_format_version,
+                                      /*read_only=*/false,
+                                      /*adopt_writer_debt=*/!read_only_index);
         if(!cache) {
             LOG_WARN("Failed to open cache store at {}: {}",
                      std::string_view(cfg.cache_dir),

--- a/src/sched/bootstrap.cpp
+++ b/src/sched/bootstrap.cpp
@@ -52,8 +52,7 @@ BootstrapReport bootstrap_workspace(Workspace& workspace,
             // owning it), while the persisted version stamps and artifact
             // metadata still seed this session's fast paths. Its own
             // metadata stays in memory and exits with it.
-            workspace.index_db =
-                index::open_database(*workspace.store, cfg.index_db, read_only_index);
+            workspace.index_db = index::open_database(*workspace.store, read_only_index);
             if(!read_only_index) {
                 // The artifact metadata moved into the index database; a
                 // cache.json left in the store by an older clice would sit

--- a/src/sched/bootstrap.h
+++ b/src/sched/bootstrap.h
@@ -26,7 +26,7 @@ struct BootstrapReport {
 
 /// The one workspace loading sequence, shared by the server's initialize
 /// and the batch driver so the two can never drift apart: open the cache
-/// store and register its namespaces, load cache.json, discover and load
+/// store and register its namespaces, discover and load
 /// the CDB, scan the dependency graph and build the module map, restore
 /// the persisted index (claiming its report into the pump), and seed the
 /// indexing sweep. The caller has already finalized workspace.config; a

--- a/src/sched/context.cpp
+++ b/src/sched/context.cpp
@@ -79,7 +79,7 @@ static ConfigID pick_host_config(Workspace& workspace,
     return candidates.front().config;
 }
 
-HeaderMode ContextResolver::header_mode(llvm::StringRef path, std::uint32_t path_id) const {
+HeaderMode ContextResolver::header_mode(llvm::StringRef path, Fid path_id) const {
     // Keep in sync with the client's C++ fragment detection
     // (editors/vscode/src/feature/context.ts).
     if(path.ends_with(".def") || path.ends_with(".inc") || path.ends_with(".inl") ||
@@ -92,23 +92,21 @@ HeaderMode ContextResolver::header_mode(llvm::StringRef path, std::uint32_t path
     return HeaderMode::Unknown;
 }
 
-void ContextResolver::forget_self_contained(std::uint32_t path_id) {
+void ContextResolver::forget_self_contained(Fid path_id) {
     if(auto it = header_modes.find(path_id);
        it != header_modes.end() && it->second == HeaderMode::SelfContained) {
         header_modes.erase(it);
     }
 }
 
-std::uint64_t ContextResolver::persisted_mode_hash(std::uint32_t path_id) const {
+std::uint64_t ContextResolver::persisted_mode_hash(Fid path_id) const {
     if(header_modes.lookup(path_id) != HeaderMode::NeedsContext) {
         return 0;
     }
     return header_mode_hashes.lookup(path_id);
 }
 
-void ContextResolver::record_header_mode(std::uint32_t path_id,
-                                         HeaderMode mode,
-                                         std::uint64_t content_hash) {
+void ContextResolver::record_header_mode(Fid path_id, HeaderMode mode, std::uint64_t content_hash) {
     auto persisted = persisted_mode_hash(path_id);
     header_modes[path_id] = mode;
     if(mode == HeaderMode::NeedsContext) {
@@ -119,7 +117,7 @@ void ContextResolver::record_header_mode(std::uint32_t path_id,
     }
 }
 
-void ContextResolver::reset_header_mode(std::uint32_t path_id) {
+void ContextResolver::reset_header_mode(Fid path_id) {
     if(persisted_mode_hash(path_id) != 0) {
         workspace.mark_artifacts_dirty();
     }
@@ -127,9 +125,8 @@ void ContextResolver::reset_header_mode(std::uint32_t path_id) {
     header_mode_hashes.erase(path_id);
 }
 
-void ContextResolver::dump_mode_slices(
-    std::vector<CacheModeEntry>& modes,
-    llvm::function_ref<std::uint32_t(std::uint32_t)> intern_id) const {
+void ContextResolver::dump_mode_slices(std::vector<CacheModeEntry>& modes,
+                                       llvm::function_ref<std::uint32_t(Fid)> intern_id) const {
     for(auto& [path_id, mode]: header_modes) {
         if(mode != HeaderMode::NeedsContext)
             continue;
@@ -147,7 +144,7 @@ void ContextResolver::dump_mode_slices(
 void ContextResolver::dump_choice_slices(
     std::vector<CacheContextEntry>& contexts,
     std::vector<CacheArtifactEntry>& artifacts,
-    llvm::function_ref<std::uint32_t(std::uint32_t)> intern_id,
+    llvm::function_ref<std::uint32_t(Fid)> intern_id,
     llvm::function_ref<std::uint32_t(llvm::StringRef)> intern_path) const {
     for(auto& entry: synthesized_hosts) {
         artifacts.push_back({intern_path(entry.getKey()), intern_id(entry.second)});
@@ -156,7 +153,7 @@ void ContextResolver::dump_choice_slices(
     for(auto& [path_id, saved]: saved_contexts) {
         CacheContextEntry entry;
         entry.file = intern_id(path_id);
-        entry.host = saved.host_path_id != no_path_id ? intern_id(saved.host_path_id) : ~0u;
+        entry.host = saved.host_path_id.valid() ? intern_id(saved.host_path_id) : ~0u;
         entry.occurrence = saved.occurrence.value_or(~0u);
         entry.command_hash = saved.command_hash;
         entry.base_hash = saved.base_hash;
@@ -217,11 +214,11 @@ void ContextResolver::load_choice_slices(
 }
 
 bool ContextResolver::fill_header_context_args(llvm::StringRef path,
-                                               std::uint32_t path_id,
+                                               Fid path_id,
                                                std::string& directory,
                                                std::vector<std::string>& arguments,
                                                ContextUse use,
-                                               std::uint32_t* host_path_id,
+                                               Fid* host_path_id,
                                                CommandRef* out_ref) {
     // Opening one of our own synthesized files (prefix/suffix/snapshot):
     // it is a fragment of the host TU it was synthesized for, so compile
@@ -267,7 +264,7 @@ bool ContextResolver::fill_header_context_args(llvm::StringRef path,
     // occurrence — even #0 — only has meaning under includer-context
     // semantics, so it forces synthesis regardless of the verdict.
     const SavedContext* choice = active_choice(use, path_id);
-    bool has_host_choice = choice && choice->host_path_id != no_path_id;
+    bool has_host_choice = choice && choice->host_path_id.valid();
     bool synthesize = header_mode(path, path_id) == HeaderMode::NeedsContext ||
                       (has_host_choice && choice->occurrence.has_value());
 
@@ -286,7 +283,7 @@ bool ContextResolver::fill_header_context_args(llvm::StringRef path,
                                     cached->host_command_hash != choice->command_hash ||
                                     cached->host_base_hash != choice->base_hash);
             bool mode_mismatch = cached->preamble_path.empty() == synthesize;
-            workspace.file_table.begin_wave();
+            auto wave = workspace.file_table.wave();
             if(override_mismatch || mode_mismatch ||
                deps_changed(workspace.file_table, cached->deps)) {
                 drop_header_context(path_id);
@@ -361,7 +358,7 @@ CommandSource ContextResolver::resolve_command(llvm::StringRef path,
                                                std::string& directory,
                                                std::vector<std::string>& arguments,
                                                ContextUse use,
-                                               std::uint32_t* host_path_id,
+                                               Fid* host_path_id,
                                                llvm::ArrayRef<std::string> extra_prepend,
                                                llvm::ArrayRef<std::string> extra_append,
                                                CommandRef* out_ref) {
@@ -388,7 +385,7 @@ CommandSource ContextResolver::resolve_command(llvm::StringRef path,
             // Multi-config projects: honor the user's chosen CDB entry,
             // matched by entry hash so the choice survives CDB reordering.
             const SavedContext* choice = active_choice(use, path_id);
-            if(choice && choice->host_path_id == no_path_id && !choice->command_hash.empty()) {
+            if(choice && !choice->host_path_id.valid() && !choice->command_hash.empty()) {
                 bool base_matched = false;
                 if(!choice->base_hash.empty()) {
                     for(auto& candidate: candidates) {
@@ -421,7 +418,7 @@ CommandSource ContextResolver::resolve_command(llvm::StringRef path,
     };
 
     const SavedContext* choice = active_choice(use, path_id);
-    bool has_host_choice = choice && choice->host_path_id != no_path_id;
+    bool has_host_choice = choice && choice->host_path_id.valid();
 
     // 1. If the file has an active header context via switchContext, use the
     //    host source's CDB entry with file path replaced and preamble injected.
@@ -470,7 +467,7 @@ CommandSource ContextResolver::resolve_command(llvm::StringRef path,
     return CommandSource::Fallback;
 }
 
-void ContextResolver::append_suffix_include(std::uint32_t path_id, std::string& text) {
+void ContextResolver::append_suffix_include(Fid path_id, std::string& text) {
     auto* context = header_context(path_id);
     if(!context || context->suffix_path.empty()) {
         return;
@@ -490,7 +487,7 @@ void ContextResolver::append_suffix_include(std::uint32_t path_id, std::string& 
     text += "\"\n";
 }
 
-std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32_t header_path_id,
+std::optional<HeaderContext> ContextResolver::resolve_header_context(Fid header_path_id,
                                                                      ContextUse use,
                                                                      bool synthesize) {
     // Find source files that transitively include this header.
@@ -502,11 +499,11 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
 
     // If there's an active context override, prefer that host (and its
     // chosen include occurrence).
-    std::uint32_t host_path_id = 0;
+    Fid host_path_id;
     std::optional<std::uint32_t> occurrence;
-    std::vector<std::uint32_t> chain;
+    std::vector<Fid> chain;
     const SavedContext* choice = active_choice(use, header_path_id);
-    bool has_host_choice = choice && choice->host_path_id != no_path_id;
+    bool has_host_choice = choice && choice->host_path_id.valid();
     if(has_host_choice) {
         auto preferred = choice->host_path_id;
         auto preferred_path = workspace.file_table.resolve(preferred);
@@ -552,7 +549,7 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
     }
 
     if(!synthesize) {
-        llvm::SmallVector<std::uint32_t> chain_ids(chain.begin(), chain.end() - 1);
+        llvm::SmallVector<Fid> chain_ids(chain.begin(), chain.end() - 1);
         return HeaderContext{host_path_id,
                              "",
                              0,
@@ -620,7 +617,7 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
     DepsSnapshot deps;
     chain_contents.reserve(chain.size() - 1);
     chain_entries.reserve(chain.size() - 1);
-    deps.deps.reserve(chain.size());
+    deps.reserve(chain.size());
     for(std::size_t i = 0; i + 1 < chain.size(); ++i) {
         auto cur_path = workspace.file_table.resolve(chain[i]);
         auto observed = read_file_observed(cur_path.data());
@@ -631,13 +628,13 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
         chain_contents.emplace_back(observed->content->getBuffer());
         chain_entries.push_back({cur_path, chain_contents.back()});
         workspace.file_table.observe(chain[i], observed->obs);
-        deps.deps.push_back({.path_id = chain[i], .hash = observed->obs.hash});
-        workspace.file_table.try_stamp(
-            workspace.file_table.intern_version(chain[i], observed->obs.hash),
-            observed->obs.size,
-            observed->obs.mtime_ns,
-            observed->obs.uid_device,
-            observed->obs.uid_file);
+        auto vid = workspace.file_table.intern_version(chain[i], observed->obs.hash);
+        deps.push_back({.path_id = chain[i], .version = vid});
+        workspace.file_table.try_stamp(vid,
+                                       observed->obs.size,
+                                       observed->obs.mtime_ns,
+                                       observed->obs.uid_device,
+                                       observed->obs.uid_file);
     }
 
     // Snapshot the header itself for other occurrences along the chain:
@@ -729,17 +726,17 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
     // The chain files' snapshot (`deps`) was recorded as they were read:
     // their content lives inside the synthesized preamble, so clang's own
     // dependency tracking never sees them.
-    llvm::SmallVector<std::uint32_t> chain_ids(chain.begin(), chain.end() - 1);
+    llvm::SmallVector<Fid> chain_ids(chain.begin(), chain.end() - 1);
     if(!self_snapshot_path.empty()) {
         // The self-snapshot mirrors the header's disk state; re-synthesize
         // when it changes so other-occurrence expansions stay current.
-        deps.deps.push_back({.path_id = chain.back(), .hash = target_observed->obs.hash});
-        workspace.file_table.try_stamp(
-            workspace.file_table.intern_version(chain.back(), target_observed->obs.hash),
-            target_observed->obs.size,
-            target_observed->obs.mtime_ns,
-            target_observed->obs.uid_device,
-            target_observed->obs.uid_file);
+        auto vid = workspace.file_table.intern_version(chain.back(), target_observed->obs.hash);
+        deps.push_back({.path_id = chain.back(), .version = vid});
+        workspace.file_table.try_stamp(vid,
+                                       target_observed->obs.size,
+                                       target_observed->obs.mtime_ns,
+                                       target_observed->obs.uid_device,
+                                       target_observed->obs.uid_file);
     }
 
     return HeaderContext{host_path_id,
@@ -770,7 +767,7 @@ bool ContextResolver::pin_alive(llvm::StringRef entry_path, const SavedContext& 
     return false;
 }
 
-void ContextResolver::validate_saved_context(std::uint32_t path_id) {
+void ContextResolver::validate_saved_context(Fid path_id) {
     auto path = workspace.file_table.resolve(path_id);
 
     // A context choice persisted from an earlier session stays authoritative
@@ -782,7 +779,7 @@ void ContextResolver::validate_saved_context(std::uint32_t path_id) {
         auto& saved = it->second;
 
         bool valid = false;
-        if(saved.host_path_id != no_path_id) {
+        if(saved.host_path_id.valid()) {
             auto host_path = ws.file_table.resolve(saved.host_path_id);
             valid = ws.cdb.has_entry(host_path) &&
                     !ws.dep_graph.find_include_chain(saved.host_path_id, path_id).empty() &&

--- a/src/sched/context.cpp
+++ b/src/sched/context.cpp
@@ -156,7 +156,7 @@ void
         // while the server was down must re-earn its trial.
         if(entry.content_hash != 0 && hash_file(file) != entry.content_hash)
             continue;
-        auto id = workspace.path_pool.intern(file);
+        auto id = workspace.file_table.intern(file);
         header_modes[id] = HeaderMode::NeedsContext;
         header_mode_hashes[id] = entry.content_hash;
     }
@@ -170,14 +170,14 @@ void
             auto host = resolve(entry.host);
             if(host.empty())
                 continue;
-            saved.host_path_id = workspace.path_pool.intern(host);
+            saved.host_path_id = workspace.file_table.intern(host);
         }
         if(entry.occurrence != ~0u) {
             saved.occurrence = entry.occurrence;
         }
         saved.command_hash = entry.command_hash;
         saved.base_hash = entry.base_hash;
-        saved_contexts[workspace.path_pool.intern(file)] = std::move(saved);
+        saved_contexts[workspace.file_table.intern(file)] = std::move(saved);
     }
 
     for(auto& entry: artifacts) {
@@ -185,7 +185,7 @@ void
         auto host = resolve(entry.host);
         if(file.empty() || host.empty())
             continue;
-        synthesized_hosts[file] = workspace.path_pool.intern(host);
+        synthesized_hosts[file] = workspace.file_table.intern(host);
     }
 }
 
@@ -207,7 +207,7 @@ bool ContextResolver::fill_header_context_args(llvm::StringRef path,
         if(it == synthesized_hosts.end()) {
             return false;
         }
-        auto host_path = workspace.path_pool.resolve(it->second);
+        auto host_path = workspace.file_table.resolve(it->second);
         auto candidates = workspace.cdb.candidate_entries(host_path);
         if(candidates.empty()) {
             return false;
@@ -260,7 +260,7 @@ bool ContextResolver::fill_header_context_args(llvm::StringRef path,
                                     cached->host_base_hash != choice->base_hash);
             bool mode_mismatch = cached->preamble_path.empty() == synthesize;
             if(override_mismatch || mode_mismatch ||
-               deps_changed(workspace.path_pool, cached->deps)) {
+               deps_changed(workspace.file_table, cached->deps)) {
                 drop_header_context(path_id);
             }
         }
@@ -284,7 +284,7 @@ bool ContextResolver::fill_header_context_args(llvm::StringRef path,
         }
     }
 
-    auto host_path = workspace.path_pool.resolve(ctx_ptr->host_path_id);
+    auto host_path = workspace.file_table.resolve(ctx_ptr->host_path_id);
     auto candidates = workspace.cdb.candidate_entries(host_path);
     if(candidates.empty()) {
         LOG_WARN("fill_header_context_args: host {} has no CDB entry", host_path);
@@ -337,7 +337,7 @@ CommandSource ContextResolver::resolve_command(llvm::StringRef path,
                                                llvm::ArrayRef<std::string> extra_prepend,
                                                llvm::ArrayRef<std::string> extra_append,
                                                CommandRef* out_ref) {
-    auto path_id = workspace.path_pool.intern(path);
+    auto path_id = workspace.file_table.intern(path);
     llvm::SmallVector<llvm::StringRef, 3> tried;
 
     // Fill from the CDB layer with config rules applied (append/remove flags
@@ -481,7 +481,7 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
     bool has_host_choice = choice && choice->host_path_id != no_path_id;
     if(has_host_choice) {
         auto preferred = choice->host_path_id;
-        auto preferred_path = workspace.path_pool.resolve(preferred);
+        auto preferred_path = workspace.file_table.resolve(preferred);
         if(workspace.cdb.has_entry(preferred_path)) {
             auto c = workspace.dep_graph.find_include_chain(preferred, header_path_id);
             if(!c.empty()) {
@@ -496,7 +496,7 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
     // a host with a synthesized command would just be a fallback in disguise.
     if(chain.empty()) {
         for(auto candidate: workspace.rank_hosts(header_path_id, hosts)) {
-            auto candidate_path = workspace.path_pool.resolve(candidate);
+            auto candidate_path = workspace.file_table.resolve(candidate);
             if(!workspace.cdb.has_entry(candidate_path))
                 continue;
             auto c = workspace.dep_graph.find_include_chain(candidate, header_path_id);
@@ -539,7 +539,7 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
     // Include directives along the chain are resolved with the host's real
     // search configuration, so same-named headers in different directories
     // cannot be confused.
-    auto host_path = workspace.path_pool.resolve(host_path_id);
+    auto host_path = workspace.file_table.resolve(host_path_id);
     auto candidates = workspace.cdb.candidate_entries(host_path);
     if(candidates.empty()) {
         return std::nullopt;
@@ -576,7 +576,7 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
         }
         // Normalize through the path pool: resolve_include builds native
         // separators, but chain paths compared against it are pool-normalized.
-        return std::string(workspace.path_pool.resolve(workspace.path_pool.intern(result->path)));
+        return std::string(workspace.file_table.resolve(workspace.file_table.intern(result->path)));
     };
 
     // Read the chain files (all but the target) from disk. The synthesized
@@ -597,7 +597,7 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
     chain_entries.reserve(chain.size() - 1);
     deps.deps.reserve(chain.size());
     for(std::size_t i = 0; i + 1 < chain.size(); ++i) {
-        auto cur_path = workspace.path_pool.resolve(chain[i]);
+        auto cur_path = workspace.file_table.resolve(chain[i]);
         auto buf = llvm::MemoryBuffer::getFile(cur_path);
         if(!buf) {
             LOG_WARN("resolve_header_context: cannot read {}", cur_path);
@@ -623,7 +623,7 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
     // Snapshot the header itself for other occurrences along the chain:
     // its real path is remapped to the open buffer at compile time, so
     // includes of it inside the prefix/suffix must point at a copy.
-    auto target_path = workspace.path_pool.resolve(chain.back());
+    auto target_path = workspace.file_table.resolve(chain.back());
     std::string self_snapshot_path;
     std::uint64_t target_hash = 0;
     llvm::sys::fs::file_status target_status;
@@ -754,7 +754,7 @@ bool ContextResolver::pin_alive(llvm::StringRef entry_path, const SavedContext& 
 }
 
 void ContextResolver::validate_saved_context(std::uint32_t path_id) {
-    auto path = workspace.path_pool.resolve(path_id);
+    auto path = workspace.file_table.resolve(path_id);
 
     // A context choice persisted from an earlier session stays authoritative
     // only if it still holds: the CDB or include graph may have changed
@@ -766,7 +766,7 @@ void ContextResolver::validate_saved_context(std::uint32_t path_id) {
 
         bool valid = false;
         if(saved.host_path_id != no_path_id) {
-            auto host_path = ws.path_pool.resolve(saved.host_path_id);
+            auto host_path = ws.file_table.resolve(saved.host_path_id);
             valid = ws.cdb.has_entry(host_path) &&
                     !ws.dep_graph.find_include_chain(saved.host_path_id, path_id).empty() &&
                     (saved.command_hash.empty() || pin_alive(host_path, saved));

--- a/src/sched/context.cpp
+++ b/src/sched/context.cpp
@@ -152,11 +152,14 @@ void
         auto file = resolve(entry.file);
         if(file.empty() || static_cast<HeaderMode>(entry.mode) != HeaderMode::NeedsContext)
             continue;
+        auto id = workspace.file_table.intern(file);
         // The verdict is tied to the header's contents — a file edited
         // while the server was down must re-earn its trial.
-        if(entry.content_hash != 0 && hash_file(file) != entry.content_hash)
-            continue;
-        auto id = workspace.file_table.intern(file);
+        if(entry.content_hash != 0) {
+            auto disk = workspace.file_table.current(id);
+            if(!disk || disk->hash != entry.content_hash)
+                continue;
+        }
         header_modes[id] = HeaderMode::NeedsContext;
         header_mode_hashes[id] = entry.content_hash;
     }
@@ -259,6 +262,7 @@ bool ContextResolver::fill_header_context_args(llvm::StringRef path,
                                     cached->host_command_hash != choice->command_hash ||
                                     cached->host_base_hash != choice->base_hash);
             bool mode_mismatch = cached->preamble_path.empty() == synthesize;
+            workspace.file_table.begin_wave();
             if(override_mismatch || mode_mismatch ||
                deps_changed(workspace.file_table, cached->deps)) {
                 drop_header_context(path_id);
@@ -581,15 +585,11 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
 
     // Read the chain files (all but the target) from disk. The synthesized
     // preamble deliberately reflects disk state, never open-document buffers:
-    // open files must not be depended upon by other files. Each file is
-    // stat'ed AFTER it is read, and only a stat older than the mtime guard
-    // becomes a fast path: a write racing the read stamps an mtime inside
-    // the guard, so such a file keeps only its hash and the next check
-    // compares the disk against the embedded bytes.
-    auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                      std::chrono::system_clock::now().time_since_epoch())
-                      .count();
-    auto baseline_before_ns = fs::stat_baseline_before_ns(now_ms);
+    // open files must not be depended upon by other files. The hash covers
+    // the bytes just read — the bytes the synthesized preamble embeds —
+    // and the paired stat becomes the version's fast path only when the
+    // read proved it reliable (see read_file_observed); otherwise the next
+    // check compares the disk against the embedded bytes.
     std::vector<std::string> chain_contents;
     llvm::SmallVector<ChainEntry> chain_entries;
     DepsSnapshot deps;
@@ -598,26 +598,19 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
     deps.deps.reserve(chain.size());
     for(std::size_t i = 0; i + 1 < chain.size(); ++i) {
         auto cur_path = workspace.file_table.resolve(chain[i]);
-        auto buf = llvm::MemoryBuffer::getFile(cur_path);
-        if(!buf) {
+        auto observed = read_file_observed(cur_path.data());
+        if(!observed) {
             LOG_WARN("resolve_header_context: cannot read {}", cur_path);
             return std::nullopt;
         }
-        chain_contents.emplace_back((*buf)->getBuffer());
+        chain_contents.emplace_back(observed->content->getBuffer());
         chain_entries.push_back({cur_path, chain_contents.back()});
-        llvm::sys::fs::file_status status;
-        if(llvm::sys::fs::status(cur_path, status)) {
-            LOG_WARN("resolve_header_context: cannot stat {}", cur_path);
-            return std::nullopt;
-        }
-        // The hash covers the buffer just read — the bytes the synthesized
-        // preamble embeds — never a re-read that could be newer.
-        auto mtime_ns = fs::mtime_ns(status);
-        bool untouched = mtime_ns <= baseline_before_ns;
-        deps.deps.push_back({.path_id = chain[i],
-                             .size = untouched ? status.getSize() : 0,
-                             .mtime_ns = untouched ? mtime_ns : 0,
-                             .hash = llvm::xxh3_64bits(chain_contents.back())});
+        workspace.file_table.observe(chain[i], observed->obs);
+        deps.deps.push_back({.path_id = chain[i], .hash = observed->obs.hash});
+        workspace.file_table.try_stamp(
+            workspace.file_table.intern_version(chain[i], observed->obs.hash),
+            observed->obs.size,
+            observed->obs.mtime_ns);
     }
 
     // Snapshot the header itself for other occurrences along the chain:
@@ -625,16 +618,13 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
     // includes of it inside the prefix/suffix must point at a copy.
     auto target_path = workspace.file_table.resolve(chain.back());
     std::string self_snapshot_path;
-    std::uint64_t target_hash = 0;
-    llvm::sys::fs::file_status target_status;
-    bool target_stat_ok = false;
+    std::optional<ObservedFile> target_observed;
     auto preamble_dir = path::join(workspace.config.project.cache_dir, "header_context");
-    if(auto target_buf = llvm::MemoryBuffer::getFile(target_path)) {
-        auto content = (*target_buf)->getBuffer();
-        target_hash = llvm::xxh3_64bits(content);
-        // Stat after the read, same discipline as the chain files above.
-        target_stat_ok = !llvm::sys::fs::status(target_path, target_status);
-        self_snapshot_path = path::join(preamble_dir, std::format("{:016x}.self.h", target_hash));
+    if((target_observed = read_file_observed(target_path.data()))) {
+        auto content = target_observed->content->getBuffer();
+        workspace.file_table.observe(chain.back(), target_observed->obs);
+        self_snapshot_path =
+            path::join(preamble_dir, std::format("{:016x}.self.h", target_observed->obs.hash));
         if(!llvm::sys::fs::exists(self_snapshot_path)) {
             auto ec = llvm::sys::fs::create_directories(preamble_dir);
             if(ec) {
@@ -715,14 +705,12 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
     llvm::SmallVector<std::uint32_t> chain_ids(chain.begin(), chain.end() - 1);
     if(!self_snapshot_path.empty()) {
         // The self-snapshot mirrors the header's disk state; re-synthesize
-        // when it changes so other-occurrence expansions stay current. A
-        // failed or too-recent stat leaves no fast path — the next check
-        // goes by hash.
-        bool target_untouched = target_stat_ok && fs::mtime_ns(target_status) <= baseline_before_ns;
-        deps.deps.push_back({.path_id = chain.back(),
-                             .size = target_untouched ? target_status.getSize() : 0,
-                             .mtime_ns = target_untouched ? fs::mtime_ns(target_status) : 0,
-                             .hash = target_hash});
+        // when it changes so other-occurrence expansions stay current.
+        deps.deps.push_back({.path_id = chain.back(), .hash = target_observed->obs.hash});
+        workspace.file_table.try_stamp(
+            workspace.file_table.intern_version(chain.back(), target_observed->obs.hash),
+            target_observed->obs.size,
+            target_observed->obs.mtime_ns);
     }
 
     return HeaderContext{host_path_id,

--- a/src/sched/context.cpp
+++ b/src/sched/context.cpp
@@ -146,7 +146,7 @@ void ContextResolver::dump_choice_slices(
     }
 }
 
-void ContextResolver::load_mode_slices(const std::vector<CacheModeEntry>& modes,
+void ContextResolver::load_mode_slices(llvm::ArrayRef<CacheModeEntry> modes,
                                        llvm::function_ref<llvm::StringRef(std::uint32_t)> resolve) {
     for(auto& entry: modes) {
         auto file = resolve(entry.file);
@@ -166,8 +166,8 @@ void ContextResolver::load_mode_slices(const std::vector<CacheModeEntry>& modes,
 }
 
 void ContextResolver::load_choice_slices(
-    const std::vector<CacheContextEntry>& contexts,
-    const std::vector<CacheArtifactEntry>& artifacts,
+    llvm::ArrayRef<CacheContextEntry> contexts,
+    llvm::ArrayRef<CacheArtifactEntry> artifacts,
     llvm::function_ref<llvm::StringRef(std::uint32_t)> resolve) {
     for(auto& entry: contexts) {
         auto file = resolve(entry.file);
@@ -584,8 +584,8 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
         if(!result) {
             return std::nullopt;
         }
-        // Normalize through the path pool: resolve_include builds native
-        // separators, but chain paths compared against it are pool-normalized.
+        // Normalize through the file table: resolve_include builds native
+        // separators, but chain paths compared against it are table-normalized.
         return std::string(workspace.file_table.resolve(workspace.file_table.intern(result->path)));
     };
 
@@ -616,7 +616,9 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
         workspace.file_table.try_stamp(
             workspace.file_table.intern_version(chain[i], observed->obs.hash),
             observed->obs.size,
-            observed->obs.mtime_ns);
+            observed->obs.mtime_ns,
+            observed->obs.uid_device,
+            observed->obs.uid_file);
     }
 
     // Snapshot the header itself for other occurrences along the chain:
@@ -716,7 +718,9 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
         workspace.file_table.try_stamp(
             workspace.file_table.intern_version(chain.back(), target_observed->obs.hash),
             target_observed->obs.size,
-            target_observed->obs.mtime_ns);
+            target_observed->obs.mtime_ns,
+            target_observed->obs.uid_device,
+            target_observed->obs.uid_file);
     }
 
     return HeaderContext{host_path_id,

--- a/src/sched/context.cpp
+++ b/src/sched/context.cpp
@@ -113,12 +113,9 @@ void ContextResolver::reset_header_mode(std::uint32_t path_id) {
     header_mode_hashes.erase(path_id);
 }
 
-void ContextResolver::dump_cache_slices(
+void ContextResolver::dump_mode_slices(
     std::vector<CacheModeEntry>& modes,
-    std::vector<CacheContextEntry>& contexts,
-    std::vector<CacheArtifactEntry>& artifacts,
-    llvm::function_ref<std::uint32_t(std::uint32_t)> intern_id,
-    llvm::function_ref<std::uint32_t(llvm::StringRef)> intern_path) const {
+    llvm::function_ref<std::uint32_t(std::uint32_t)> intern_id) const {
     for(auto& [path_id, mode]: header_modes) {
         if(mode != HeaderMode::NeedsContext)
             continue;
@@ -127,7 +124,13 @@ void ContextResolver::dump_cache_slices(
                          static_cast<std::uint32_t>(mode),
                          hash_it != header_mode_hashes.end() ? hash_it->second : 0});
     }
+}
 
+void ContextResolver::dump_choice_slices(
+    std::vector<CacheContextEntry>& contexts,
+    std::vector<CacheArtifactEntry>& artifacts,
+    llvm::function_ref<std::uint32_t(std::uint32_t)> intern_id,
+    llvm::function_ref<std::uint32_t(llvm::StringRef)> intern_path) const {
     for(auto& entry: synthesized_hosts) {
         artifacts.push_back({intern_path(entry.getKey()), intern_id(entry.second)});
     }
@@ -143,11 +146,9 @@ void ContextResolver::dump_cache_slices(
     }
 }
 
-void
-    ContextResolver::load_cache_slices(const std::vector<CacheModeEntry>& modes,
-                                       const std::vector<CacheContextEntry>& contexts,
-                                       const std::vector<CacheArtifactEntry>& artifacts,
-                                       llvm::function_ref<llvm::StringRef(std::uint32_t)> resolve) {
+void ContextResolver::load_mode_slices(
+    const std::vector<CacheModeEntry>& modes,
+    llvm::function_ref<llvm::StringRef(std::uint32_t)> resolve) {
     for(auto& entry: modes) {
         auto file = resolve(entry.file);
         if(file.empty() || static_cast<HeaderMode>(entry.mode) != HeaderMode::NeedsContext)
@@ -163,7 +164,12 @@ void
         header_modes[id] = HeaderMode::NeedsContext;
         header_mode_hashes[id] = entry.content_hash;
     }
+}
 
+void ContextResolver::load_choice_slices(
+    const std::vector<CacheContextEntry>& contexts,
+    const std::vector<CacheArtifactEntry>& artifacts,
+    llvm::function_ref<llvm::StringRef(std::uint32_t)> resolve) {
     for(auto& entry: contexts) {
         auto file = resolve(entry.file);
         if(file.empty())

--- a/src/sched/context.cpp
+++ b/src/sched/context.cpp
@@ -213,6 +213,15 @@ void ContextResolver::load_choice_slices(
     }
 }
 
+void ContextResolver::record_synthesized_host(llvm::StringRef path, Fid host_path_id) {
+    auto [it, inserted] = synthesized_hosts.try_emplace(path, host_path_id);
+    if(!inserted && it->second == host_path_id) {
+        return;
+    }
+    it->second = host_path_id;
+    workspace.mark_contexts_dirty();
+}
+
 bool ContextResolver::fill_header_context_args(llvm::StringRef path,
                                                Fid path_id,
                                                std::string& directory,
@@ -667,7 +676,7 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(Fid header_
     }
 
     if(!self_snapshot_path.empty()) {
-        synthesized_hosts[self_snapshot_path] = host_path_id;
+        record_synthesized_host(self_snapshot_path, host_path_id);
     }
 
     auto synthesized =
@@ -703,7 +712,7 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(Fid header_
                  preamble_path,
                  header_path_id);
     }
-    synthesized_hosts[preamble_path] = host_path_id;
+    record_synthesized_host(preamble_path, host_path_id);
 
     // The suffix restores everything after the include position (closing
     // braces of enums/functions the fragment is embedded in). Injected by
@@ -720,7 +729,7 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(Fid header_
                 return std::nullopt;
             }
         }
-        synthesized_hosts[suffix_path] = host_path_id;
+        record_synthesized_host(suffix_path, host_path_id);
     }
 
     // The chain files' snapshot (`deps`) was recorded as they were read:
@@ -790,6 +799,9 @@ void ContextResolver::validate_saved_context(Fid path_id) {
         if(!valid) {
             LOG_INFO("didOpen: dropping stale saved context for {}", path);
             saved_contexts.erase(it);
+            // The drop must reach the contexts blob, or the stale choice
+            // resurrects from disk at the next start.
+            workspace.mark_contexts_dirty();
         }
     }
 }

--- a/src/sched/context.cpp
+++ b/src/sched/context.cpp
@@ -99,16 +99,30 @@ void ContextResolver::forget_self_contained(std::uint32_t path_id) {
     }
 }
 
+std::uint64_t ContextResolver::persisted_mode_hash(std::uint32_t path_id) const {
+    if(header_modes.lookup(path_id) != HeaderMode::NeedsContext) {
+        return 0;
+    }
+    return header_mode_hashes.lookup(path_id);
+}
+
 void ContextResolver::record_header_mode(std::uint32_t path_id,
                                          HeaderMode mode,
                                          std::uint64_t content_hash) {
+    auto persisted = persisted_mode_hash(path_id);
     header_modes[path_id] = mode;
     if(mode == HeaderMode::NeedsContext) {
         header_mode_hashes[path_id] = content_hash;
     }
+    if(persisted_mode_hash(path_id) != persisted) {
+        workspace.mark_artifacts_dirty();
+    }
 }
 
 void ContextResolver::reset_header_mode(std::uint32_t path_id) {
+    if(persisted_mode_hash(path_id) != 0) {
+        workspace.mark_artifacts_dirty();
+    }
     header_modes.erase(path_id);
     header_mode_hashes.erase(path_id);
 }
@@ -119,10 +133,14 @@ void ContextResolver::dump_mode_slices(
     for(auto& [path_id, mode]: header_modes) {
         if(mode != HeaderMode::NeedsContext)
             continue;
-        auto hash_it = header_mode_hashes.find(path_id);
-        modes.push_back({intern_id(path_id),
-                         static_cast<std::uint32_t>(mode),
-                         hash_it != header_mode_hashes.end() ? hash_it->second : 0});
+        // A verdict scored with no disk observation (hash 0) cannot be
+        // validated on load, so it stays in memory: persisted, it would
+        // skip the self-containment trial for whatever bytes the next
+        // session finds on disk.
+        auto hash = header_mode_hashes.lookup(path_id);
+        if(hash == 0)
+            continue;
+        modes.push_back({intern_id(path_id), static_cast<std::uint32_t>(mode), hash});
     }
 }
 
@@ -150,16 +168,17 @@ void ContextResolver::load_mode_slices(llvm::ArrayRef<CacheModeEntry> modes,
                                        llvm::function_ref<llvm::StringRef(std::uint32_t)> resolve) {
     for(auto& entry: modes) {
         auto file = resolve(entry.file);
-        if(file.empty() || static_cast<HeaderMode>(entry.mode) != HeaderMode::NeedsContext)
+        // The writer never emits unbound (hash 0) verdicts; an entry
+        // carrying one is corrupt and must not bypass the content gate.
+        if(file.empty() || entry.content_hash == 0 ||
+           static_cast<HeaderMode>(entry.mode) != HeaderMode::NeedsContext)
             continue;
         auto id = workspace.file_table.intern(file);
         // The verdict is tied to the header's contents — a file edited
         // while the server was down must re-earn its trial.
-        if(entry.content_hash != 0) {
-            auto disk = workspace.file_table.current(id);
-            if(!disk || disk->hash != entry.content_hash)
-                continue;
-        }
+        auto disk = workspace.file_table.current(id);
+        if(!disk || disk->hash != entry.content_hash)
+            continue;
         header_modes[id] = HeaderMode::NeedsContext;
         header_mode_hashes[id] = entry.content_hash;
     }

--- a/src/sched/context.cpp
+++ b/src/sched/context.cpp
@@ -566,6 +566,7 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
 
     auto search_config = workspace.cdb.search_config(host_ref);
     DirListingCache dir_cache;
+    dir_cache.shared = &workspace.file_table;
     auto resolved_config = resolve_search_config(search_config, dir_cache);
 
     auto resolver = [&](llvm::StringRef filename,

--- a/src/sched/context.cpp
+++ b/src/sched/context.cpp
@@ -146,9 +146,8 @@ void ContextResolver::dump_choice_slices(
     }
 }
 
-void ContextResolver::load_mode_slices(
-    const std::vector<CacheModeEntry>& modes,
-    llvm::function_ref<llvm::StringRef(std::uint32_t)> resolve) {
+void ContextResolver::load_mode_slices(const std::vector<CacheModeEntry>& modes,
+                                       llvm::function_ref<llvm::StringRef(std::uint32_t)> resolve) {
     for(auto& entry: modes) {
         auto file = resolve(entry.file);
         if(file.empty() || static_cast<HeaderMode>(entry.mode) != HeaderMode::NeedsContext)

--- a/src/sched/context.h
+++ b/src/sched/context.h
@@ -22,8 +22,9 @@ enum class ContextUse : std::uint8_t {
     Background,
 };
 
-/// cache.json slice entries for context-domain state. The structs mirror the
-/// on-disk JSON layout field for field — changing them changes the format.
+/// Persisted slice entries for context-domain state (the artifacts and
+/// contexts blobs in the index database). The structs mirror the on-disk
+/// JSON layout field for field — changing them changes the format.
 
 struct CacheModeEntry {
     std::uint32_t file;          // index into the cache path table
@@ -51,7 +52,7 @@ struct CacheArtifactEntry {
 /// resolution and synthesis (prefix/suffix/self-snapshot files restoring the
 /// includer's preprocessor state) plus the context-domain state: self-
 /// containment verdicts, user context choices and synthesized-artifact
-/// attribution (all persisted in cache.json), and the resolved header
+/// attribution (all persisted through the index database), and the resolved header
 /// contexts, which outlive their sessions so a reopened header reuses its
 /// synthesized preamble. The editor-facing context protocol handlers
 /// (clice/queryContext, currentContext, switchContext) live on the server
@@ -60,22 +61,22 @@ class ContextResolver {
 public:
     explicit ContextResolver(Workspace& workspace) : workspace(workspace) {}
 
-    /// Self-containment verdicts for headers, persisted in cache.json.
-    /// Reset when the header itself is saved.
+    /// Self-containment verdicts for headers, persisted in the artifacts
+    /// blob. Reset when the header itself is saved.
     llvm::DenseMap<std::uint32_t, HeaderMode> header_modes;
 
     /// Content hash of the header at the time its NeedsContext verdict was
     /// scored — persisted so a stale verdict is dropped on cache load.
     llvm::DenseMap<std::uint32_t, std::uint64_t> header_mode_hashes;
 
-    /// User context choices (clice/switchContext), persisted in cache.json
+    /// User context choices (clice/switchContext), persisted in the contexts blob
     /// and validated against the CDB and include graph on didOpen. The
     /// single source of truth for a file's active context.
     llvm::DenseMap<std::uint32_t, SavedContext> saved_contexts;
 
     /// Host source of each synthesized artifact (prefix/suffix/snapshot
     /// file path -> host path_id), recorded at synthesis time and
-    /// persisted in cache.json. Opening an artifact compiles it with its
+    /// persisted in the contexts blob. Opening an artifact compiles it with its
     /// host's command — it is a fragment of that TU, and treated as
     /// self-contained (an artifact needing context itself is out of scope).
     llvm::StringMap<std::uint32_t> synthesized_hosts;
@@ -160,22 +161,32 @@ public:
     /// compile re-earns it.
     void reset_header_mode(std::uint32_t path_id);
 
-    /// Fill the context-domain cache.json slices. @param intern_id maps a
-    /// runtime path id and @param intern_path a raw path into the shared
-    /// cache path table; interning order is part of the on-disk format.
-    void dump_cache_slices(std::vector<CacheModeEntry>& modes,
-                           std::vector<CacheContextEntry>& contexts,
-                           std::vector<CacheArtifactEntry>& artifacts,
-                           llvm::function_ref<std::uint32_t(std::uint32_t)> intern_id,
-                           llvm::function_ref<std::uint32_t(llvm::StringRef)> intern_path) const;
+    /// Fill the validation slice of the artifacts blob (header-mode
+    /// verdicts, content-hash gated at load). @param intern_id maps a
+    /// runtime path id into the blob's path table; interning order is part
+    /// of the on-disk format.
+    void dump_mode_slices(std::vector<CacheModeEntry>& modes,
+                          llvm::function_ref<std::uint32_t(std::uint32_t)> intern_id) const;
 
-    /// Restore the context-domain state from cache.json slices. @param
-    /// resolve maps a cache path table index back to a path (empty when the
-    /// index is invalid).
-    void load_cache_slices(const std::vector<CacheModeEntry>& modes,
-                           const std::vector<CacheContextEntry>& contexts,
-                           const std::vector<CacheArtifactEntry>& artifacts,
-                           llvm::function_ref<llvm::StringRef(std::uint32_t)> resolve);
+    /// Restore header-mode verdicts. @param resolve maps a path table
+    /// index back to a path (empty when the index is invalid).
+    void load_mode_slices(const std::vector<CacheModeEntry>& modes,
+                          llvm::function_ref<llvm::StringRef(std::uint32_t)> resolve);
+
+    /// Fill the sovereignty slices of the contexts blob (user context
+    /// choices and synthesized-artifact hosts — never invalidated by
+    /// content, only by the user or a vanished CDB anchor). @param
+    /// intern_path interns a raw path (synthesized artifacts have no fid
+    /// requirement at this layer).
+    void dump_choice_slices(std::vector<CacheContextEntry>& contexts,
+                            std::vector<CacheArtifactEntry>& artifacts,
+                            llvm::function_ref<std::uint32_t(std::uint32_t)> intern_id,
+                            llvm::function_ref<std::uint32_t(llvm::StringRef)> intern_path) const;
+
+    /// Restore the sovereignty slices; see dump_choice_slices.
+    void load_choice_slices(const std::vector<CacheContextEntry>& contexts,
+                            const std::vector<CacheArtifactEntry>& artifacts,
+                            llvm::function_ref<llvm::StringRef(std::uint32_t)> resolve);
 
     /// Fill compile arguments for a file and report where they came from.
     /// Tries, in order: CDB entry, header context through the include graph,

--- a/src/sched/context.h
+++ b/src/sched/context.h
@@ -154,11 +154,14 @@ public:
     void forget_self_contained(std::uint32_t path_id);
 
     /// Record a header trial's verdict. NeedsContext carries the content
-    /// hash it was scored on so a stale verdict is dropped on cache load.
+    /// hash it was scored on so a stale verdict is dropped on cache load;
+    /// scored with no disk observation (hash 0) it stays session-local.
+    /// Marks the artifacts blob dirty when the persisted slice changes.
     void record_header_mode(std::uint32_t path_id, HeaderMode mode, std::uint64_t content_hash = 0);
 
     /// Drop a header's verdict entirely (its content changed); the next
-    /// compile re-earns it.
+    /// compile re-earns it. Marks the artifacts blob dirty when a
+    /// persisted verdict is dropped.
     void reset_header_mode(std::uint32_t path_id);
 
     /// Fill the validation slice of the artifacts blob (header-mode
@@ -257,6 +260,14 @@ private:
     std::optional<HeaderContext> resolve_header_context(std::uint32_t header_path_id,
                                                         ContextUse use,
                                                         bool synthesize);
+
+    /// What dump_mode_slices would emit for this file (0 = nothing) — the
+    /// before/after probe record and reset compare to mark the artifacts
+    /// blob dirty exactly when the persisted slice changes. A persisted
+    /// verdict must not outlive its in-memory drop: the header's own
+    /// content hash still matches on restart even though a dependency
+    /// change deliberately reset the verdict.
+    std::uint64_t persisted_mode_hash(std::uint32_t path_id) const;
 
     Workspace& workspace;
 };

--- a/src/sched/context.h
+++ b/src/sched/context.h
@@ -261,6 +261,12 @@ private:
                                                         ContextUse use,
                                                         bool synthesize);
 
+    /// Record a synthesized artifact's host attribution, marking the
+    /// contexts blob dirty when the mapping actually changes — synthesis
+    /// re-derives the same content-addressed paths on every resolve, and
+    /// an unconditional mark would rewrite the blob each time.
+    void record_synthesized_host(llvm::StringRef path, Fid host_path_id);
+
     /// What dump_mode_slices would emit for this file (0 = nothing) — the
     /// before/after probe record and reset compare to mark the artifacts
     /// blob dirty exactly when the persisted slice changes. A persisted

--- a/src/sched/context.h
+++ b/src/sched/context.h
@@ -170,7 +170,7 @@ public:
 
     /// Restore header-mode verdicts. @param resolve maps a path table
     /// index back to a path (empty when the index is invalid).
-    void load_mode_slices(const std::vector<CacheModeEntry>& modes,
+    void load_mode_slices(llvm::ArrayRef<CacheModeEntry> modes,
                           llvm::function_ref<llvm::StringRef(std::uint32_t)> resolve);
 
     /// Fill the sovereignty slices of the contexts blob (user context
@@ -184,8 +184,8 @@ public:
                             llvm::function_ref<std::uint32_t(llvm::StringRef)> intern_path) const;
 
     /// Restore the sovereignty slices; see dump_choice_slices.
-    void load_choice_slices(const std::vector<CacheContextEntry>& contexts,
-                            const std::vector<CacheArtifactEntry>& artifacts,
+    void load_choice_slices(llvm::ArrayRef<CacheContextEntry> contexts,
+                            llvm::ArrayRef<CacheArtifactEntry> artifacts,
                             llvm::function_ref<llvm::StringRef(std::uint32_t)> resolve);
 
     /// Fill compile arguments for a file and report where they came from.

--- a/src/sched/context.h
+++ b/src/sched/context.h
@@ -109,7 +109,7 @@ public:
     }
 
     /// Drop the header context's dependency fast paths so the next use
-    /// re-validates every chain file by content hash. The context itself is
+    /// re-validates every chain file by a real read. The context itself is
     /// kept: an in-flight compile can clobber ast_dirty when it finishes,
     /// and the surviving snapshot is what lets is_stale() recover. A
     /// self-contained borrow tracks no chain deps, so forcing its
@@ -124,7 +124,7 @@ public:
         if(context->deps.empty()) {
             drop_header_context(path_id);
         } else {
-            context->deps.force_revalidate();
+            context->deps.force_revalidate(workspace.file_table);
         }
     }
 

--- a/src/sched/context.h
+++ b/src/sched/context.h
@@ -63,23 +63,23 @@ public:
 
     /// Self-containment verdicts for headers, persisted in the artifacts
     /// blob. Reset when the header itself is saved.
-    llvm::DenseMap<std::uint32_t, HeaderMode> header_modes;
+    llvm::DenseMap<Fid, HeaderMode> header_modes;
 
     /// Content hash of the header at the time its NeedsContext verdict was
     /// scored — persisted so a stale verdict is dropped on cache load.
-    llvm::DenseMap<std::uint32_t, std::uint64_t> header_mode_hashes;
+    llvm::DenseMap<Fid, std::uint64_t> header_mode_hashes;
 
     /// User context choices (clice/switchContext), persisted in the contexts blob
     /// and validated against the CDB and include graph on didOpen. The
     /// single source of truth for a file's active context.
-    llvm::DenseMap<std::uint32_t, SavedContext> saved_contexts;
+    llvm::DenseMap<Fid, SavedContext> saved_contexts;
 
     /// Host source of each synthesized artifact (prefix/suffix/snapshot
     /// file path -> host path_id), recorded at synthesis time and
     /// persisted in the contexts blob. Opening an artifact compiles it with its
     /// host's command — it is a fragment of that TU, and treated as
     /// self-contained (an artifact needing context itself is out of scope).
-    llvm::StringMap<std::uint32_t> synthesized_hosts;
+    llvm::StringMap<Fid> synthesized_hosts;
 
     /// Resolved compilation contexts of header files, keyed by the header.
     /// Entries outlive their sessions: closing a header keeps its
@@ -90,22 +90,22 @@ public:
     /// deliberately wins over re-ranking hosts on reopen.
     /// TODO: entries for headers never reopened accumulate for the server's
     /// lifetime; add eviction if observation shows it matters.
-    llvm::DenseMap<std::uint32_t, HeaderContext> header_contexts;
+    llvm::DenseMap<Fid, HeaderContext> header_contexts;
 
     /// The file's resolved header context, or nullptr.
-    HeaderContext* header_context(std::uint32_t path_id) {
+    HeaderContext* header_context(Fid path_id) {
         auto it = header_contexts.find(path_id);
         return it != header_contexts.end() ? &it->second : nullptr;
     }
 
-    const HeaderContext* header_context(std::uint32_t path_id) const {
+    const HeaderContext* header_context(Fid path_id) const {
         auto it = header_contexts.find(path_id);
         return it != header_contexts.end() ? &it->second : nullptr;
     }
 
     /// Discard the file's resolved header context so the next compile
     /// re-resolves (and possibly re-synthesizes) it.
-    void drop_header_context(std::uint32_t path_id) {
+    void drop_header_context(Fid path_id) {
         header_contexts.erase(path_id);
     }
 
@@ -117,7 +117,7 @@ public:
     /// re-validation could never trigger anything — drop it instead and let
     /// the next use re-resolve against the updated include graph (cheap: no
     /// synthesis on that route).
-    void invalidate_header_deps(std::uint32_t path_id) {
+    void invalidate_header_deps(Fid path_id) {
         auto* context = header_context(path_id);
         if(!context) {
             return;
@@ -125,15 +125,15 @@ public:
         if(context->deps.empty()) {
             drop_header_context(path_id);
         } else {
-            context->deps.force_revalidate(workspace.file_table);
+            force_revalidate_deps(workspace.file_table, context->deps);
         }
     }
 
     /// Headers whose resolved context embeds `path_id` through its include
     /// chain — the synthesized preamble copies the chain files' content, so
     /// a save along it must force re-validation.
-    llvm::SmallVector<std::uint32_t> chain_dependents(std::uint32_t path_id) const {
-        llvm::SmallVector<std::uint32_t> result;
+    llvm::SmallVector<Fid> chain_dependents(Fid path_id) const {
+        llvm::SmallVector<Fid> result;
         for(auto& [header_id, context]: header_contexts) {
             if(llvm::is_contained(context.chain, path_id)) {
                 result.push_back(header_id);
@@ -147,29 +147,29 @@ public:
     /// the persisted verdict. Only NeedsContext is ever persisted — a
     /// "self-contained" impression is session-local and re-evaluated when
     /// compile inputs change, so it can never go stale.
-    HeaderMode header_mode(llvm::StringRef path, std::uint32_t path_id) const;
+    HeaderMode header_mode(llvm::StringRef path, Fid path_id) const;
 
     /// Drop an in-memory SelfContained verdict (never a persisted
     /// NeedsContext) so the next compile re-runs the trial.
-    void forget_self_contained(std::uint32_t path_id);
+    void forget_self_contained(Fid path_id);
 
     /// Record a header trial's verdict. NeedsContext carries the content
     /// hash it was scored on so a stale verdict is dropped on cache load;
     /// scored with no disk observation (hash 0) it stays session-local.
     /// Marks the artifacts blob dirty when the persisted slice changes.
-    void record_header_mode(std::uint32_t path_id, HeaderMode mode, std::uint64_t content_hash = 0);
+    void record_header_mode(Fid path_id, HeaderMode mode, std::uint64_t content_hash = 0);
 
     /// Drop a header's verdict entirely (its content changed); the next
     /// compile re-earns it. Marks the artifacts blob dirty when a
     /// persisted verdict is dropped.
-    void reset_header_mode(std::uint32_t path_id);
+    void reset_header_mode(Fid path_id);
 
     /// Fill the validation slice of the artifacts blob (header-mode
     /// verdicts, content-hash gated at load). @param intern_id maps a
     /// runtime path id into the blob's path table; interning order is part
     /// of the on-disk format.
     void dump_mode_slices(std::vector<CacheModeEntry>& modes,
-                          llvm::function_ref<std::uint32_t(std::uint32_t)> intern_id) const;
+                          llvm::function_ref<std::uint32_t(Fid)> intern_id) const;
 
     /// Restore header-mode verdicts. @param resolve maps a path table
     /// index back to a path (empty when the index is invalid).
@@ -183,7 +183,7 @@ public:
     /// requirement at this layer).
     void dump_choice_slices(std::vector<CacheContextEntry>& contexts,
                             std::vector<CacheArtifactEntry>& artifacts,
-                            llvm::function_ref<std::uint32_t(std::uint32_t)> intern_id,
+                            llvm::function_ref<std::uint32_t(Fid)> intern_id,
                             llvm::function_ref<std::uint32_t(llvm::StringRef)> intern_path) const;
 
     /// Restore the sovereignty slices; see dump_choice_slices.
@@ -209,7 +209,7 @@ public:
                                   std::string& directory,
                                   std::vector<std::string>& arguments,
                                   ContextUse use = ContextUse::Background,
-                                  std::uint32_t* host_path_id = nullptr,
+                                  Fid* host_path_id = nullptr,
                                   llvm::ArrayRef<std::string> extra_prepend = {},
                                   llvm::ArrayRef<std::string> extra_append = {},
                                   CommandRef* out_ref = nullptr);
@@ -219,28 +219,28 @@ public:
     /// lives in its own file so features never see it, while the token stream
     /// still closes any braces the fragment is embedded in. The single extra
     /// line sits past the editor's EOF and is invisible to the client.
-    void append_suffix_include(std::uint32_t path_id, std::string& text);
+    void append_suffix_include(Fid path_id, std::string& text);
 
     /// Fill compile arguments for a header from a host source's command found
     /// through the include graph, synthesizing a preamble prefix/suffix when
     /// the header needs includer context. Returns false when no usable host
     /// context exists.
     bool fill_header_context_args(llvm::StringRef path,
-                                  std::uint32_t path_id,
+                                  Fid path_id,
                                   std::string& directory,
                                   std::vector<std::string>& arguments,
                                   ContextUse use,
-                                  std::uint32_t* host_path_id,
+                                  Fid* host_path_id,
                                   CommandRef* out_ref = nullptr);
 
     /// Validate a context choice persisted from an earlier run against the
     /// current CDB and include graph, dropping it when stale. Called on
     /// didOpen; a surviving entry is the file's active context.
-    void validate_saved_context(std::uint32_t path_id);
+    void validate_saved_context(Fid path_id);
 
     /// The file's context choice, or nullptr — editor use only: user
     /// choices steer editor-facing compiles, never background indexing.
-    const SavedContext* active_choice(ContextUse use, std::uint32_t path_id) const {
+    const SavedContext* active_choice(ContextUse use, Fid path_id) const {
         if(use != ContextUse::Editor) {
             return nullptr;
         }
@@ -257,7 +257,7 @@ public:
     bool pin_alive(llvm::StringRef entry_path, const SavedContext& saved) const;
 
 private:
-    std::optional<HeaderContext> resolve_header_context(std::uint32_t header_path_id,
+    std::optional<HeaderContext> resolve_header_context(Fid header_path_id,
                                                         ContextUse use,
                                                         bool synthesize);
 
@@ -267,7 +267,7 @@ private:
     /// verdict must not outlive its in-memory drop: the header's own
     /// content hash still matches on restart even though a dependency
     /// change deliberately reset the verdict.
-    std::uint64_t persisted_mode_hash(std::uint32_t path_id) const;
+    std::uint64_t persisted_mode_hash(Fid path_id) const;
 
     Workspace& workspace;
 };

--- a/src/sched/families/pch.cpp
+++ b/src/sched/families/pch.cpp
@@ -104,7 +104,7 @@ kota::task<RoundOutcome> PCHFamily::attempt(RoundContext& ctx, std::uint64_t key
             // load_state() found the blob unreadable earlier; republish
             // the pair rather than serving a PCH with no index forever.
             pch_miss = "idx_unreadable";
-        } else if(deps_changed(workspace.path_pool, st.deps)) {
+        } else if(deps_changed(workspace.file_table, st.deps)) {
             pch_miss = "deps_changed";
         } else {
             LOG_PERF("cache", "ns=pch event=hit key={} file={}", pch_key, request.file);
@@ -269,7 +269,7 @@ kota::task<RoundOutcome> PCHFamily::attempt(RoundContext& ctx, std::uint64_t key
     st.path = *committed.value().pch_path;
     st.bound = request.preamble_bound;
     st.deps =
-        capture_deps_snapshot(workspace.path_pool, result.value().deps, result.value().build_at);
+        capture_deps_snapshot(workspace.file_table, result.value().deps, result.value().build_at);
     st.index_path = *committed.value().index_path;
     // Replace the previous blob's mapping (same key, rebuilt content);
     // in-flight holders of the old shared_ptr stay valid.
@@ -295,7 +295,7 @@ bool PCHFamily::fresh(llvm::StringRef pch_key) {
        !workspace.store->lookup_aux("pch", pch_key)) {
         return false;
     }
-    return !deps_changed(workspace.path_pool, it->second.deps);
+    return !deps_changed(workspace.file_table, it->second.deps);
 }
 
 bool PCHFamily::building(llvm::StringRef pch_key) const {

--- a/src/sched/families/pch.cpp
+++ b/src/sched/families/pch.cpp
@@ -92,63 +92,36 @@ kota::task<RoundOutcome> PCHFamily::attempt(RoundContext& ctx, std::uint64_t key
     // (crash between commits, failed aux commit) rebuilds whole. The
     // store lookup refreshes the blob's LRU position.
     llvm::StringRef pch_miss = "no_entry";
-    workspace.file_table.begin_wave();
-    if(auto it = workspace.pch_cache.find(pch_key); it != workspace.pch_cache.end()) {
-        auto& st = it->second;
-        bool in_store = workspace.store && workspace.store->lookup("pch", pch_key) &&
-                        workspace.store->lookup_aux("pch", pch_key);
-        if(st.path.empty()) {
-            pch_miss = "incomplete_entry";
-        } else if(!in_store) {
-            pch_miss = "evicted";
-        } else if(st.index_path.empty()) {
-            // load_state() found the blob unreadable earlier; republish
-            // the pair rather than serving a PCH with no index forever.
-            pch_miss = "idx_unreadable";
-        } else if(!binding_stat_matches(st.path, st.binding) ||
-                  !binding_stat_matches(st.index_path, st.index_binding)) {
-            // The key is not fully content-addressed: a concurrent writer
-            // (batch lint shares the store) can republish different bytes
-            // under it, and this metadata does not vouch for those.
-            pch_miss = "blob_replaced";
-        } else if(deps_changed(workspace.file_table, st.deps)) {
-            pch_miss = "deps_changed";
-        } else if(st.verify_content) {
-            // Adopted after a writer died before its metadata barrier:
-            // prove once that the records describe these bytes.
-            auto pch_path = st.path;
-            auto index_path = st.index_path;
-            auto binding = st.binding;
-            auto index_binding = st.index_binding;
-            auto verify = co_await kota::queue([&] {
-                return binding_content_matches(pch_path, binding) &&
-                       binding_content_matches(index_path, index_binding);
-            });
-            if(!verify.has_value()) {
-                co_return RoundOutcome::Stale;
-            }
-            bool verified = verify.value();
-            auto settled = workspace.pch_cache.find(pch_key);
-            if(settled != workspace.pch_cache.end() && verified) {
-                settled->second.verify_content = false;
-                // Persisted per record: the cleared debt must not resurrect
-                // on the next load.
-                workspace.mark_artifacts_dirty();
+    {
+        auto wave = workspace.file_table.wave();
+        if(auto it = workspace.pch_cache.find(pch_key); it != workspace.pch_cache.end()) {
+            auto& st = it->second;
+            bool in_store = workspace.store && workspace.store->lookup("pch", pch_key) &&
+                            workspace.store->lookup_aux("pch", pch_key);
+            if(st.path.empty()) {
+                pch_miss = "incomplete_entry";
+            } else if(!in_store) {
+                pch_miss = "evicted";
+            } else if(st.index_path.empty()) {
+                // load_state() found the blob unreadable earlier; republish
+                // the pair rather than serving a PCH with no index forever.
+                pch_miss = "idx_unreadable";
+            } else if(deps_changed(workspace.file_table, st.deps)) {
+                // FIXME: deps are the only revalidation — the blobs
+                // themselves are not pinned, so metadata surviving a
+                // crashed flush or a concurrent writer's republish is
+                // trusted on its deps alone (see CacheStore's FIXME);
+                // clang's own validation backstops.
+                pch_miss = "deps_changed";
+            } else {
                 LOG_PERF("cache", "ns=pch event=hit key={} file={}", pch_key, request.file);
                 co_return RoundOutcome::Success;
             }
-            if(settled != workspace.pch_cache.end() && !verified) {
-                workspace.pch_cache.erase(settled);
+            // Blob evicted by the store's LRU: drop the metadata too, or
+            // the content-keyed map grows for the server's lifetime.
+            if(!in_store) {
+                workspace.pch_cache.erase(pch_key);
             }
-            pch_miss = "verify_content";
-        } else {
-            LOG_PERF("cache", "ns=pch event=hit key={} file={}", pch_key, request.file);
-            co_return RoundOutcome::Success;
-        }
-        // Blob evicted by the store's LRU: drop the metadata too, or the
-        // content-keyed map grows for the server's lifetime.
-        if(!in_store) {
-            workspace.pch_cache.erase(pch_key);
         }
     }
     LOG_PERF("cache",
@@ -247,13 +220,11 @@ kota::task<RoundOutcome> PCHFamily::attempt(RoundContext& ctx, std::uint64_t key
         std::optional<std::string> pch_path;
         std::optional<std::string> index_path;
         std::shared_ptr<index::TUIndex> state;
-        BlobBinding binding;
-        BlobBinding index_binding;
     };
 
     auto committed = co_await kota::queue([&]() -> PairCommit {
         PairCommit outcome;
-        auto pch_path = workspace.store->commit(std::move(pending), &outcome.binding);
+        auto pch_path = workspace.store->commit(std::move(pending));
         if(!pch_path) {
             // pending_idx cleans its own tmp blob when the frame unwinds.
             return outcome;
@@ -262,13 +233,13 @@ kota::task<RoundOutcome> PCHFamily::attempt(RoundContext& ctx, std::uint64_t key
 
         // The pair is only usable complete: when the index blob cannot be
         // published, retract the PCH too — the next round rebuilds both.
-        auto index_path = workspace.store->commit(std::move(pending_idx), &outcome.index_binding);
+        auto index_path = workspace.store->commit(std::move(pending_idx));
         if(!index_path) {
             workspace.store->invalidate("pch", pch_key);
             return outcome;
         }
         outcome.index_path = std::move(*index_path);
-        outcome.state = load_pch_envelope(*outcome.index_path, outcome.index_binding.hash);
+        outcome.state = load_pch_envelope(*outcome.index_path);
         // A committed envelope that fails verification is as unusable as
         // an uncommitted one: retract the pair rather than publish a PCH
         // whose preamble state every consumer would fail to load.
@@ -307,9 +278,6 @@ kota::task<RoundOutcome> PCHFamily::attempt(RoundContext& ctx, std::uint64_t key
     st.bound = request.preamble_bound;
     st.deps =
         capture_deps_snapshot(workspace.file_table, result.value().deps, result.value().build_at);
-    st.binding = committed.value().binding;
-    st.index_binding = committed.value().index_binding;
-    st.verify_content = false;
     st.index_path = *committed.value().index_path;
     // Replace the previous blob's mapping (same key, rebuilt content);
     // in-flight holders of the old shared_ptr stay valid.
@@ -335,13 +303,7 @@ bool PCHFamily::fresh(llvm::StringRef pch_key) {
         return false;
     }
     auto& st = it->second;
-    // Unverified post-crash records read as not-fresh so the ensure path
-    // runs the content verification.
-    if(st.verify_content || !binding_stat_matches(st.path, st.binding) ||
-       !binding_stat_matches(st.index_path, st.index_binding)) {
-        return false;
-    }
-    workspace.file_table.begin_wave();
+    auto wave = workspace.file_table.wave();
     return !deps_changed(workspace.file_table, st.deps);
 }
 

--- a/src/sched/families/pch.cpp
+++ b/src/sched/families/pch.cpp
@@ -105,8 +105,42 @@ kota::task<RoundOutcome> PCHFamily::attempt(RoundContext& ctx, std::uint64_t key
             // load_state() found the blob unreadable earlier; republish
             // the pair rather than serving a PCH with no index forever.
             pch_miss = "idx_unreadable";
+        } else if(!binding_stat_matches(st.path, st.binding) ||
+                  !binding_stat_matches(st.index_path, st.index_binding)) {
+            // The key is not fully content-addressed: a concurrent writer
+            // (batch lint shares the store) can republish different bytes
+            // under it, and this metadata does not vouch for those.
+            pch_miss = "blob_replaced";
         } else if(deps_changed(workspace.file_table, st.deps)) {
             pch_miss = "deps_changed";
+        } else if(st.verify_content) {
+            // Adopted after a writer died before its metadata barrier:
+            // prove once that the records describe these bytes.
+            auto pch_path = st.path;
+            auto index_path = st.index_path;
+            auto binding = st.binding;
+            auto index_binding = st.index_binding;
+            auto verify = co_await kota::queue([&] {
+                return binding_content_matches(pch_path, binding) &&
+                       binding_content_matches(index_path, index_binding);
+            });
+            if(!verify.has_value()) {
+                co_return RoundOutcome::Stale;
+            }
+            bool verified = verify.value();
+            auto settled = workspace.pch_cache.find(pch_key);
+            if(settled != workspace.pch_cache.end() && verified) {
+                settled->second.verify_content = false;
+                // Persisted per record: the cleared debt must not resurrect
+                // on the next load.
+                workspace.mark_artifacts_dirty();
+                LOG_PERF("cache", "ns=pch event=hit key={} file={}", pch_key, request.file);
+                co_return RoundOutcome::Success;
+            }
+            if(settled != workspace.pch_cache.end() && !verified) {
+                workspace.pch_cache.erase(settled);
+            }
+            pch_miss = "verify_content";
         } else {
             LOG_PERF("cache", "ns=pch event=hit key={} file={}", pch_key, request.file);
             co_return RoundOutcome::Success;
@@ -114,7 +148,7 @@ kota::task<RoundOutcome> PCHFamily::attempt(RoundContext& ctx, std::uint64_t key
         // Blob evicted by the store's LRU: drop the metadata too, or the
         // content-keyed map grows for the server's lifetime.
         if(!in_store) {
-            workspace.pch_cache.erase(it);
+            workspace.pch_cache.erase(pch_key);
         }
     }
     LOG_PERF("cache",
@@ -213,11 +247,13 @@ kota::task<RoundOutcome> PCHFamily::attempt(RoundContext& ctx, std::uint64_t key
         std::optional<std::string> pch_path;
         std::optional<std::string> index_path;
         std::shared_ptr<index::TUIndex> state;
+        BlobBinding binding;
+        BlobBinding index_binding;
     };
 
     auto committed = co_await kota::queue([&]() -> PairCommit {
         PairCommit outcome;
-        auto pch_path = workspace.store->commit(std::move(pending));
+        auto pch_path = workspace.store->commit(std::move(pending), &outcome.binding);
         if(!pch_path) {
             // pending_idx cleans its own tmp blob when the frame unwinds.
             return outcome;
@@ -226,13 +262,13 @@ kota::task<RoundOutcome> PCHFamily::attempt(RoundContext& ctx, std::uint64_t key
 
         // The pair is only usable complete: when the index blob cannot be
         // published, retract the PCH too — the next round rebuilds both.
-        auto index_path = workspace.store->commit(std::move(pending_idx));
+        auto index_path = workspace.store->commit(std::move(pending_idx), &outcome.index_binding);
         if(!index_path) {
             workspace.store->invalidate("pch", pch_key);
             return outcome;
         }
         outcome.index_path = std::move(*index_path);
-        outcome.state = load_pch_envelope(*outcome.index_path);
+        outcome.state = load_pch_envelope(*outcome.index_path, outcome.index_binding.hash);
         // A committed envelope that fails verification is as unusable as
         // an uncommitted one: retract the pair rather than publish a PCH
         // whose preamble state every consumer would fail to load.
@@ -271,6 +307,9 @@ kota::task<RoundOutcome> PCHFamily::attempt(RoundContext& ctx, std::uint64_t key
     st.bound = request.preamble_bound;
     st.deps =
         capture_deps_snapshot(workspace.file_table, result.value().deps, result.value().build_at);
+    st.binding = committed.value().binding;
+    st.index_binding = committed.value().index_binding;
+    st.verify_content = false;
     st.index_path = *committed.value().index_path;
     // Replace the previous blob's mapping (same key, rebuilt content);
     // in-flight holders of the old shared_ptr stay valid.
@@ -280,8 +319,7 @@ kota::task<RoundOutcome> PCHFamily::attempt(RoundContext& ctx, std::uint64_t key
 
     LOG_INFO("PCH built for {}: {}", bp.file, st.path);
 
-    // Persist cache metadata after successful build.
-    workspace.save_cache(contexts);
+    workspace.mark_artifacts_dirty();
 
     co_return RoundOutcome::Success;
 }
@@ -296,8 +334,15 @@ bool PCHFamily::fresh(llvm::StringRef pch_key) {
        !workspace.store->lookup_aux("pch", pch_key)) {
         return false;
     }
+    auto& st = it->second;
+    // Unverified post-crash records read as not-fresh so the ensure path
+    // runs the content verification.
+    if(st.verify_content || !binding_stat_matches(st.path, st.binding) ||
+       !binding_stat_matches(st.index_path, st.index_binding)) {
+        return false;
+    }
     workspace.file_table.begin_wave();
-    return !deps_changed(workspace.file_table, it->second.deps);
+    return !deps_changed(workspace.file_table, st.deps);
 }
 
 bool PCHFamily::building(llvm::StringRef pch_key) const {

--- a/src/sched/families/pch.cpp
+++ b/src/sched/families/pch.cpp
@@ -92,6 +92,7 @@ kota::task<RoundOutcome> PCHFamily::attempt(RoundContext& ctx, std::uint64_t key
     // (crash between commits, failed aux commit) rebuilds whole. The
     // store lookup refreshes the blob's LRU position.
     llvm::StringRef pch_miss = "no_entry";
+    workspace.file_table.begin_wave();
     if(auto it = workspace.pch_cache.find(pch_key); it != workspace.pch_cache.end()) {
         auto& st = it->second;
         bool in_store = workspace.store && workspace.store->lookup("pch", pch_key) &&
@@ -295,6 +296,7 @@ bool PCHFamily::fresh(llvm::StringRef pch_key) {
        !workspace.store->lookup_aux("pch", pch_key)) {
         return false;
     }
+    workspace.file_table.begin_wave();
     return !deps_changed(workspace.file_table, it->second.deps);
 }
 

--- a/src/sched/families/pcm.cpp
+++ b/src/sched/families/pcm.cpp
@@ -162,8 +162,36 @@ kota::task<RoundOutcome> PCMFamily::run(RoundContext& ctx, std::uint32_t path_id
             pcm_miss = "key_changed";
         } else if(!workspace.store->lookup("pcm", pcm_key)) {
             pcm_miss = "evicted";
+        } else if(!binding_stat_matches(pcm_it->second.path, pcm_it->second.binding)) {
+            // The key is content-free: a concurrent writer can republish
+            // different bytes under it, and this metadata does not vouch
+            // for those.
+            pcm_miss = "blob_replaced";
         } else if(deps_changed(workspace.file_table, pcm_it->second.deps)) {
             pcm_miss = "deps_changed";
+        } else if(pcm_it->second.verify_content) {
+            // Adopted after a writer died before its metadata barrier:
+            // prove once that the record describes these bytes.
+            auto blob_path = pcm_it->second.path;
+            auto binding = pcm_it->second.binding;
+            auto verify =
+                co_await kota::queue([&] { return binding_content_matches(blob_path, binding); });
+            if(!verify.has_value()) {
+                co_return RoundOutcome::Stale;
+            }
+            bool verified = verify.value();
+            auto settled = workspace.pcm_cache.find(path_id);
+            if(settled != workspace.pcm_cache.end() && verified) {
+                settled->second.verify_content = false;
+                workspace.mark_artifacts_dirty();
+                workspace.pcm_paths[path_id] = settled->second.path;
+                LOG_PERF("cache", "ns=pcm event=hit key={} module={}", pcm_key, module_name);
+                co_return RoundOutcome::Success;
+            }
+            if(settled != workspace.pcm_cache.end() && !verified) {
+                workspace.pcm_cache.erase(settled);
+            }
+            pcm_miss = "verify_content";
         } else {
             workspace.pcm_paths[path_id] = pcm_it->second.path;
             LOG_PERF("cache", "ns=pcm event=hit key={} module={}", pcm_key, module_name);
@@ -237,8 +265,9 @@ kota::task<RoundOutcome> PCMFamily::run(RoundContext& ctx, std::uint32_t path_id
     }
 
     // Commit on the thread pool: it fsyncs the freshly written PCM.
-    auto committed =
-        co_await kota::queue([&] { return workspace.store->commit(std::move(pending)); });
+    BlobBinding binding;
+    auto committed = co_await kota::queue(
+        [&] { return workspace.store->commit(std::move(pending), &binding); });
     if(!committed.has_value() || !committed.value().has_value()) {
         LOG_WARN("Failed to commit PCM for module {}", module_name);
         co_return RoundOutcome::Failed;
@@ -250,11 +279,11 @@ kota::task<RoundOutcome> PCMFamily::run(RoundContext& ctx, std::uint32_t path_id
     workspace.pcm_cache[path_id] = {
         pcm_path,
         pcm_key,
-        capture_deps_snapshot(workspace.file_table, result.value().deps, result.value().build_at)};
+        capture_deps_snapshot(workspace.file_table, result.value().deps, result.value().build_at),
+        binding};
     LOG_INFO("Built PCM for module {}: {}", module_name, pcm_path);
 
-    // Persist cache metadata after successful build.
-    workspace.save_cache(contexts);
+    workspace.mark_artifacts_dirty();
 
     // Signal that new index data is available for background merge.
     if(on_indexing_needed)

--- a/src/sched/families/pcm.cpp
+++ b/src/sched/families/pcm.cpp
@@ -35,7 +35,7 @@ PCMFamily::ModuleDeps PCMFamily::direct_deps(std::uint32_t path_id,
     // The same resolution the real build uses (run() below): a module unit
     // scanned with a different command than it compiles with would edge
     // against a different dependency set.
-    auto file_path = workspace.path_pool.resolve(path_id);
+    auto file_path = workspace.file_table.resolve(path_id);
     std::string directory;
     std::vector<std::string> arguments;
     contexts.resolve_command(file_path, directory, arguments);
@@ -132,7 +132,7 @@ kota::task<RoundOutcome> PCMFamily::run(RoundContext& ctx, std::uint32_t path_id
     // path_to_module, rehashing the DenseMap and invalidating mod_it.
     auto module_name = mod_it->second;
 
-    auto file_path = std::string(workspace.path_pool.resolve(path_id));
+    auto file_path = std::string(workspace.file_table.resolve(path_id));
 
     worker::BuildPCMParams bp;
     bp.file = file_path;
@@ -161,7 +161,7 @@ kota::task<RoundOutcome> PCMFamily::run(RoundContext& ctx, std::uint32_t path_id
             pcm_miss = "key_changed";
         } else if(!workspace.store->lookup("pcm", pcm_key)) {
             pcm_miss = "evicted";
-        } else if(deps_changed(workspace.path_pool, pcm_it->second.deps)) {
+        } else if(deps_changed(workspace.file_table, pcm_it->second.deps)) {
             pcm_miss = "deps_changed";
         } else {
             workspace.pcm_paths[path_id] = pcm_it->second.path;
@@ -249,7 +249,7 @@ kota::task<RoundOutcome> PCMFamily::run(RoundContext& ctx, std::uint32_t path_id
     workspace.pcm_cache[path_id] = {
         pcm_path,
         pcm_key,
-        capture_deps_snapshot(workspace.path_pool, result.value().deps, result.value().build_at)};
+        capture_deps_snapshot(workspace.file_table, result.value().deps, result.value().build_at)};
     LOG_INFO("Built PCM for module {}: {}", module_name, pcm_path);
 
     // Persist cache metadata after successful build.

--- a/src/sched/families/pcm.cpp
+++ b/src/sched/families/pcm.cpp
@@ -26,12 +26,11 @@ PCMFamily::PCMFamily(TaskGraph& graph,
 
 void PCMFamily::register_runner() {
     graph.register_family(pcm_family, [this](RoundContext& ctx, NodeId id) {
-        return run(ctx, static_cast<std::uint32_t>(id.key));
+        return run(ctx, Fid{static_cast<std::uint32_t>(id.key)});
     });
 }
 
-PCMFamily::ModuleDeps PCMFamily::direct_deps(std::uint32_t path_id,
-                                             std::optional<llvm::StringRef> content) {
+PCMFamily::ModuleDeps PCMFamily::direct_deps(Fid path_id, std::optional<llvm::StringRef> content) {
     // The same resolution the real build uses (run() below): a module unit
     // scanned with a different command than it compiles with would edge
     // against a different dependency set.
@@ -48,7 +47,7 @@ PCMFamily::ModuleDeps PCMFamily::direct_deps(std::uint32_t path_id,
     return direct_deps(path_id, argv, directory, content);
 }
 
-PCMFamily::ModuleDeps PCMFamily::direct_deps(std::uint32_t path_id,
+PCMFamily::ModuleDeps PCMFamily::direct_deps(Fid path_id,
                                              llvm::ArrayRef<const char*> arguments,
                                              llvm::StringRef directory,
                                              std::optional<llvm::StringRef> content) {
@@ -89,9 +88,7 @@ llvm::SmallVector<NodeId> PCMFamily::provider_appeared(llvm::StringRef name) {
         // invalidate() does for content changes — a PCM built against
         // the unresolved name embeds the failure.
         if(id.family == pcm_family && !is_unresolved(id)) {
-            auto pid = static_cast<std::uint32_t>(id.key);
-            workspace.pcm_paths.erase(pid);
-            erased |= workspace.pcm_cache.erase(pid);
+            erased |= workspace.pcm_cache.erase(Fid{static_cast<std::uint32_t>(id.key)});
         }
     }
     // The records are persisted, and this drop is invisible to their own
@@ -103,11 +100,11 @@ llvm::SmallVector<NodeId> PCMFamily::provider_appeared(llvm::StringRef name) {
     return dirtied;
 }
 
-void PCMFamily::declare_deps(std::uint32_t path_id, llvm::ArrayRef<NodeId> deps) {
+void PCMFamily::declare_deps(Fid path_id, llvm::ArrayRef<NodeId> deps) {
     graph.declare(node(path_id), deps);
 }
 
-kota::task<RoundOutcome> PCMFamily::run(RoundContext& ctx, std::uint32_t path_id) {
+kota::task<RoundOutcome> PCMFamily::run(RoundContext& ctx, Fid path_id) {
     // The import list is scanner truth, not build output: commit it as
     // durable edges before building, so a unit whose build fails stays
     // cascade-reachable from its imports — fixing an import must re-dirty
@@ -163,46 +160,23 @@ kota::task<RoundOutcome> PCMFamily::run(RoundContext& ctx, std::uint32_t path_id
 
     // Check if cached PCM is still valid.
     llvm::StringRef pcm_miss = "no_entry";
-    workspace.file_table.begin_wave();
-    if(auto pcm_it = workspace.pcm_cache.find(path_id); pcm_it != workspace.pcm_cache.end()) {
-        if(pcm_it->second.key != pcm_key) {
-            pcm_miss = "key_changed";
-        } else if(!workspace.store->lookup("pcm", pcm_key)) {
-            pcm_miss = "evicted";
-        } else if(!binding_stat_matches(pcm_it->second.path, pcm_it->second.binding)) {
-            // The key is content-free: a concurrent writer can republish
-            // different bytes under it, and this metadata does not vouch
-            // for those.
-            pcm_miss = "blob_replaced";
-        } else if(deps_changed(workspace.file_table, pcm_it->second.deps)) {
-            pcm_miss = "deps_changed";
-        } else if(pcm_it->second.verify_content) {
-            // Adopted after a writer died before its metadata barrier:
-            // prove once that the record describes these bytes.
-            auto blob_path = pcm_it->second.path;
-            auto binding = pcm_it->second.binding;
-            auto verify =
-                co_await kota::queue([&] { return binding_content_matches(blob_path, binding); });
-            if(!verify.has_value()) {
-                co_return RoundOutcome::Stale;
-            }
-            bool verified = verify.value();
-            auto settled = workspace.pcm_cache.find(path_id);
-            if(settled != workspace.pcm_cache.end() && verified) {
-                settled->second.verify_content = false;
-                workspace.mark_artifacts_dirty();
-                workspace.pcm_paths[path_id] = settled->second.path;
+    {
+        auto wave = workspace.file_table.wave();
+        if(auto pcm_it = workspace.pcm_cache.find(path_id); pcm_it != workspace.pcm_cache.end()) {
+            if(pcm_it->second.key != pcm_key) {
+                pcm_miss = "key_changed";
+            } else if(!workspace.store->lookup("pcm", pcm_key)) {
+                pcm_miss = "evicted";
+            } else if(deps_changed(workspace.file_table, pcm_it->second.deps)) {
+                // FIXME: deps are the only revalidation, and the key is
+                // content-free — metadata surviving a crashed flush or a
+                // concurrent writer's republish is trusted on its deps alone
+                // (see CacheStore's FIXME); clang's own validation backstops.
+                pcm_miss = "deps_changed";
+            } else {
                 LOG_PERF("cache", "ns=pcm event=hit key={} module={}", pcm_key, module_name);
                 co_return RoundOutcome::Success;
             }
-            if(settled != workspace.pcm_cache.end() && !verified) {
-                workspace.pcm_cache.erase(settled);
-            }
-            pcm_miss = "verify_content";
-        } else {
-            workspace.pcm_paths[path_id] = pcm_it->second.path;
-            LOG_PERF("cache", "ns=pcm event=hit key={} module={}", pcm_key, module_name);
-            co_return RoundOutcome::Success;
         }
     }
     LOG_PERF("cache",
@@ -232,7 +206,7 @@ kota::task<RoundOutcome> PCMFamily::run(RoundContext& ctx, std::uint32_t path_id
 
     // Clang needs ALL transitive PCM deps, not just direct imports.
     // Exclude the module being built — its old PCM path may still be
-    // in pcm_paths from a previous (now-invalidated) build.
+    // cached from a previous (now-invalidated) build.
     workspace.fill_pcm_deps(bp.pcms, path_id);
 
     // The interest class is read at dispatch time: a foreground requester
@@ -272,9 +246,8 @@ kota::task<RoundOutcome> PCMFamily::run(RoundContext& ctx, std::uint32_t path_id
     }
 
     // Commit on the thread pool: it fsyncs the freshly written PCM.
-    BlobBinding binding;
     auto committed =
-        co_await kota::queue([&] { return workspace.store->commit(std::move(pending), &binding); });
+        co_await kota::queue([&] { return workspace.store->commit(std::move(pending)); });
     if(!committed.has_value() || !committed.value().has_value()) {
         LOG_WARN("Failed to commit PCM for module {}", module_name);
         co_return RoundOutcome::Failed;
@@ -282,13 +255,11 @@ kota::task<RoundOutcome> PCMFamily::run(RoundContext& ctx, std::uint32_t path_id
 
     workspace.build_crashes.on_land(budget_key);
     auto pcm_path = std::move(committed.value().value());
-    workspace.pcm_paths[path_id] = pcm_path;
     workspace.pcm_cache[path_id] = {.path = pcm_path,
                                     .key = pcm_key,
                                     .deps = capture_deps_snapshot(workspace.file_table,
                                                                   result.value().deps,
-                                                                  result.value().build_at),
-                                    .binding = binding};
+                                                                  result.value().build_at)};
     LOG_INFO("Built PCM for module {}: {}", module_name, pcm_path);
 
     workspace.mark_artifacts_dirty();
@@ -301,9 +272,9 @@ kota::task<RoundOutcome> PCMFamily::run(RoundContext& ctx, std::uint32_t path_id
 }
 
 bool PCMFamily::revalidate_blobs() {
-    llvm::SmallVector<std::uint32_t> evicted;
-    for(auto& [pid, pcm_path]: workspace.pcm_paths) {
-        if(!llvm::sys::fs::exists(pcm_path)) {
+    llvm::SmallVector<Fid> evicted;
+    for(auto& [pid, st]: workspace.pcm_cache) {
+        if(!llvm::sys::fs::exists(st.path)) {
             evicted.push_back(pid);
         }
     }
@@ -314,13 +285,12 @@ bool PCMFamily::revalidate_blobs() {
         // rebuilding its imports — under a cache budget smaller than the
         // working set, that voids and respawns the waiter forever.
         graph.mark_dirty(node(pid));
-        workspace.pcm_paths.erase(pid);
         workspace.pcm_cache.erase(pid);
     }
     return !evicted.empty();
 }
 
-kota::task<bool> PCMFamily::prepare_deps(std::uint32_t path_id,
+kota::task<bool> PCMFamily::prepare_deps(Fid path_id,
                                          llvm::ArrayRef<const char*> arguments,
                                          llvm::StringRef directory,
                                          std::optional<llvm::StringRef> content,
@@ -372,16 +342,15 @@ kota::task<bool> PCMFamily::prepare_deps(std::uint32_t path_id,
     co_return true;
 }
 
-bool PCMFamily::tracks(std::uint32_t path_id) const {
+bool PCMFamily::tracks(Fid path_id) const {
     return graph.has_node(node(path_id));
 }
 
-llvm::SmallVector<std::uint32_t> PCMFamily::invalidate(std::uint32_t path_id) {
-    llvm::SmallVector<std::uint32_t> dirtied;
+llvm::SmallVector<Fid> PCMFamily::invalidate(Fid path_id) {
+    llvm::SmallVector<Fid> dirtied;
     bool erased = false;
     for(auto id: graph.update(node(path_id))) {
-        auto pid = static_cast<std::uint32_t>(id.key);
-        workspace.pcm_paths.erase(pid);
+        auto pid = Fid{static_cast<std::uint32_t>(id.key)};
         erased |= workspace.pcm_cache.erase(pid);
         dirtied.push_back(pid);
     }

--- a/src/sched/families/pcm.cpp
+++ b/src/sched/families/pcm.cpp
@@ -156,6 +156,7 @@ kota::task<RoundOutcome> PCMFamily::run(RoundContext& ctx, std::uint32_t path_id
 
     // Check if cached PCM is still valid.
     llvm::StringRef pcm_miss = "no_entry";
+    workspace.file_table.begin_wave();
     if(auto pcm_it = workspace.pcm_cache.find(path_id); pcm_it != workspace.pcm_cache.end()) {
         if(pcm_it->second.key != pcm_key) {
             pcm_miss = "key_changed";

--- a/src/sched/families/pcm.cpp
+++ b/src/sched/families/pcm.cpp
@@ -276,11 +276,12 @@ kota::task<RoundOutcome> PCMFamily::run(RoundContext& ctx, std::uint32_t path_id
     workspace.build_crashes.on_land(budget_key);
     auto pcm_path = std::move(committed.value().value());
     workspace.pcm_paths[path_id] = pcm_path;
-    workspace.pcm_cache[path_id] = {
-        pcm_path,
-        pcm_key,
-        capture_deps_snapshot(workspace.file_table, result.value().deps, result.value().build_at),
-        binding};
+    workspace.pcm_cache[path_id] = {.path = pcm_path,
+                                    .key = pcm_key,
+                                    .deps = capture_deps_snapshot(workspace.file_table,
+                                                                  result.value().deps,
+                                                                  result.value().build_at),
+                                    .binding = binding};
     LOG_INFO("Built PCM for module {}: {}", module_name, pcm_path);
 
     workspace.mark_artifacts_dirty();

--- a/src/sched/families/pcm.cpp
+++ b/src/sched/families/pcm.cpp
@@ -266,8 +266,8 @@ kota::task<RoundOutcome> PCMFamily::run(RoundContext& ctx, std::uint32_t path_id
 
     // Commit on the thread pool: it fsyncs the freshly written PCM.
     BlobBinding binding;
-    auto committed = co_await kota::queue(
-        [&] { return workspace.store->commit(std::move(pending), &binding); });
+    auto committed =
+        co_await kota::queue([&] { return workspace.store->commit(std::move(pending), &binding); });
     if(!committed.has_value() || !committed.value().has_value()) {
         LOG_WARN("Failed to commit PCM for module {}", module_name);
         co_return RoundOutcome::Failed;

--- a/src/sched/families/pcm.cpp
+++ b/src/sched/families/pcm.cpp
@@ -83,6 +83,7 @@ PCMFamily::ModuleDeps PCMFamily::direct_deps(std::uint32_t path_id,
 
 llvm::SmallVector<NodeId> PCMFamily::provider_appeared(llvm::StringRef name) {
     auto dirtied = graph.update(unresolved_node(name));
+    bool erased = false;
     for(auto id: dirtied) {
         // Dirtied module units drop their cached PCM state, exactly as
         // invalidate() does for content changes — a PCM built against
@@ -90,8 +91,14 @@ llvm::SmallVector<NodeId> PCMFamily::provider_appeared(llvm::StringRef name) {
         if(id.family == pcm_family && !is_unresolved(id)) {
             auto pid = static_cast<std::uint32_t>(id.key);
             workspace.pcm_paths.erase(pid);
-            workspace.pcm_cache.erase(pid);
+            erased |= workspace.pcm_cache.erase(pid);
         }
+    }
+    // The records are persisted, and this drop is invisible to their own
+    // validation (the missing provider never entered the dep snapshots) —
+    // without a rewrite, a restart resurrects them.
+    if(erased) {
+        workspace.mark_artifacts_dirty();
     }
     return dirtied;
 }
@@ -371,11 +378,15 @@ bool PCMFamily::tracks(std::uint32_t path_id) const {
 
 llvm::SmallVector<std::uint32_t> PCMFamily::invalidate(std::uint32_t path_id) {
     llvm::SmallVector<std::uint32_t> dirtied;
+    bool erased = false;
     for(auto id: graph.update(node(path_id))) {
         auto pid = static_cast<std::uint32_t>(id.key);
         workspace.pcm_paths.erase(pid);
-        workspace.pcm_cache.erase(pid);
+        erased |= workspace.pcm_cache.erase(pid);
         dirtied.push_back(pid);
+    }
+    if(erased) {
+        workspace.mark_artifacts_dirty();
     }
     return dirtied;
 }

--- a/src/sched/families/pcm.h
+++ b/src/sched/families/pcm.h
@@ -45,7 +45,7 @@ public:
     /// dependency can itself evict another clean module's PCM under
     /// budget pressure, which reopens the window the revalidation just
     /// closed — hence the bounded retry until the set is stable.
-    kota::task<bool> prepare_deps(std::uint32_t path_id,
+    kota::task<bool> prepare_deps(Fid path_id,
                                   llvm::ArrayRef<const char*> arguments,
                                   llvm::StringRef directory,
                                   std::optional<llvm::StringRef> content,
@@ -56,7 +56,7 @@ public:
     /// invalidated instead of handing clang a dangling path. Returns
     /// whether anything was evicted.
     ///
-    /// FIXME: this scans every pcm_paths entry (one stat() per module) on
+    /// FIXME: this scans every pcm_cache entry (one stat() per module) on
     /// every compile, even in steady state when nothing was evicted. For
     /// large modular projects on NFS this adds measurable latency.
     /// Consider having CacheStore notify on eviction or caching the scan
@@ -65,7 +65,7 @@ public:
 
     /// Whether the graph has a node for this module unit (it was built or
     /// depended on before).
-    bool tracks(std::uint32_t path_id) const;
+    bool tracks(Fid path_id) const;
 
     /// Mark a module unit and its transitive importers dirty, voiding
     /// in-flight rounds and dropping their cached PCM state — the single
@@ -73,7 +73,7 @@ public:
     /// (cache eviction) goes through revalidate_blobs' graph.mark_dirty
     /// instead: no cascade, importers' results still describe unchanged
     /// content. Returns the dirtied path_ids.
-    llvm::SmallVector<std::uint32_t> invalidate(std::uint32_t path_id);
+    llvm::SmallVector<Fid> invalidate(Fid path_id);
 
     /// Invoked after a PCM lands so background indexing can pick up the
     /// new artifact.
@@ -84,7 +84,7 @@ public:
     /// full durable edge set — resolved units' nodes plus one sentinel
     /// per unresolved name.
     struct ModuleDeps {
-        llvm::SmallVector<std::uint32_t> resolved;
+        llvm::SmallVector<Fid> resolved;
         llvm::SmallVector<NodeId, 8> declared;
     };
 
@@ -115,15 +115,14 @@ public:
     /// it in place of the file's on-disk text — even when empty (an open
     /// buffer's imports count before they are saved, and an emptied
     /// buffer has none).
-    ModuleDeps direct_deps(std::uint32_t path_id,
-                           std::optional<llvm::StringRef> content = std::nullopt);
+    ModuleDeps direct_deps(Fid path_id, std::optional<llvm::StringRef> content = std::nullopt);
 
     /// The already-resolved-command flavor: scans under exactly the
     /// arguments the caller will compile with. The AST path uses it so a
     /// context choice or donated header host cannot diverge between the
     /// scan and the parse — the path_id flavor re-picks a CDB entry,
     /// which is only right for whole-TU runs on real commands.
-    ModuleDeps direct_deps(std::uint32_t path_id,
+    ModuleDeps direct_deps(Fid path_id,
                            llvm::ArrayRef<const char*> arguments,
                            llvm::StringRef directory,
                            std::optional<llvm::StringRef> content);
@@ -131,14 +130,14 @@ public:
 private:
     /// Commit the scan's full edge set as the unit's durable edges (see
     /// TaskGraph::declare).
-    void declare_deps(std::uint32_t path_id, llvm::ArrayRef<NodeId> deps);
+    void declare_deps(Fid path_id, llvm::ArrayRef<NodeId> deps);
 
     /// One PCM round: declare dependency edges, revalidate the cache, and
     /// dispatch the build.
-    kota::task<RoundOutcome> run(RoundContext& ctx, std::uint32_t path_id);
+    kota::task<RoundOutcome> run(RoundContext& ctx, Fid path_id);
 
-    static NodeId node(std::uint32_t path_id) {
-        return {pcm_family, path_id};
+    static NodeId node(Fid path_id) {
+        return {pcm_family, path_id.raw};
     }
 
     TaskGraph& graph;

--- a/src/sched/families/turun.cpp
+++ b/src/sched/families/turun.cpp
@@ -21,11 +21,11 @@ TURunFamily::TURunFamily(TaskGraph& graph,
 
 void TURunFamily::register_runner() {
     graph.register_family(turun_family, [this](RoundContext& ctx, NodeId id) {
-        return round(ctx, static_cast<std::uint32_t>(id.key));
+        return round(ctx, Fid{static_cast<std::uint32_t>(id.key)});
     });
 }
 
-kota::task<TURunFamily::Outcome> TURunFamily::run(std::uint32_t path_id, Plan plan, Guards guards) {
+kota::task<TURunFamily::Outcome> TURunFamily::run(Fid path_id, Plan plan, Guards guards) {
     inputs[path_id] = {std::move(plan), std::move(guards)};
     // A clean node left by an earlier success must not satisfy this request
     // without running: the request's existence means work is owed, so
@@ -44,7 +44,7 @@ kota::task<TURunFamily::Outcome> TURunFamily::run(std::uint32_t path_id, Plan pl
     co_return outcome;
 }
 
-kota::task<RoundOutcome> TURunFamily::round(RoundContext& ctx, std::uint32_t path_id) {
+kota::task<RoundOutcome> TURunFamily::round(RoundContext& ctx, Fid path_id) {
     auto it = inputs.find(path_id);
     assert(it != inputs.end() && "a TURun round spawns only under run()'s stash");
     // Copied: the map may rehash under a concurrent run() for another
@@ -72,7 +72,7 @@ kota::task<RoundOutcome> TURunFamily::round(RoundContext& ctx, std::uint32_t pat
     // when it produces the resolved line, and every later consumer of
     // params.arguments (dependency scan, worker parse) sees one truth.
     auto extras = tidy::command_extra_args(params.tidy_extra_args, params.tidy_extra_args_before);
-    std::uint32_t host_path_id = no_path_id;
+    Fid host_path_id;
     auto source = contexts.resolve_command(file_path,
                                            params.directory,
                                            params.arguments,
@@ -115,7 +115,7 @@ kota::task<RoundOutcome> TURunFamily::round(RoundContext& ctx, std::uint32_t pat
         PCMFamily::ModuleDeps deps;
         if(own_module) {
             deps.resolved.push_back(path_id);
-            deps.declared.push_back({pcm_family, path_id});
+            deps.declared.push_back({pcm_family, path_id.raw});
         }
         // The scan must evaluate the same conditionals the worker's
         // parse will — the resolved command already carries the plan's
@@ -156,7 +156,7 @@ kota::task<RoundOutcome> TURunFamily::round(RoundContext& ctx, std::uint32_t pat
                 break;
             }
             for(auto dep: deps.resolved) {
-                if(co_await ctx.depend({pcm_family, dep}) == DependResult::Cancelled) {
+                if(co_await ctx.depend({pcm_family, dep.raw}) == DependResult::Cancelled) {
                     landed[path_id] = {.verdict = Verdict::Preempted};
                     co_return RoundOutcome::Stale;
                 }

--- a/src/sched/families/turun.cpp
+++ b/src/sched/families/turun.cpp
@@ -51,7 +51,7 @@ kota::task<RoundOutcome> TURunFamily::round(RoundContext& ctx, std::uint32_t pat
     // file while this round is suspended.
     auto [plan, guards] = it->second;
 
-    auto file_path = std::string(workspace.path_pool.resolve(path_id));
+    auto file_path = std::string(workspace.file_table.resolve(path_id));
 
     worker::TURunParams params;
     params.file = file_path;

--- a/src/sched/families/turun.h
+++ b/src/sched/families/turun.h
@@ -120,13 +120,13 @@ public:
     /// request's existence means work is owed, and a clean node left by an
     /// earlier success would otherwise satisfy the join without running
     /// anything.
-    kota::task<Outcome> run(std::uint32_t path_id, Plan plan, Guards guards = {});
+    kota::task<Outcome> run(Fid path_id, Plan plan, Guards guards = {});
 
 private:
-    kota::task<RoundOutcome> round(RoundContext& ctx, std::uint32_t path_id);
+    kota::task<RoundOutcome> round(RoundContext& ctx, Fid path_id);
 
-    static NodeId node(std::uint32_t path_id) {
-        return {turun_family, path_id};
+    static NodeId node(Fid path_id) {
+        return {turun_family, path_id.raw};
     }
 
     TaskGraph& graph;
@@ -146,8 +146,8 @@ private:
     /// out after it. Each consumer runs one attempt per file at a time
     /// (the pump's ledger, the lint driver's sweep), so at most one live
     /// entry per TU.
-    llvm::DenseMap<std::uint32_t, Inputs> inputs;
-    llvm::DenseMap<std::uint32_t, Outcome> landed;
+    llvm::DenseMap<Fid, Inputs> inputs;
+    llvm::DenseMap<Fid, Outcome> landed;
 };
 
 }  // namespace clice

--- a/src/sched/index/ledger.cpp
+++ b/src/sched/index/ledger.cpp
@@ -4,7 +4,7 @@
 
 namespace clice {
 
-bool PendingLedger::record(std::uint32_t id, ReindexReason reason) {
+bool PendingLedger::record(Fid id, ReindexReason reason) {
     // A fresh slot means any prior slot was already consumed (or none
     // existed); a queued-and-unconsumed slot makes this call a duplicate.
     bool fresh_slot = queued.insert(id).second;
@@ -36,7 +36,7 @@ bool PendingLedger::record(std::uint32_t id, ReindexReason reason) {
     return fresh_slot;
 }
 
-std::optional<PendingLedger::Claim> PendingLedger::claim(std::uint32_t id) {
+std::optional<PendingLedger::Claim> PendingLedger::claim(Fid id) {
     queued.erase(id);
     auto it = entries.find(id);
     if(it == entries.end()) {
@@ -45,7 +45,7 @@ std::optional<PendingLedger::Claim> PendingLedger::claim(std::uint32_t id) {
     return Claim{id, it->second.ticket};
 }
 
-std::optional<PendingLedger::Claim> PendingLedger::peek(std::uint32_t id) const {
+std::optional<PendingLedger::Claim> PendingLedger::peek(Fid id) const {
     auto it = entries.find(id);
     if(it == entries.end()) {
         return std::nullopt;
@@ -105,8 +105,8 @@ PendingLedger::FailureOutcome PendingLedger::on_dispatch_failure(const Claim& cl
     return {FailureVerdict::Requeued, needs_slot};
 }
 
-llvm::SmallVector<std::uint32_t> PendingLedger::pending_files() const {
-    llvm::SmallVector<std::uint32_t> files;
+llvm::SmallVector<Fid> PendingLedger::pending_files() const {
+    llvm::SmallVector<Fid> files;
     files.reserve(entries.size());
     for(auto id: llvm::make_first_range(entries)) {
         files.push_back(id);

--- a/src/sched/index/ledger.h
+++ b/src/sched/index/ledger.h
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <optional>
 
+#include "vfs/file_table.h"
+
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -64,7 +66,7 @@ enum class Admission : std::uint8_t {
 class PendingLedger {
 public:
     struct Claim {
-        std::uint32_t id = 0;
+        Fid id;
         std::uint64_t ticket = 0;
     };
 
@@ -97,16 +99,16 @@ public:
     /// Every recording shields the entry from an in-flight attempt's
     /// settle; ContentChanged additionally starts a fresh crash budget —
     /// the crashes the old bytes caused say nothing about the fixed ones.
-    bool record(std::uint32_t id, ReindexReason reason);
+    bool record(Fid id, ReindexReason reason);
 
     /// Atomically claim the file's current debt at dispatch, consuming
     /// its queued-slot state. Empty when the entry was cleared while the
     /// slot sat in the queue (file removed): the slot is skipped.
-    std::optional<Claim> claim(std::uint32_t id);
+    std::optional<Claim> claim(Fid id);
 
     /// The claim a dispatch of the file's current debt would take, with
     /// nothing consumed — for waiters binding to the pending attempt.
-    std::optional<Claim> peek(std::uint32_t id) const;
+    std::optional<Claim> peek(Fid id) const;
 
     /// Settle the claimed debt after its attempt: erases the entry unless
     /// a recording during the flight booked newer debt, which survives.
@@ -130,7 +132,7 @@ public:
 
     /// Why the file awaits re-indexing (queued or in flight), or nullopt
     /// when nothing is pending. O(1), no I/O.
-    std::optional<ReindexReason> pending_reason(std::uint32_t id) const {
+    std::optional<ReindexReason> pending_reason(Fid id) const {
         auto it = entries.find(id);
         if(it == entries.end()) {
             return std::nullopt;
@@ -138,7 +140,7 @@ public:
         return it->second.reason;
     }
 
-    bool contains(std::uint32_t id) const {
+    bool contains(Fid id) const {
         return entries.count(id);
     }
 
@@ -146,13 +148,13 @@ public:
     /// disk): nothing is left to reindex, and a lingering ContentChanged
     /// reason would suppress its deliberately still-serving shard
     /// forever.
-    void clear(std::uint32_t id) {
+    void clear(Fid id) {
         entries.erase(id);
         queued.erase(id);
     }
 
     /// Every file with booked debt (batch debt reporting).
-    llvm::SmallVector<std::uint32_t> pending_files() const;
+    llvm::SmallVector<Fid> pending_files() const;
 
     /// No debt and no queued slots.
     bool empty() const {
@@ -185,12 +187,12 @@ private:
         unsigned requeue_attempts = 0;
     };
 
-    llvm::DenseMap<std::uint32_t, Entry> entries;
+    llvm::DenseMap<Fid, Entry> entries;
 
     /// Files holding a queued-and-unconsumed slot, for record()'s
     /// fresh-slot decision; the queue itself (ordering, rounds) belongs
     /// to the pump.
-    llvm::DenseSet<std::uint32_t> queued;
+    llvm::DenseSet<Fid> queued;
 
     std::uint64_t ticket = 0;
     unsigned max_requeue_attempts;

--- a/src/sched/index/pump.cpp
+++ b/src/sched/index/pump.cpp
@@ -298,6 +298,7 @@ kota::task<> IndexPump::run_index_task(PendingLedger::Claim claim,
             switch(outcome.verdict) {
                 case TURunFamily::Verdict::Completed: {
                     failed_ids.erase(server_path_id);
+                    indexed_total += 1;
                     LOG_PERF("index",
                              "progress={}/{} file={} bytes={} index_ms={} merge_ms={}",
                              index,

--- a/src/sched/index/pump.cpp
+++ b/src/sched/index/pump.cpp
@@ -38,6 +38,11 @@ void IndexPump::boost(std::uint32_t server_path_id) {
 }
 
 void IndexPump::enqueue(std::uint32_t server_path_id, ReindexReason reason) {
+    // New debt voids the running round's freshness memos: a claim taken
+    // after this recording must re-judge against the disk, or its skip
+    // would settle the fresh ticket on a verdict memoized before the
+    // change and the file would never re-index.
+    store.begin_round();
     if(!ledger.record(server_path_id, reason)) {
         return;
     }

--- a/src/sched/index/pump.cpp
+++ b/src/sched/index/pump.cpp
@@ -257,7 +257,7 @@ kota::task<> IndexPump::run_index_task(PendingLedger::Claim claim,
     // later round.
     auto admit = admission ? admission(server_path_id) : Admission::Admit;
     if(admit == Admission::Admit) {
-        auto file_path = std::string(workspace.path_pool.resolve(server_path_id));
+        auto file_path = std::string(workspace.file_table.resolve(server_path_id));
         // The engine's own observation is authoritative for content
         // changes: it saw the event. The dep-hash check cannot be trusted
         // to see a file's own edit (it validates the recorded

--- a/src/sched/index/pump.cpp
+++ b/src/sched/index/pump.cpp
@@ -23,7 +23,7 @@ IndexPump::IndexPump(kota::event_loop& loop,
     capacity_conn = pool.on_stateless_capacity.connect([this] { capacity_event.set(); });
 }
 
-void IndexPump::boost(std::uint32_t server_path_id) {
+void IndexPump::boost(Fid server_path_id) {
     enqueue(server_path_id, ReindexReason::DepsOnly);
     // Front of the un-consumed tail: the file someone is reading beats
     // the bulk backlog. A running round is not disturbed (its snapshot
@@ -37,7 +37,7 @@ void IndexPump::boost(std::uint32_t server_path_id) {
     schedule(/*immediate=*/true);
 }
 
-void IndexPump::enqueue(std::uint32_t server_path_id, ReindexReason reason) {
+void IndexPump::enqueue(Fid server_path_id, ReindexReason reason) {
     // New debt voids the running round's freshness memos: a claim taken
     // after this recording must re-judge against the disk, or its skip
     // would settle the fresh ticket on a verdict memoized before the
@@ -58,14 +58,14 @@ void IndexPump::claim_report(const IndexStore::Report& report) {
     }
 }
 
-llvm::SmallVector<std::uint32_t> IndexPump::save_debt() const {
-    llvm::SmallVector<std::uint32_t> debt(failed_ids.begin(), failed_ids.end());
+llvm::SmallVector<Fid> IndexPump::save_debt() const {
+    llvm::SmallVector<Fid> debt(failed_ids.begin(), failed_ids.end());
     auto pending = ledger.pending_files();
     debt.append(pending.begin(), pending.end());
     return debt;
 }
 
-kota::task<> IndexPump::await_attempt(std::uint32_t server_path_id) {
+kota::task<> IndexPump::await_attempt(Fid server_path_id) {
     auto pending = ledger.peek(server_path_id);
     if(!pending) {
         co_return;
@@ -84,7 +84,7 @@ kota::task<> IndexPump::await_attempt(std::uint32_t server_path_id) {
     co_await event->wait();
 }
 
-void IndexPump::settle_attempt_waits(std::uint32_t server_path_id, std::uint64_t ticket) {
+void IndexPump::settle_attempt_waits(Fid server_path_id, std::uint64_t ticket) {
     auto it = attempt_waits.find(server_path_id);
     if(it == attempt_waits.end()) {
         return;
@@ -427,10 +427,9 @@ kota::task<> IndexPump::run_background_indexing() {
     // running round, but staleness is re-judged per round anyway.
     store.begin_round();
 
-    std::stable_partition(
-        index_queue.begin() + index_queue_pos,
-        index_queue.end(),
-        [this](std::uint32_t id) { return workspace.path_to_module.contains(id); });
+    std::stable_partition(index_queue.begin() + index_queue_pos, index_queue.end(), [this](Fid id) {
+        return workspace.path_to_module.contains(id);
+    });
 
     // This round consumes [index_queue_pos, round_end) only. Anything
     // appended during the round — including its own failures' requeues —

--- a/src/sched/index/pump.h
+++ b/src/sched/index/pump.h
@@ -51,20 +51,20 @@ public:
     /// A veto settles the claimed debt — an ordinary open session's skip
     /// must clear it, or the pump spins; only Defer keeps the debt for a
     /// later round.
-    std::function<Admission(std::uint32_t)> admission;
+    std::function<Admission(Fid)> admission;
 
     /// Invoked when an index attempt settled with no retry pending, before
     /// the attempt's waiters wake (contract 15): the serving side decides
     /// whether the settled state can ever serve an open session and
     /// escalates it otherwise, so the waking waiters re-derive their route
     /// against the escalated state.
-    std::function<void(std::uint32_t path_id)> on_attempt_settled;
+    std::function<void(Fid path_id)> on_attempt_settled;
 
     /// Emitted when store rows that may be index-served changed (merged,
     /// re-masked, dropped or shed). Carries the affected path_ids; the
     /// serving adapter checks which of them an open session serves and
     /// refreshes those clients.
-    Signal<llvm::ArrayRef<std::uint32_t>> on_rows_changed;
+    Signal<llvm::ArrayRef<Fid>> on_rows_changed;
 
     /// Temporarily pause background indexing to give priority to user
     /// requests.  Indexing tasks already dispatched to workers continue,
@@ -98,13 +98,13 @@ public:
     /// keeps a single queue entry; its reason is upgraded to ContentChanged
     /// if either enqueue says so (a file both cascaded onto and edited is
     /// as stale as the edit makes it).
-    void enqueue(std::uint32_t server_path_id, ReindexReason reason);
+    void enqueue(Fid server_path_id, ReindexReason reason);
 
     /// Someone is reading `server_path_id` through the index and nothing
     /// serves it yet: enqueue it at the front of the un-consumed queue and
     /// start a round without the idle delay. A running round finishes
     /// undisturbed; the file then leads the next one.
-    void boost(std::uint32_t server_path_id);
+    void boost(Fid server_path_id);
 
     /// Wait until the pending (re)index attempt observed at call time
     /// settles — the merge landed, the attempt gave up, or the entry was
@@ -114,12 +114,12 @@ public:
     /// refresh request (outline, links): answered while the didOpen
     /// boost is still running, the empty result would freeze until the
     /// next edit.
-    kota::task<> await_attempt(std::uint32_t server_path_id);
+    kota::task<> await_attempt(Fid server_path_id);
 
     /// Why the file awaits re-indexing (queued or currently being indexed),
     /// or nullopt when its index is not pending an update. O(1), no I/O —
     /// the query path calls this per candidate file.
-    std::optional<ReindexReason> pending_reason(std::uint32_t server_path_id) const {
+    std::optional<ReindexReason> pending_reason(Fid server_path_id) const {
         return ledger.pending_reason(server_path_id);
     }
 
@@ -129,7 +129,7 @@ public:
     /// still-serving shard forever. A queue slot already consumed stays
     /// consumed; one not yet consumed is skipped at dispatch time (the
     /// consume loop treats a missing ledger entry as a cleared slot).
-    void clear_pending(std::uint32_t server_path_id) {
+    void clear_pending(Fid server_path_id) {
         ledger.clear(server_path_id);
         settle_attempt_waits(server_path_id);
     }
@@ -149,7 +149,7 @@ public:
 
     /// The pump debt a save()'s CDB snapshot persists: files whose latest
     /// attempt failed for good plus everything still booked in the ledger.
-    llvm::SmallVector<std::uint32_t> save_debt() const;
+    llvm::SmallVector<Fid> save_debt() const;
 
     /// Cancel background indexing and wait for all tasks to settle.
     kota::task<> stop();
@@ -210,7 +210,7 @@ private:
     /// Background indexing queue and scheduling state. The ledger tracks
     /// which files hold an un-consumed slot so enqueue can dedupe; the
     /// queue is compacted once a round has fully drained.
-    std::vector<std::uint32_t> index_queue;
+    std::vector<Fid> index_queue;
     std::size_t index_queue_pos = 0;
 
     /// The pending-reindex debt: claim/settle bookkeeping, tickets and
@@ -236,9 +236,9 @@ private:
     /// settled attempt covers (`ticket` and older) and drop their events.
     /// The default wakes every waiter — for the paths where no further
     /// attempt will come (entry cleared, shutdown).
-    void settle_attempt_waits(std::uint32_t server_path_id, std::uint64_t ticket = -1);
+    void settle_attempt_waits(Fid server_path_id, std::uint64_t ticket = -1);
 
-    llvm::DenseSet<std::uint32_t> failed_ids;
+    llvm::DenseSet<Fid> failed_ids;
 
     struct AttemptWait {
         std::uint64_t ticket;
@@ -250,7 +250,7 @@ private:
     /// its ticket settles (or wholesale at stop()). Keyed by ticket so a
     /// requeue during an attempt's flight cannot extend earlier waits —
     /// await_attempt promises one attempt, not a settled file.
-    llvm::DenseMap<std::uint32_t, llvm::SmallVector<AttemptWait, 2>> attempt_waits;
+    llvm::DenseMap<Fid, llvm::SmallVector<AttemptWait, 2>> attempt_waits;
     bool indexing_active = false;
     bool indexing_scheduled = false;
     std::shared_ptr<kota::timer> index_idle_timer;

--- a/src/sched/index/pump.h
+++ b/src/sched/index/pump.h
@@ -178,6 +178,13 @@ public:
         return failed_ids.size();
     }
 
+    /// TUs actually indexed and merged this session — dispatched claims the
+    /// freshness gate skipped do not count. The one-shot `clice index`
+    /// reports its work from this, so a warm rerun honestly says 0.
+    std::size_t indexed_files() const {
+        return indexed_total;
+    }
+
     /// Progress of the current (or last) indexing round. The reporter reads
     /// this on each on_progress_changed emission — the signal only wakes it,
     /// the numbers live here.
@@ -239,6 +246,7 @@ private:
     void settle_attempt_waits(Fid server_path_id, std::uint64_t ticket = -1);
 
     llvm::DenseSet<Fid> failed_ids;
+    std::size_t indexed_total = 0;
 
     struct AttemptWait {
         std::uint64_t ticket;

--- a/src/sched/index/store.cpp
+++ b/src/sched/index/store.cpp
@@ -83,7 +83,7 @@ CDBSnapshot build_cdb_snapshot(Workspace& workspace,
                                llvm::ArrayRef<std::uint32_t> standalone_debt) {
     CDBSnapshot snapshot;
     for(auto& [path_id, hashes]: workspace.cdb.command_hash_snapshot()) {
-        auto file = workspace.path_pool.resolve(path_id).str();
+        auto file = workspace.file_table.resolve(path_id).str();
         auto rules = rules_hash(workspace.config, file);
         snapshot.entries.push_back({
             .file = std::move(file),
@@ -96,7 +96,7 @@ CDBSnapshot build_cdb_snapshot(Workspace& workspace,
     // depends on their own matched rules and their borrowed host's command
     // — both must be snapshot to detect offline changes.
     auto add_standalone = [&](std::uint32_t tu) {
-        auto file = workspace.path_pool.resolve(tu);
+        auto file = workspace.file_table.resolve(tu);
         if(workspace.cdb.has_entry(file)) {
             return;
         }
@@ -105,7 +105,7 @@ CDBSnapshot build_cdb_snapshot(Workspace& workspace,
             .file = file.str(),
             .rules = rules_hash(workspace.config, file),
             .host = host_it != header_hosts.end()
-                        ? workspace.path_pool.resolve(host_it->second).str()
+                        ? workspace.file_table.resolve(host_it->second).str()
                         : std::string(),
         });
     };
@@ -157,7 +157,7 @@ std::optional<IndexStore::Report> IndexStore::merge(const void* tu_index_data, s
     llvm::SmallVector<std::uint32_t> file_ids_map;
     file_ids_map.resize_for_overwrite(view.path_count());
     for(std::uint32_t i = 0; i < view.path_count(); i += 1) {
-        file_ids_map[i] = workspace.path_pool.intern(view.path(i));
+        file_ids_map[i] = workspace.file_table.intern(view.path(i));
     }
     auto tu_path_id = file_ids_map[main_local_id];
 
@@ -187,7 +187,7 @@ std::optional<IndexStore::Report> IndexStore::merge(const void* tu_index_data, s
         if(path_hash != 0 && path_hash != content_hash) {
             LOG_WARN("Reject merge for {}: rows for {} consumed other content than the compiler",
                      main_tu_path,
-                     workspace.path_pool.resolve(file_ids_map[local_id]));
+                     workspace.file_table.resolve(file_ids_map[local_id]));
             return false;
         }
         consumed_hashes[local_id] = content_hash;
@@ -225,14 +225,14 @@ std::optional<IndexStore::Report> IndexStore::merge(const void* tu_index_data, s
         if(llvm::xxh3_64bits(bytes) != blob_hash) {
             LOG_WARN("Reject merge for {}: rows section for {} failed verification",
                      main_tu_path,
-                     workspace.path_pool.resolve(global_id));
+                     workspace.file_table.resolve(global_id));
             return std::nullopt;
         }
         auto fresh = index::Shard::from_buffer(llvm::MemoryBuffer::getMemBufferCopy(bytes));
         if(!fresh.loaded()) {
             LOG_WARN("Reject merge for {}: rows for {} do not form a valid shard",
                      main_tu_path,
-                     workspace.path_pool.resolve(global_id));
+                     workspace.file_table.resolve(global_id));
             return std::nullopt;
         }
         if(!record_consumed(local_id, fresh.content_hash())) {
@@ -460,13 +460,13 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<std::uint32_t>
     startup_removes.clear();
     for(auto path_id: retired) {
         removals.push_back(
-            {index::IndexBlobKind::Shard, blob_key(workspace.path_pool.resolve(path_id))});
+            {index::IndexBlobKind::Shard, blob_key(workspace.file_table.resolve(path_id))});
     }
     for(auto path_id: dirty_shards) {
         auto it = workspace.shards.find(path_id);
         assert(it != workspace.shards.end() && "dirty shards stay resident until retirement");
         batch.push_back({index::IndexBlobKind::Shard,
-                         blob_key(workspace.path_pool.resolve(path_id)),
+                         blob_key(workspace.file_table.resolve(path_id)),
                          it->second.bytes().str()});
         shard_ids.push_back(path_id);
     }
@@ -484,7 +484,7 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<std::uint32_t>
     }
     for(auto tu_path_id: dirty_manifests) {
         auto it = project.manifests.find(tu_path_id);
-        auto key = blob_key(workspace.path_pool.resolve(tu_path_id));
+        auto key = blob_key(workspace.file_table.resolve(tu_path_id));
         // Dirty with no in-memory manifest means dropped (drop_index): the
         // persisted blob must go too, or a restart resurrects the TU's
         // rows as fresh.
@@ -508,7 +508,7 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<std::uint32_t>
     if(global_dirty) {
         std::string bytes;
         llvm::raw_string_ostream os(bytes);
-        project.serialize_global(os, workspace.path_pool);
+        project.serialize_global(os, workspace.file_table);
         batch.push_back({index::IndexBlobKind::Global, "global", std::move(bytes)});
     }
 
@@ -702,7 +702,7 @@ kota::task<> IndexStore::migrate_shard_views(Report& report) {
             continue;
         }
         auto blob =
-            db.read(index::IndexBlobKind::Shard, blob_key(workspace.path_pool.resolve(path_id)));
+            db.read(index::IndexBlobKind::Shard, blob_key(workspace.file_table.resolve(path_id)));
         if(!blob || !it->second.rebind(std::move(blob.buffer))) {
             // Corruption can also surface first here (a damaged page only
             // this re-read reaches); the recovery below sheds the whole
@@ -714,7 +714,7 @@ kota::task<> IndexStore::migrate_shard_views(Report& report) {
             // its owners requeued to rebuild the rows, while keeping the
             // old view would dangle once the snapshot retires.
             LOG_ERROR("Index shard for {} diverged during snapshot migration",
-                      workspace.path_pool.resolve(path_id));
+                      workspace.file_table.resolve(path_id));
             assert(false && "persisted shard must survive snapshot migration");
             workspace.shards.erase(path_id);
             report.add_rows_changed(path_id);
@@ -827,7 +827,7 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
         return result;
     }
     llvm::DenseMap<std::uint32_t, std::uint64_t> manifest_pins;
-    if(!project.load_global(global.buffer->getBuffer(), workspace.path_pool, manifest_pins)) {
+    if(!project.load_global(global.buffer->getBuffer(), workspace.file_table, manifest_pins)) {
         LOG_INFO("Discarding old-format index global blob");
         sweep_all();
         if(!read_only) {
@@ -910,7 +910,7 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
     llvm::StringSet<> expected_keys;
     llvm::SmallVector<std::uint32_t> unservable;
     for(auto& [path_id, entry]: project.contributions) {
-        auto key = blob_key(workspace.path_pool.resolve(path_id));
+        auto key = blob_key(workspace.file_table.resolve(path_id));
         auto shard = index::Shard::from_buffer(db.read(index::IndexBlobKind::Shard, key).buffer);
         // A blob can verify yet miss a contributed variant, or carry
         // another content generation than the contributions pin (crash or
@@ -927,7 +927,7 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
                         llvm::all_of(llvm::make_second_range(entry),
                                      [&](std::uint64_t hash) { return shard.has_variant(hash); });
         if(!servable) {
-            LOG_INFO("Discarding unservable shard for {}", workspace.path_pool.resolve(path_id));
+            LOG_INFO("Discarding unservable shard for {}", workspace.file_table.resolve(path_id));
             unservable.push_back(path_id);
             continue;
         }
@@ -953,7 +953,7 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
             mask_refresh.append(affected.begin(), affected.end());
             if(!read_only) {
                 startup_removes.push_back(
-                    {index::IndexBlobKind::Manifest, blob_key(workspace.path_pool.resolve(tu))});
+                    {index::IndexBlobKind::Manifest, blob_key(workspace.file_table.resolve(tu))});
             }
             report.add_reindex(tu);
         }
@@ -990,7 +990,7 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
     if(!read_only && db.corrupted()) {
         LOG_WARN("Index database is corrupt; discarding it and rebuilding from scratch");
         for(auto tu: llvm::make_first_range(project.manifests)) {
-            if(!workspace.cdb.has_entry(workspace.path_pool.resolve(tu))) {
+            if(!workspace.cdb.has_entry(workspace.file_table.resolve(tu))) {
                 report.add_reindex(tu);
             }
         }
@@ -1024,7 +1024,7 @@ llvm::SmallVector<std::uint32_t>
     llvm::DenseSet<std::uint32_t> seen;
     for(auto id: candidates) {
         if(workspace.project_index.manifests.contains(id) ||
-           workspace.cdb.has_entry(workspace.path_pool.resolve(id)) || !seen.insert(id).second) {
+           workspace.cdb.has_entry(workspace.file_table.resolve(id)) || !seen.insert(id).second) {
             continue;
         }
         debt.push_back(id);
@@ -1059,7 +1059,7 @@ void IndexStore::reconcile_cdb_snapshot(Report& report) {
         if(entry.hashes.empty()) {
             continue;
         }
-        auto server_id = workspace.path_pool.intern(entry.file);
+        auto server_id = workspace.file_table.intern(entry.file);
         cdb_ids.insert(server_id);
         auto it = before.find(entry.file);
         // `selected` guards the offline winner flip: the candidate multiset
@@ -1102,7 +1102,7 @@ void IndexStore::reconcile_cdb_snapshot(Report& report) {
         if(!old.hashes.empty()) {
             continue;
         }
-        auto server_id = workspace.path_pool.intern(entry.file);
+        auto server_id = workspace.file_table.intern(entry.file);
         if(old.rules != entry.rules) {
             LOG_INFO("Config rules changed since the last session; reindexing {}", entry.file);
             drop_index_into(server_id, report);
@@ -1112,7 +1112,7 @@ void IndexStore::reconcile_cdb_snapshot(Report& report) {
         if(old.host.empty()) {
             continue;
         }
-        auto host_id = workspace.path_pool.intern(old.host);
+        auto host_id = workspace.file_table.intern(old.host);
         if(!workspace.cdb.has_entry(old.host) || llvm::is_contained(changed_ids, host_id)) {
             LOG_INFO("Host compile command changed since the last session; reindexing {}",
                      entry.file);
@@ -1148,7 +1148,7 @@ void IndexStore::reconcile_cdb_snapshot(Report& report) {
         if(!old.hashes.empty() || workspace.cdb.has_entry(old.file)) {
             continue;
         }
-        auto server_id = workspace.path_pool.intern(old.file);
+        auto server_id = workspace.file_table.intern(old.file);
         if(project.manifests.contains(server_id) || !fs::exists(old.file)) {
             continue;
         }
@@ -1172,7 +1172,7 @@ void IndexStore::reconcile_cdb_snapshot(Report& report) {
     }
     for(auto header_id: hosted) {
         LOG_INFO("Host compile command changed since the last session; reindexing {}",
-                 workspace.path_pool.resolve(header_id));
+                 workspace.file_table.resolve(header_id));
         drop_index_into(header_id, report);
         report.add_reindex(header_id);
     }
@@ -1189,7 +1189,7 @@ bool IndexStore::file_version_stale(std::uint32_t fv_id) {
         return true;
     }
     auto& record = record_it->second;
-    auto path = workspace.path_pool.resolve(record.path_id);
+    auto path = workspace.file_table.resolve(record.path_id);
 
     // Two-layer test on the shared FileVersion: Layer 1 trusts a stat EQUAL
     // to the recorded stamp (no file read) — equality, not a watermark, so
@@ -1223,7 +1223,7 @@ bool IndexStore::file_version_stale(std::uint32_t fv_id) {
 
 bool IndexStore::need_update(llvm::StringRef file_path) {
     auto& project = workspace.project_index;
-    auto manifest_it = project.manifests.find(workspace.path_pool.intern(file_path));
+    auto manifest_it = project.manifests.find(workspace.file_table.intern(file_path));
     if(manifest_it == project.manifests.end())
         return true;
 

--- a/src/sched/index/store.cpp
+++ b/src/sched/index/store.cpp
@@ -172,6 +172,10 @@ struct ArtifactsData {
     // lazily on the first overlay query — which cannot trigger a rebuild.
     std::uint32_t pch_index_format = 0;
 
+    // FileTable::revocation_generation at write time; gates adopt_stamp
+    // against a global blob recording revocations these records predate.
+    std::uint64_t revocation_generation = 0;
+
     std::vector<CachePCHEntry> pch;
     std::vector<CachePCMEntry> pcm;
     std::vector<CacheModeEntry> header_modes;
@@ -191,6 +195,7 @@ IndexStore::IndexStore(kota::event_loop& loop, Workspace& workspace, ContextReso
 std::string IndexStore::serialize_artifacts() {
     ArtifactsData data;
     data.pch_index_format = index::index_format_version;
+    data.revocation_generation = workspace.file_table.revocation_generation;
     llvm::StringMap<std::uint32_t> index_map;
 
     auto intern = [&](Fid fid) -> std::uint32_t {
@@ -295,6 +300,11 @@ void IndexStore::load_artifacts(llvm::StringRef bytes) {
     auto resolve = [&](std::uint32_t idx) -> llvm::StringRef {
         return idx < data.paths.size() ? llvm::StringRef(data.paths[idx]) : "";
     };
+    // A blob written before the loaded global's last revocation carries
+    // stamps that revocation dropped; adopting them would undo it (a crash
+    // between the two non-atomic blob writes leaves exactly this pair on
+    // disk). The dep records themselves stay: they self-validate by hash.
+    bool adopt_stamps = data.revocation_generation >= workspace.file_table.revocation_generation;
     auto load_deps = [&](const std::vector<CacheDepEntry>& dep_entries) -> DepsSnapshot {
         DepsSnapshot deps;
         for(auto& dep: dep_entries) {
@@ -306,7 +316,9 @@ void IndexStore::load_artifacts(llvm::StringRef bytes) {
             state.missing = dep.missing;
             if(dep.hash != 0) {
                 state.version = workspace.file_table.intern_version(state.path_id, dep.hash);
-                workspace.file_table.adopt_stamp(state.version, dep.size, dep.mtime_ns);
+                if(adopt_stamps) {
+                    workspace.file_table.adopt_stamp(state.version, dep.size, dep.mtime_ns);
+                }
             }
         }
         return deps;
@@ -795,20 +807,20 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<Fid> debt) {
     }
 
     // Metadata blobs ride every save: dirty artifact records and context
-    // choices flush on whatever save runs next. The epoch is snapshotted
-    // here — marks landing past this point are not covered by these bytes
-    // and wait for the next save (a durability waiter's ticket compares
-    // against committed_metadata_epoch).
-    auto flush_epoch = workspace.metadata_epoch;
+    // choices flush on whatever save runs next. The contexts epoch is
+    // snapshotted here — marks landing past this point are not covered by
+    // these bytes and wait for the next save (a durability waiter's ticket
+    // compares against committed_contexts_epoch). The contexts blob's fate
+    // is tracked on its own: a failing artifacts blob must not park a
+    // switchContext ack whose choice is already durable.
+    auto flush_epoch = workspace.contexts_epoch;
     std::optional<std::size_t> artifacts_index;
     std::optional<std::size_t> contexts_index;
-    bool metadata_ok = true;
+    bool contexts_ok = true;
     if(workspace.artifacts_dirty) {
         if(auto bytes = serialize_artifacts(); !bytes.empty()) {
             artifacts_index = batch.size();
             batch.push_back({index::IndexBlobKind::Artifacts, "artifacts", std::move(bytes)});
-        } else {
-            metadata_ok = false;
         }
     }
     if(workspace.contexts_dirty) {
@@ -816,7 +828,7 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<Fid> debt) {
             contexts_index = batch.size();
             batch.push_back({index::IndexBlobKind::Contexts, "contexts", std::move(bytes)});
         } else {
-            metadata_ok = false;
+            contexts_ok = false;
         }
     }
 
@@ -851,9 +863,9 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<Fid> debt) {
         // A serialize-only failure builds no batch: waiters still must see
         // the failed attempt (see the failure pulse below), or a request
         // bounded on failed saves never counts one.
-        if(!metadata_ok) {
-            workspace.metadata_committed.set();
-            workspace.metadata_committed.reset();
+        if(!contexts_ok) {
+            workspace.contexts_committed.set();
+            workspace.contexts_committed.reset();
         }
         co_return report;
     }
@@ -904,10 +916,9 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<Fid> debt) {
             cdb_index.reset();
         } else if(artifacts_index && i == *artifacts_index) {
             workspace.artifacts_dirty = true;
-            metadata_ok = false;
         } else if(contexts_index && i == *contexts_index) {
             workspace.contexts_dirty = true;
-            metadata_ok = false;
+            contexts_ok = false;
         } else {
             global_dirty = true;
         }
@@ -919,20 +930,17 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<Fid> debt) {
     saved_shards = shard_count - failed_shards;
     saving_shards = 0;
 
-    // Metadata as of the snapshot point is durable: advance the epoch and
-    // wake durability waiters (switchContext tickets).
-    if(metadata_ok) {
-        workspace.committed_metadata_epoch =
-            std::max(workspace.committed_metadata_epoch, flush_epoch);
-        workspace.metadata_committed.set();
-        workspace.metadata_committed.reset();
-    } else {
-        // Waiters must see failed attempts too, or a permanently failing
-        // metadata write (full disk, unserializable path) parks every
-        // durability wait forever; they give up after a few of these.
-        workspace.metadata_committed.set();
-        workspace.metadata_committed.reset();
+    // Context choices as of the snapshot point are durable: advance the
+    // epoch and wake durability waiters (switchContext tickets). Failed
+    // attempts pulse too, or a permanently failing write (full disk,
+    // unserializable path) parks every durability wait forever; they give
+    // up after a few of these.
+    if(contexts_ok) {
+        workspace.committed_contexts_epoch =
+            std::max(workspace.committed_contexts_epoch, flush_epoch);
     }
+    workspace.contexts_committed.set();
+    workspace.contexts_committed.reset();
 
     // Corruption can surface first at write time (a damaged page only the
     // write's tree descent reaches): heal like load-time corruption instead
@@ -1096,7 +1104,7 @@ void IndexStore::recover_corrupt_database(Report& report) {
 void IndexStore::reopen_fresh_database() {
     workspace.index_db->condemn();
     workspace.index_db.reset();
-    workspace.index_db = index::open_database(*workspace.store, workspace.config.project.index_db);
+    workspace.index_db = index::open_database(*workspace.store);
     // The metadata blobs died with the condemned database while their
     // loaded state lives on in memory; without a re-dirty the next save
     // skips them and a restart loses the user's context choices and every
@@ -1107,8 +1115,8 @@ void IndexStore::reopen_fresh_database() {
     // reopen disables persistence for the session, and a parked
     // switchContext would otherwise sleep forever — no later save pulses,
     // they all early-return on the null database.
-    workspace.metadata_committed.set();
-    workspace.metadata_committed.reset();
+    workspace.contexts_committed.set();
+    workspace.contexts_committed.reset();
 }
 
 IndexStore::LoadResult IndexStore::load(bool read_only) {

--- a/src/sched/index/store.cpp
+++ b/src/sched/index/store.cpp
@@ -1,6 +1,7 @@
 #include "sched/index/store.h"
 
 #include <algorithm>
+#include <unordered_map>
 #include <cassert>
 #include <format>
 #include <utility>
@@ -8,6 +9,8 @@
 
 #include "index/database.h"
 #include "index/manifest.h"
+#include "index/serialization.h"
+#include "sched/context.h"
 #include "index/shard.h"
 #include "index/tu_index.h"
 #include "support/filesystem.h"
@@ -131,10 +134,289 @@ std::string serialize_cdb_snapshot(Workspace& workspace,
     return json ? std::move(*json) : std::string();
 }
 
+/// The artifacts and contexts blobs: JSON envelopes in the index
+/// database, the persisted form of PCH/PCM validity metadata, header-mode
+/// verdicts and user context choices (the cache.json successor). Paths are
+/// persisted as spellings and re-interned at load — runtime fids are not
+/// stable across sessions. Per-dep stamps are the shared versions',
+/// written at save and adopted back at load, so the fast paths survive a
+/// restart without the records referencing version ids (they self-heal
+/// against any index state).
+
+struct CacheDepEntry {
+    std::uint32_t path;  // index into the envelope's paths table
+    std::uint64_t hash;
+    std::uint64_t size;
+    std::int64_t mtime_ns;
+    bool missing;
+};
+
+struct CacheBindingEntry {
+    std::uint64_t size;
+    std::int64_t mtime_ns;
+    std::uint64_t uid_device;
+    std::uint64_t uid_file;
+    std::uint64_t hash;
+};
+
+struct CachePCHEntry {
+    std::string key;  // CacheStore key in the "pch" namespace
+    std::uint32_t bound;
+    std::vector<CacheDepEntry> deps;
+    CacheBindingEntry blob;
+    CacheBindingEntry index_blob;
+
+    // Still owing the post-unclean-shutdown content verification. Persisted
+    // per record: the dead writer's dirty marker is consumed by the open
+    // that finds it, and a session can crash before verifying — the debt
+    // must survive that chain until the verification actually runs.
+    bool verify_content;
+};
+
+struct CachePCMEntry {
+    std::string key;  // CacheStore key in the "pcm" namespace
+    std::uint32_t source_file;
+    std::string module_name;
+    std::vector<CacheDepEntry> deps;
+    CacheBindingEntry blob;
+    bool verify_content;
+};
+
+struct ArtifactsData {
+    std::vector<std::string> paths;
+
+    // index_format_version the .pch.idx envelopes were written with (one
+    // binary writes them all). A mismatch drops every PCH entry at load so
+    // the pairs rebuild immediately, instead of the mismatch surfacing
+    // lazily on the first overlay query — which cannot trigger a rebuild.
+    std::uint32_t pch_index_format = 0;
+
+    std::vector<CachePCHEntry> pch;
+    std::vector<CachePCMEntry> pcm;
+    std::vector<CacheModeEntry> header_modes;
+};
+
+struct ContextsData {
+    std::vector<std::string> paths;
+    std::vector<CacheContextEntry> contexts;
+    std::vector<CacheArtifactEntry> artifacts;
+};
+
+BlobBinding to_binding(const CacheBindingEntry& entry) {
+    return {entry.size, entry.mtime_ns, entry.uid_device, entry.uid_file, entry.hash};
+}
+
+CacheBindingEntry from_binding(const BlobBinding& binding) {
+    return {binding.size, binding.mtime_ns, binding.uid_device, binding.uid_file, binding.hash};
+}
+
 }  // namespace
 
-IndexStore::IndexStore(kota::event_loop& loop, Workspace& workspace) :
-    loop(loop), workspace(workspace) {}
+IndexStore::IndexStore(kota::event_loop& loop, Workspace& workspace, ContextResolver& contexts) :
+    loop(loop), workspace(workspace), contexts(contexts) {}
+
+std::string IndexStore::serialize_artifacts() {
+    ArtifactsData data;
+    data.pch_index_format = index::index_format_version;
+    std::unordered_map<std::string, std::uint32_t> index_map;
+
+    auto intern = [&](std::uint32_t fid) -> std::uint32_t {
+        auto path = std::string(workspace.file_table.resolve(fid));
+        auto [it, inserted] =
+            index_map.try_emplace(path, static_cast<std::uint32_t>(data.paths.size()));
+        if(inserted) {
+            data.paths.push_back(path);
+        }
+        return it->second;
+    };
+
+    // The persisted per-dep stamp is the shared version's — earned once,
+    // written for every artifact referencing the version.
+    auto stamp_of = [&](const DepState& dep) -> std::pair<std::uint64_t, std::int64_t> {
+        auto it = workspace.file_table.version_ids.find({dep.path_id, dep.hash});
+        if(it == workspace.file_table.version_ids.end()) {
+            return {0, 0};
+        }
+        auto& version = workspace.file_table.version(it->second);
+        return {version.size, version.mtime_ns};
+    };
+    auto dump_deps = [&](const DepsSnapshot& snap, std::vector<CacheDepEntry>& out) {
+        for(auto& dep: snap.deps) {
+            auto [size, mtime_ns] = stamp_of(dep);
+            out.push_back({intern(dep.path_id), dep.hash, size, mtime_ns, dep.missing});
+        }
+    };
+
+    for(auto& e: workspace.pch_cache) {
+        auto& st = e.second;
+        if(st.path.empty())
+            continue;
+        CachePCHEntry entry;
+        entry.key = e.getKey().str();
+        entry.bound = st.bound;
+        dump_deps(st.deps, entry.deps);
+        entry.blob = from_binding(st.binding);
+        entry.index_blob = from_binding(st.index_binding);
+        entry.verify_content = st.verify_content;
+        data.pch.push_back(std::move(entry));
+    }
+
+    for(auto& [path_id, st]: workspace.pcm_cache) {
+        if(st.path.empty())
+            continue;
+        CachePCMEntry entry;
+        entry.key = st.key;
+        entry.source_file = intern(path_id);
+        auto mod_it = workspace.path_to_module.find(path_id);
+        entry.module_name = mod_it != workspace.path_to_module.end() ? mod_it->second : "";
+        dump_deps(st.deps, entry.deps);
+        entry.blob = from_binding(st.binding);
+        entry.verify_content = st.verify_content;
+        data.pcm.push_back(std::move(entry));
+    }
+
+    contexts.dump_mode_slices(data.header_modes, intern);
+
+    auto json = kota::codec::json::to_string(data);
+    if(!json) {
+        LOG_WARN("Failed to serialize the artifacts blob");
+        return {};
+    }
+    return std::move(*json);
+}
+
+std::string IndexStore::serialize_contexts() {
+    ContextsData data;
+    std::unordered_map<std::string, std::uint32_t> index_map;
+
+    auto intern_path = [&](llvm::StringRef path) -> std::uint32_t {
+        auto [it, inserted] =
+            index_map.try_emplace(path.str(), static_cast<std::uint32_t>(data.paths.size()));
+        if(inserted) {
+            data.paths.push_back(path.str());
+        }
+        return it->second;
+    };
+    auto intern = [&](std::uint32_t fid) -> std::uint32_t {
+        return intern_path(workspace.file_table.resolve(fid));
+    };
+
+    contexts.dump_choice_slices(data.contexts, data.artifacts, intern, intern_path);
+
+    auto json = kota::codec::json::to_string(data);
+    if(!json) {
+        LOG_WARN("Failed to serialize the contexts blob");
+        return {};
+    }
+    return std::move(*json);
+}
+
+void IndexStore::load_artifacts(llvm::StringRef bytes) {
+    if(bytes.empty() || !workspace.store) {
+        return;
+    }
+    ArtifactsData data;
+    if(!kota::codec::json::from_string(bytes, data)) {
+        LOG_WARN("Failed to parse the artifacts blob");
+        return;
+    }
+
+    auto resolve = [&](std::uint32_t idx) -> llvm::StringRef {
+        return idx < data.paths.size() ? llvm::StringRef(data.paths[idx]) : "";
+    };
+    auto load_deps = [&](const std::vector<CacheDepEntry>& dep_entries) -> DepsSnapshot {
+        DepsSnapshot deps;
+        for(auto& dep: dep_entries) {
+            auto dep_path = resolve(dep.path);
+            if(dep_path.empty())
+                continue;
+            auto path_id = workspace.file_table.intern(dep_path);
+            deps.deps.push_back({.path_id = path_id, .hash = dep.hash, .missing = dep.missing});
+            if(dep.hash != 0) {
+                workspace.file_table.adopt_stamp(
+                    workspace.file_table.intern_version(path_id, dep.hash),
+                    dep.size,
+                    dep.mtime_ns);
+            }
+        }
+        return deps;
+    };
+
+    // Records published by a writer that died before its metadata barrier
+    // may describe blobs they never matched: verify content hashes on the
+    // records' first use.
+    bool verify_content = workspace.store->dead_writer_dirty();
+
+    bool pch_format_ok = data.pch_index_format == index::index_format_version;
+    for(auto& entry: data.pch) {
+        if(!pch_format_ok) {
+            break;
+        }
+        auto pch_path = workspace.store->lookup("pch", entry.key);
+        if(!pch_path)
+            continue;
+        // A PCH without its pch.idx envelope is an incomplete pair
+        // (crash between the two commits): treat it as absent so the next
+        // compile rebuilds both.
+        auto index_path = workspace.store->lookup_aux("pch", entry.key);
+        if(!index_path)
+            continue;
+
+        auto& st = workspace.pch_cache[entry.key];
+        st.path = *pch_path;
+        st.bound = entry.bound;
+        st.deps = load_deps(entry.deps);
+        st.binding = to_binding(entry.blob);
+        st.index_binding = to_binding(entry.index_blob);
+        st.verify_content = entry.verify_content || verify_content;
+        st.index_path = *index_path;
+    }
+
+    for(auto& entry: data.pcm) {
+        auto pcm_path = workspace.store->lookup("pcm", entry.key);
+        auto source = resolve(entry.source_file);
+        if(!pcm_path || source.empty())
+            continue;
+        // A dep-less entry is an unvalidatable snapshot that would blindly
+        // serve a stale PCM (the key embeds no content). Drop it and let
+        // the module rebuild once.
+        if(entry.deps.empty()) {
+            continue;
+        }
+        auto path_id = workspace.file_table.intern(source);
+        auto& st = workspace.pcm_cache[path_id];
+        st.path = *pcm_path;
+        st.key = entry.key;
+        st.deps = load_deps(entry.deps);
+        st.binding = to_binding(entry.blob);
+        st.verify_content = entry.verify_content || verify_content;
+        workspace.pcm_paths[path_id] = *pcm_path;
+    }
+
+    auto intern_resolve = [&](std::uint32_t idx) -> llvm::StringRef {
+        return resolve(idx);
+    };
+    contexts.load_mode_slices(data.header_modes, intern_resolve);
+
+    LOG_INFO("Loaded artifact metadata: {} PCH entries, {} PCM entries",
+             workspace.pch_cache.size(),
+             workspace.pcm_cache.size());
+}
+
+void IndexStore::load_contexts(llvm::StringRef bytes) {
+    if(bytes.empty()) {
+        return;
+    }
+    ContextsData data;
+    if(!kota::codec::json::from_string(bytes, data)) {
+        LOG_WARN("Failed to parse the contexts blob");
+        return;
+    }
+    auto resolve = [&](std::uint32_t idx) -> llvm::StringRef {
+        return idx < data.paths.size() ? llvm::StringRef(data.paths[idx]) : "";
+    };
+    contexts.load_choice_slices(data.contexts, data.artifacts, resolve);
+}
 
 std::optional<IndexStore::Report> IndexStore::merge(const void* tu_index_data, std::size_t size) {
     // Zero-copy consumption: the wire stays serialized; a new variant's
@@ -416,8 +698,13 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<std::uint32_t>
     // nothing, and the gauge must not keep exposing the previous round's
     // count as current.
     saved_shards = 0;
-    if(!workspace.index_db)
+    // A read-only session (batch lint, stats) keeps its metadata in memory
+    // and exits with it — it must never write into a database a concurrent
+    // writer owns.
+    if(!workspace.index_db || workspace.index_db->read_only())
         co_return report;
+    co_await save_gate.acquire();
+    auto gate = llvm::make_scope_exit([this] { save_gate.release(); });
     auto& db = *workspace.index_db;
     auto& project = workspace.project_index;
     ScopedTimer timer;
@@ -544,10 +831,45 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<std::uint32_t>
         }
     }
 
+    // Metadata blobs ride every save: dirty artifact records and context
+    // choices flush on whatever save runs next. The epoch is snapshotted
+    // here — marks landing past this point are not covered by these bytes
+    // and wait for the next save (a durability waiter's ticket compares
+    // against committed_metadata_epoch). The writer-dirty marker clears
+    // below only when no blob was published after this same point.
+    auto flush_epoch = workspace.metadata_epoch;
+    auto store_marks = workspace.store ? workspace.store->writer_mark_count() : 0;
+    std::optional<std::size_t> artifacts_index;
+    std::optional<std::size_t> contexts_index;
+    bool metadata_ok = true;
+    if(workspace.artifacts_dirty) {
+        if(auto bytes = serialize_artifacts(); !bytes.empty()) {
+            artifacts_index = batch.size();
+            batch.push_back({index::IndexBlobKind::Artifacts, "artifacts", std::move(bytes)});
+        } else {
+            metadata_ok = false;
+        }
+    }
+    if(workspace.contexts_dirty) {
+        if(auto bytes = serialize_contexts(); !bytes.empty()) {
+            contexts_index = batch.size();
+            batch.push_back({index::IndexBlobKind::Contexts, "contexts", std::move(bytes)});
+        } else {
+            metadata_ok = false;
+        }
+    }
+
     bool had_global = global_dirty;
     dirty_shards.clear();
     dirty_manifests.clear();
     global_dirty = false;
+    // Serialization failures keep their dirty flag for the next attempt.
+    if(artifacts_index) {
+        workspace.artifacts_dirty = false;
+    }
+    if(contexts_index) {
+        workspace.contexts_dirty = false;
+    }
 
     // A deferred load-time sweep can name a key this very save re-writes:
     // the swept TU was re-enqueued at load and has already re-indexed.
@@ -587,6 +909,8 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<std::uint32_t>
         dirty_manifests.insert(manifest_ids.begin(), manifest_ids.end());
         global_dirty = global_dirty || had_global;
         cdb_dirty = cdb_dirty || cdb_index.has_value();
+        workspace.artifacts_dirty = workspace.artifacts_dirty || artifacts_index.has_value();
+        workspace.contexts_dirty = workspace.contexts_dirty || contexts_index.has_value();
         startup_removes.append(std::make_move_iterator(removals.begin()),
                                std::make_move_iterator(removals.end()));
         saving_shards = 0;
@@ -610,6 +934,12 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<std::uint32_t>
             // save retries even when nothing else changes by then.
             cdb_dirty = true;
             cdb_index.reset();
+        } else if(artifacts_index && i == *artifacts_index) {
+            workspace.artifacts_dirty = true;
+            metadata_ok = false;
+        } else if(contexts_index && i == *contexts_index) {
+            workspace.contexts_dirty = true;
+            metadata_ok = false;
         } else {
             global_dirty = true;
         }
@@ -620,6 +950,20 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<std::uint32_t>
     }
     saved_shards = shard_count - failed_shards;
     saving_shards = 0;
+
+    // Metadata as of the snapshot point is durable: advance the epoch and
+    // wake durability waiters (switchContext tickets). The writer-dirty
+    // marker clears only when no blob was published since the snapshot —
+    // a commit landing across the write await is not covered.
+    if(metadata_ok) {
+        workspace.committed_metadata_epoch =
+            std::max(workspace.committed_metadata_epoch, flush_epoch);
+        workspace.metadata_committed.set();
+        workspace.metadata_committed.reset();
+        if(workspace.store && failed.empty() && !db.corrupted()) {
+            workspace.store->clear_writer_dirty(store_marks);
+        }
+    }
 
     // Corruption can surface first at write time (a damaged page only the
     // write's tree descent reaches): heal like load-time corruption instead
@@ -806,6 +1150,19 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
         }
     };
 
+    // Artifact metadata and context choices are index-independent: they
+    // load (and self-validate) whatever happened to the global blob. Must
+    // run after load_global though — the deps they intern would otherwise
+    // occupy version ids the blob restores id-for-id.
+    auto load_metadata = [&] {
+        if(auto artifacts = db.read(index::IndexBlobKind::Artifacts, "artifacts")) {
+            load_artifacts(artifacts.buffer->getBuffer());
+        }
+        if(auto choices = db.read(index::IndexBlobKind::Contexts, "contexts")) {
+            load_contexts(choices.buffer->getBuffer());
+        }
+    };
+
     auto global = db.read(index::IndexBlobKind::Global, "global");
     if(!global) {
         // A global blob that exists but failed to open is a transient IO
@@ -824,6 +1181,9 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
                 LOG_WARN("Index database is corrupt; discarding it and rebuilding from scratch");
                 reopen_fresh_database();
             } else {
+                // Best effort before detaching: the metadata blobs may
+                // still read while only the global is unreadable.
+                load_metadata();
                 LOG_WARN("Index global blob unreadable; disabling index persistence this session");
                 workspace.index_db.reset();
             }
@@ -832,18 +1192,21 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
         // No global table means no resolvable manifests: everything else
         // is unreachable data, swept so it cannot survive as orphans.
         sweep_all();
+        load_metadata();
         return result;
     }
     llvm::DenseMap<std::uint32_t, std::uint64_t> manifest_pins;
     if(!project.load_global(global.buffer->getBuffer(), workspace.file_table, manifest_pins)) {
         LOG_INFO("Discarding old-format index global blob");
         sweep_all();
+        load_metadata();
         if(!read_only) {
             startup_removes.push_back({index::IndexBlobKind::Global, "global"});
         }
         result.decoded = false;
         return result;
     }
+    load_metadata();
 
     // Adopt exactly the manifests the global blob pins, at exactly the
     // pinned generation stamp and with every FileVersion resolvable. The
@@ -919,7 +1282,16 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
     llvm::SmallVector<std::uint32_t> unservable;
     for(auto& [path_id, entry]: project.contributions) {
         auto key = blob_key(workspace.file_table.resolve(path_id));
-        auto shard = index::Shard::from_buffer(db.read(index::IndexBlobKind::Shard, key).buffer);
+        auto blob = db.read(index::IndexBlobKind::Shard, key);
+        if(read_only && blob && blob.generation != 0) {
+            // A read-only session never advances snapshots, so borrowed
+            // bytes would pin the opening snapshot for its whole lifetime
+            // while a concurrent writer churns; copies let the snapshot
+            // retire right after the load.
+            blob.buffer = llvm::MemoryBuffer::getMemBufferCopy(blob.buffer->getBuffer());
+            blob.generation = 0;
+        }
+        auto shard = index::Shard::from_buffer(std::move(blob.buffer));
         // A blob can verify yet miss a contributed variant, or carry
         // another content generation than the contributions pin (crash or
         // failed write left a manifest newer than its shard); set_live
@@ -1009,6 +1381,16 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
         cdb_dirty = true;
         reopen_fresh_database();
         return result;
+    }
+
+    if(read_only) {
+        // Everything is deserialized or copied by now, so nothing borrows
+        // the opening snapshot; retiring it keeps a long read-only session
+        // (batch lint) from pinning a concurrent writer's page
+        // reclamation to session start.
+        if(db.advance_read_snapshot()) {
+            db.retire_old_snapshot();
+        }
     }
 
     if(!workspace.shards.empty()) {

--- a/src/sched/index/store.cpp
+++ b/src/sched/index/store.cpp
@@ -81,8 +81,8 @@ std::string rules_hash(const Config& config, llvm::StringRef file) {
 }
 
 CDBSnapshot build_cdb_snapshot(Workspace& workspace,
-                               const llvm::DenseMap<std::uint32_t, std::uint32_t>& header_hosts,
-                               llvm::ArrayRef<std::uint32_t> standalone_debt) {
+                               const llvm::DenseMap<Fid, Fid>& header_hosts,
+                               llvm::ArrayRef<Fid> standalone_debt) {
     CDBSnapshot snapshot;
     for(auto& [path_id, hashes]: workspace.cdb.command_hash_snapshot()) {
         auto file = workspace.file_table.resolve(path_id).str();
@@ -97,7 +97,7 @@ CDBSnapshot build_cdb_snapshot(Workspace& workspace,
     // Standalone-indexed TUs have no CDB entry, yet their effective command
     // depends on their own matched rules and their borrowed host's command
     // — both must be snapshot to detect offline changes.
-    auto add_standalone = [&](std::uint32_t tu) {
+    auto add_standalone = [&](Fid tu) {
         auto file = workspace.file_table.resolve(tu);
         if(workspace.cdb.has_entry(file)) {
             return;
@@ -126,8 +126,8 @@ CDBSnapshot build_cdb_snapshot(Workspace& workspace,
 }
 
 std::string serialize_cdb_snapshot(Workspace& workspace,
-                                   const llvm::DenseMap<std::uint32_t, std::uint32_t>& header_hosts,
-                                   llvm::ArrayRef<std::uint32_t> standalone_debt) {
+                                   const llvm::DenseMap<Fid, Fid>& header_hosts,
+                                   llvm::ArrayRef<Fid> standalone_debt) {
     auto json =
         kota::codec::json::to_string(build_cdb_snapshot(workspace, header_hosts, standalone_debt));
     return json ? std::move(*json) : std::string();
@@ -150,26 +150,10 @@ struct CacheDepEntry {
     bool missing;
 };
 
-struct CacheBindingEntry {
-    std::uint64_t size;
-    std::int64_t mtime_ns;
-    std::uint64_t uid_device;
-    std::uint64_t uid_file;
-    std::uint64_t hash;
-};
-
 struct CachePCHEntry {
     std::string key;  // CacheStore key in the "pch" namespace
     std::uint32_t bound;
     std::vector<CacheDepEntry> deps;
-    CacheBindingEntry blob;
-    CacheBindingEntry index_blob;
-
-    // Still owing the post-unclean-shutdown content verification. Persisted
-    // per record: the dead writer's dirty marker is consumed by the open
-    // that finds it, and a session can crash before verifying — the debt
-    // must survive that chain until the verification actually runs.
-    bool verify_content;
 };
 
 struct CachePCMEntry {
@@ -177,8 +161,6 @@ struct CachePCMEntry {
     std::uint32_t source_file;
     std::string module_name;
     std::vector<CacheDepEntry> deps;
-    CacheBindingEntry blob;
-    bool verify_content;
 };
 
 struct ArtifactsData {
@@ -201,22 +183,6 @@ struct ContextsData {
     std::vector<CacheArtifactEntry> artifacts;
 };
 
-BlobBinding to_binding(const CacheBindingEntry& entry) {
-    return {.size = entry.size,
-            .mtime_ns = entry.mtime_ns,
-            .uid_device = entry.uid_device,
-            .uid_file = entry.uid_file,
-            .hash = entry.hash};
-}
-
-CacheBindingEntry from_binding(const BlobBinding& binding) {
-    return {.size = binding.size,
-            .mtime_ns = binding.mtime_ns,
-            .uid_device = binding.uid_device,
-            .uid_file = binding.uid_file,
-            .hash = binding.hash};
-}
-
 }  // namespace
 
 IndexStore::IndexStore(kota::event_loop& loop, Workspace& workspace, ContextResolver& contexts) :
@@ -227,7 +193,7 @@ std::string IndexStore::serialize_artifacts() {
     data.pch_index_format = index::index_format_version;
     llvm::StringMap<std::uint32_t> index_map;
 
-    auto intern = [&](std::uint32_t fid) -> std::uint32_t {
+    auto intern = [&](Fid fid) -> std::uint32_t {
         auto path = std::string(workspace.file_table.resolve(fid));
         auto [it, inserted] =
             index_map.try_emplace(path, static_cast<std::uint32_t>(data.paths.size()));
@@ -237,20 +203,23 @@ std::string IndexStore::serialize_artifacts() {
         return it->second;
     };
 
-    // The persisted per-dep stamp is the shared version's — earned once,
-    // written for every artifact referencing the version.
-    auto stamp_of = [&](const DepState& dep) -> std::pair<std::uint64_t, std::int64_t> {
-        auto it = workspace.file_table.version_ids.find({dep.path_id, dep.hash});
-        if(it == workspace.file_table.version_ids.end()) {
-            return {0, 0};
-        }
-        auto& version = workspace.file_table.version(it->second);
-        return {version.size, version.mtime_ns};
-    };
+    // Deps persist as (spelling, hash) pairs so they self-heal against any
+    // index state; the per-dep stamp is the shared version's — earned
+    // once, written for every artifact referencing the version. A
+    // version-less dep (missing or unhashable at capture) writes hash 0
+    // and reloads as one.
     auto dump_deps = [&](const DepsSnapshot& snap, std::vector<CacheDepEntry>& out) {
-        for(auto& dep: snap.deps) {
-            auto [size, mtime_ns] = stamp_of(dep);
-            out.push_back({intern(dep.path_id), dep.hash, size, mtime_ns, dep.missing});
+        for(auto& dep: snap) {
+            if(!dep.version.valid()) {
+                out.push_back({intern(dep.path_id), 0, 0, 0, dep.missing});
+                continue;
+            }
+            auto& version = workspace.file_table.version(dep.version);
+            out.push_back({intern(dep.path_id),
+                           version.content_hash,
+                           version.size,
+                           version.mtime_ns,
+                           dep.missing});
         }
     };
 
@@ -262,9 +231,6 @@ std::string IndexStore::serialize_artifacts() {
         entry.key = e.getKey().str();
         entry.bound = st.bound;
         dump_deps(st.deps, entry.deps);
-        entry.blob = from_binding(st.binding);
-        entry.index_blob = from_binding(st.index_binding);
-        entry.verify_content = st.verify_content;
         data.pch.push_back(std::move(entry));
     }
 
@@ -277,8 +243,6 @@ std::string IndexStore::serialize_artifacts() {
         auto mod_it = workspace.path_to_module.find(path_id);
         entry.module_name = mod_it != workspace.path_to_module.end() ? mod_it->second : "";
         dump_deps(st.deps, entry.deps);
-        entry.blob = from_binding(st.binding);
-        entry.verify_content = st.verify_content;
         data.pcm.push_back(std::move(entry));
     }
 
@@ -304,7 +268,7 @@ std::string IndexStore::serialize_contexts() {
         }
         return it->second;
     };
-    auto intern = [&](std::uint32_t fid) -> std::uint32_t {
+    auto intern = [&](Fid fid) -> std::uint32_t {
         return intern_path(workspace.file_table.resolve(fid));
     };
 
@@ -337,22 +301,16 @@ void IndexStore::load_artifacts(llvm::StringRef bytes) {
             auto dep_path = resolve(dep.path);
             if(dep_path.empty())
                 continue;
-            auto path_id = workspace.file_table.intern(dep_path);
-            deps.deps.push_back({.path_id = path_id, .hash = dep.hash, .missing = dep.missing});
+            auto& state = deps.emplace_back();
+            state.path_id = workspace.file_table.intern(dep_path);
+            state.missing = dep.missing;
             if(dep.hash != 0) {
-                workspace.file_table.adopt_stamp(
-                    workspace.file_table.intern_version(path_id, dep.hash),
-                    dep.size,
-                    dep.mtime_ns);
+                state.version = workspace.file_table.intern_version(state.path_id, dep.hash);
+                workspace.file_table.adopt_stamp(state.version, dep.size, dep.mtime_ns);
             }
         }
         return deps;
     };
-
-    // Records published by a writer that died before its metadata barrier
-    // may describe blobs they never matched: verify content hashes on the
-    // records' first use.
-    bool verify_content = workspace.store->dead_writer_dirty();
 
     bool pch_format_ok = data.pch_index_format == index::index_format_version;
     for(auto& entry: data.pch) {
@@ -373,9 +331,6 @@ void IndexStore::load_artifacts(llvm::StringRef bytes) {
         st.path = *pch_path;
         st.bound = entry.bound;
         st.deps = load_deps(entry.deps);
-        st.binding = to_binding(entry.blob);
-        st.index_binding = to_binding(entry.index_blob);
-        st.verify_content = entry.verify_content || verify_content;
         st.index_path = *index_path;
     }
 
@@ -395,23 +350,12 @@ void IndexStore::load_artifacts(llvm::StringRef bytes) {
         st.path = *pcm_path;
         st.key = entry.key;
         st.deps = load_deps(entry.deps);
-        st.binding = to_binding(entry.blob);
-        st.verify_content = entry.verify_content || verify_content;
-        workspace.pcm_paths[path_id] = *pcm_path;
     }
 
     auto intern_resolve = [&](std::uint32_t idx) -> llvm::StringRef {
         return resolve(idx);
     };
     contexts.load_mode_slices(data.header_modes, intern_resolve);
-
-    // The latched debt must reach the blob before the writer-dirty marker
-    // may clear: an unrelated save would otherwise clear it with the flags
-    // only in memory, and the session after next would trust the records
-    // on a stat match alone.
-    if(verify_content && (!workspace.pch_cache.empty() || !workspace.pcm_cache.empty())) {
-        workspace.mark_artifacts_dirty();
-    }
 
     LOG_INFO("Loaded artifact metadata: {} PCH entries, {} PCM entries",
              workspace.pch_cache.size(),
@@ -451,7 +395,7 @@ std::optional<IndexStore::Report> IndexStore::merge(const void* tu_index_data, s
     // FileVersions, the manifest, shards) commits only below the section
     // loop, once every part of the result validated.
     auto& project = workspace.project_index;
-    llvm::SmallVector<std::uint32_t> file_ids_map;
+    llvm::SmallVector<Fid> file_ids_map;
     file_ids_map.resize_for_overwrite(view.path_count());
     for(std::uint32_t i = 0; i < view.path_count(); i += 1) {
         file_ids_map[i] = workspace.file_table.intern(view.path(i));
@@ -467,11 +411,11 @@ std::optional<IndexStore::Report> IndexStore::merge(const void* tu_index_data, s
     // whole result mid-loop, and shards installed before that point would
     // leave the surviving manifest referencing variants the new blobs no
     // longer store.
-    llvm::SmallVector<std::pair<std::uint32_t, index::Shard>> replacements;
+    llvm::SmallVector<std::pair<Fid, index::Shard>> replacements;
     // (TU-local path id, variant identity) per serving section; the
     // FileVersions these will reference are interned only at commit.
     llvm::SmallVector<std::pair<std::uint32_t, std::uint64_t>> section_contributions;
-    llvm::SmallVector<std::uint32_t> rebuilt_ids;
+    llvm::SmallVector<Fid> rebuilt_ids;
     // TU-local path id -> content hash of the bytes each section's rows
     // were built from (0 = no section). A section's shard already records
     // that hash, so the FileVersion baseline below adopts it: pairing the
@@ -578,7 +522,7 @@ std::optional<IndexStore::Report> IndexStore::merge(const void* tu_index_data, s
     // were never built from, so those files re-earn their fast path
     // through a hash check instead (see file_version_stale).
     auto baseline_before_ns = fs::stat_baseline_before_ns(view.built_at());
-    llvm::SmallVector<std::uint32_t> fv_of;
+    llvm::SmallVector<VersionID> fv_of;
     fv_of.resize_for_overwrite(view.path_count());
     for(std::uint32_t i = 0; i < view.path_count(); i += 1) {
         llvm::StringRef path = view.path(i);
@@ -682,13 +626,13 @@ std::optional<IndexStore::Report> IndexStore::merge(const void* tu_index_data, s
     return report;
 }
 
-IndexStore::Report IndexStore::drop_index(std::uint32_t tu_path_id) {
+IndexStore::Report IndexStore::drop_index(Fid tu_path_id) {
     Report report;
     drop_index_into(tu_path_id, report);
     return report;
 }
 
-void IndexStore::drop_index_into(std::uint32_t tu_path_id, Report& report) {
+void IndexStore::drop_index_into(Fid tu_path_id, Report& report) {
     auto& project = workspace.project_index;
     if(!project.manifests.contains(tu_path_id)) {
         return;
@@ -707,7 +651,7 @@ void IndexStore::drop_index_into(std::uint32_t tu_path_id, Report& report) {
     global_dirty = true;
 }
 
-kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<std::uint32_t> debt) {
+kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<Fid> debt) {
     Report report;
     // Reset up front: every early return below means this save committed
     // nothing, and the gauge must not keep exposing the previous round's
@@ -738,7 +682,7 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<std::uint32_t>
     // already does. The pinning TUs are re-enqueued: no in-process event
     // would rebuild their rows otherwise (a reverted file even reads fresh
     // by hash), only a restart reaching load()'s re-enqueue.
-    llvm::SmallVector<std::uint32_t> retired;
+    llvm::SmallVector<Fid> retired;
     for(auto& [path_id, shard]: workspace.shards) {
         auto live = project.live_variants(path_id);
         if(llvm::none_of(live, [&](std::uint64_t hash) { return shard.has_variant(hash); })) {
@@ -768,8 +712,8 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<std::uint32_t>
     // for the next save. The id vectors parallel the batch so a failed
     // entry can be re-dirtied by its batch index.
     std::vector<index::BlobDatabase::Blob> batch;
-    llvm::SmallVector<std::uint32_t> shard_ids;
-    llvm::SmallVector<std::uint32_t> manifest_ids;
+    llvm::SmallVector<Fid> shard_ids;
+    llvm::SmallVector<Fid> manifest_ids;
     llvm::SmallVector<index::BlobKey> removals = std::move(startup_removes);
     startup_removes.clear();
     for(auto path_id: retired) {
@@ -854,10 +798,8 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<std::uint32_t>
     // choices flush on whatever save runs next. The epoch is snapshotted
     // here — marks landing past this point are not covered by these bytes
     // and wait for the next save (a durability waiter's ticket compares
-    // against committed_metadata_epoch). The writer-dirty marker clears
-    // below only when no blob was published after this same point.
+    // against committed_metadata_epoch).
     auto flush_epoch = workspace.metadata_epoch;
-    auto store_marks = workspace.store ? workspace.store->writer_mark_count() : 0;
     std::optional<std::size_t> artifacts_index;
     std::optional<std::size_t> contexts_index;
     bool metadata_ok = true;
@@ -978,17 +920,12 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<std::uint32_t>
     saving_shards = 0;
 
     // Metadata as of the snapshot point is durable: advance the epoch and
-    // wake durability waiters (switchContext tickets). The writer-dirty
-    // marker clears only when no blob was published since the snapshot —
-    // a commit landing across the write await is not covered.
+    // wake durability waiters (switchContext tickets).
     if(metadata_ok) {
         workspace.committed_metadata_epoch =
             std::max(workspace.committed_metadata_epoch, flush_epoch);
         workspace.metadata_committed.set();
         workspace.metadata_committed.reset();
-        if(workspace.store && failed.empty() && !db.corrupted()) {
-            workspace.store->clear_writer_dirty(store_marks);
-        }
     } else {
         // Waiters must see failed attempts too, or a permanently failing
         // metadata write (full disk, unserializable path) parks every
@@ -1070,7 +1007,7 @@ kota::task<> IndexStore::migrate_shard_views(Report& report) {
     }
 
     constexpr std::size_t rebind_batch = 512;
-    llvm::SmallVector<std::uint32_t> resident;
+    llvm::SmallVector<Fid> resident;
     for(auto path_id: llvm::make_first_range(workspace.shards)) {
         if(!dirty_shards.contains(path_id)) {
             resident.push_back(path_id);
@@ -1115,7 +1052,7 @@ kota::task<> IndexStore::migrate_shard_views(Report& report) {
     db.retire_old_snapshot();
 }
 
-void IndexStore::requeue_owners(std::uint32_t path_id, Report& report) {
+void IndexStore::requeue_owners(Fid path_id, Report& report) {
     auto it = workspace.project_index.contributions.find(path_id);
     if(it == workspace.project_index.contributions.end()) {
         return;
@@ -1126,7 +1063,7 @@ void IndexStore::requeue_owners(std::uint32_t path_id, Report& report) {
 }
 
 void IndexStore::shed_borrowed_shards(Report& report) {
-    llvm::SmallVector<std::uint32_t> shed;
+    llvm::SmallVector<Fid> shed;
     for(auto path_id: llvm::make_first_range(workspace.shards)) {
         if(!dirty_shards.contains(path_id)) {
             shed.push_back(path_id);
@@ -1251,7 +1188,7 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
         retire_snapshot();
         return result;
     }
-    llvm::DenseMap<std::uint32_t, std::uint64_t> manifest_pins;
+    llvm::DenseMap<VersionID, std::uint64_t> manifest_pins;
     if(!project.load_global(global.buffer->getBuffer(), workspace.file_table, manifest_pins)) {
         LOG_INFO("Discarding old-format index global blob");
         sweep_all();
@@ -1270,7 +1207,7 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
     // rest are stale residue — a crash between batch phases, a failed
     // write under a landed global, a dropped TU whose removal was lost —
     // and are swept, with their TUs re-enqueued where recoverable.
-    llvm::DenseSet<std::uint32_t> adopted_pins;
+    llvm::DenseSet<VersionID> adopted_pins;
     llvm::SmallVector<std::string> dead_manifests;
     db.for_each_key(index::IndexBlobKind::Manifest, [&](llvm::StringRef key) {
         auto blob = db.read(index::IndexBlobKind::Manifest, key);
@@ -1284,9 +1221,8 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
             // re-enqueue it: the CDB sweep never covers standalone-indexed
             // headers.
             if(manifest) {
-                auto fv = workspace.file_table.versions.find(manifest->tu_fv);
-                if(fv != workspace.file_table.versions.end()) {
-                    report.add_reindex(fv->second.fid);
+                if(workspace.file_table.knows_version(manifest->tu_fv)) {
+                    report.add_reindex(workspace.file_table.version(manifest->tu_fv).fid);
                 }
             }
             return;
@@ -1317,7 +1253,7 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
     // versions would match the disk while positions map through the old
     // text, forever. A version with no consumed-content hash (0) pins
     // nothing — it is permanently stale and reindexes its TU anyway.
-    llvm::DenseMap<std::uint32_t, llvm::SmallVector<std::uint64_t, 1>> generations;
+    llvm::DenseMap<Fid, llvm::SmallVector<std::uint64_t, 1>> generations;
     for(auto& manifest: llvm::make_second_range(project.manifests)) {
         for(auto fv: llvm::make_first_range(manifest.contributions)) {
             auto& record = workspace.file_table.version(fv);
@@ -1336,7 +1272,7 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
     // unservable, so those manifests are dropped and the TUs reindex (for
     // headers no CDB entry would ever re-enqueue them otherwise).
     llvm::StringSet<> expected_keys;
-    llvm::SmallVector<std::uint32_t> unservable;
+    llvm::SmallVector<Fid> unservable;
     for(auto& [path_id, entry]: project.contributions) {
         auto key = blob_key(workspace.file_table.resolve(path_id));
         auto blob = db.read(index::IndexBlobKind::Shard, key);
@@ -1372,13 +1308,13 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
         shard.set_live(project.live_variants(path_id));
         workspace.shards[path_id] = std::move(shard);
     }
-    llvm::SmallVector<std::uint32_t> mask_refresh;
+    llvm::SmallVector<Fid> mask_refresh;
     for(auto path_id: unservable) {
         auto contribution_it = project.contributions.find(path_id);
         if(contribution_it == project.contributions.end()) {
             continue;
         }
-        llvm::SmallVector<std::uint32_t> owners;
+        llvm::SmallVector<Fid> owners;
         for(auto tu: llvm::make_first_range(contribution_it->second)) {
             owners.push_back(tu);
         }
@@ -1457,10 +1393,9 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
     return result;
 }
 
-llvm::SmallVector<std::uint32_t>
-    IndexStore::standalone_of(llvm::ArrayRef<std::uint32_t> candidates) {
-    llvm::SmallVector<std::uint32_t> debt;
-    llvm::DenseSet<std::uint32_t> seen;
+llvm::SmallVector<Fid> IndexStore::standalone_of(llvm::ArrayRef<Fid> candidates) {
+    llvm::SmallVector<Fid> debt;
+    llvm::DenseSet<Fid> seen;
     for(auto id: candidates) {
         if(workspace.project_index.manifests.contains(id) ||
            workspace.cdb.has_entry(workspace.file_table.resolve(id)) || !seen.insert(id).second) {
@@ -1491,8 +1426,8 @@ void IndexStore::reconcile_cdb_snapshot(Report& report) {
         before[entry.file] = &entry;
     }
     auto& project = workspace.project_index;
-    llvm::DenseSet<std::uint32_t> cdb_ids;
-    llvm::SmallVector<std::uint32_t> changed_ids;
+    llvm::DenseSet<Fid> cdb_ids;
+    llvm::SmallVector<Fid> changed_ids;
     auto snapshot = build_cdb_snapshot(workspace, header_hosts, {});
     for(auto& entry: snapshot.entries) {
         if(entry.hashes.empty()) {
@@ -1523,7 +1458,7 @@ void IndexStore::reconcile_cdb_snapshot(Report& report) {
     // invalidation. A header whose recorded host survives unchanged and
     // still includes it is pinned fresh; one with no recorded host (older
     // snapshot) falls back to the include-reachability approximation below.
-    llvm::DenseSet<std::uint32_t> pinned_fresh;
+    llvm::DenseSet<Fid> pinned_fresh;
     for(auto& entry: snapshot.entries) {
         if(!entry.hashes.empty()) {
             continue;
@@ -1598,12 +1533,12 @@ void IndexStore::reconcile_cdb_snapshot(Report& report) {
         return;
     }
 
-    llvm::SmallVector<std::uint32_t> hosted;
+    llvm::SmallVector<Fid> hosted;
     for(auto tu: llvm::make_first_range(project.manifests)) {
         if(cdb_ids.contains(tu) || pinned_fresh.contains(tu)) {
             continue;
         }
-        if(llvm::any_of(changed_ids, [&](std::uint32_t host) {
+        if(llvm::any_of(changed_ids, [&](Fid host) {
                return !workspace.dep_graph.find_include_chain(host, tu).empty();
            })) {
             hosted.push_back(tu);
@@ -1617,7 +1552,7 @@ void IndexStore::reconcile_cdb_snapshot(Report& report) {
     }
 }
 
-bool IndexStore::file_version_stale(std::uint32_t fv_id) {
+bool IndexStore::file_version_stale(VersionID fv_id) {
     auto [cached, inserted] = fv_verdicts.try_emplace(fv_id, true);
     if(!inserted) {
         return cached->second;
@@ -1637,7 +1572,7 @@ bool IndexStore::file_version_stale(std::uint32_t fv_id) {
 }
 
 bool IndexStore::need_update(llvm::StringRef file_path) {
-    workspace.file_table.begin_wave();
+    auto wave = workspace.file_table.wave();
     auto& project = workspace.project_index;
     auto manifest_it = project.manifests.find(workspace.file_table.intern(file_path));
     if(manifest_it == project.manifests.end())

--- a/src/sched/index/store.cpp
+++ b/src/sched/index/store.cpp
@@ -1,18 +1,18 @@
 #include "sched/index/store.h"
 
 #include <algorithm>
-#include <unordered_map>
 #include <cassert>
 #include <format>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include "index/database.h"
 #include "index/manifest.h"
 #include "index/serialization.h"
-#include "sched/context.h"
 #include "index/shard.h"
 #include "index/tu_index.h"
+#include "sched/context.h"
 #include "support/filesystem.h"
 #include "support/logging.h"
 #include "support/timer.h"
@@ -580,9 +580,7 @@ std::optional<IndexStore::Report> IndexStore::merge(const void* tu_index_data, s
             // holds the consumed bytes, so take their hash from the shared
             // pair — or one read, unless the file moved between the stat
             // and the read, which voids the proof.
-            auto obs = workspace.file_table.observe_for(file_ids_map[i],
-                                                        status.getSize(),
-                                                        fs::mtime_ns(status));
+            auto obs = workspace.file_table.observe_for(file_ids_map[i], status);
             if(obs && obs->size == status.getSize() && obs->mtime_ns == fs::mtime_ns(status)) {
                 hash = obs->hash;
             }
@@ -598,9 +596,7 @@ std::optional<IndexStore::Report> IndexStore::merge(const void* tu_index_data, s
             // read (usually the shared pair, already paid for); an
             // already-stamped version earned its stamp the same way and
             // need not re-prove it every merge.
-            if(auto obs = workspace.file_table.observe_for(file_ids_map[i],
-                                                          status.getSize(),
-                                                          fs::mtime_ns(status))) {
+            if(auto obs = workspace.file_table.observe_for(file_ids_map[i], status)) {
                 workspace.file_table.try_stamp(fv, obs->size, obs->mtime_ns);
             }
         }

--- a/src/sched/index/store.cpp
+++ b/src/sched/index/store.cpp
@@ -906,6 +906,13 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<std::uint32_t>
     }
 
     if(batch.empty() && removals.empty()) {
+        // A serialize-only failure builds no batch: waiters still must see
+        // the failed attempt (see the failure pulse below), or a request
+        // bounded on failed saves never counts one.
+        if(!metadata_ok) {
+            workspace.metadata_committed.set();
+            workspace.metadata_committed.reset();
+        }
         co_return report;
     }
 

--- a/src/sched/index/store.cpp
+++ b/src/sched/index/store.cpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <cassert>
 #include <format>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -203,11 +202,19 @@ struct ContextsData {
 };
 
 BlobBinding to_binding(const CacheBindingEntry& entry) {
-    return {entry.size, entry.mtime_ns, entry.uid_device, entry.uid_file, entry.hash};
+    return {.size = entry.size,
+            .mtime_ns = entry.mtime_ns,
+            .uid_device = entry.uid_device,
+            .uid_file = entry.uid_file,
+            .hash = entry.hash};
 }
 
 CacheBindingEntry from_binding(const BlobBinding& binding) {
-    return {binding.size, binding.mtime_ns, binding.uid_device, binding.uid_file, binding.hash};
+    return {.size = binding.size,
+            .mtime_ns = binding.mtime_ns,
+            .uid_device = binding.uid_device,
+            .uid_file = binding.uid_file,
+            .hash = binding.hash};
 }
 
 }  // namespace
@@ -218,7 +225,7 @@ IndexStore::IndexStore(kota::event_loop& loop, Workspace& workspace, ContextReso
 std::string IndexStore::serialize_artifacts() {
     ArtifactsData data;
     data.pch_index_format = index::index_format_version;
-    std::unordered_map<std::string, std::uint32_t> index_map;
+    llvm::StringMap<std::uint32_t> index_map;
 
     auto intern = [&](std::uint32_t fid) -> std::uint32_t {
         auto path = std::string(workspace.file_table.resolve(fid));
@@ -287,7 +294,7 @@ std::string IndexStore::serialize_artifacts() {
 
 std::string IndexStore::serialize_contexts() {
     ContextsData data;
-    std::unordered_map<std::string, std::uint32_t> index_map;
+    llvm::StringMap<std::uint32_t> index_map;
 
     auto intern_path = [&](llvm::StringRef path) -> std::uint32_t {
         auto [it, inserted] =
@@ -397,6 +404,14 @@ void IndexStore::load_artifacts(llvm::StringRef bytes) {
         return resolve(idx);
     };
     contexts.load_mode_slices(data.header_modes, intern_resolve);
+
+    // The latched debt must reach the blob before the writer-dirty marker
+    // may clear: an unrelated save would otherwise clear it with the flags
+    // only in memory, and the session after next would trust the records
+    // on a stat match alone.
+    if(verify_content && (!workspace.pch_cache.empty() || !workspace.pcm_cache.empty())) {
+        workspace.mark_artifacts_dirty();
+    }
 
     LOG_INFO("Loaded artifact metadata: {} PCH entries, {} PCM entries",
              workspace.pch_cache.size(),
@@ -597,7 +612,11 @@ std::optional<IndexStore::Report> IndexStore::merge(const void* tu_index_data, s
             // already-stamped version earned its stamp the same way and
             // need not re-prove it every merge.
             if(auto obs = workspace.file_table.observe_for(file_ids_map[i], status)) {
-                workspace.file_table.try_stamp(fv, obs->size, obs->mtime_ns);
+                workspace.file_table.try_stamp(fv,
+                                               obs->size,
+                                               obs->mtime_ns,
+                                               obs->uid_device,
+                                               obs->uid_file);
             }
         }
         fv_of[i] = fv;
@@ -701,6 +720,10 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<std::uint32_t>
         co_return report;
     co_await save_gate.acquire();
     auto gate = llvm::make_scope_exit([this] { save_gate.release(); });
+    // Re-checked: the gate holder we just waited out may have hit
+    // corruption and failed to reopen the database.
+    if(!workspace.index_db || workspace.index_db->read_only())
+        co_return report;
     auto& db = *workspace.index_db;
     auto& project = workspace.project_index;
     ScopedTimer timer;
@@ -959,6 +982,12 @@ kota::task<IndexStore::Report> IndexStore::save(llvm::SmallVector<std::uint32_t>
         if(workspace.store && failed.empty() && !db.corrupted()) {
             workspace.store->clear_writer_dirty(store_marks);
         }
+    } else {
+        // Waiters must see failed attempts too, or a permanently failing
+        // metadata write (full disk, unserializable path) parks every
+        // durability wait forever; they give up after a few of these.
+        workspace.metadata_committed.set();
+        workspace.metadata_committed.reset();
     }
 
     // Corruption can surface first at write time (a damaged page only the
@@ -1124,6 +1153,12 @@ void IndexStore::reopen_fresh_database() {
     workspace.index_db->condemn();
     workspace.index_db.reset();
     workspace.index_db = index::open_database(*workspace.store, workspace.config.project.index_db);
+    // Durability waiters re-evaluate against the new database: a failed
+    // reopen disables persistence for the session, and a parked
+    // switchContext would otherwise sleep forever — no later save pulses,
+    // they all early-return on the null database.
+    workspace.metadata_committed.set();
+    workspace.metadata_committed.reset();
 }
 
 IndexStore::LoadResult IndexStore::load(bool read_only) {
@@ -1143,6 +1178,17 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
             db.for_each_key(kind, [&](llvm::StringRef key) {
                 startup_removes.push_back({kind, key.str()});
             });
+        }
+    };
+
+    // Everything a read-only session keeps is deserialized or copied, so
+    // nothing borrows the opening snapshot; retiring it keeps a long
+    // read-only session (batch lint) from pinning a concurrent writer's
+    // page reclamation to session start. Every return path that leaves
+    // the database open owes this.
+    auto retire_snapshot = [&] {
+        if(read_only && workspace.index_db && db.advance_read_snapshot()) {
+            db.retire_old_snapshot();
         }
     };
 
@@ -1189,6 +1235,7 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
         // is unreachable data, swept so it cannot survive as orphans.
         sweep_all();
         load_metadata();
+        retire_snapshot();
         return result;
     }
     llvm::DenseMap<std::uint32_t, std::uint64_t> manifest_pins;
@@ -1200,6 +1247,7 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
             startup_removes.push_back({index::IndexBlobKind::Global, "global"});
         }
         result.decoded = false;
+        retire_snapshot();
         return result;
     }
     load_metadata();
@@ -1379,15 +1427,7 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
         return result;
     }
 
-    if(read_only) {
-        // Everything is deserialized or copied by now, so nothing borrows
-        // the opening snapshot; retiring it keeps a long read-only session
-        // (batch lint) from pinning a concurrent writer's page
-        // reclamation to session start.
-        if(db.advance_read_snapshot()) {
-            db.retire_old_snapshot();
-        }
-    }
+    retire_snapshot();
 
     if(!workspace.shards.empty()) {
         LOG_INFO("Loaded {} index shards, {} manifests, {} symbols",

--- a/src/sched/index/store.cpp
+++ b/src/sched/index/store.cpp
@@ -295,23 +295,31 @@ std::optional<IndexStore::Report> IndexStore::merge(const void* tu_index_data, s
         if(hash == 0 && untouched) {
             // The worker had no buffer to hash (e.g. behind a PCM) and no
             // rows recorded one; the unchanged mtime proves the disk still
-            // holds the consumed bytes, so hash it here.
-            hash = hash_file(path);
+            // holds the consumed bytes, so take their hash from the shared
+            // pair — or one read, unless the file moved between the stat
+            // and the read, which voids the proof.
+            auto obs = workspace.file_table.observe_for(file_ids_map[i],
+                                                        status.getSize(),
+                                                        fs::mtime_ns(status));
+            if(obs && obs->size == status.getSize() && obs->mtime_ns == fs::mtime_ns(status)) {
+                hash = obs->hash;
+            }
         }
 
-        auto fv = project.intern_file_version(file_ids_map[i], hash);
-        if(untouched && hash != 0) {
+        auto fv = workspace.file_table.intern_version(file_ids_map[i], hash);
+        if(untouched && hash != 0 && workspace.file_table.version(fv).mtime_ns == 0) {
             // The untouched mtime alone is no proof: a rewrite during the
             // build that preserves the size and backdates the mtime
             // (rsync -t) would stamp a stat describing bytes the rows were
-            // never built from, and file_version_stale's equality fast
-            // path would then judge them fresh forever. Stamp only under a
-            // disk-hash match; an already-stamped version earned its stamp
-            // the same way, so it need not re-prove it every merge.
-            auto& record = project.file_versions.find(fv)->second;
-            if(record.mtime_ns == 0 && hash_file(path) == hash) {
-                record.size = status.getSize();
-                record.mtime_ns = fs::mtime_ns(status);
+            // never built from, and the equality fast path would then judge
+            // them fresh forever. So the stamp must be corroborated by a
+            // read (usually the shared pair, already paid for); an
+            // already-stamped version earned its stamp the same way and
+            // need not re-prove it every merge.
+            if(auto obs = workspace.file_table.observe_for(file_ids_map[i],
+                                                          status.getSize(),
+                                                          fs::mtime_ns(status))) {
+                workspace.file_table.try_stamp(fv, obs->size, obs->mtime_ns);
             }
         }
         fv_of[i] = fv;
@@ -337,7 +345,7 @@ std::optional<IndexStore::Report> IndexStore::merge(const void* tu_index_data, s
     // Replace this TU's manifest wholesale: files it no longer touches lose
     // their contribution here, which is also what retires their variants —
     // no sweep over other shards is needed.
-    auto affected = project.apply_manifest(tu_path_id, std::move(manifest));
+    auto affected = project.apply_manifest(workspace.file_table, tu_path_id, std::move(manifest));
     for(auto path_id: affected) {
         report.add_rows_changed(path_id);
         auto it = workspace.shards.find(path_id);
@@ -391,7 +399,7 @@ void IndexStore::drop_index_into(std::uint32_t tu_path_id, Report& report) {
     // Dropped rows change index-served answers exactly like merged rows
     // do; without the refresh the client keeps them forever, since no
     // later merge or compile is owed.
-    for(auto path_id: project.remove_manifest(tu_path_id)) {
+    for(auto path_id: project.remove_manifest(workspace.file_table, tu_path_id)) {
         auto it = workspace.shards.find(path_id);
         if(it != workspace.shards.end()) {
             it->second.set_live(project.live_variants(path_id));
@@ -849,23 +857,23 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
         auto manifest = blob ? index::deserialize_manifest(blob.buffer->getBuffer()) : std::nullopt;
         auto pin = manifest ? manifest_pins.find(manifest->tu_fv) : manifest_pins.end();
         if(!manifest || pin == manifest_pins.end() || pin->second != manifest->global_gen ||
-           !project.knows_file_versions(*manifest)) {
+           !project.knows_file_versions(workspace.file_table, *manifest)) {
             dead_manifests.push_back(key.str());
             // The manifest raced a crash ahead of the global blob (its own
             // pin never landed). When the TU's version is still resolvable,
             // re-enqueue it: the CDB sweep never covers standalone-indexed
             // headers.
             if(manifest) {
-                auto fv = project.file_versions.find(manifest->tu_fv);
-                if(fv != project.file_versions.end()) {
-                    report.add_reindex(fv->second.path_id);
+                auto fv = workspace.file_table.versions.find(manifest->tu_fv);
+                if(fv != workspace.file_table.versions.end()) {
+                    report.add_reindex(fv->second.fid);
                 }
             }
             return;
         }
         adopted_pins.insert(manifest->tu_fv);
-        auto tu_path_id = project.file_versions.find(manifest->tu_fv)->second.path_id;
-        project.apply_manifest(tu_path_id, std::move(*manifest));
+        auto tu_path_id = workspace.file_table.version(manifest->tu_fv).fid;
+        project.apply_manifest(workspace.file_table, tu_path_id, std::move(*manifest));
     });
     if(!read_only) {
         for(auto& key: dead_manifests) {
@@ -878,7 +886,7 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
     // load_global rejects a blob whose pins its own table cannot cover.
     for(auto fv: llvm::make_first_range(manifest_pins)) {
         if(!adopted_pins.contains(fv)) {
-            report.add_reindex(project.file_versions.find(fv)->second.path_id);
+            report.add_reindex(workspace.file_table.version(fv).fid);
         }
     }
 
@@ -892,11 +900,11 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
     llvm::DenseMap<std::uint32_t, llvm::SmallVector<std::uint64_t, 1>> generations;
     for(auto& manifest: llvm::make_second_range(project.manifests)) {
         for(auto fv: llvm::make_first_range(manifest.contributions)) {
-            auto& record = project.file_versions.find(fv)->second;
+            auto& record = workspace.file_table.version(fv);
             if(record.content_hash == 0) {
                 continue;
             }
-            auto& pinned = generations[record.path_id];
+            auto& pinned = generations[record.fid];
             if(!llvm::is_contained(pinned, record.content_hash)) {
                 pinned.push_back(record.content_hash);
             }
@@ -949,7 +957,7 @@ IndexStore::LoadResult IndexStore::load(bool read_only) {
             // The removal retires the TU's contributions to EVERY file it
             // touched, not just the unservable one; the affected set feeds
             // the mask refresh below, like the merge path's.
-            auto affected = project.remove_manifest(tu);
+            auto affected = project.remove_manifest(workspace.file_table, tu);
             mask_refresh.append(affected.begin(), affected.end());
             if(!read_only) {
                 startup_removes.push_back(
@@ -1184,44 +1192,21 @@ bool IndexStore::file_version_stale(std::uint32_t fv_id) {
         return cached->second;
     }
 
-    auto record_it = workspace.project_index.file_versions.find(fv_id);
-    if(record_it == workspace.project_index.file_versions.end()) {
-        return true;
-    }
-    auto& record = record_it->second;
-    auto path = workspace.file_table.resolve(record.path_id);
-
-    // Two-layer test on the shared FileVersion: Layer 1 trusts a stat EQUAL
-    // to the recorded stamp (no file read) — equality, not a watermark, so
-    // backdated or preserved mtimes cannot masquerade as fresh; Layer 2
-    // re-hashes the disk against the consumed-content hash and treats a
-    // match as a mere touch, repairing the stamp in place — once, for every
-    // TU that consumes this version.
-    auto stale = [&] {
-        fs::file_status status;
-        if(auto err = fs::status(path, status)) {
-            return true;
-        }
-        if(record.mtime_ns != 0 && record.size == status.getSize() &&
-           record.mtime_ns == fs::mtime_ns(status)) {
-            return false;
-        }
-        if(record.content_hash == 0) {
-            return true;
-        }
-        if(hash_file(path) != record.content_hash) {
-            return true;
-        }
-        record.size = status.getSize();
-        record.mtime_ns = fs::mtime_ns(status);
+    // Missing and unreadable both read as stale — conservative, the
+    // reindex re-observes. A repair of the version's stat fast path must
+    // reach the persisted global blob, or the next session re-earns it by
+    // hash for every repaired version at once.
+    auto generation = workspace.file_table.stamp_generation;
+    bool stale = workspace.file_table.check_version(fv_id) != FileTable::Verdict::Fresh;
+    if(workspace.file_table.stamp_generation != generation) {
         global_dirty = true;
-        return false;
-    }();
+    }
     fv_verdicts[fv_id] = stale;
     return stale;
 }
 
 bool IndexStore::need_update(llvm::StringRef file_path) {
+    workspace.file_table.begin_wave();
     auto& project = workspace.project_index;
     auto manifest_it = project.manifests.find(workspace.file_table.intern(file_path));
     if(manifest_it == project.manifests.end())

--- a/src/sched/index/store.cpp
+++ b/src/sched/index/store.cpp
@@ -1160,6 +1160,12 @@ void IndexStore::reopen_fresh_database() {
     workspace.index_db->condemn();
     workspace.index_db.reset();
     workspace.index_db = index::open_database(*workspace.store, workspace.config.project.index_db);
+    // The metadata blobs died with the condemned database while their
+    // loaded state lives on in memory; without a re-dirty the next save
+    // skips them and a restart loses the user's context choices and every
+    // rebuildable artifact record.
+    workspace.mark_artifacts_dirty();
+    workspace.mark_contexts_dirty();
     // Durability waiters re-evaluate against the new database: a failed
     // reopen disables persistence for the session, and a parked
     // switchContext would otherwise sleep forever — no later save pulses,

--- a/src/sched/index/store.h
+++ b/src/sched/index/store.h
@@ -16,6 +16,8 @@
 
 namespace clice {
 
+class ContextResolver;
+
 namespace testing {
 
 struct IndexerFixture;
@@ -85,7 +87,7 @@ public:
         Report report;
     };
 
-    IndexStore(kota::event_loop& loop, Workspace& workspace);
+    IndexStore(kota::event_loop& loop, Workspace& workspace, ContextResolver& contexts);
 
     /// Merge a TUIndex result: intern FileVersions, replace the TU's
     /// manifest, and write row blobs only for variants no shard stores yet
@@ -170,6 +172,25 @@ private:
 
     kota::event_loop& loop;
     Workspace& workspace;
+
+    /// Context-domain state the contexts and artifacts blobs persist
+    /// (header modes, saved choices, synthesized hosts).
+    ContextResolver& contexts;
+
+    /// Serializes concurrent save() calls: the pump's round-end save, the
+    /// master's metadata flush and the shutdown save may overlap on the
+    /// event loop, and the dirty-snapshot/restore discipline inside save()
+    /// assumes one save at a time.
+    kota::semaphore save_gate{1};
+
+    /// Serialize the artifact-validity / user-context blob from live
+    /// state; empty on serialization failure (stays dirty, retried).
+    std::string serialize_artifacts();
+    std::string serialize_contexts();
+
+    /// Restore the blobs read at load; a null blob is a first run.
+    void load_artifacts(llvm::StringRef data);
+    void load_contexts(llvm::StringRef data);
 
     /// Blobs mutated since the last save, plus whether the global blob
     /// (symbols, FileVersion table) changed.

--- a/src/sched/index/store.h
+++ b/src/sched/index/store.h
@@ -39,14 +39,14 @@ public:
         /// TUs owed a ContentChanged reindex: their rows are missing,
         /// stale or discarded and no in-process event would rebuild them.
         /// The pump claims these before the current attempt settles.
-        llvm::ArrayRef<std::uint32_t> reindex() const {
+        llvm::ArrayRef<Fid> reindex() const {
             return reindex_ids;
         }
 
         /// Files whose stored rows were replaced, re-masked or dropped
         /// while possibly index-served: the serving adapter checks which
         /// of them an open session actually serves and refreshes those.
-        llvm::ArrayRef<std::uint32_t> rows_changed() const {
+        llvm::ArrayRef<Fid> rows_changed() const {
             return rows_ids;
         }
 
@@ -55,13 +55,13 @@ public:
         /// one metadata retry; a live session's next save covers it.
         bool snapshot_stale = false;
 
-        void add_reindex(std::uint32_t id) {
+        void add_reindex(Fid id) {
             if(reindex_seen.insert(id).second) {
                 reindex_ids.push_back(id);
             }
         }
 
-        void add_rows_changed(std::uint32_t id) {
+        void add_rows_changed(Fid id) {
             if(rows_seen.insert(id).second) {
                 rows_ids.push_back(id);
             }
@@ -72,10 +72,10 @@ public:
         }
 
     private:
-        llvm::SmallVector<std::uint32_t> reindex_ids;
-        llvm::SmallVector<std::uint32_t> rows_ids;
-        llvm::DenseSet<std::uint32_t> reindex_seen;
-        llvm::DenseSet<std::uint32_t> rows_seen;
+        llvm::SmallVector<Fid> reindex_ids;
+        llvm::SmallVector<Fid> rows_ids;
+        llvm::DenseSet<Fid> reindex_seen;
+        llvm::DenseSet<Fid> rows_seen;
     };
 
     struct LoadResult {
@@ -103,7 +103,7 @@ public:
     /// compile-command change — where a surviving manifest would keep
     /// judging the old-command rows fresh, in this session and after a
     /// restart.
-    Report drop_index(std::uint32_t tu_path_id);
+    Report drop_index(Fid tu_path_id);
 
     /// Persist the dirty state (rewritten shards, replaced manifests, the
     /// global blob) through the index storage. Serialization runs on the
@@ -116,7 +116,7 @@ public:
     /// discovers before serializing joins the same snapshot; debt surfaced
     /// after it (write-time corruption recovery) comes back in the report
     /// with snapshot_stale set.
-    kota::task<Report> save(llvm::SmallVector<std::uint32_t> debt);
+    kota::task<Report> save(llvm::SmallVector<Fid> debt);
 
     /// Load the global blob, adopt every resolvable manifest, fetch the
     /// shard blobs the contributions expect, and sweep the rest.
@@ -128,7 +128,7 @@ public:
     /// Record the host source whose command a standalone-indexed header's
     /// retained rows borrowed. Written when a merge lands, persisted in
     /// the CDB snapshot for the offline invalidation diff.
-    void record_header_host(std::uint32_t header, std::uint32_t host) {
+    void record_header_host(Fid header, Fid host) {
         header_hosts[header] = host;
     }
 
@@ -201,8 +201,8 @@ private:
 
     /// Blobs mutated since the last save, plus whether the global blob
     /// (symbols, FileVersion table) changed.
-    llvm::DenseSet<std::uint32_t> dirty_shards;
-    llvm::DenseSet<std::uint32_t> dirty_manifests;
+    llvm::DenseSet<Fid> dirty_shards;
+    llvm::DenseSet<Fid> dirty_manifests;
     bool global_dirty = false;
 
     /// Blob removals discovered during load (stale manifests, orphan
@@ -230,16 +230,16 @@ private:
     /// include graph is rebuilt from the NEW commands before load(), so
     /// reachability alone cannot see a change that removed or redirected
     /// the very include edge the header's context came through.
-    llvm::DenseMap<std::uint32_t, std::uint32_t> header_hosts;
+    llvm::DenseMap<Fid, Fid> header_hosts;
 
     /// Filter the debt candidates down to standalone TUs the CDB snapshot
     /// must record: no manifest pin and no CDB entry means the snapshot is
     /// the only record that an index is owed.
-    llvm::SmallVector<std::uint32_t> standalone_of(llvm::ArrayRef<std::uint32_t> candidates);
+    llvm::SmallVector<Fid> standalone_of(llvm::ArrayRef<Fid> candidates);
 
     /// drop_index body, appending into the caller's report — reconcile
     /// drops several TUs into the one load report.
-    void drop_index_into(std::uint32_t tu_path_id, Report& report);
+    void drop_index_into(Fid tu_path_id, Report& report);
 
     /// Diff the persisted CDB snapshot against the live CDB and drop the
     /// index of every TU whose compile command changed while no server was
@@ -252,18 +252,18 @@ private:
 
     /// Per-round FileVersion staleness verdicts: many TUs share the same
     /// versions, and one stat (or repair) per version per round is enough.
-    llvm::DenseMap<std::uint32_t, bool> fv_verdicts;
+    llvm::DenseMap<VersionID, bool> fv_verdicts;
 
     /// Two-layer staleness test on a FileVersion, cached per round; a hash
     /// match after a stat mismatch repairs the version's stat fast path in
     /// place for every consumer.
-    bool file_version_stale(std::uint32_t fv_id);
+    bool file_version_stale(VersionID fv_id);
 
     /// Add every TU contributing to `path_id`'s shard to the report's
     /// reindex debt. Used when the file's resident rows are lost while its
     /// manifests still read fresh: no in-process event would ever rebuild
     /// them, and for standalone headers no restart sweep would either.
-    void requeue_owners(std::uint32_t path_id, Report& report);
+    void requeue_owners(Fid path_id, Report& report);
 
     /// Drop every resident shard that may borrow database memory —
     /// everything not dirty, since dirty shards own their bytes by

--- a/src/sched/index/store.h
+++ b/src/sched/index/store.h
@@ -167,6 +167,13 @@ public:
         return !dirty_shards.empty() || !dirty_manifests.empty() || global_dirty || cdb_dirty;
     }
 
+    /// The FileVersion table's persisted stamps moved outside the store's
+    /// own checks (force_revalidate revoked them): rewrite the global blob
+    /// on the next save so the revocation survives a restart.
+    void mark_global_dirty() {
+        global_dirty = true;
+    }
+
 private:
     friend struct testing::IndexerFixture;
 

--- a/src/sched/workspace.cpp
+++ b/src/sched/workspace.cpp
@@ -21,7 +21,6 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
-#include "llvm/Support/xxhash.h"
 
 namespace clice {
 
@@ -260,26 +259,19 @@ std::string discover_compile_commands(const Config& config, llvm::StringRef work
     return {};
 }
 
-std::uint64_t hash_file(llvm::StringRef path) {
-    auto buf = llvm::MemoryBuffer::getFile(path);
-    if(!buf)
-        return 0;
-    return llvm::xxh3_64bits((*buf)->getBuffer());
-}
-
-DepsSnapshot capture_deps_snapshot(FileTable& pool,
+DepsSnapshot capture_deps_snapshot(FileTable& files,
                                    llvm::ArrayRef<DepFile> deps,
                                    std::int64_t build_at) {
     // Files whose mtime falls within the guard of the build start count as
-    // "possibly modified during the build" and get no fast-path baseline;
-    // one passing hash comparison repairs them (see deps_changed).
+    // "possibly modified during the build" and offer no fast-path
+    // baseline; one passing hash comparison repairs them (check_version).
     auto baseline_before_ns = fs::stat_baseline_before_ns(build_at);
 
     DepsSnapshot snap;
     snap.deps.reserve(deps.size());
     for(const auto& file: deps) {
         auto& dep = snap.deps.emplace_back();
-        dep.path_id = pool.intern(file.path);
+        dep.path_id = files.intern(file.path);
         dep.hash = file.hash;
 
         llvm::sys::fs::file_status status;
@@ -295,65 +287,62 @@ DepsSnapshot capture_deps_snapshot(FileTable& pool,
             continue;
         }
 
+        auto size = status.getSize();
         auto mtime_ns = fs::mtime_ns(status);
-        if(mtime_ns > baseline_before_ns) {
-            // Possibly modified during or after the build: this stat may
-            // describe content the build never saw, so it must not become a
-            // fast-path baseline. The consumed hash stays; the next check
-            // compares the disk against it and repairs the fast path on a
-            // match.
-            continue;
+        bool untouched = mtime_ns <= baseline_before_ns;
+        if(dep.hash == 0) {
+            if(!untouched) {
+                // The worker could not hash the consumed bytes and the file
+                // may have changed during the build — no version can name
+                // them. The zero hash reads as changed and the rebuild's
+                // capture retries.
+                continue;
+            }
+            // The unchanged mtime proves the disk still holds the consumed
+            // bytes, so their hash can be taken from the shared pair — or
+            // one read, unless the file moved between the stat and the
+            // read, which voids the proof.
+            auto obs = files.observe_for(dep.path_id, size, mtime_ns);
+            if(!obs || obs->size != size || obs->mtime_ns != mtime_ns) {
+                continue;
+            }
+            dep.hash = obs->hash;
         }
 
-        // Untouched since before the build started — the disk still holds
-        // the consumed bytes, so the stat is a trustworthy fast path.
-        dep.size = status.getSize();
-        dep.mtime_ns = mtime_ns;
-        if(dep.hash == 0) {
-            // The worker could not hash the consumed bytes; the unchanged
-            // mtime proves the disk still holds them, so hash it here.
-            dep.hash = hash_file(file.path);
+        auto vid = files.intern_version(dep.path_id, dep.hash);
+        if(untouched) {
+            // Untouched since before the build started — the disk still
+            // holds the consumed bytes, so the stat is a trustworthy fast
+            // path (recorded only when corroborated, see try_stamp).
+            files.try_stamp(vid, size, mtime_ns);
         }
     }
     return snap;
 }
 
-bool deps_changed(const FileTable& pool, DepsSnapshot& snap) {
+bool deps_changed(FileTable& files, const DepsSnapshot& snap) {
     for(auto& dep: snap.deps) {
-        auto path = pool.resolve(dep.path_id);
-        llvm::sys::fs::file_status status;
-        if(auto ec = llvm::sys::fs::status(path, status)) {
-            // Gone now: a change unless it was already missing at build time.
-            if(!dep.missing)
-                return true;
-            continue;
-        }
         if(dep.missing) {
-            // Missing at build time, present now.
-            return true;
-        }
-
-        // Layer 1: an unchanged stat proves unchanged content — the baseline
-        // is only ever recorded or repaired against the consumed hash.
-        auto size = status.getSize();
-        auto mtime_ns = fs::mtime_ns(status);
-        if(dep.mtime_ns != 0 && dep.size == size && dep.mtime_ns == mtime_ns)
+            // Gone at build time: reappearing is the change; still-missing
+            // stays unchanged (see the capture).
+            if(fs::exists(files.resolve(dep.path_id))) {
+                return true;
+            }
             continue;
+        }
 
         // No trusted hash to compare against: rebuild once to converge.
-        if(dep.hash == 0)
+        if(dep.hash == 0) {
             return true;
+        }
 
-        // Layer 2: compare the disk against the consumed bytes. hash_file's
-        // 0 sentinel (unreadable right now) cannot match and counts as
-        // changed — conservative, retried by the next check.
-        if(hash_file(path) != dep.hash)
+        // Missing means gone now — a change, since the build saw the file.
+        // Unreadable cannot prove the disk unchanged and counts as changed
+        // — conservative, retried by the rebuild's capture.
+        if(files.check_version(files.intern_version(dep.path_id, dep.hash)) !=
+           FileTable::Verdict::Fresh) {
             return true;
-
-        // Touched but not modified — repair the fast path so the next check
-        // is a single stat again.
-        dep.size = size;
-        dep.mtime_ns = mtime_ns;
+        }
     }
     return false;
 }
@@ -533,11 +522,13 @@ void Workspace::load_cache(ContextResolver& contexts) {
             auto dep_path = resolve(dep.path);
             if(dep_path.empty())
                 continue;
-            deps.deps.push_back({.path_id = file_table.intern(dep_path),
-                                 .size = dep.size,
-                                 .mtime_ns = dep.mtime_ns,
-                                 .hash = dep.hash,
-                                 .missing = dep.missing});
+            auto path_id = file_table.intern(dep_path);
+            deps.deps.push_back({.path_id = path_id, .hash = dep.hash, .missing = dep.missing});
+            if(dep.hash != 0) {
+                file_table.adopt_stamp(file_table.intern_version(path_id, dep.hash),
+                                       dep.size,
+                                       dep.mtime_ns);
+            }
         }
         return deps;
     };
@@ -617,6 +608,17 @@ void Workspace::save_cache(const ContextResolver& contexts) {
         return it->second;
     };
 
+    // The persisted per-dep stamp is the shared version's — earned once,
+    // written for every artifact referencing the version.
+    auto stamp_of = [&](const DepState& dep) -> std::pair<std::uint64_t, std::int64_t> {
+        auto it = file_table.version_ids.find({dep.path_id, dep.hash});
+        if(it == file_table.version_ids.end()) {
+            return {0, 0};
+        }
+        auto& version = file_table.versions.find(it->second)->second;
+        return {version.size, version.mtime_ns};
+    };
+
     for(auto& e: pch_cache) {
         auto& st = e.second;
         if(st.path.empty())
@@ -626,8 +628,8 @@ void Workspace::save_cache(const ContextResolver& contexts) {
         entry.key = e.getKey().str();
         entry.bound = st.bound;
         for(auto& dep: st.deps.deps) {
-            entry.deps.push_back(
-                {intern(dep.path_id), dep.hash, dep.size, dep.mtime_ns, dep.missing});
+            auto [size, mtime_ns] = stamp_of(dep);
+            entry.deps.push_back({intern(dep.path_id), dep.hash, size, mtime_ns, dep.missing});
         }
         data.pch.push_back(std::move(entry));
     }
@@ -642,8 +644,8 @@ void Workspace::save_cache(const ContextResolver& contexts) {
         auto mod_it = path_to_module.find(path_id);
         entry.module_name = mod_it != path_to_module.end() ? mod_it->second : "";
         for(auto& dep: st.deps.deps) {
-            entry.deps.push_back(
-                {intern(dep.path_id), dep.hash, dep.size, dep.mtime_ns, dep.missing});
+            auto [size, mtime_ns] = stamp_of(dep);
+            entry.deps.push_back({intern(dep.path_id), dep.hash, size, mtime_ns, dep.missing});
         }
         data.pcm.push_back(std::move(entry));
     }

--- a/src/sched/workspace.cpp
+++ b/src/sched/workspace.cpp
@@ -38,8 +38,8 @@ std::uint32_t Workspace::count_occurrences(std::uint32_t host_id, std::uint32_t 
     if(chain.size() < 2) {
         return 0;
     }
-    auto includer_path = path_pool.resolve(chain[chain.size() - 2]);
-    auto target_path = path_pool.resolve(target_id);
+    auto includer_path = file_table.resolve(chain[chain.size() - 2]);
+    auto target_path = file_table.resolve(target_id);
     auto buf = llvm::MemoryBuffer::getFile(includer_path);
     if(!buf) {
         return 0;
@@ -56,12 +56,12 @@ std::uint32_t Workspace::count_occurrences(std::uint32_t host_id, std::uint32_t 
 
 llvm::SmallVector<std::uint32_t> Workspace::rank_hosts(std::uint32_t header_path_id,
                                                        llvm::ArrayRef<std::uint32_t> hosts) const {
-    auto header_path = path_pool.resolve(header_path_id);
+    auto header_path = file_table.resolve(header_path_id);
     auto header_stem = llvm::sys::path::stem(header_path);
     auto header_dir = llvm::sys::path::parent_path(header_path);
 
     auto score = [&](std::uint32_t host_id) -> std::tuple<int, int, std::size_t> {
-        auto host_path = path_pool.resolve(host_id);
+        auto host_path = file_table.resolve(host_id);
         int stem_match = llvm::sys::path::stem(host_path) == header_stem ? 0 : 1;
         int same_dir = llvm::sys::path::parent_path(host_path) == header_dir ? 0 : 1;
         // Longer shared prefix means "closer" in the tree; negate for
@@ -80,13 +80,13 @@ llvm::SmallVector<std::uint32_t> Workspace::rank_hosts(std::uint32_t header_path
         if(sa != sb) {
             return sa < sb;
         }
-        return path_pool.resolve(a) < path_pool.resolve(b);
+        return file_table.resolve(a) < file_table.resolve(b);
     });
     return ranked;
 }
 
 void Workspace::rescan_includes(std::uint32_t path_id) {
-    auto path = path_pool.resolve(path_id);
+    auto path = file_table.resolve(path_id);
     dep_graph.clear_includes(path_id);
 
     if(auto buf = llvm::MemoryBuffer::getFile(path)) {
@@ -96,7 +96,7 @@ void Workspace::rescan_includes(std::uint32_t path_id) {
         llvm::StringRef cmd_path = path;
         if(!cdb.has_entry(path)) {
             for(auto host: rank_hosts(path_id, dep_graph.find_host_sources(path_id))) {
-                auto host_path = path_pool.resolve(host);
+                auto host_path = file_table.resolve(host);
                 if(cdb.has_entry(host_path)) {
                     cmd_path = host_path;
                     break;
@@ -145,7 +145,7 @@ void Workspace::rescan_includes(std::uint32_t path_id) {
                                                 resolved_config,
                                                 dir_cache);
                 if(resolved) {
-                    ids.push_back(path_pool.intern(resolved->path));
+                    ids.push_back(file_table.intern(resolved->path));
                 }
             }
             dep_graph.set_includes(path_id, ci, std::move(ids));
@@ -165,7 +165,7 @@ void Workspace::rescan_after_save(std::uint32_t path_id) {
     // module maps: path_to_module gates the module code paths, and the
     // dep_graph side is what import resolution reads — left stale, an
     // interface saved mid-session could never satisfy its importers.
-    auto file_path = path_pool.resolve(path_id);
+    auto file_path = file_table.resolve(path_id);
     if(auto buf = llvm::MemoryBuffer::getFile(file_path)) {
         auto result = scan_quick((*buf)->getBuffer());
         // A module declaration inside a preprocessor conditional is beyond
@@ -267,7 +267,7 @@ std::uint64_t hash_file(llvm::StringRef path) {
     return llvm::xxh3_64bits((*buf)->getBuffer());
 }
 
-DepsSnapshot capture_deps_snapshot(PathPool& pool,
+DepsSnapshot capture_deps_snapshot(FileTable& pool,
                                    llvm::ArrayRef<DepFile> deps,
                                    std::int64_t build_at) {
     // Files whose mtime falls within the guard of the build start count as
@@ -318,7 +318,7 @@ DepsSnapshot capture_deps_snapshot(PathPool& pool,
     return snap;
 }
 
-bool deps_changed(const PathPool& pool, DepsSnapshot& snap) {
+bool deps_changed(const FileTable& pool, DepsSnapshot& snap) {
     for(auto& dep: snap.deps) {
         auto path = pool.resolve(dep.path_id);
         llvm::sys::fs::file_status status;
@@ -533,7 +533,7 @@ void Workspace::load_cache(ContextResolver& contexts) {
             auto dep_path = resolve(dep.path);
             if(dep_path.empty())
                 continue;
-            deps.deps.push_back({.path_id = path_pool.intern(dep_path),
+            deps.deps.push_back({.path_id = file_table.intern(dep_path),
                                  .size = dep.size,
                                  .mtime_ns = dep.mtime_ns,
                                  .hash = dep.hash,
@@ -584,7 +584,7 @@ void Workspace::load_cache(ContextResolver& contexts) {
             continue;
         }
 
-        auto path_id = path_pool.intern(source);
+        auto path_id = file_table.intern(source);
         pcm_cache[path_id] = {*pcm_path, entry.key, load_deps(entry.deps)};
         pcm_paths[path_id] = *pcm_path;
 
@@ -608,7 +608,7 @@ void Workspace::save_cache(const ContextResolver& contexts) {
     std::unordered_map<std::string, std::uint32_t> index_map;
 
     auto intern = [&](std::uint32_t runtime_path_id) -> std::uint32_t {
-        auto path = std::string(path_pool.resolve(runtime_path_id));
+        auto path = std::string(file_table.resolve(runtime_path_id));
         auto [it, inserted] =
             index_map.try_emplace(path, static_cast<std::uint32_t>(data.paths.size()));
         if(inserted) {

--- a/src/sched/workspace.cpp
+++ b/src/sched/workspace.cpp
@@ -323,7 +323,8 @@ DepsSnapshot capture_deps_snapshot(FileTable& files,
             // Untouched since before the build started — the disk still
             // holds the consumed bytes, so the stat is a trustworthy fast
             // path (recorded only when corroborated, see try_stamp).
-            files.try_stamp(vid, size, mtime_ns);
+            auto uid = status.getUniqueID();
+            files.try_stamp(vid, size, mtime_ns, uid.getDevice(), uid.getFile());
         }
     }
     return snap;

--- a/src/sched/workspace.cpp
+++ b/src/sched/workspace.cpp
@@ -30,7 +30,7 @@ bool Workspace::is_synthesized_artifact(llvm::StringRef path) const {
     return path.starts_with(artifact_dir);
 }
 
-std::uint32_t Workspace::count_occurrences(std::uint32_t host_id, std::uint32_t target_id) const {
+std::uint32_t Workspace::count_occurrences(Fid host_id, Fid target_id) const {
     auto chain = dep_graph.find_include_chain(host_id, target_id);
     if(chain.size() < 2) {
         return 0;
@@ -51,13 +51,12 @@ std::uint32_t Workspace::count_occurrences(std::uint32_t host_id, std::uint32_t 
                                      null_resolver);
 }
 
-llvm::SmallVector<std::uint32_t> Workspace::rank_hosts(std::uint32_t header_path_id,
-                                                       llvm::ArrayRef<std::uint32_t> hosts) const {
+llvm::SmallVector<Fid> Workspace::rank_hosts(Fid header_path_id, llvm::ArrayRef<Fid> hosts) const {
     auto header_path = file_table.resolve(header_path_id);
     auto header_stem = llvm::sys::path::stem(header_path);
     auto header_dir = llvm::sys::path::parent_path(header_path);
 
-    auto score = [&](std::uint32_t host_id) -> std::tuple<int, int, std::size_t> {
+    auto score = [&](Fid host_id) -> std::tuple<int, int, std::size_t> {
         auto host_path = file_table.resolve(host_id);
         int stem_match = llvm::sys::path::stem(host_path) == header_stem ? 0 : 1;
         int same_dir = llvm::sys::path::parent_path(host_path) == header_dir ? 0 : 1;
@@ -71,8 +70,8 @@ llvm::SmallVector<std::uint32_t> Workspace::rank_hosts(std::uint32_t header_path
         return {stem_match, same_dir, n - common};
     };
 
-    llvm::SmallVector<std::uint32_t> ranked(hosts.begin(), hosts.end());
-    std::ranges::sort(ranked, [&](std::uint32_t a, std::uint32_t b) {
+    llvm::SmallVector<Fid> ranked(hosts.begin(), hosts.end());
+    std::ranges::sort(ranked, [&](Fid a, Fid b) {
         auto sa = score(a), sb = score(b);
         if(sa != sb) {
             return sa < sb;
@@ -82,7 +81,7 @@ llvm::SmallVector<std::uint32_t> Workspace::rank_hosts(std::uint32_t header_path
     return ranked;
 }
 
-void Workspace::rescan_after_save(std::uint32_t path_id) {
+void Workspace::rescan_after_save(Fid path_id) {
     auto path = file_table.resolve(path_id);
     dep_graph.clear_includes(path_id);
 
@@ -140,7 +139,7 @@ void Workspace::rescan_after_save(std::uint32_t path_id) {
             auto resolved_config = resolve_search_config(search_config, dir_cache);
             auto entries = resolve_dir(dir, dir_cache);
 
-            llvm::SmallVector<std::uint32_t> ids;
+            llvm::SmallVector<IncludeEdge> edges;
             for(auto& include: scan.includes) {
                 auto resolved = resolve_include(include.path,
                                                 include.is_angled,
@@ -151,10 +150,10 @@ void Workspace::rescan_after_save(std::uint32_t path_id) {
                                                 resolved_config,
                                                 dir_cache);
                 if(resolved) {
-                    ids.push_back(file_table.intern(resolved->path));
+                    edges.push_back({file_table.intern(resolved->path), include.conditional});
                 }
             }
-            dep_graph.set_includes(path_id, ci, std::move(ids));
+            dep_graph.set_includes(path_id, ci, std::move(edges));
         }
 
         dep_graph.build_reverse_map();
@@ -219,7 +218,7 @@ void Workspace::rescan_after_save(std::uint32_t path_id) {
     context_epoch += 1;
 }
 
-void Workspace::on_file_closed(std::uint32_t path_id) {
+void Workspace::on_file_closed(Fid path_id) {
     // PCH entries are content-keyed and may be shared with other sessions,
     // so nothing entry-level to clean up — but the loaded-state budget
     // shrinks with the open count, and this is the moment it does.
@@ -277,11 +276,11 @@ DepsSnapshot capture_deps_snapshot(FileTable& files,
     auto baseline_before_ns = fs::stat_baseline_before_ns(build_at);
 
     DepsSnapshot snap;
-    snap.deps.reserve(deps.size());
+    snap.reserve(deps.size());
     for(const auto& file: deps) {
-        auto& dep = snap.deps.emplace_back();
+        auto& dep = snap.emplace_back();
         dep.path_id = files.intern(file.path);
-        dep.hash = file.hash;
+        auto hash = file.hash;
 
         llvm::sys::fs::file_status status;
         if(llvm::sys::fs::status(file.path, status)) {
@@ -292,19 +291,18 @@ DepsSnapshot capture_deps_snapshot(FileTable& files,
             // last remaining truth for the file (and dependents' recovery
             // is the DiskRemoved cascade's job, not this snapshot's).
             dep.missing = true;
-            dep.hash = 0;
             continue;
         }
 
         auto size = status.getSize();
         auto mtime_ns = fs::mtime_ns(status);
         bool untouched = mtime_ns <= baseline_before_ns;
-        if(dep.hash == 0) {
+        if(hash == 0) {
             if(!untouched) {
                 // The worker could not hash the consumed bytes and the file
                 // may have changed during the build — no version can name
-                // them. The zero hash reads as changed and the rebuild's
-                // capture retries.
+                // them. The dep stays version-less and reads as changed
+                // until the rebuild's capture retries.
                 continue;
             }
             // The unchanged mtime proves the disk still holds the consumed
@@ -315,23 +313,23 @@ DepsSnapshot capture_deps_snapshot(FileTable& files,
             if(!obs || obs->size != size || obs->mtime_ns != mtime_ns) {
                 continue;
             }
-            dep.hash = obs->hash;
+            hash = obs->hash;
         }
 
-        auto vid = files.intern_version(dep.path_id, dep.hash);
+        dep.version = files.intern_version(dep.path_id, hash);
         if(untouched) {
             // Untouched since before the build started — the disk still
             // holds the consumed bytes, so the stat is a trustworthy fast
             // path (recorded only when corroborated, see try_stamp).
             auto uid = status.getUniqueID();
-            files.try_stamp(vid, size, mtime_ns, uid.getDevice(), uid.getFile());
+            files.try_stamp(dep.version, size, mtime_ns, uid.getDevice(), uid.getFile());
         }
     }
     return snap;
 }
 
 bool deps_changed(FileTable& files, const DepsSnapshot& snap) {
-    for(auto& dep: snap.deps) {
+    for(auto& dep: snap) {
         if(dep.missing) {
             // Gone at build time: reappearing is the change; still-missing
             // stays unchanged (see the capture).
@@ -341,29 +339,30 @@ bool deps_changed(FileTable& files, const DepsSnapshot& snap) {
             continue;
         }
 
-        // No trusted hash to compare against: rebuild once to converge.
-        if(dep.hash == 0) {
+        // No version names the consumed bytes: rebuild once to converge.
+        if(!dep.version.valid()) {
             return true;
         }
 
         // Missing means gone now — a change, since the build saw the file.
         // Unreadable cannot prove the disk unchanged and counts as changed
         // — conservative, retried by the rebuild's capture.
-        if(files.check_version(files.intern_version(dep.path_id, dep.hash)) !=
-           FileTable::Verdict::Fresh) {
+        if(files.check_version(dep.version) != FileTable::Verdict::Fresh) {
             return true;
         }
     }
     return false;
 }
 
-std::shared_ptr<index::TUIndex> load_pch_envelope(llvm::StringRef path,
-                                                  std::uint64_t expected_hash) {
+void force_revalidate_deps(FileTable& files, const DepsSnapshot& snap) {
+    for(auto& dep: snap) {
+        files.force_revalidate(dep.path_id);
+    }
+}
+
+std::shared_ptr<index::TUIndex> load_pch_envelope(llvm::StringRef path) {
     auto buffer = llvm::MemoryBuffer::getFile(path);
     if(!buffer) {
-        return nullptr;
-    }
-    if(expected_hash != 0 && llvm::xxh3_64bits((*buffer)->getBuffer()) != expected_hash) {
         return nullptr;
     }
     // A stale or truncated pair must never crash the server: the envelope
@@ -379,7 +378,7 @@ std::shared_ptr<index::TUIndex> load_pch_envelope(llvm::StringRef path,
 
 const std::shared_ptr<index::TUIndex>& PCHState::load_state() {
     if(!state && !index_path.empty()) {
-        state = load_pch_envelope(index_path, index_binding.hash);
+        state = load_pch_envelope(index_path);
         if(!state) {
             // Unreadable blob: clear the path so queries don't retry the
             // mmap + verification on every call. The pair now looks
@@ -466,13 +465,13 @@ void Workspace::build_module_map() {
 }
 
 void Workspace::fill_pcm_deps(std::unordered_map<std::string, std::string>& pcms,
-                              std::uint32_t exclude_path_id) const {
-    for(auto& [pid, pcm_path]: pcm_paths) {
+                              Fid exclude_path_id) const {
+    for(auto& [pid, st]: pcm_cache) {
         if(pid == exclude_path_id)
             continue;
         auto mod_it = path_to_module.find(pid);
         if(mod_it != path_to_module.end()) {
-            pcms[mod_it->second] = pcm_path;
+            pcms[mod_it->second] = st.path;
         }
     }
 }

--- a/src/sched/workspace.cpp
+++ b/src/sched/workspace.cpp
@@ -14,13 +14,11 @@
 #include "syntax/preamble_synthesis.h"
 #include "syntax/scan.h"
 
-#include "kota/codec/json/json.h"
-#include "kota/codec/macro.h"
 #include "llvm/Support/Chrono.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
-#include "llvm/Support/Process.h"
+#include "llvm/Support/xxhash.h"
 
 namespace clice {
 
@@ -347,60 +345,14 @@ bool deps_changed(FileTable& files, const DepsSnapshot& snap) {
     return false;
 }
 
-namespace {
 
-struct CacheDepEntry {
-    std::uint32_t path;  // index into CacheData::paths
-    std::uint64_t hash;
-    // Defaulted so cache.json files written before the per-dep stat baseline
-    // still load: the fields read back zeroed ("no fast path") and the first
-    // staleness check re-earns them by hash. Their old entry-level build_at
-    // is skipped as an unknown field.
-    KOTATSU_ANNOTATE(defaulted = true)
-    <std::uint64_t> size;
-
-    KOTATSU_ANNOTATE(defaulted = true)
-    <std::int64_t> mtime_ns;
-
-    KOTATSU_ANNOTATE(defaulted = true)
-    <bool> missing;
-};
-
-struct CachePCHEntry {
-    std::string key;  // CacheStore key in the "pch" namespace
-    std::uint32_t bound;
-    std::vector<CacheDepEntry> deps;
-};
-
-struct CachePCMEntry {
-    std::string key;  // CacheStore key in the "pcm" namespace
-    std::uint32_t source_file;
-    std::string module_name;
-    std::vector<CacheDepEntry> deps;
-};
-
-struct CacheData {
-    std::vector<std::string> paths;
-
-    // index_format_version the .pch.idx envelopes were written with (one
-    // binary writes them all). A mismatch drops every PCH entry at load so
-    // the pairs rebuild immediately, instead of the mismatch surfacing
-    // lazily on the first overlay query — which cannot trigger a rebuild.
-    // Old cache.json files read back 0 and are dropped the same way.
-    std::uint32_t pch_index_format = 0;
-
-    std::vector<CachePCHEntry> pch;
-    std::vector<CachePCMEntry> pcm;
-    std::vector<CacheModeEntry> header_modes;
-    std::vector<CacheContextEntry> contexts;
-    std::vector<CacheArtifactEntry> artifacts;
-};
-
-}  // namespace
-
-std::shared_ptr<index::TUIndex> load_pch_envelope(llvm::StringRef path) {
+std::shared_ptr<index::TUIndex> load_pch_envelope(llvm::StringRef path,
+                                                  std::uint64_t expected_hash) {
     auto buffer = llvm::MemoryBuffer::getFile(path);
     if(!buffer) {
+        return nullptr;
+    }
+    if(expected_hash != 0 && llvm::xxh3_64bits((*buffer)->getBuffer()) != expected_hash) {
         return nullptr;
     }
     // A stale or truncated pair must never crash the server: the envelope
@@ -416,7 +368,7 @@ std::shared_ptr<index::TUIndex> load_pch_envelope(llvm::StringRef path) {
 
 const std::shared_ptr<index::TUIndex>& PCHState::load_state() {
     if(!state && !index_path.empty()) {
-        state = load_pch_envelope(index_path);
+        state = load_pch_envelope(index_path, index_binding.hash);
         if(!state) {
             // Unreadable blob: clear the path so queries don't retry the
             // mmap + verification on every call. The pair now looks
@@ -491,199 +443,6 @@ void Workspace::enforce_loaded_budget() {
         LOG_DEBUG("Unloading pch.idx envelope of {} (budget {})", loaded_state_lru[i], budget);
         it->second.state.reset();
         loaded_state_lru.erase(loaded_state_lru.begin() + i);
-    }
-}
-
-void Workspace::load_cache(ContextResolver& contexts) {
-    if(!store)
-        return;
-
-    auto cache_path = path::join(store->base_dir(), "cache.json");
-    auto content = fs::read(cache_path);
-    if(!content) {
-        LOG_DEBUG("No cache.json found at {}", cache_path);
-        return;
-    }
-
-    CacheData data;
-    auto status = kota::codec::json::from_string(*content, data);
-    if(!status) {
-        LOG_WARN("Failed to parse cache.json");
-        return;
-    }
-
-    auto resolve = [&](std::uint32_t idx) -> llvm::StringRef {
-        return idx < data.paths.size() ? llvm::StringRef(data.paths[idx]) : "";
-    };
-
-    auto load_deps = [&](const auto& dep_entries) -> DepsSnapshot {
-        DepsSnapshot deps;
-        for(auto& dep: dep_entries) {
-            auto dep_path = resolve(dep.path);
-            if(dep_path.empty())
-                continue;
-            auto path_id = file_table.intern(dep_path);
-            deps.deps.push_back({.path_id = path_id, .hash = dep.hash, .missing = dep.missing});
-            if(dep.hash != 0) {
-                file_table.adopt_stamp(file_table.intern_version(path_id, dep.hash),
-                                       dep.size,
-                                       dep.mtime_ns);
-            }
-        }
-        return deps;
-    };
-
-    bool pch_format_ok = data.pch_index_format == index::index_format_version;
-    for(auto& entry: data.pch) {
-        if(!pch_format_ok) {
-            break;
-        }
-
-        auto pch_path = store->lookup("pch", entry.key);
-        if(!pch_path)
-            continue;
-
-        // A PCH without its pch.idx envelope is an incomplete pair
-        // (crash between the two commits): treat it as absent so the next
-        // compile rebuilds both.
-        auto index_path = store->lookup_aux("pch", entry.key);
-        if(!index_path)
-            continue;
-
-        auto& st = pch_cache[entry.key];
-        st.path = *pch_path;
-        st.bound = entry.bound;
-        st.deps = load_deps(entry.deps);
-        st.index_path = *index_path;
-
-        LOG_DEBUG("Loaded cached PCH: {} -> {}", entry.key, *pch_path);
-    }
-
-    for(auto& entry: data.pcm) {
-        auto pcm_path = store->lookup("pcm", entry.key);
-        auto source = resolve(entry.source_file);
-        if(!pcm_path || source.empty())
-            continue;
-
-        // PCM builds now always record at least the module source itself as
-        // a dependency, so an empty list marks an entry from before deps
-        // were populated — an unvalidatable snapshot that would blindly
-        // serve a stale PCM (the key embeds no content). Drop it and let
-        // the module rebuild once.
-        if(entry.deps.empty()) {
-            LOG_INFO("Dropping dep-less cached PCM for {} (pre-upgrade entry)", source);
-            continue;
-        }
-
-        auto path_id = file_table.intern(source);
-        pcm_cache[path_id] = {*pcm_path, entry.key, load_deps(entry.deps)};
-        pcm_paths[path_id] = *pcm_path;
-
-        LOG_DEBUG("Loaded cached PCM: {} (module {}) -> {}", source, entry.module_name, *pcm_path);
-    }
-
-    contexts.load_cache_slices(data.header_modes, data.contexts, data.artifacts, resolve);
-
-    LOG_INFO("Loaded cache.json: {} PCH entries, {} PCM entries, {} context choices",
-             pch_cache.size(),
-             pcm_cache.size(),
-             contexts.saved_contexts.size());
-}
-
-void Workspace::save_cache(const ContextResolver& contexts) {
-    if(!store)
-        return;
-
-    CacheData data;
-    data.pch_index_format = index::index_format_version;
-    std::unordered_map<std::string, std::uint32_t> index_map;
-
-    auto intern = [&](std::uint32_t runtime_path_id) -> std::uint32_t {
-        auto path = std::string(file_table.resolve(runtime_path_id));
-        auto [it, inserted] =
-            index_map.try_emplace(path, static_cast<std::uint32_t>(data.paths.size()));
-        if(inserted) {
-            data.paths.push_back(path);
-        }
-        return it->second;
-    };
-
-    // The persisted per-dep stamp is the shared version's — earned once,
-    // written for every artifact referencing the version.
-    auto stamp_of = [&](const DepState& dep) -> std::pair<std::uint64_t, std::int64_t> {
-        auto it = file_table.version_ids.find({dep.path_id, dep.hash});
-        if(it == file_table.version_ids.end()) {
-            return {0, 0};
-        }
-        auto& version = file_table.versions.find(it->second)->second;
-        return {version.size, version.mtime_ns};
-    };
-
-    for(auto& e: pch_cache) {
-        auto& st = e.second;
-        if(st.path.empty())
-            continue;
-
-        CachePCHEntry entry;
-        entry.key = e.getKey().str();
-        entry.bound = st.bound;
-        for(auto& dep: st.deps.deps) {
-            auto [size, mtime_ns] = stamp_of(dep);
-            entry.deps.push_back({intern(dep.path_id), dep.hash, size, mtime_ns, dep.missing});
-        }
-        data.pch.push_back(std::move(entry));
-    }
-
-    for(auto& [path_id, st]: pcm_cache) {
-        if(st.path.empty())
-            continue;
-
-        CachePCMEntry entry;
-        entry.key = st.key;
-        entry.source_file = intern(path_id);
-        auto mod_it = path_to_module.find(path_id);
-        entry.module_name = mod_it != path_to_module.end() ? mod_it->second : "";
-        for(auto& dep: st.deps.deps) {
-            auto [size, mtime_ns] = stamp_of(dep);
-            entry.deps.push_back({intern(dep.path_id), dep.hash, size, mtime_ns, dep.missing});
-        }
-        data.pcm.push_back(std::move(entry));
-    }
-
-    auto intern_path = [&](llvm::StringRef path) -> std::uint32_t {
-        auto [it, inserted] =
-            index_map.try_emplace(path.str(), static_cast<std::uint32_t>(data.paths.size()));
-        if(inserted) {
-            data.paths.push_back(path.str());
-        }
-        return it->second;
-    };
-    contexts.dump_cache_slices(data.header_modes,
-                               data.contexts,
-                               data.artifacts,
-                               intern,
-                               intern_path);
-
-    auto json_str = kota::codec::json::to_string(data);
-    if(!json_str) {
-        LOG_WARN("Failed to serialize cache.json");
-        return;
-    }
-
-    auto cache_path = path::join(store->base_dir(), "cache.json");
-    // Stage inside this instance's store tmp directory: other instances of
-    // the same workspace must not clobber each other's half-written file.
-    auto pid = llvm::sys::Process::getProcessId();
-    auto tmp_path = path::join(store->base_dir(), "tmp", std::to_string(pid), "cache.json");
-    auto write_result = fs::write(tmp_path, *json_str);
-    if(!write_result) {
-        LOG_WARN("Failed to write cache.json.tmp: {}", write_result.error().message());
-        return;
-    }
-    auto rename_result = fs::rename(tmp_path, cache_path);
-    if(!rename_result) {
-        LOG_WARN("Failed to rename cache.json.tmp to cache.json: {}",
-                 rename_result.error().message());
     }
 }
 

--- a/src/sched/workspace.cpp
+++ b/src/sched/workspace.cpp
@@ -311,7 +311,7 @@ DepsSnapshot capture_deps_snapshot(FileTable& files,
             // bytes, so their hash can be taken from the shared pair — or
             // one read, unless the file moved between the stat and the
             // read, which voids the proof.
-            auto obs = files.observe_for(dep.path_id, size, mtime_ns);
+            auto obs = files.observe_for(dep.path_id, status);
             if(!obs || obs->size != size || obs->mtime_ns != mtime_ns) {
                 continue;
             }
@@ -355,7 +355,6 @@ bool deps_changed(FileTable& files, const DepsSnapshot& snap) {
     }
     return false;
 }
-
 
 std::shared_ptr<index::TUIndex> load_pch_envelope(llvm::StringRef path,
                                                   std::uint64_t expected_hash) {

--- a/src/sched/workspace.cpp
+++ b/src/sched/workspace.cpp
@@ -133,6 +133,7 @@ void Workspace::rescan_after_save(std::uint32_t path_id) {
         // index serves as config id — prior keys were just cleared and
         // consumers read the union.
         DirListingCache dir_cache;
+        dir_cache.shared = &file_table;
         auto dir = llvm::sys::path::parent_path(path);
         for(std::uint32_t ci = 0; ci < refs.size(); ++ci) {
             auto search_config = cdb.search_config(refs[ci]);

--- a/src/sched/workspace.cpp
+++ b/src/sched/workspace.cpp
@@ -82,11 +82,20 @@ llvm::SmallVector<std::uint32_t> Workspace::rank_hosts(std::uint32_t header_path
     return ranked;
 }
 
-void Workspace::rescan_includes(std::uint32_t path_id) {
+void Workspace::rescan_after_save(std::uint32_t path_id) {
     auto path = file_table.resolve(path_id);
     dep_graph.clear_includes(path_id);
 
-    if(auto buf = llvm::MemoryBuffer::getFile(path)) {
+    // One read serves everything a save invalidates: the shared pair (so
+    // hash comparisons elsewhere stop re-reading), the lexical scan
+    // (include edges and the module declaration), and the bytes the
+    // module-decl preprocessor fallback must consume.
+    auto observed = read_file_observed(path.data());
+    if(observed) {
+        file_table.observe(path_id, observed->obs);
+        const auto& scan =
+            file_table.scan_of(path_id, observed->obs.hash, observed->content->getBuffer());
+
         // Search paths come from the file's own command, or a host's for
         // headers without a CDB entry; the synthesized default still
         // resolves quote includes via the includer directory.
@@ -123,7 +132,6 @@ void Workspace::rescan_includes(std::uint32_t path_id) {
         // reachable through the -I set of a non-first CDB entry. The local
         // index serves as config id — prior keys were just cleared and
         // consumers read the union.
-        auto includes = scan_quick((*buf)->getBuffer()).includes;
         DirListingCache dir_cache;
         auto dir = llvm::sys::path::parent_path(path);
         for(std::uint32_t ci = 0; ci < refs.size(); ++ci) {
@@ -132,7 +140,7 @@ void Workspace::rescan_includes(std::uint32_t path_id) {
             auto entries = resolve_dir(dir, dir_cache);
 
             llvm::SmallVector<std::uint32_t> ids;
-            for(auto& include: includes) {
+            for(auto& include: scan.includes) {
                 auto resolved = resolve_include(include.path,
                                                 include.is_angled,
                                                 entries,
@@ -147,65 +155,67 @@ void Workspace::rescan_includes(std::uint32_t path_id) {
             }
             dep_graph.set_includes(path_id, ci, std::move(ids));
         }
-    }
 
-    dep_graph.build_reverse_map();
-}
+        dep_graph.build_reverse_map();
+        context_epoch += 1;
 
-void Workspace::rescan_after_save(std::uint32_t path_id) {
-    // Contexts must see includes added/removed by this save.
-    rescan_includes(path_id);
-
-    context_epoch += 1;
-
-    // Re-scan the saved file for module declarations, updating both
-    // module maps: path_to_module gates the module code paths, and the
-    // dep_graph side is what import resolution reads — left stale, an
-    // interface saved mid-session could never satisfy its importers.
-    auto file_path = file_table.resolve(path_id);
-    if(auto buf = llvm::MemoryBuffer::getFile(file_path)) {
-        auto result = scan_quick((*buf)->getBuffer());
+        // Update both module maps: path_to_module gates the module code
+        // paths, and the dep_graph side is what import resolution reads —
+        // left stale, an interface saved mid-session could never satisfy
+        // its importers.
+        auto module_name = scan.module_name;
+        bool is_interface_unit = scan.is_interface_unit;
         // A module declaration inside a preprocessor conditional is beyond
         // the lexical scan (need_preprocess, name left empty): resolve it
         // with the same scan_module_decl() fallback the startup scan uses,
         // or this save would drop a guarded interface from both provider
         // maps and leave its importers unresolved until a reload.
-        if(result.need_preprocess) {
-            auto candidates = cdb.candidate_entries(file_path);
-            bool has_entry = !candidates.empty();
-            auto base = has_entry ? candidates.front().config : cdb.fallback_config(file_path);
-            // Same rules-applied command as the startup scan: a rule-added
-            // define may be what unguards the module declaration.
-            std::vector<std::string> append, remove;
-            config.match_rules(file_path, append, remove);
-            auto applied = cdb.apply_rules(base, {.remove = remove, .append = append});
-            CommandRef ref{path_id,
-                           applied,
-                           cdb.input_kind(applied, file_path),
-                           has_entry ? CommandSource::CDBExact : CommandSource::Fallback};
-            auto fallback = scan_module_decl(cdb.render(ref),
-                                             cdb.config(ref.config).directory,
-                                             (*buf)->getBuffer());
-            if(!fallback.module_name.empty()) {
-                result.module_name = std::move(fallback.module_name);
-                result.is_interface_unit = fallback.is_interface_unit;
+        if(scan.need_preprocess && !refs.empty()) {
+            auto& ref = refs.front();
+            auto rendered = cdb.render(ref);
+            llvm::SmallString<512> joined;
+            for(auto* arg: rendered) {
+                joined.append(arg);
+                joined.push_back('\0');
+            }
+            auto key = std::pair{observed->obs.hash, llvm::xxh3_64bits(joined)};
+            auto cached = file_table.module_decls.find(key);
+            if(cached == file_table.module_decls.end()) {
+                // The preprocessor consumes the very bytes that produced
+                // the scan; negative results memoize too.
+                auto fallback = scan_module_decl(rendered,
+                                                 cdb.config(ref.config).directory,
+                                                 observed->content->getBuffer());
+                cached = file_table.module_decls
+                             .try_emplace(key,
+                                          FileTable::ModuleDecl{fallback.module_name,
+                                                                fallback.is_interface_unit})
+                             .first;
+            }
+            if(!cached->second.name.empty()) {
+                module_name = cached->second.name;
+                is_interface_unit = cached->second.is_interface_unit;
             }
         }
         // Both maps hold interface units only, mirroring the startup scan:
         // an implementation unit (`module foo;`) must never satisfy
         // lookup_module — importers would edge to it and try to build it
         // as an interface — nor claim a PCM node of its own.
-        if(!result.is_interface_unit) {
-            result.module_name.clear();
+        if(!is_interface_unit) {
+            module_name.clear();
         }
-        dep_graph.update_module_decl(path_id, result.module_name);
-        dep_graph.set_import_candidate(path_id, result.has_import);
-        if(!result.module_name.empty()) {
-            path_to_module[path_id] = std::move(result.module_name);
+        dep_graph.update_module_decl(path_id, module_name);
+        dep_graph.set_import_candidate(path_id, scan.has_import);
+        if(!module_name.empty()) {
+            path_to_module[path_id] = std::move(module_name);
         } else {
             path_to_module.erase(path_id);
         }
+        return;
     }
+
+    dep_graph.build_reverse_map();
+    context_epoch += 1;
 }
 
 void Workspace::on_file_closed(std::uint32_t path_id) {

--- a/src/sched/workspace.h
+++ b/src/sched/workspace.h
@@ -43,35 +43,21 @@ constexpr inline std::uint32_t no_path_id = ~0u;
 /// One dependency's freshness record inside a DepsSnapshot.
 ///
 /// `hash` describes the bytes the build actually consumed (reported by the
-/// worker from the compiler's own buffers). `size`/`mtime_ns` are a stat
-/// fast path: they are only recorded when the file provably did not change
-/// since before the build started, so matching them proves the disk still
-/// holds the consumed content. mtime_ns == 0 means "no fast path" — the
-/// check falls through to the hash comparison and, on a match, repairs the
-/// fast path in place. The index's form of the same fast path is
-/// `index::FileVersionRecord`, shared by every TU consuming the version.
+/// worker from the compiler's own buffers) — it names a FileVersion in the
+/// shared table, where the stat fast path and the two-layer check live
+/// (FileTable::check_version), shared by every artifact and TU consuming
+/// the version. What stays per reference is capture state: `missing` is
+/// what THIS build saw, not a property of the version.
 struct DepState {
     std::uint32_t path_id = no_path_id;
-    std::uint64_t size = 0;
-    std::int64_t mtime_ns = 0;
     std::uint64_t hash = 0;
     /// The file did not exist when the artifact was built (hash is 0 then).
     bool missing = false;
 };
 
-/// Two-layer staleness snapshot for compilation artifacts (PCH, PCM, AST,
-/// synthesized header preambles). Same vocabulary as FileTracker::FileState.
-///
-/// Layer 1 (fast): stat each dep; size and mtime_ns EQUAL to the record
-///   means unchanged (zero I/O beyond stat). Equality — not a watermark —
-///   so backdated or preserved mtimes cannot masquerade as fresh. The one
-///   deliberate residual: different bytes behind an identical size AND
-///   identical nanosecond mtime are invisible, the universal limit of any
-///   stat-based fast path (FileTracker, ccache and clangd accept the same).
-///
-/// Layer 2 (precise): otherwise hash the disk content and compare against
-///   the consumed-content hash. A match means the file was touched but not
-///   modified: the record's fast path is repaired and no rebuild happens.
+/// Staleness snapshot for compilation artifacts (PCH, PCM, AST, synthesized
+/// header preambles): the consumed versions, checked through the shared
+/// version table (see FileTable::check_version for the two-layer test).
 struct DepsSnapshot {
     llvm::SmallVector<DepState> deps;
 
@@ -79,13 +65,15 @@ struct DepsSnapshot {
         return deps.empty();
     }
 
-    /// Drop every fast-path baseline so the next check re-validates each
-    /// dependency by content hash (the hashes stay: they describe what the
-    /// artifact was built from). Used when embedded copies of dependency
-    /// content may disagree with the files themselves.
-    void force_revalidate() {
+    /// Drop every trust anchor of the snapshot's files so the next check
+    /// re-validates each dependency by a real read (the hashes stay: they
+    /// describe what the artifact was built from). Used when embedded
+    /// copies of dependency content may disagree with the files
+    /// themselves. Shared-level on purpose: the anchors live on the
+    /// versions, so other consumers of a forced file pay one re-read too.
+    void force_revalidate(FileTable& files) const {
         for(auto& dep: deps) {
-            dep.mtime_ns = 0;
+            files.force_revalidate(dep.path_id);
         }
     }
 };
@@ -364,23 +352,24 @@ struct Workspace {
 /// exists yet — the file tracker keeps looking on its CDB poll.
 std::string discover_compile_commands(const Config& config, llvm::StringRef workspace_root);
 
-/// Hash a file's content using xxh3_64bits. Returns 0 on read failure.
-std::uint64_t hash_file(llvm::StringRef path);
-
-/// Capture a staleness snapshot from a build's reported inputs.
+/// Capture a staleness snapshot from a build's reported inputs, interning
+/// the consumed versions into the shared table.
 ///
 /// `deps` carries the consumed-content hashes the worker computed at build
 /// time; `build_at` is milliseconds since epoch, sampled before the build
 /// started. Each dependency is stat'ed once: a file untouched since
-/// `build_at` gets a {size, mtime_ns} fast-path baseline, a file modified
-/// during or after the build gets none — the next check must prove the disk
-/// still matches the consumed hash before trusting (and repairing) the stat.
-DepsSnapshot capture_deps_snapshot(FileTable& pool,
+/// `build_at` offers its stat as the version's fast-path baseline
+/// (recorded only when corroborated, see FileTable::try_stamp), a file
+/// modified during or after the build offers none — the next check must
+/// prove the disk still matches the consumed hash before trusting (and
+/// repairing) the stat.
+DepsSnapshot capture_deps_snapshot(FileTable& files,
                                    llvm::ArrayRef<DepFile> deps,
                                    std::int64_t build_at);
 
-/// Two-layer staleness check; see DepsSnapshot. Repairs fast-path baselines
-/// in place when a hash comparison proves a touched file unchanged.
-bool deps_changed(const FileTable& pool, DepsSnapshot& snap);
+/// Whether any consumed version stopped matching the disk; see
+/// FileTable::check_version for the two-layer test and DepState for the
+/// per-reference missing policy. Callers open the memo wave.
+bool deps_changed(FileTable& files, const DepsSnapshot& snap);
 
 }  // namespace clice

--- a/src/sched/workspace.h
+++ b/src/sched/workspace.h
@@ -147,13 +147,30 @@ struct SavedContext {
 /// Open a PCH's `.pch.idx` envelope (memory-mapped). Returns nullptr when
 /// the file is unreadable, structurally invalid, of a different format
 /// version, or any embedded shard blob fails verification — callers treat
-/// all of these as a PCH cache miss.
-std::shared_ptr<index::TUIndex> load_pch_envelope(llvm::StringRef path);
+/// all of these as a PCH cache miss. `expected_hash`, when nonzero, is the
+/// committed envelope's xxh3 (BlobBinding::hash): the bytes are in hand
+/// anyway, so a swapped or torn blob behind a matching path is rejected
+/// for free.
+std::shared_ptr<index::TUIndex> load_pch_envelope(llvm::StringRef path,
+                                                  std::uint64_t expected_hash = 0);
 
 struct PCHState {
     std::string path;
     std::uint32_t bound = 0;
     DepsSnapshot deps;
+
+    /// Identities of the committed pair (see BlobBinding): the stat triple
+    /// is verified on every freshness judgment — the PCH key is not fully
+    /// content-addressed, so a concurrent writer (batch lint shares the
+    /// store) can republish different bytes under this key, and metadata
+    /// adopted for the old generation must not vouch for the new one.
+    BlobBinding binding;
+    BlobBinding index_binding;
+
+    /// Adopted after a writer died with unflushed metadata: the records
+    /// may describe blobs that never matched them, so the first use also
+    /// verifies the content hashes, not just the stat triples.
+    bool verify_content = false;
 
     /// Path of the paired pch.idx envelope.
     std::string index_path;
@@ -176,6 +193,12 @@ struct PCMState {
     /// CacheStore key: "{module}-{hash}" over source path + canonical flags.
     std::string key;
     DepsSnapshot deps;
+
+    /// Identity of the committed blob; see PCHState::binding.
+    BlobBinding binding;
+
+    /// See PCHState::verify_content.
+    bool verify_content = false;
 };
 
 /// All persistent, project-wide state derived from files on disk.
@@ -214,7 +237,8 @@ struct Workspace {
     /// Unified on-disk blob store for PCH/PCM/index artifacts.  Opened by
     /// load_workspace() when cache_dir is configured; absent means caching
     /// is disabled.  Owns blob lifecycle (atomic writes, LRU, crash
-    /// recovery); validity metadata (deps snapshots) stays in cache.json.
+    /// recovery); validity metadata (deps snapshots) lives in the index
+    /// database, written by IndexStore::save.
     std::optional<CacheStore> store;
 
     /// Index blob persistence, opened together with the cache store.
@@ -313,7 +337,7 @@ struct Workspace {
     /// Open the pch.idx envelope of a cached PCH. The single consumption
     /// gate for `.pch.idx` blobs: when the blob turns out unreadable, the
     /// on-disk pair is retracted from the store as well — otherwise every
-    /// later session re-adopts the corrupt pair from cache.json and
+    /// later session re-adopts the corrupt pair from the artifacts blob and
     /// silently degrades again. With the pair gone the next ensure_pch is
     /// a miss and rebuilds both halves. Loads count against the
     /// loaded-state budget (see enforce_loaded_budget).
@@ -332,13 +356,38 @@ struct Workspace {
     /// reopens the blob from disk.
     void enforce_loaded_budget();
 
-    /// Load PCH/PCM validity metadata plus the context resolver's slices
-    /// from cache.json (under the store's versioned root); entries whose
-    /// blob is gone from the store are dropped.
-    void load_cache(ContextResolver& contexts);
-    /// Save PCH/PCM validity metadata plus the context resolver's slices
-    /// to cache.json.
-    void save_cache(const ContextResolver& contexts);
+    /// Persistence signals for the metadata the index database carries
+    /// beyond the index itself: artifact validity (PCH/PCM records, header
+    /// modes) and user context choices. Producers mark; the single write
+    /// pipeline (IndexStore::save) flushes both on its next run and
+    /// advances `committed_metadata_epoch`, waking `metadata_committed` —
+    /// the ticket a caller needing durability (switchContext) waits on.
+    bool artifacts_dirty = false;
+    bool contexts_dirty = false;
+    std::uint64_t metadata_epoch = 0;
+    std::uint64_t committed_metadata_epoch = 0;
+    kota::event metadata_committed;
+
+    /// Wired by the master to schedule a flush soon after a mark; unset
+    /// (tests, batch tools) means the owner saves on its own cadence.
+    std::function<void()> request_flush;
+
+    void mark_artifacts_dirty() {
+        artifacts_dirty = true;
+        metadata_epoch += 1;
+        if(request_flush) {
+            request_flush();
+        }
+    }
+
+    void mark_contexts_dirty() {
+        contexts_dirty = true;
+        metadata_epoch += 1;
+        if(request_flush) {
+            request_flush();
+        }
+    }
+
     /// Build path_to_module reverse mapping from dep_graph.
     void build_module_map();
     /// Fill PCM paths for all built modules, excluding exclude_path_id.

--- a/src/sched/workspace.h
+++ b/src/sched/workspace.h
@@ -37,52 +37,39 @@ class ContextResolver;
 /// Bump to discard all cached artifacts after incompatible format changes.
 constexpr inline std::uint32_t cache_format_version = 8;
 
-/// Sentinel for "no path": file ids start at 0, so 0 is a real file.
-constexpr inline std::uint32_t no_path_id = ~0u;
-
-/// One dependency's freshness record inside a DepsSnapshot.
+/// One dependency of a compilation artifact.
 ///
-/// `hash` describes the bytes the build actually consumed (reported by the
-/// worker from the compiler's own buffers) — it names a FileVersion in the
-/// shared table, where the stat fast path and the two-layer check live
-/// (FileTable::check_version), shared by every artifact and TU consuming
-/// the version. What stays per reference is capture state: `missing` is
-/// what THIS build saw, not a property of the version.
+/// `version` names the FileVersion the build actually consumed (interned
+/// from the worker-reported content hash) — the stat fast path and the
+/// two-layer freshness test live on the shared version, paid once per
+/// wave for every artifact and TU referencing it (FileTable::
+/// check_version). An invalid version means the build saw no nameable
+/// bytes: `missing` distinguishes "the file was absent" (reappearing is
+/// the change) from "the bytes could not be hashed" (stale until a
+/// rebuild's capture converges).
 struct DepState {
-    std::uint32_t path_id = no_path_id;
-    std::uint64_t hash = 0;
-    /// The file did not exist when the artifact was built (hash is 0 then).
+    Fid path_id;
+    VersionID version;
     bool missing = false;
 };
 
 /// Staleness snapshot for compilation artifacts (PCH, PCM, AST, synthesized
-/// header preambles): the consumed versions, checked through the shared
-/// version table (see FileTable::check_version for the two-layer test).
-struct DepsSnapshot {
-    llvm::SmallVector<DepState> deps;
+/// header preambles): the consumed versions, checked via deps_changed.
+using DepsSnapshot = llvm::SmallVector<DepState>;
 
-    bool empty() const {
-        return deps.empty();
-    }
-
-    /// Drop every trust anchor of the snapshot's files so the next check
-    /// re-validates each dependency by a real read (the hashes stay: they
-    /// describe what the artifact was built from). Used when embedded
-    /// copies of dependency content may disagree with the files
-    /// themselves. Shared-level on purpose: the anchors live on the
-    /// versions, so other consumers of a forced file pay one re-read too.
-    void force_revalidate(FileTable& files) const {
-        for(auto& dep: deps) {
-            files.force_revalidate(dep.path_id);
-        }
-    }
-};
+/// Drop every trust anchor of the snapshot's files so the next check
+/// re-validates each dependency by a real read (the versions stay: they
+/// describe what the artifact was built from). Used when embedded copies
+/// of dependency content may disagree with the files themselves.
+/// Shared-level on purpose: the anchors live on the versions, so other
+/// consumers of a forced file pay one re-read too.
+void force_revalidate_deps(FileTable& files, const DepsSnapshot& snap);
 
 /// Context for compiling a header file that lacks its own CDB entry.
 struct HeaderContext {
-    std::uint32_t host_path_id = no_path_id;  ///< Source file acting as host.
-    std::string preamble_path;                ///< Path to generated preamble file on disk.
-    std::uint64_t preamble_hash;              ///< Hash of preamble content for staleness.
+    Fid host_path_id;             ///< Source file acting as host.
+    std::string preamble_path;    ///< Path to generated preamble file on disk.
+    std::uint64_t preamble_hash;  ///< Hash of preamble content for staleness.
 
     /// Path to the generated suffix file (content after the include
     /// position along the chain), appended to the header's buffer as one
@@ -104,7 +91,7 @@ struct HeaderContext {
     /// Include chain from host to the target's direct includer (excludes the
     /// target itself). The synthesized preamble embeds these files' content,
     /// so clang never opens them — staleness must be tracked here.
-    llvm::SmallVector<std::uint32_t> chain;
+    llvm::SmallVector<Fid> chain;
 
     /// Staleness snapshot over the chain files (mtime + content hash).
     DepsSnapshot deps;
@@ -122,8 +109,8 @@ enum class HeaderMode : std::uint32_t {
 
 /// A user's context choice, persisted across sessions.
 struct SavedContext {
-    /// Header context host; no_path_id = none.
-    std::uint32_t host_path_id = no_path_id;
+    /// Header context host; invalid = none.
+    Fid host_path_id;
 
     /// Pinned include occurrence; no value = automatic.
     std::optional<std::uint32_t> occurrence;
@@ -147,30 +134,13 @@ struct SavedContext {
 /// Open a PCH's `.pch.idx` envelope (memory-mapped). Returns nullptr when
 /// the file is unreadable, structurally invalid, of a different format
 /// version, or any embedded shard blob fails verification — callers treat
-/// all of these as a PCH cache miss. `expected_hash`, when nonzero, is the
-/// committed envelope's xxh3 (BlobBinding::hash): the bytes are in hand
-/// anyway, so a swapped or torn blob behind a matching path is rejected
-/// for free.
-std::shared_ptr<index::TUIndex> load_pch_envelope(llvm::StringRef path,
-                                                  std::uint64_t expected_hash = 0);
+/// all of these as a PCH cache miss.
+std::shared_ptr<index::TUIndex> load_pch_envelope(llvm::StringRef path);
 
 struct PCHState {
     std::string path;
     std::uint32_t bound = 0;
     DepsSnapshot deps;
-
-    /// Identities of the committed pair (see BlobBinding): the stat triple
-    /// is verified on every freshness judgment — the PCH key is not fully
-    /// content-addressed, so a concurrent writer (batch lint shares the
-    /// store) can republish different bytes under this key, and metadata
-    /// adopted for the old generation must not vouch for the new one.
-    BlobBinding binding;
-    BlobBinding index_binding;
-
-    /// Adopted after a writer died with unflushed metadata: the records
-    /// may describe blobs that never matched them, so the first use also
-    /// verifies the content hashes, not just the stat triples.
-    bool verify_content = false;
 
     /// Path of the paired pch.idx envelope.
     std::string index_path;
@@ -193,12 +163,6 @@ struct PCMState {
     /// CacheStore key: "{module}-{hash}" over source path + canonical flags.
     std::string key;
     DepsSnapshot deps;
-
-    /// Identity of the committed blob; see PCHState::binding.
-    BlobBinding binding;
-
-    /// See PCHState::verify_content.
-    bool verify_content = false;
 };
 
 /// All persistent, project-wide state derived from files on disk.
@@ -254,7 +218,7 @@ struct Workspace {
     /// Reverse mapping: file path_id → module name (e.g. "std", "foo.bar").
     /// Built from dep_graph at startup; updated on didSave when module
     /// declarations change.
-    llvm::DenseMap<std::uint32_t, std::string> path_to_module;
+    llvm::DenseMap<Fid, std::string> path_to_module;
 
     /// PCH cache, keyed by content key (preamble text + canonical flags),
     /// so files with identical preambles share one PCH.  Hot-path mirror
@@ -278,11 +242,7 @@ struct Workspace {
     CrashBudget build_crashes;
 
     /// PCM cache, keyed by module source path_id.
-    llvm::DenseMap<std::uint32_t, PCMState> pcm_cache;
-
-    /// PCM output paths, keyed by module source path_id.
-    /// Maps to the .pcm file on disk used as -fmodule-file argument.
-    llvm::DenseMap<std::uint32_t, std::string> pcm_paths;
+    llvm::DenseMap<Fid, PCMState> pcm_cache;
 
     /// The index's global layer: symbols, FileVersions, per-TU manifests
     /// and the derived contribution map.
@@ -291,7 +251,7 @@ struct Workspace {
     /// Per-file row blobs from background indexing, keyed by project-level
     /// path_id: symbol occurrences, relations and stored content for
     /// position mapping, served zero-copy.
-    llvm::DenseMap<std::uint32_t, index::Shard> shards;
+    llvm::DenseMap<Fid, index::Shard> shards;
 
     /// Monotonic generation of context-affecting workspace state (include
     /// graph, CDB, disk contents). Bumped on didSave; clice/queryContext
@@ -311,25 +271,24 @@ struct Workspace {
     /// the target. Spelling-based (no search-path resolution): multiple
     /// inclusions of one header always share a spelling, and synthesis
     /// validates the real occurrence anyway.
-    std::uint32_t count_occurrences(std::uint32_t host_id, std::uint32_t target_id) const;
+    std::uint32_t count_occurrences(Fid host_id, Fid target_id) const;
 
     /// Rank host source candidates for a header by relevance: a source
     /// with the header's stem (utils.h -> utils.cpp) wins, then sources in
     /// the same directory, then longer common path prefixes; ties break
     /// lexicographically so the choice is deterministic.
-    llvm::SmallVector<std::uint32_t> rank_hosts(std::uint32_t header_path_id,
-                                                llvm::ArrayRef<std::uint32_t> hosts) const;
+    llvm::SmallVector<Fid> rank_hosts(Fid header_path_id, llvm::ArrayRef<Fid> hosts) const;
 
     /// Rescan a file after it was saved to disk, from one read: refresh
     /// its include edges (so host lookups and context queries see includes
     /// the save added or removed) and its module declaration. The
     /// module-graph cascade is the invalidator's job
     /// (PCMFamily::invalidate).
-    void rescan_after_save(std::uint32_t path_id);
+    void rescan_after_save(Fid path_id);
 
     /// Called when a file is closed.  Notifies compile_graph if this file
     /// is a module unit so dependents can be re-evaluated on next compile.
-    void on_file_closed(std::uint32_t path_id);
+    void on_file_closed(Fid path_id);
 
     /// Open the pch.idx envelope of a cached PCH. The single consumption
     /// gate for `.pch.idx` blobs: when the blob turns out unreadable, the
@@ -389,7 +348,7 @@ struct Workspace {
     void build_module_map();
     /// Fill PCM paths for all built modules, excluding exclude_path_id.
     void fill_pcm_deps(std::unordered_map<std::string, std::string>& pcms,
-                       std::uint32_t exclude_path_id = UINT32_MAX) const;
+                       Fid exclude_path_id = {}) const;
 };
 
 /// Find the workspace's compile_commands.json: the configured paths first

--- a/src/sched/workspace.h
+++ b/src/sched/workspace.h
@@ -37,7 +37,7 @@ class ContextResolver;
 /// Bump to discard all cached artifacts after incompatible format changes.
 constexpr inline std::uint32_t cache_format_version = 8;
 
-/// Sentinel for "no path": path pool ids start at 0, so 0 is a real file.
+/// Sentinel for "no path": file ids start at 0, so 0 is a real file.
 constexpr inline std::uint32_t no_path_id = ~0u;
 
 /// One dependency's freshness record inside a DepsSnapshot.

--- a/src/sched/workspace.h
+++ b/src/sched/workspace.h
@@ -19,8 +19,8 @@
 #include "sched/crash_budget.h"
 #include "semantic/symbol.h"
 #include "support/cache_store.h"
-#include "vfs/file_table.h"
 #include "syntax/dependency_graph.h"
+#include "vfs/file_table.h"
 
 #include "kota/async/async.h"
 #include "llvm/ADT/ArrayRef.h"

--- a/src/sched/workspace.h
+++ b/src/sched/workspace.h
@@ -19,7 +19,7 @@
 #include "sched/crash_budget.h"
 #include "semantic/symbol.h"
 #include "support/cache_store.h"
-#include "support/path_pool.h"
+#include "vfs/file_table.h"
 #include "syntax/dependency_graph.h"
 
 #include "kota/async/async.h"
@@ -216,11 +216,12 @@ struct Workspace {
     /// loaded user config and finalizes it after the initializationOptions
     /// overlay.
     Config config;
-    CompilationDatabase cdb;
 
-    /// The single path-id space: the CDB owns it, everything else shares
-    /// it — CDB entry file ids and workspace path ids are the same ids.
-    PathPool& path_pool = cdb.paths();
+    /// The single fid space, shared by everything below — CDB entry file
+    /// ids and workspace fids are the same ids.
+    FileTable file_table;
+
+    CompilationDatabase cdb{file_table};
 
     /// Unified on-disk blob store for PCH/PCM/index artifacts.  Opened by
     /// load_workspace() when cache_dir is configured; absent means caching
@@ -374,12 +375,12 @@ std::uint64_t hash_file(llvm::StringRef path);
 /// `build_at` gets a {size, mtime_ns} fast-path baseline, a file modified
 /// during or after the build gets none — the next check must prove the disk
 /// still matches the consumed hash before trusting (and repairing) the stat.
-DepsSnapshot capture_deps_snapshot(PathPool& pool,
+DepsSnapshot capture_deps_snapshot(FileTable& pool,
                                    llvm::ArrayRef<DepFile> deps,
                                    std::int64_t build_at);
 
 /// Two-layer staleness check; see DepsSnapshot. Repairs fast-path baselines
 /// in place when a hash comparison proves a touched file unchanged.
-bool deps_changed(const PathPool& pool, DepsSnapshot& snap);
+bool deps_changed(const FileTable& pool, DepsSnapshot& snap);
 
 }  // namespace clice

--- a/src/sched/workspace.h
+++ b/src/sched/workspace.h
@@ -320,14 +320,11 @@ struct Workspace {
     llvm::SmallVector<std::uint32_t> rank_hosts(std::uint32_t header_path_id,
                                                 llvm::ArrayRef<std::uint32_t> hosts) const;
 
-    /// Re-resolve a saved file's direct include edges from its disk
-    /// content, so host lookups and context queries see includes the save
-    /// added or removed.
-    void rescan_includes(std::uint32_t path_id);
-
-    /// Rescan a file after it was saved to disk: refresh its include
-    /// edges and module declaration. The module-graph cascade is the
-    /// invalidator's job (PCMFamily::invalidate).
+    /// Rescan a file after it was saved to disk, from one read: refresh
+    /// its include edges (so host lookups and context queries see includes
+    /// the save added or removed) and its module declaration. The
+    /// module-graph cascade is the invalidator's job
+    /// (PCMFamily::invalidate).
     void rescan_after_save(std::uint32_t path_id);
 
     /// Called when a file is closed.  Notifies compile_graph if this file

--- a/src/sched/workspace.h
+++ b/src/sched/workspace.h
@@ -315,14 +315,19 @@ struct Workspace {
     /// Persistence signals for the metadata the index database carries
     /// beyond the index itself: artifact validity (PCH/PCM records, header
     /// modes) and user context choices. Producers mark; the single write
-    /// pipeline (IndexStore::save) flushes both on its next run and
-    /// advances `committed_metadata_epoch`, waking `metadata_committed` —
-    /// the ticket a caller needing durability (switchContext) waits on.
+    /// pipeline (IndexStore::save) flushes both on its next run. Only the
+    /// contexts blob has a durability waiter (switchContext), so only it
+    /// carries an epoch: the ticket resolves once a save whose snapshot
+    /// covers the mark commits that blob — independent of the artifacts
+    /// blob, whose failures retry through the dirty flag alone and must
+    /// not hold a context ack hostage. `contexts_committed` pulses after
+    /// every attempt, failed ones included, so waiters can give up on a
+    /// disk that cannot take the write.
     bool artifacts_dirty = false;
     bool contexts_dirty = false;
-    std::uint64_t metadata_epoch = 0;
-    std::uint64_t committed_metadata_epoch = 0;
-    kota::event metadata_committed;
+    std::uint64_t contexts_epoch = 0;
+    std::uint64_t committed_contexts_epoch = 0;
+    kota::event contexts_committed;
 
     /// Wired by the master to schedule a flush soon after a mark; unset
     /// (tests, batch tools) means the owner saves on its own cadence.
@@ -330,7 +335,6 @@ struct Workspace {
 
     void mark_artifacts_dirty() {
         artifacts_dirty = true;
-        metadata_epoch += 1;
         if(request_flush) {
             request_flush();
         }
@@ -338,7 +342,7 @@ struct Workspace {
 
     void mark_contexts_dirty() {
         contexts_dirty = true;
-        metadata_epoch += 1;
+        contexts_epoch += 1;
         if(request_flush) {
             request_flush();
         }

--- a/src/server/service/ast_family.cpp
+++ b/src/server/service/ast_family.cpp
@@ -790,7 +790,6 @@ kota::task<RoundOutcome> ASTFamily::run(RoundContext& ctx, std::uint32_t path_id
                 contexts.record_header_mode(path_id,
                                             HeaderMode::NeedsContext,
                                             disk ? disk->hash : 0);
-                workspace.mark_artifacts_dirty();
                 contexts.drop_header_context(path_id);
                 adopted_pch.reset();
                 continue;

--- a/src/server/service/ast_family.cpp
+++ b/src/server/service/ast_family.cpp
@@ -790,7 +790,7 @@ kota::task<RoundOutcome> ASTFamily::run(RoundContext& ctx, std::uint32_t path_id
                 contexts.record_header_mode(path_id,
                                             HeaderMode::NeedsContext,
                                             disk ? disk->hash : 0);
-                workspace.save_cache(contexts);
+                workspace.mark_artifacts_dirty();
                 contexts.drop_header_context(path_id);
                 adopted_pch.reset();
                 continue;

--- a/src/server/service/ast_family.cpp
+++ b/src/server/service/ast_family.cpp
@@ -53,7 +53,7 @@ static kota::codec::RawValue quarantine_diagnostics(unsigned crashes) {
 
 PCHPlan plan_pch(Workspace& workspace,
                  ContextResolver& contexts,
-                 std::uint32_t path_id,
+                 Fid path_id,
                  llvm::StringRef text,
                  const std::string& directory,
                  const std::vector<std::string>& arguments) {
@@ -115,7 +115,7 @@ ASTFamily::ASTFamily(Workspace& workspace,
 
 void ASTFamily::register_runner() {
     graph.register_family(ast_family, [this](RoundContext& ctx, NodeId id) {
-        return run(ctx, static_cast<std::uint32_t>(id.key));
+        return run(ctx, Fid{static_cast<std::uint32_t>(id.key)});
     });
 }
 
@@ -156,7 +156,7 @@ void ASTFamily::publish_output(const std::shared_ptr<Session>& session, CompileO
 }
 
 bool ASTFamily::is_stale(const Session& session) {
-    workspace.file_table.begin_wave();
+    auto wave = workspace.file_table.wave();
     auto it = projections.entries.find(session.path_id);
     if(it != projections.entries.end() && it->second.deps.has_value() &&
        deps_changed(workspace.file_table, *it->second.deps)) {
@@ -183,13 +183,13 @@ bool ASTFamily::is_stale(const Session& session) {
     return false;
 }
 
-void ASTFamily::touch(std::uint32_t path_id) {
+void ASTFamily::touch(Fid path_id) {
     auto& entry = projections.entries[path_id];
     entry.current = false;
     entry.epoch += 1;
 }
 
-void ASTFamily::supersede(std::uint32_t path_id) {
+void ASTFamily::supersede(Fid path_id) {
     touch(path_id);
     graph.update(node(path_id));
     // Not a wire cancel: the notification flips the compile's stop flag
@@ -199,12 +199,12 @@ void ASTFamily::supersede(std::uint32_t path_id) {
     // round lands.
     if(graph.is_compiling(node(path_id))) {
         pool.notify_stateful(
-            path_id,
+            path_id.raw,
             worker::CancelCompileParams{std::string(workspace.file_table.resolve(path_id))});
     }
 }
 
-void ASTFamily::invalidate(std::uint32_t path_id) {
+void ASTFamily::invalidate(Fid path_id) {
     touch(path_id);
     // The in-flight round's token fires, but its parse keeps running: the
     // buffer is unchanged, so the product is worth publishing as bounded
@@ -212,7 +212,7 @@ void ASTFamily::invalidate(std::uint32_t path_id) {
     graph.update(node(path_id));
 }
 
-void ASTFamily::drop(std::uint32_t path_id) {
+void ASTFamily::drop(Fid path_id) {
     graph.update(node(path_id));
     projections.entries.erase(path_id);
 }
@@ -256,10 +256,10 @@ kota::task<> ASTFamily::stop() {
     // Sessions, not projection entries: a first compile has no entry
     // until it lands, and its round is exactly the parse worth
     // interrupting.
-    sessions.for_each([&](std::uint32_t path_id, const Session&) {
+    sessions.for_each([&](Fid path_id, const Session&) {
         if(graph.is_compiling(node(path_id))) {
             pool.notify_stateful(
-                path_id,
+                path_id.raw,
                 worker::CancelCompileParams{std::string(workspace.file_table.resolve(path_id))});
         }
         return true;
@@ -325,7 +325,7 @@ kota::task<bool> ASTFamily::ensure_compiled(std::shared_ptr<Session> session) {
 }
 
 kota::task<DependResult> ASTFamily::depend_modules(RoundContext& ctx,
-                                                   std::uint32_t path_id,
+                                                   Fid path_id,
                                                    llvm::StringRef directory,
                                                    const std::vector<std::string>& arguments,
                                                    llvm::StringRef text) {
@@ -402,7 +402,7 @@ kota::task<DependResult> ASTFamily::depend_modules(RoundContext& ctx,
         }
 
         for(auto dep: deps.resolved) {
-            switch(co_await ctx.depend({pcm_family, dep})) {
+            switch(co_await ctx.depend({pcm_family, dep.raw})) {
                 case DependResult::Ready: break;
                 case DependResult::Failed: co_return DependResult::Failed;
                 case DependResult::Cancelled: co_return DependResult::Cancelled;
@@ -412,7 +412,7 @@ kota::task<DependResult> ASTFamily::depend_modules(RoundContext& ctx,
     co_return DependResult::Ready;
 }
 
-kota::task<RoundOutcome> ASTFamily::run(RoundContext& ctx, std::uint32_t path_id) {
+kota::task<RoundOutcome> ASTFamily::run(RoundContext& ctx, Fid path_id) {
     // The session is resolved at round start: a didClose between spawn
     // and entry leaves nothing to compile.
     auto session = sessions.find(path_id);
@@ -622,7 +622,7 @@ kota::task<RoundOutcome> ASTFamily::run(RoundContext& ctx, std::uint32_t path_id
         // on it (contract 2). A supersede interrupts the worker with a
         // CancelCompile notification instead (see supersede/stop), and
         // the stale reply is discarded at the validity gate below.
-        auto result = co_await pool.send_stateful(path_id, params, {}, suspect);
+        auto result = co_await pool.send_stateful(path_id.raw, params, {}, suspect);
 
         // Crash accounting runs even for superseded rounds: the crash came
         // from content this document dispatched, and skipping it would let a

--- a/src/server/service/ast_family.cpp
+++ b/src/server/service/ast_family.cpp
@@ -156,6 +156,7 @@ void ASTFamily::publish_output(const std::shared_ptr<Session>& session, CompileO
 }
 
 bool ASTFamily::is_stale(const Session& session) {
+    workspace.file_table.begin_wave();
     auto it = projections.entries.find(session.path_id);
     if(it != projections.entries.end() && it->second.deps.has_value() &&
        deps_changed(workspace.file_table, *it->second.deps)) {
@@ -785,9 +786,10 @@ kota::task<RoundOutcome> ASTFamily::run(RoundContext& ctx, std::uint32_t path_id
 
             if(indicates_missing_context(diagnostics)) {
                 LOG_INFO("Header {} needs includer context, re-compiling with prefix", uri_str);
+                auto disk = workspace.file_table.current(path_id);
                 contexts.record_header_mode(path_id,
                                             HeaderMode::NeedsContext,
-                                            hash_file(file_path));
+                                            disk ? disk->hash : 0);
                 workspace.save_cache(contexts);
                 contexts.drop_header_context(path_id);
                 adopted_pch.reset();

--- a/src/server/service/ast_family.cpp
+++ b/src/server/service/ast_family.cpp
@@ -57,7 +57,7 @@ PCHPlan plan_pch(Workspace& workspace,
                  llvm::StringRef text,
                  const std::string& directory,
                  const std::vector<std::string>& arguments) {
-    auto path = workspace.path_pool.resolve(path_id);
+    auto path = workspace.file_table.resolve(path_id);
     auto bound = compute_preamble_bound(text);
     auto* header_context = contexts.header_context(path_id);
     bool has_prefix = header_context && !header_context->preamble_path.empty();
@@ -158,14 +158,14 @@ void ASTFamily::publish_output(const std::shared_ptr<Session>& session, CompileO
 bool ASTFamily::is_stale(const Session& session) {
     auto it = projections.entries.find(session.path_id);
     if(it != projections.entries.end() && it->second.deps.has_value() &&
-       deps_changed(workspace.path_pool, *it->second.deps)) {
+       deps_changed(workspace.file_table, *it->second.deps)) {
         return true;
     }
 
     // Chain files of a header context are embedded in the synthesized
     // preamble, invisible to the deps snapshot — check them explicitly.
     if(auto* header_context = contexts.header_context(session.path_id);
-       header_context && deps_changed(workspace.path_pool, header_context->deps)) {
+       header_context && deps_changed(workspace.file_table, header_context->deps)) {
         return true;
     }
 
@@ -174,7 +174,7 @@ bool ASTFamily::is_stale(const Session& session) {
     if(projection && projection->pch_key.has_value()) {
         auto pch_it = workspace.pch_cache.find(*projection->pch_key);
         if(pch_it != workspace.pch_cache.end() &&
-           deps_changed(workspace.path_pool, pch_it->second.deps)) {
+           deps_changed(workspace.file_table, pch_it->second.deps)) {
             return true;
         }
     }
@@ -199,7 +199,7 @@ void ASTFamily::supersede(std::uint32_t path_id) {
     if(graph.is_compiling(node(path_id))) {
         pool.notify_stateful(
             path_id,
-            worker::CancelCompileParams{std::string(workspace.path_pool.resolve(path_id))});
+            worker::CancelCompileParams{std::string(workspace.file_table.resolve(path_id))});
     }
 }
 
@@ -259,7 +259,7 @@ kota::task<> ASTFamily::stop() {
         if(graph.is_compiling(node(path_id))) {
             pool.notify_stateful(
                 path_id,
-                worker::CancelCompileParams{std::string(workspace.path_pool.resolve(path_id))});
+                worker::CancelCompileParams{std::string(workspace.file_table.resolve(path_id))});
         }
         return true;
     });
@@ -281,7 +281,7 @@ kota::task<bool> ASTFamily::ensure_compiled(std::shared_ptr<Session> session) {
     // burning slot after slot. A content change grants one probe attempt.
     if(session->quarantine.blocked()) {
         LOG_WARN("ensure_compiled: {} quarantined after {} worker crashes",
-                 workspace.path_pool.resolve(path_id),
+                 workspace.file_table.resolve(path_id),
                  session->quarantine.crashes());
         // A quarantine reached outside the compile-failure landing (a
         // completion or PCH build tipped the streak, or the crash landed on
@@ -436,7 +436,7 @@ kota::task<RoundOutcome> ASTFamily::run(RoundContext& ctx, std::uint32_t path_id
     }
 
     ScopedTimer timer;
-    auto file_path = std::string(workspace.path_pool.resolve(path_id));
+    auto file_path = std::string(workspace.file_table.resolve(path_id));
     auto uri = lsp::URI::from_file_path(file_path);
     std::string uri_str = uri.has_value() ? uri->str() : file_path;
 
@@ -839,7 +839,7 @@ kota::task<RoundOutcome> ASTFamily::run(RoundContext& ctx, std::uint32_t path_id
 
         auto& entry = projections.entries[path_id];
         entry.projection = std::move(next);
-        entry.deps = capture_deps_snapshot(workspace.path_pool,
+        entry.deps = capture_deps_snapshot(workspace.file_table,
                                            result.value().deps,
                                            result.value().build_at);
         entry.current = current;

--- a/src/server/service/ast_family.h
+++ b/src/server/service/ast_family.h
@@ -95,18 +95,18 @@ public:
     /// the worker's parse with a CancelCompile notification — FIFO order
     /// puts it ahead of any replacement Compile, and the round still
     /// observes its real reply (crash accounting depends on it).
-    void supersede(std::uint32_t path_id);
+    void supersede(Fid path_id);
 
     /// A Lost-type invalidation (dependency changed on disk, worker
     /// crash, eviction — the buffer itself is unchanged): the projection
     /// is no longer current and an in-flight round must not land as
     /// such, but its parse keeps running — the round publishes the
     /// product as bounded staleness before reporting Stale.
-    void invalidate(std::uint32_t path_id);
+    void invalidate(Fid path_id);
 
     /// didClose (and didOpen replacing a live session): the document's
     /// products die with it.
-    void drop(std::uint32_t path_id);
+    void drop(Fid path_id);
 
     /// clice/switchContext: the new context is a different compilation
     /// identity. Supersede any in-flight compile and drop the state
@@ -128,7 +128,7 @@ public:
     /// it into the event pipeline as a DiskChanged (synchronously), so lazy
     /// detection and the file tracker's polling share one invalidation
     /// cascade instead of maintaining two.
-    std::function<void(std::uint32_t path_id)> on_stale;
+    std::function<void(Fid path_id)> on_stale;
 
     /// Publish the quarantine diagnostic as the document's current output
     /// and mark the spell announced. `source` falls back to the previous
@@ -155,12 +155,12 @@ public:
     kota::task<> stop();
 
 private:
-    static NodeId node(std::uint32_t path_id) {
-        return {ast_family, path_id};
+    static NodeId node(Fid path_id) {
+        return {ast_family, path_id.raw};
     }
 
     /// One compile round; see the class comment for its obligations.
-    kota::task<RoundOutcome> run(RoundContext& ctx, std::uint32_t path_id);
+    kota::task<RoundOutcome> run(RoundContext& ctx, Fid path_id);
 
     /// The module-dependency phase of a round: resolve imports from the
     /// round's buffer snapshot under the round's resolved command,
@@ -169,7 +169,7 @@ private:
     /// import could never re-dirty this document), and wait on each
     /// import through depend.
     kota::task<DependResult> depend_modules(RoundContext& ctx,
-                                            std::uint32_t path_id,
+                                            Fid path_id,
                                             llvm::StringRef directory,
                                             const std::vector<std::string>& arguments,
                                             llvm::StringRef text);
@@ -180,7 +180,7 @@ private:
 
     /// current=false + epoch bump: the shared prefix of every
     /// invalidation flavor.
-    void touch(std::uint32_t path_id);
+    void touch(Fid path_id);
 
     Workspace& workspace;
     ContextResolver& contexts;
@@ -207,7 +207,7 @@ struct PCHPlan {
 
 PCHPlan plan_pch(Workspace& workspace,
                  ContextResolver& contexts,
-                 std::uint32_t path_id,
+                 Fid path_id,
                  llvm::StringRef text,
                  const std::string& directory,
                  const std::vector<std::string>& arguments);

--- a/src/server/service/context_service.cpp
+++ b/src/server/service/context_service.cpp
@@ -57,7 +57,7 @@ static std::string flags_label(Workspace& ws, ConfigID config) {
 }
 
 ext::QueryContextResult ContextService::query_contexts(llvm::StringRef path,
-                                                       std::uint32_t path_id,
+                                                       Fid path_id,
                                                        const ext::QueryContextParams& params) {
     auto& ws = workspace;
     int offset_val = std::max(0, params.offset.value_or(0));
@@ -168,7 +168,7 @@ ext::CurrentContextResult ContextService::current_context(llvm::StringRef path,
     ext::CurrentContextResult result;
     const SavedContext* choice =
         session ? resolver.active_choice(ContextUse::Editor, session->path_id) : nullptr;
-    if(choice && choice->host_path_id != no_path_id) {
+    if(choice && choice->host_path_id.valid()) {
         auto ctx_path = workspace.file_table.resolve(choice->host_path_id);
         auto ctx_uri_opt = lsp::URI::from_file_path(std::string(ctx_path));
         if(ctx_uri_opt) {
@@ -214,10 +214,10 @@ ext::CurrentContextResult ContextService::current_context(llvm::StringRef path,
 
 kota::task<ext::SwitchContextResult>
     ContextService::switch_context(llvm::StringRef path,
-                                   std::uint32_t path_id,
+                                   Fid path_id,
                                    Session* session,
                                    llvm::StringRef context_path,
-                                   std::uint32_t context_path_id,
+                                   Fid context_path_id,
                                    const ext::SwitchContextParams& params) {
     auto& ws = workspace;
 
@@ -335,7 +335,7 @@ bool ContextService::drop_orphaned_choices(SessionStore& sessions) {
         auto host_id = saved.host_path_id;
         auto& occurrence = saved.occurrence;
         bool orphaned = false;
-        if(host_id != no_path_id) {
+        if(host_id.valid()) {
             orphaned = workspace.dep_graph.find_include_chain(host_id, session_id).empty();
             // A pinned occurrence can vanish while other inclusions of the
             // header survive (the chain stays non-empty) — recount it.

--- a/src/server/service/context_service.cpp
+++ b/src/server/service/context_service.cpp
@@ -300,13 +300,24 @@ kota::task<ext::SwitchContextResult>
     // The table entry is the active choice; persist it across sessions:
     // the ticket resolves once a write batch whose snapshot covers this
     // mark has committed — an already-running save that snapshotted
-    // earlier cannot acknowledge it, the next one does.
+    // earlier cannot acknowledge it, the next one does. Failed saves pulse
+    // the event without advancing the epoch; after a few such wakeups the
+    // request reports failure instead of parking forever on a disk that
+    // cannot take the metadata (the choice stays active in memory).
     resolver.saved_contexts[path_id] = std::move(saved);
     ws.mark_contexts_dirty();
     auto ticket = ws.metadata_epoch;
+    int failed_saves = 0;
     while(ws.request_flush && ws.index_db && !ws.index_db->read_only() &&
           ws.committed_metadata_epoch < ticket) {
+        auto seen = ws.committed_metadata_epoch;
         co_await ws.metadata_committed.wait();
+        if(ws.committed_metadata_epoch == seen) {
+            failed_saves += 1;
+            if(failed_saves >= 3) {
+                co_return result;
+            }
+        }
     }
 
     result.success = true;

--- a/src/server/service/context_service.cpp
+++ b/src/server/service/context_service.cpp
@@ -306,13 +306,13 @@ kota::task<ext::SwitchContextResult>
     // cannot take the metadata (the choice stays active in memory).
     resolver.saved_contexts[path_id] = std::move(saved);
     ws.mark_contexts_dirty();
-    auto ticket = ws.metadata_epoch;
+    auto ticket = ws.contexts_epoch;
     int failed_saves = 0;
     while(ws.request_flush && ws.index_db && !ws.index_db->read_only() &&
-          ws.committed_metadata_epoch < ticket) {
-        auto seen = ws.committed_metadata_epoch;
-        co_await ws.metadata_committed.wait();
-        if(ws.committed_metadata_epoch == seen) {
+          ws.committed_contexts_epoch < ticket) {
+        auto seen = ws.committed_contexts_epoch;
+        co_await ws.contexts_committed.wait();
+        if(ws.committed_contexts_epoch == seen) {
             failed_saves += 1;
             if(failed_saves >= 3) {
                 co_return result;

--- a/src/server/service/context_service.cpp
+++ b/src/server/service/context_service.cpp
@@ -77,7 +77,7 @@ ext::QueryContextResult ContextService::query_contexts(llvm::StringRef path,
 
     auto hosts = ws.dep_graph.find_host_sources(path_id);
     for(auto host_id: ws.rank_hosts(path_id, hosts)) {
-        auto host_path = ws.path_pool.resolve(host_id);
+        auto host_path = ws.file_table.resolve(host_id);
         if(!ws.cdb.has_entry(host_path))
             continue;
         auto host_uri_opt = lsp::URI::from_file_path(std::string(host_path));
@@ -169,7 +169,7 @@ ext::CurrentContextResult ContextService::current_context(llvm::StringRef path,
     const SavedContext* choice =
         session ? resolver.active_choice(ContextUse::Editor, session->path_id) : nullptr;
     if(choice && choice->host_path_id != no_path_id) {
-        auto ctx_path = workspace.path_pool.resolve(choice->host_path_id);
+        auto ctx_path = workspace.file_table.resolve(choice->host_path_id);
         auto ctx_uri_opt = lsp::URI::from_file_path(std::string(ctx_path));
         if(ctx_uri_opt) {
             ext::ContextItem item;
@@ -326,15 +326,15 @@ bool ContextService::drop_orphaned_choices(SessionStore& sessions) {
             // The pinned host command itself can vanish (a CDB reload
             // changed the entry's flags): same validation didOpen applies.
             if(!orphaned && !saved.command_hash.empty()) {
-                orphaned = !resolver.pin_alive(workspace.path_pool.resolve(host_id), saved);
+                orphaned = !resolver.pin_alive(workspace.file_table.resolve(host_id), saved);
             }
         } else if(!saved.command_hash.empty()) {
             // Own-entry pin: the pinned command must still exist in the CDB.
-            orphaned = !resolver.pin_alive(workspace.path_pool.resolve(session_id), saved);
+            orphaned = !resolver.pin_alive(workspace.file_table.resolve(session_id), saved);
         }
         if(orphaned) {
             LOG_INFO("Dropping orphaned context choice for {}: its basis no longer exists",
-                     workspace.path_pool.resolve(session_id));
+                     workspace.file_table.resolve(session_id));
             resolver.drop_header_context(session_id);
             ast.switch_identity(*session);
             resolver.saved_contexts.erase(it);

--- a/src/server/service/context_service.cpp
+++ b/src/server/service/context_service.cpp
@@ -212,12 +212,13 @@ ext::CurrentContextResult ContextService::current_context(llvm::StringRef path,
     return result;
 }
 
-ext::SwitchContextResult ContextService::switch_context(llvm::StringRef path,
-                                                        std::uint32_t path_id,
-                                                        Session* session,
-                                                        llvm::StringRef context_path,
-                                                        std::uint32_t context_path_id,
-                                                        const ext::SwitchContextParams& params) {
+kota::task<ext::SwitchContextResult>
+    ContextService::switch_context(llvm::StringRef path,
+                                   std::uint32_t path_id,
+                                   Session* session,
+                                   llvm::StringRef context_path,
+                                   std::uint32_t context_path_id,
+                                   const ext::SwitchContextParams& params) {
     auto& ws = workspace;
 
     ext::SwitchContextResult result;
@@ -226,11 +227,11 @@ ext::SwitchContextResult ContextService::switch_context(llvm::StringRef path,
     // contexts that no longer exist — make the client re-query.
     if(params.epoch.has_value() && *params.epoch != ws.context_epoch) {
         result.stale = true;
-        return result;
+        co_return result;
     }
 
     if(!session) {
-        return result;
+        co_return result;
     }
 
     // Validate that `hash` names a real CDB entry of `entry_path` and
@@ -255,7 +256,7 @@ ext::SwitchContextResult ContextService::switch_context(llvm::StringRef path,
         // Pin one of the file's own CDB entries.
         auto base = find_command(path, *params.command_hash);
         if(!base) {
-            return result;
+            co_return result;
         }
         saved.command_hash = *params.command_hash;
         saved.base_hash = std::move(*base);
@@ -264,22 +265,22 @@ ext::SwitchContextResult ContextService::switch_context(llvm::StringRef path,
         // entry, actually (transitively) include this header, and —
         // for multi-configuration hosts — own the pinned entry.
         if(!ws.cdb.has_entry(context_path)) {
-            return result;
+            co_return result;
         }
         if(ws.dep_graph.find_include_chain(context_path_id, path_id).empty()) {
-            return result;
+            co_return result;
         }
         std::optional<std::string> base;
         if(params.command_hash.has_value()) {
             base = find_command(context_path, *params.command_hash);
             if(!base) {
-                return result;
+                co_return result;
             }
         }
         if(params.occurrence.has_value() && *params.occurrence > 0) {
             auto count = ws.count_occurrences(context_path_id, path_id);
             if(count > 0 && *params.occurrence >= count) {
-                return result;
+                co_return result;
             }
         }
         saved.host_path_id = context_path_id;
@@ -296,12 +297,20 @@ ext::SwitchContextResult ContextService::switch_context(llvm::StringRef path,
     ast.switch_identity(*session);
     resolver.forget_self_contained(path_id);
 
-    // The table entry is the active choice; persist it across sessions.
+    // The table entry is the active choice; persist it across sessions:
+    // the ticket resolves once a write batch whose snapshot covers this
+    // mark has committed — an already-running save that snapshotted
+    // earlier cannot acknowledge it, the next one does.
     resolver.saved_contexts[path_id] = std::move(saved);
-    ws.save_cache(resolver);
+    ws.mark_contexts_dirty();
+    auto ticket = ws.metadata_epoch;
+    while(ws.request_flush && ws.index_db && !ws.index_db->read_only() &&
+          ws.committed_metadata_epoch < ticket) {
+        co_await ws.metadata_committed.wait();
+    }
 
     result.success = true;
-    return result;
+    co_return result;
 }
 
 bool ContextService::drop_orphaned_choices(SessionStore& sessions) {

--- a/src/server/service/context_service.h
+++ b/src/server/service/context_service.h
@@ -7,7 +7,6 @@
 #include "server/state/session.h"
 
 #include "kota/async/async.h"
-
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 

--- a/src/server/service/context_service.h
+++ b/src/server/service/context_service.h
@@ -36,7 +36,7 @@ struct ContextService {
     /// clice/queryContext: list the compilation contexts (host sources and
     /// the file's own CDB configurations) available for a file, paginated.
     ext::QueryContextResult query_contexts(llvm::StringRef path,
-                                           std::uint32_t path_id,
+                                           Fid path_id,
                                            const ext::QueryContextParams& params);
 
     /// clice/currentContext: describe the file's currently active context.
@@ -52,10 +52,10 @@ struct ContextService {
     /// writable database (read-only, caching disabled, open failure) apply
     /// the choice in memory and acknowledge immediately.
     kota::task<ext::SwitchContextResult> switch_context(llvm::StringRef path,
-                                                        std::uint32_t path_id,
+                                                        Fid path_id,
                                                         Session* session,
                                                         llvm::StringRef context_path,
-                                                        std::uint32_t context_path_id,
+                                                        Fid context_path_id,
                                                         const ext::SwitchContextParams& params);
 
     /// Drop active context choices whose include edge no longer exists. A

--- a/src/server/service/context_service.h
+++ b/src/server/service/context_service.h
@@ -45,10 +45,12 @@ struct ContextService {
                                               const ext::CurrentContextParams& params);
 
     /// clice/switchContext: pin a host source or CDB entry as the file's
-    /// compilation context and persist the choice across sessions. Success
-    /// is acknowledged only once the choice is durably committed (the
-    /// interface promises cross-session persistence): the request marks
-    /// the contexts blob dirty and awaits the write pipeline's ticket.
+    /// compilation context and persist the choice across sessions. When
+    /// persistence is available, success is acknowledged only once the
+    /// choice is durably committed: the request marks the contexts blob
+    /// dirty and awaits the write pipeline's ticket. Sessions without a
+    /// writable database (read-only, caching disabled, open failure) apply
+    /// the choice in memory and acknowledge immediately.
     kota::task<ext::SwitchContextResult> switch_context(llvm::StringRef path,
                                                         std::uint32_t path_id,
                                                         Session* session,

--- a/src/server/service/context_service.h
+++ b/src/server/service/context_service.h
@@ -6,6 +6,8 @@
 #include "server/protocol/extension.h"
 #include "server/state/session.h"
 
+#include "kota/async/async.h"
+
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 
@@ -44,13 +46,16 @@ struct ContextService {
                                               const ext::CurrentContextParams& params);
 
     /// clice/switchContext: pin a host source or CDB entry as the file's
-    /// compilation context and persist the choice across sessions.
-    ext::SwitchContextResult switch_context(llvm::StringRef path,
-                                            std::uint32_t path_id,
-                                            Session* session,
-                                            llvm::StringRef context_path,
-                                            std::uint32_t context_path_id,
-                                            const ext::SwitchContextParams& params);
+    /// compilation context and persist the choice across sessions. Success
+    /// is acknowledged only once the choice is durably committed (the
+    /// interface promises cross-session persistence): the request marks
+    /// the contexts blob dirty and awaits the write pipeline's ticket.
+    kota::task<ext::SwitchContextResult> switch_context(llvm::StringRef path,
+                                                        std::uint32_t path_id,
+                                                        Session* session,
+                                                        llvm::StringRef context_path,
+                                                        std::uint32_t context_path_id,
+                                                        const ext::SwitchContextParams& params);
 
     /// Drop active context choices whose include edge no longer exists. A
     /// stale choice suppresses automatic host resolution, so it would strand

--- a/src/server/service/feature_router.cpp
+++ b/src/server/service/feature_router.cpp
@@ -158,7 +158,7 @@ static std::optional<CommandLang> command_lang(Workspace& workspace, llvm::Strin
 }
 
 const clang::LangOptions& FeatureRouter::index_lang_options(const Session& session) {
-    auto path = workspace.path_pool.resolve(session.path_id);
+    auto path = workspace.file_table.resolve(session.path_id);
     auto own = command_lang(workspace, path);
     if(own && own->forces_c) {
         return feature::index_lang_options("", *own->forces_c, own->standard);
@@ -178,7 +178,7 @@ const clang::LangOptions& FeatureRouter::index_lang_options(const Session& sessi
         }
     }
     if(host != no_path_id) {
-        auto host_path = workspace.path_pool.resolve(host);
+        auto host_path = workspace.file_table.resolve(host);
         auto host_lang = command_lang(workspace, host_path);
         if(host_lang && host_lang->forces_c) {
             return feature::index_lang_options("", *host_lang->forces_c, host_lang->standard);
@@ -193,7 +193,7 @@ const clang::LangOptions& FeatureRouter::index_lang_options(const Session& sessi
     auto it = contributions.find(session.path_id);
     bool c_rows = it != contributions.end() && !it->second.empty() &&
                   llvm::all_of(llvm::make_first_range(it->second), [&](std::uint32_t tu) {
-                      return workspace.path_pool.resolve(tu).ends_with(".c");
+                      return workspace.file_table.resolve(tu).ends_with(".c");
                   });
     return feature::index_lang_options(path,
                                        c_rows,
@@ -480,7 +480,7 @@ FeatureRouter::RawResult FeatureRouter::hover(std::shared_ptr<Session> session,
         co_return kota::outcome_error(document_not_open());
     }
 
-    auto path = workspace.path_pool.resolve(session->path_id);
+    auto path = workspace.file_table.resolve(session->path_id);
     auto index_card = [&]() -> std::optional<serde_raw> {
         if(auto info = index_query.hover_card(path, position, session.get())) {
             return to_raw(
@@ -735,7 +735,7 @@ FeatureRouter::RawResult FeatureRouter::completion(std::shared_ptr<Session> sess
     }
 
     auto path_id = session->path_id;
-    auto path = std::string(workspace.path_pool.resolve(path_id));
+    auto path = std::string(workspace.file_table.resolve(path_id));
 
     auto map = session->line_map();
     auto offset = map.to_offset(position);

--- a/src/server/service/feature_router.cpp
+++ b/src/server/service/feature_router.cpp
@@ -167,17 +167,17 @@ const clang::LangOptions& FeatureRouter::index_lang_options(const Session& sessi
     // A header's active context (the user's persisted choice, else the
     // resolved host) names the view being read; its command beats the
     // contributor union the way it does for the AST after an escalation.
-    auto host = no_path_id;
+    Fid host;
     if(auto it = contexts.saved_contexts.find(session.path_id);
        it != contexts.saved_contexts.end()) {
         host = it->second.host_path_id;
     }
-    if(host == no_path_id) {
+    if(!host.valid()) {
         if(const auto* context = contexts.header_context(session.path_id)) {
             host = context->host_path_id;
         }
     }
-    if(host != no_path_id) {
+    if(host.valid()) {
         auto host_path = workspace.file_table.resolve(host);
         auto host_lang = command_lang(workspace, host_path);
         if(host_lang && host_lang->forces_c) {
@@ -192,7 +192,7 @@ const clang::LangOptions& FeatureRouter::index_lang_options(const Session& sessi
     auto& contributions = workspace.project_index.contributions;
     auto it = contributions.find(session.path_id);
     bool c_rows = it != contributions.end() && !it->second.empty() &&
-                  llvm::all_of(llvm::make_first_range(it->second), [&](std::uint32_t tu) {
+                  llvm::all_of(llvm::make_first_range(it->second), [&](Fid tu) {
                       return workspace.file_table.resolve(tu).ends_with(".c");
                   });
     return feature::index_lang_options(path,

--- a/src/server/service/feature_router.cpp
+++ b/src/server/service/feature_router.cpp
@@ -772,6 +772,7 @@ FeatureRouter::RawResult FeatureRouter::completion(std::shared_ptr<Session> sess
 
             auto search_config = workspace.cdb.search_config(ref);
             DirListingCache dir_cache;
+            dir_cache.shared = &workspace.file_table;
             auto resolved = resolve_search_config(search_config, dir_cache);
             bool angled = (pctx.kind == CompletionContext::IncludeAngled);
             auto candidates = complete_include_path(resolved, pctx.prefix, angled, dir_cache);

--- a/src/server/service/query.cpp
+++ b/src/server/service/query.cpp
@@ -103,7 +103,7 @@ bool IndexQuery::serves_preamble(const Session& session, const index::TUIndex& s
     // gating is needed on top. The blob stores clang's native path
     // (backslashes on Windows) while the pool normalizes separators, so
     // compare through the pool's lookup, not raw strings.
-    return workspace.path_pool.find(state.path(state.path_count() - 1)) == session.path_id &&
+    return workspace.file_table.find(state.path(state.path_count() - 1)) == session.path_id &&
            state.matches_prefix(session.text);
 }
 
@@ -115,7 +115,7 @@ bool IndexQuery::should_serve_overlay_file(llvm::StringRef path) const {
     // Freshness contract, clause 2, same as shards: a file whose own
     // content changed on disk has its rows suppressed until an up-to-date
     // view lands — the blob snapshot describes text that no longer exists.
-    if(auto path_id = workspace.path_pool.find(path)) {
+    if(auto path_id = workspace.file_table.find(path)) {
         if(is_path_open(*path_id) || skip_stale_contribution(*path_id)) {
             return false;
         }
@@ -350,7 +350,7 @@ IndexQuery::CursorHit IndexQuery::resolve_cursor(llvm::StringRef path,
     // text) from the mixed-view lookup the contract exists to prevent.
     // Closed files keep the stale-contribution gate against their disk
     // baseline instead.
-    auto path_id = workspace.path_pool.find(path);
+    auto path_id = workspace.file_table.find(path);
     if(!path_id)
         return {};
     if(!session && skip_stale_contribution(*path_id))
@@ -391,7 +391,7 @@ std::vector<protocol::Location> IndexQuery::collect_relation_locations(index::Sy
             auto shard_it = workspace.shards.find(file_id);
             if(shard_it == workspace.shards.end())
                 continue;
-            auto uri = lsp::URI::from_file_path(workspace.path_pool.resolve(file_id));
+            auto uri = lsp::URI::from_file_path(workspace.file_table.resolve(file_id));
             if(!uri)
                 continue;
             auto& merged_index = shard_it->second;
@@ -407,7 +407,7 @@ std::vector<protocol::Location> IndexQuery::collect_relation_locations(index::Sy
     }
 
     visit_sessions([&](std::uint32_t id, const Session& session) -> bool {
-        auto uri = lsp::URI::from_file_path(std::string(workspace.path_pool.resolve(id)));
+        auto uri = lsp::URI::from_file_path(std::string(workspace.file_table.resolve(id)));
         if(!uri)
             return true;
         auto map = session.line_map();
@@ -439,7 +439,7 @@ std::vector<protocol::Location> IndexQuery::collect_relation_locations(index::Sy
 
     // Preamble entries: the buffers' own preamble regions.
     visit_preambles([&](std::uint32_t id, const Session& session, const index::TUIndex& state) {
-        auto uri = lsp::URI::from_file_path(std::string(workspace.path_pool.resolve(id)));
+        auto uri = lsp::URI::from_file_path(std::string(workspace.file_table.resolve(id)));
         if(!uri)
             return true;
         auto map = session.line_map();
@@ -509,10 +509,10 @@ std::string IndexQuery::self_uri(llvm::StringRef path) {
     // Collected locations spell URIs from the pool's canonical form; the
     // transport's raw path can differ (drive case on Windows), which would
     // defeat cursor-site detection.
-    auto path_id = workspace.path_pool.find(path);
+    auto path_id = workspace.file_table.find(path);
     if(!path_id)
         return {};
-    auto uri = lsp::URI::from_file_path(workspace.path_pool.resolve(*path_id));
+    auto uri = lsp::URI::from_file_path(workspace.file_table.resolve(*path_id));
     return uri ? uri->str() : std::string{};
 }
 
@@ -631,7 +631,7 @@ std::optional<protocol::Location> IndexQuery::find_relation_location(index::Symb
                                                                      RelationKind kind) {
     std::optional<protocol::Location> session_result;
     visit_sessions([&](std::uint32_t id, const Session& session) -> bool {
-        auto uri = lsp::URI::from_file_path(std::string(workspace.path_pool.resolve(id)));
+        auto uri = lsp::URI::from_file_path(std::string(workspace.file_table.resolve(id)));
         if(!uri)
             return true;
         auto map = session.line_map();
@@ -653,7 +653,7 @@ std::optional<protocol::Location> IndexQuery::find_relation_location(index::Symb
     // First the buffers' own preamble regions, then the header entries.
     std::optional<protocol::Location> overlay_result;
     visit_preambles([&](std::uint32_t id, const Session& session, const index::TUIndex& state) {
-        auto uri = lsp::URI::from_file_path(std::string(workspace.path_pool.resolve(id)));
+        auto uri = lsp::URI::from_file_path(std::string(workspace.file_table.resolve(id)));
         if(!uri)
             return true;
         auto map = session.line_map();
@@ -697,7 +697,7 @@ std::optional<protocol::Location> IndexQuery::find_relation_location(index::Symb
         auto shard_it = workspace.shards.find(file_id);
         if(shard_it == workspace.shards.end())
             continue;
-        auto uri = lsp::URI::from_file_path(workspace.path_pool.resolve(file_id));
+        auto uri = lsp::URI::from_file_path(workspace.file_table.resolve(file_id));
         if(!uri)
             continue;
         auto& merged_index = shard_it->second;
@@ -942,7 +942,7 @@ std::optional<IndexQuery::DefinitionText> IndexQuery::get_definition_text(index:
         if(shard_it == workspace.shards.end())
             continue;
         auto& merged_index = shard_it->second;
-        auto file_path = workspace.path_pool.resolve(file_id);
+        auto file_path = workspace.file_table.resolve(file_id);
         std::unique_ptr<llvm::MemoryBuffer> storage;
         auto text = indexed_text(file_path, merged_index, storage);
         if(!text)
@@ -1023,7 +1023,7 @@ std::vector<feature::IndexIncludeEdge> IndexQuery::include_edges(const Session& 
             }
             edges.push_back({
                 .line = node.line,
-                .target = std::string(workspace.path_pool.resolve(target->path_id)),
+                .target = std::string(workspace.file_table.resolve(target->path_id)),
             });
         }
     };
@@ -1111,7 +1111,7 @@ std::optional<feature::HoverInfo> IndexQuery::hover_card(llvm::StringRef path,
                     continue;
                 std::unique_ptr<llvm::MemoryBuffer> storage;
                 auto text =
-                    indexed_text(workspace.path_pool.resolve(file_id), shard_it->second, storage);
+                    indexed_text(workspace.file_table.resolve(file_id), shard_it->second, storage);
                 if(text && slice_from(shard_it->second, *text))
                     break;
             }
@@ -1143,7 +1143,7 @@ std::vector<IndexQuery::ReferenceWithContext> IndexQuery::collect_references(ind
             if(shard_it == workspace.shards.end())
                 continue;
             auto& merged_index = shard_it->second;
-            auto file_path = workspace.path_pool.resolve(file_id);
+            auto file_path = workspace.file_table.resolve(file_id);
             // A moved-on ASCII file yields no text: positions still map
             // through the line table, only the context line degrades.
             std::unique_ptr<llvm::MemoryBuffer> storage;
@@ -1378,7 +1378,7 @@ std::vector<ResolvedSymbol> IndexQuery::locate_symbols(const agentic::ReadSymbol
         auto path_str = *loc.path;
         auto target_line = static_cast<protocol::uinteger>(*loc.line - 1);
 
-        auto path_id = workspace.path_pool.find(path_str);
+        auto path_id = workspace.file_table.find(path_str);
         if(!path_id)
             return {};
 

--- a/src/server/service/query.cpp
+++ b/src/server/service/query.cpp
@@ -39,7 +39,7 @@ void IndexQuery::visit_sessions(SessionVisitor visitor) const {
     if(options.disk_only) {
         return;
     }
-    sessions.for_each([&](std::uint32_t path_id, const Session& session) -> bool {
+    sessions.for_each([&](Fid path_id, const Session& session) -> bool {
         // Freshness contract, clause 3: a dirty session's file index may
         // describe a buffer that no longer exists — skip it.
         if(ast.index_current(path_id)) {
@@ -49,7 +49,7 @@ void IndexQuery::visit_sessions(SessionVisitor visitor) const {
     });
 }
 
-bool IndexQuery::is_path_open(std::uint32_t path_id) const {
+bool IndexQuery::is_path_open(Fid path_id) const {
     return sessions.find(path_id) != nullptr;
 }
 
@@ -69,7 +69,7 @@ void IndexQuery::visit_overlays(llvm::function_ref<bool(const index::TUIndex&)> 
     }
     // Sessions with identical preambles share one blob; visit it once.
     llvm::StringSet<> seen;
-    sessions.for_each([&](std::uint32_t path_id, const Session& session) -> bool {
+    sessions.for_each([&](Fid path_id, const Session& session) -> bool {
         auto projection = ast.projection(path_id);
         if(!projection || !projection->pch_key || !seen.insert(*projection->pch_key).second) {
             return true;
@@ -80,11 +80,11 @@ void IndexQuery::visit_overlays(llvm::function_ref<bool(const index::TUIndex&)> 
 }
 
 void IndexQuery::visit_preambles(
-    llvm::function_ref<bool(std::uint32_t, const Session&, const index::TUIndex&)> visitor) const {
+    llvm::function_ref<bool(Fid, const Session&, const index::TUIndex&)> visitor) const {
     if(options.disk_only) {
         return;
     }
-    sessions.for_each([&](std::uint32_t path_id, const Session& session) -> bool {
+    sessions.for_each([&](Fid path_id, const Session& session) -> bool {
         auto state = overlay_of(session);
         if(!state || !serves_preamble(session, *state)) {
             return true;
@@ -223,7 +223,7 @@ static void drop_cursor_site(std::vector<protocol::Location>& locations,
     }
 }
 
-bool IndexQuery::skip_shard(std::uint32_t path_id) const {
+bool IndexQuery::skip_shard(Fid path_id) const {
     if(options.disk_only) {
         return skip_stale_contribution(path_id);
     }
@@ -245,7 +245,7 @@ bool IndexQuery::skip_shard(std::uint32_t path_id) const {
     return it == workspace.shards.end() || !it->second.matches_content(session->text);
 }
 
-bool IndexQuery::skip_stale_contribution(std::uint32_t path_id) const {
+bool IndexQuery::skip_stale_contribution(Fid path_id) const {
     // With background indexing disabled nothing ever catches up: serving
     // the last-known rows beats a permanent hole.
     if(!workspace.config.project.enable_indexing.value) {
@@ -259,7 +259,7 @@ bool IndexQuery::find_symbol_info(index::SymbolHash hash,
                                   SymbolKind& kind) const {
     // Check open sessions first (has all symbols for unsaved buffers).
     bool found = false;
-    visit_sessions([&](std::uint32_t path_id, const Session& session) -> bool {
+    visit_sessions([&](Fid path_id, const Session& session) -> bool {
         if(auto identity = ast.projection(path_id)->index->find_symbol(hash)) {
             name = std::string(identity->name);
             kind = identity->kind;
@@ -386,12 +386,12 @@ std::vector<protocol::Location> IndexQuery::collect_relation_locations(index::Sy
     auto sym_it = workspace.project_index.symbols.find(hash);
     if(sym_it != workspace.project_index.symbols.end()) {
         for(auto file_id: sym_it->second.reference_files) {
-            if(skip_shard(file_id))
+            if(skip_shard(Fid{file_id}))
                 continue;
-            auto shard_it = workspace.shards.find(file_id);
+            auto shard_it = workspace.shards.find(Fid{file_id});
             if(shard_it == workspace.shards.end())
                 continue;
-            auto uri = lsp::URI::from_file_path(workspace.file_table.resolve(file_id));
+            auto uri = lsp::URI::from_file_path(workspace.file_table.resolve(Fid{file_id}));
             if(!uri)
                 continue;
             auto& merged_index = shard_it->second;
@@ -406,7 +406,7 @@ std::vector<protocol::Location> IndexQuery::collect_relation_locations(index::Sy
         }
     }
 
-    visit_sessions([&](std::uint32_t id, const Session& session) -> bool {
+    visit_sessions([&](Fid id, const Session& session) -> bool {
         auto uri = lsp::URI::from_file_path(std::string(workspace.file_table.resolve(id)));
         if(!uri)
             return true;
@@ -438,7 +438,7 @@ std::vector<protocol::Location> IndexQuery::collect_relation_locations(index::Sy
     });
 
     // Preamble entries: the buffers' own preamble regions.
-    visit_preambles([&](std::uint32_t id, const Session& session, const index::TUIndex& state) {
+    visit_preambles([&](Fid id, const Session& session, const index::TUIndex& state) {
         auto uri = lsp::URI::from_file_path(std::string(workspace.file_table.resolve(id)));
         if(!uri)
             return true;
@@ -630,7 +630,7 @@ std::optional<SymbolInfo> IndexQuery::lookup_symbol(const std::string& uri,
 std::optional<protocol::Location> IndexQuery::find_relation_location(index::SymbolHash hash,
                                                                      RelationKind kind) {
     std::optional<protocol::Location> session_result;
-    visit_sessions([&](std::uint32_t id, const Session& session) -> bool {
+    visit_sessions([&](Fid id, const Session& session) -> bool {
         auto uri = lsp::URI::from_file_path(std::string(workspace.file_table.resolve(id)));
         if(!uri)
             return true;
@@ -652,7 +652,7 @@ std::optional<protocol::Location> IndexQuery::find_relation_location(index::Symb
     // been indexed — the in-memory-file case behind empty go-to-definition.
     // First the buffers' own preamble regions, then the header entries.
     std::optional<protocol::Location> overlay_result;
-    visit_preambles([&](std::uint32_t id, const Session& session, const index::TUIndex& state) {
+    visit_preambles([&](Fid id, const Session& session, const index::TUIndex& state) {
         auto uri = lsp::URI::from_file_path(std::string(workspace.file_table.resolve(id)));
         if(!uri)
             return true;
@@ -692,12 +692,12 @@ std::optional<protocol::Location> IndexQuery::find_relation_location(index::Symb
         return std::nullopt;
 
     for(auto file_id: sym_it->second.reference_files) {
-        if(skip_shard(file_id))
+        if(skip_shard(Fid{file_id}))
             continue;
-        auto shard_it = workspace.shards.find(file_id);
+        auto shard_it = workspace.shards.find(Fid{file_id});
         if(shard_it == workspace.shards.end())
             continue;
-        auto uri = lsp::URI::from_file_path(workspace.file_table.resolve(file_id));
+        auto uri = lsp::URI::from_file_path(workspace.file_table.resolve(Fid{file_id}));
         if(!uri)
             continue;
         auto& merged_index = shard_it->second;
@@ -757,9 +757,9 @@ void IndexQuery::collect_grouped_relations(
     auto sym_it = workspace.project_index.symbols.find(hash);
     if(sym_it != workspace.project_index.symbols.end()) {
         for(auto file_id: sym_it->second.reference_files) {
-            if(skip_shard(file_id))
+            if(skip_shard(Fid{file_id}))
                 continue;
-            auto shard_it = workspace.shards.find(file_id);
+            auto shard_it = workspace.shards.find(Fid{file_id});
             if(shard_it == workspace.shards.end())
                 continue;
             auto& merged_index = shard_it->second;
@@ -773,7 +773,7 @@ void IndexQuery::collect_grouped_relations(
             });
         }
     }
-    visit_sessions([&](std::uint32_t id, const Session& session) -> bool {
+    visit_sessions([&](Fid id, const Session& session) -> bool {
         auto map = session.line_map();
         ast.projection(id)->file_rows().lookup(hash, kind, [&](const index::Relation& r) {
             if(auto range = map.to_range(r.range.begin, r.range.end))
@@ -823,9 +823,9 @@ void IndexQuery::collect_unique_targets(index::SymbolHash hash,
     auto sym_it = workspace.project_index.symbols.find(hash);
     if(sym_it != workspace.project_index.symbols.end()) {
         for(auto file_id: sym_it->second.reference_files) {
-            if(skip_shard(file_id))
+            if(skip_shard(Fid{file_id}))
                 continue;
-            auto shard_it = workspace.shards.find(file_id);
+            auto shard_it = workspace.shards.find(Fid{file_id});
             if(shard_it == workspace.shards.end())
                 continue;
             shard_it->second.lookup(hash, kind, [&](const index::Relation& r) {
@@ -836,7 +836,7 @@ void IndexQuery::collect_unique_targets(index::SymbolHash hash,
             });
         }
     }
-    visit_sessions([&](std::uint32_t id, const Session&) -> bool {
+    visit_sessions([&](Fid id, const Session&) -> bool {
         ast.projection(id)->file_rows().lookup(hash, kind, [&](const index::Relation& r) {
             if(seen.insert(r.target_symbol).second) {
                 targets.push_back(r.target_symbol);
@@ -936,13 +936,13 @@ std::optional<IndexQuery::DefinitionText> IndexQuery::get_definition_text(index:
         return std::nullopt;
 
     for(auto file_id: sym_it->second.reference_files) {
-        if(skip_shard(file_id))
+        if(skip_shard(Fid{file_id}))
             continue;
-        auto shard_it = workspace.shards.find(file_id);
+        auto shard_it = workspace.shards.find(Fid{file_id});
         if(shard_it == workspace.shards.end())
             continue;
         auto& merged_index = shard_it->second;
-        auto file_path = workspace.file_table.resolve(file_id);
+        auto file_path = workspace.file_table.resolve(Fid{file_id});
         std::unique_ptr<llvm::MemoryBuffer> storage;
         auto text = indexed_text(file_path, merged_index, storage);
         if(!text)
@@ -991,11 +991,10 @@ std::vector<feature::IndexIncludeEdge> IndexQuery::include_edges(const Session& 
     }
     auto generation = shard_it->second.content_hash();
 
-    auto version_of = [&](std::uint32_t fv) -> const FileTable::FileVersion* {
-        auto it = workspace.file_table.versions.find(fv);
-        return it == workspace.file_table.versions.end() ? nullptr : &it->second;
+    auto version_of = [&](VersionID fv) -> const FileTable::FileVersion* {
+        return workspace.file_table.knows_version(fv) ? &workspace.file_table.version(fv) : nullptr;
     };
-    auto is_document = [&](std::uint32_t fv) {
+    auto is_document = [&](VersionID fv) {
         const auto* version = version_of(fv);
         return version && version->fid == session.path_id && version->content_hash == generation;
     };
@@ -1094,23 +1093,24 @@ std::optional<feature::HoverInfo> IndexQuery::hover_card(llvm::StringRef path,
                 // its disk shard — so slice from those buffer-true rows
                 // instead of losing the definition text.
                 if(!options.disk_only) {
-                    if(auto other = sessions.find(file_id)) {
-                        if(ast.index_current(file_id) &&
-                           slice_from(ast.projection(file_id)->file_rows(), other->text))
+                    if(auto other = sessions.find(Fid{file_id})) {
+                        if(ast.index_current(Fid{file_id}) &&
+                           slice_from(ast.projection(Fid{file_id})->file_rows(), other->text))
                             break;
                         if(auto* shard = open_session_shard(*other);
                            shard && slice_from(*shard, other->text))
                             break;
                     }
                 }
-                if(skip_shard(file_id))
+                if(skip_shard(Fid{file_id}))
                     continue;
-                auto shard_it = workspace.shards.find(file_id);
+                auto shard_it = workspace.shards.find(Fid{file_id});
                 if(shard_it == workspace.shards.end())
                     continue;
                 std::unique_ptr<llvm::MemoryBuffer> storage;
-                auto text =
-                    indexed_text(workspace.file_table.resolve(file_id), shard_it->second, storage);
+                auto text = indexed_text(workspace.file_table.resolve(Fid{file_id}),
+                                         shard_it->second,
+                                         storage);
                 if(text && slice_from(shard_it->second, *text))
                     break;
             }
@@ -1136,13 +1136,13 @@ std::vector<IndexQuery::ReferenceWithContext> IndexQuery::collect_references(ind
     auto sym_it = workspace.project_index.symbols.find(hash);
     if(sym_it != workspace.project_index.symbols.end()) {
         for(auto file_id: sym_it->second.reference_files) {
-            if(skip_shard(file_id))
+            if(skip_shard(Fid{file_id}))
                 continue;
-            auto shard_it = workspace.shards.find(file_id);
+            auto shard_it = workspace.shards.find(Fid{file_id});
             if(shard_it == workspace.shards.end())
                 continue;
             auto& merged_index = shard_it->second;
-            auto file_path = workspace.file_table.resolve(file_id);
+            auto file_path = workspace.file_table.resolve(Fid{file_id});
             // A moved-on ASCII file yields no text: positions still map
             // through the line table, only the context line degrades.
             std::unique_ptr<llvm::MemoryBuffer> storage;
@@ -1269,7 +1269,7 @@ std::vector<protocol::SymbolInformation> IndexQuery::search_symbols(llvm::String
         seen.insert(hash);
     }
 
-    visit_sessions([&](std::uint32_t id, const Session&) -> bool {
+    visit_sessions([&](Fid id, const Session&) -> bool {
         if(results.size() >= max_results)
             return false;
         ast.projection(id)->index->iterate_symbols(
@@ -1396,7 +1396,7 @@ std::vector<ResolvedSymbol> IndexQuery::locate_symbols(const agentic::ReadSymbol
                            merged_index.line_starts());
 
         for(auto& [hash, symbol]: workspace.project_index.symbols) {
-            if(!symbol.reference_files.contains(*path_id))
+            if(!symbol.reference_files.contains(path_id->raw))
                 continue;
             bool found = false;
             merged_index.lookup(hash, RelationKind::Definition, [&](const index::Relation& r) {

--- a/src/server/service/query.cpp
+++ b/src/server/service/query.cpp
@@ -997,8 +997,7 @@ std::vector<feature::IndexIncludeEdge> IndexQuery::include_edges(const Session& 
     };
     auto is_document = [&](std::uint32_t fv) {
         const auto* version = version_of(fv);
-        return version && version->fid == session.path_id &&
-               version->content_hash == generation;
+        return version && version->fid == session.path_id && version->content_hash == generation;
     };
 
     // A directive line of the document is a node whose parent node entered

--- a/src/server/service/query.cpp
+++ b/src/server/service/query.cpp
@@ -991,13 +991,13 @@ std::vector<feature::IndexIncludeEdge> IndexQuery::include_edges(const Session& 
     }
     auto generation = shard_it->second.content_hash();
 
-    auto version_of = [&](std::uint32_t fv) -> const index::FileVersionRecord* {
-        auto it = project.file_versions.find(fv);
-        return it == project.file_versions.end() ? nullptr : &it->second;
+    auto version_of = [&](std::uint32_t fv) -> const FileTable::FileVersion* {
+        auto it = workspace.file_table.versions.find(fv);
+        return it == workspace.file_table.versions.end() ? nullptr : &it->second;
     };
     auto is_document = [&](std::uint32_t fv) {
         const auto* version = version_of(fv);
-        return version && version->path_id == session.path_id &&
+        return version && version->fid == session.path_id &&
                version->content_hash == generation;
     };
 
@@ -1023,7 +1023,7 @@ std::vector<feature::IndexIncludeEdge> IndexQuery::include_edges(const Session& 
             }
             edges.push_back({
                 .line = node.line,
-                .target = std::string(workspace.file_table.resolve(target->path_id)),
+                .target = std::string(workspace.file_table.resolve(target->fid)),
             });
         }
     };

--- a/src/server/service/query.h
+++ b/src/server/service/query.h
@@ -113,8 +113,7 @@ struct IndexQueryOptions {
 class IndexQuery {
 public:
     /// Visitor for iterating open Sessions.  Returns false to stop early.
-    using SessionVisitor =
-        std::function<bool(std::uint32_t server_path_id, const Session& session)>;
+    using SessionVisitor = std::function<bool(Fid server_path_id, const Session& session)>;
 
     IndexQuery(Workspace& workspace,
                const SessionStore& sessions,
@@ -253,7 +252,7 @@ public:
     /// Whether a file's shard sits this query out: its own disk content
     /// changed and awaits reindexing (clause 2), or — unless disk_only —
     /// the file is open and its session serves it instead.
-    bool skip_shard(std::uint32_t path_id) const;
+    bool skip_shard(Fid path_id) const;
 
     /// The shard that may serve `session`'s document as if closed
     /// (freshness clause 4): the session has no current file index and
@@ -325,7 +324,7 @@ private:
 
     /// Visit each open session whose overlay preamble entry may serve
     /// (see serves_preamble), paired with that blob.
-    void visit_preambles(llvm::function_ref<bool(std::uint32_t server_path_id,
+    void visit_preambles(llvm::function_ref<bool(Fid server_path_id,
                                                  const Session& session,
                                                  const index::TUIndex& state)> visitor) const;
 
@@ -371,12 +370,12 @@ private:
                                                              RelationKind kind);
 
     /// Check whether a path_id has an active Session.
-    bool is_path_open(std::uint32_t path_id) const;
+    bool is_path_open(Fid path_id) const;
 
     /// Freshness contract, clause 2: whether a closed file's contribution
     /// must be skipped because its own content changed and the reindex has
     /// not landed yet. O(1) per candidate file, no I/O.
-    bool skip_stale_contribution(std::uint32_t path_id) const;
+    bool skip_stale_contribution(Fid path_id) const;
 
     Workspace& workspace;
     const SessionStore& sessions;

--- a/src/server/service/worker_forwarder.cpp
+++ b/src/server/service/worker_forwarder.cpp
@@ -261,7 +261,8 @@ WorkerForwarder::RawResult
     if(recovery) {
         probe_guard.emplace(session->quarantine);
     }
-    auto result = co_await pool.send_stateful(path_id, wp, {.token = std::move(token)}, suspect);
+    auto result =
+        co_await pool.send_stateful(path_id.raw, wp, {.token = std::move(token)}, suspect);
     if(!result.has_value()) {
         // A query that kills the worker is this document's doing even
         // though its compile landed: per-kind ledger, since only this query
@@ -325,7 +326,7 @@ kota::task<std::vector<feature::DocumentLink>, kota::ipc::Error>
     if(recovery) {
         probe_guard.emplace(session->quarantine);
     }
-    auto result = co_await pool.send_stateful(path_id,
+    auto result = co_await pool.send_stateful(path_id.raw,
                                               worker::DocumentLinkParams{path},
                                               {.token = std::move(token)},
                                               suspect);

--- a/src/server/service/worker_forwarder.cpp
+++ b/src/server/service/worker_forwarder.cpp
@@ -111,7 +111,7 @@ kota::task<bool> WorkerForwarder::ensure_pch(const std::shared_ptr<Session>& ses
     // adopted PCH if it is still available.
     if(!pch.fresh(pch_key) && !is_preamble_complete(session->text, plan.request.preamble_bound)) {
         LOG_DEBUG("Preamble incomplete for {}, deferring PCH rebuild",
-                  workspace.path_pool.resolve(path_id));
+                  workspace.file_table.resolve(path_id));
         auto projection = ast.projections.projection(path_id);
         if(projection && projection->pch_key.has_value()) {
             auto it = workspace.pch_cache.find(*projection->pch_key);
@@ -210,7 +210,7 @@ WorkerForwarder::RawResult
                                    std::optional<protocol::Range> range,
                                    std::optional<kota::cancellation_token> token) {
     auto path_id = session->path_id;
-    auto path = std::string(workspace.path_pool.resolve(path_id));
+    auto path = std::string(workspace.file_table.resolve(path_id));
     auto gen = session->generation;
     auto map = session->line_map();
 
@@ -302,7 +302,7 @@ kota::task<std::vector<feature::DocumentLink>, kota::ipc::Error>
     WorkerForwarder::forward_document_links(std::shared_ptr<Session> session,
                                             std::optional<kota::cancellation_token> token) {
     auto path_id = session->path_id;
-    auto path = std::string(workspace.path_pool.resolve(path_id));
+    auto path = std::string(workspace.file_table.resolve(path_id));
     auto gen = session->generation;
 
     ScopedTimer timer;
@@ -371,7 +371,7 @@ WorkerForwarder::RawResult
                                          std::shared_ptr<Session> session,
                                          std::optional<kota::cancellation_token> token) {
     auto path_id = session->path_id;
-    auto path = std::string(workspace.path_pool.resolve(path_id));
+    auto path = std::string(workspace.file_table.resolve(path_id));
     auto gen = session->generation;
 
     // This build compiles the same content the quarantine watches: while
@@ -509,7 +509,7 @@ WorkerForwarder::RawResult
                                     std::optional<protocol::Range> range,
                                     std::optional<kota::cancellation_token> token) {
     auto path_id = session->path_id;
-    auto path = std::string(workspace.path_pool.resolve(path_id));
+    auto path = std::string(workspace.file_table.resolve(path_id));
     auto gen = session->generation;
 
     // Formatting runs no sema, but it is still this document's content on

--- a/src/server/state/ast_projection.h
+++ b/src/server/state/ast_projection.h
@@ -100,22 +100,22 @@ struct ASTProjectionTable {
         std::uint64_t epoch = 0;
     };
 
-    llvm::DenseMap<std::uint32_t, Entry> entries;
+    llvm::DenseMap<Fid, Entry> entries;
 
-    const Entry* find(std::uint32_t path_id) const {
+    const Entry* find(Fid path_id) const {
         auto it = entries.find(path_id);
         return it == entries.end() ? nullptr : &it->second;
     }
 
     /// The document's projection, or null before its first compile.
-    std::shared_ptr<const ASTProjection> projection(std::uint32_t path_id) const {
+    std::shared_ptr<const ASTProjection> projection(Fid path_id) const {
         const auto* entry = find(path_id);
         return entry ? entry->projection : nullptr;
     }
 
     /// The last compile landed and no invalidation arrived since
     /// (!ast_dirty of the old world).
-    bool current(std::uint32_t path_id) const {
+    bool current(Fid path_id) const {
         const auto* entry = find(path_id);
         return entry && entry->current;
     }
@@ -124,27 +124,27 @@ struct ASTProjectionTable {
     /// arbitration key of the index freshness contract (IndexQuery
     /// clauses 3-4): a current-but-indexless projection (fatal error, no
     /// AST) is an honest gap, not a servable index.
-    bool index_current(std::uint32_t path_id) const {
+    bool index_current(Fid path_id) const {
         const auto* entry = find(path_id);
         return entry && entry->current && entry->projection && entry->projection->index &&
                entry->projection->index->loaded();
     }
 
-    std::uint64_t epoch(std::uint32_t path_id) const {
+    std::uint64_t epoch(Fid path_id) const {
         const auto* entry = find(path_id);
         return entry ? entry->epoch : 0;
     }
 
     /// Replace one field of the projection, keeping the rest (readers
     /// holding the old shared_ptr are unaffected).
-    void set_pch_key(std::uint32_t path_id, std::optional<std::string> pch_key) {
+    void set_pch_key(Fid path_id, std::optional<std::string> pch_key) {
         auto& entry = entries[path_id];
         auto next = entry.projection ? ASTProjection(*entry.projection) : ASTProjection();
         next.pch_key = std::move(pch_key);
         entry.projection = std::make_shared<const ASTProjection>(std::move(next));
     }
 
-    void set_output(std::uint32_t path_id, CompileOutput output) {
+    void set_output(Fid path_id, CompileOutput output) {
         auto& entry = entries[path_id];
         auto next = entry.projection ? ASTProjection(*entry.projection) : ASTProjection();
         next.output = std::move(output);

--- a/src/server/state/file_tracker.cpp
+++ b/src/server/state/file_tracker.cpp
@@ -206,7 +206,8 @@ kota::task<llvm::SmallVector<FileEvent>> FileTracker::tick_workspace() {
             auto mtime_ns = fs::mtime_ns(status);
             auto uid = status.getUniqueID();
             if(!state.missing && state.size == size && state.mtime_ns == mtime_ns &&
-               state.uid_device == uid.getDevice() && state.uid_file == uid.getFile()) {
+               (!fs::stable_file_ids ||
+                (state.uid_device == uid.getDevice() && state.uid_file == uid.getFile()))) {
                 continue;
             }
 

--- a/src/server/state/file_tracker.cpp
+++ b/src/server/state/file_tracker.cpp
@@ -176,9 +176,7 @@ kota::task<llvm::SmallVector<FileEvent>> FileTracker::tick_workspace() {
                 FileState state;
                 state.missing = !exists;
                 if(exists) {
-                    auto obs = workspace.file_table.observe_for(path_id,
-                                                                status.getSize(),
-                                                                fs::mtime_ns(status));
+                    auto obs = workspace.file_table.observe_for(path_id, status);
                     if(!obs) {
                         // Unreadable right now: don't seed a baseline that
                         // would later compare as a change. Retry next tick.
@@ -210,7 +208,7 @@ kota::task<llvm::SmallVector<FileEvent>> FileTracker::tick_workspace() {
 
             // The stamp moved: only a confirmed content change counts, so
             // touches and checkouts of identical bytes stay silent.
-            auto obs = workspace.file_table.observe_for(path_id, size, mtime_ns);
+            auto obs = workspace.file_table.observe_for(path_id, status);
             if(!obs) {
                 // The file stats fine but cannot be read right now (e.g. an
                 // antivirus scanner briefly holding a fresh file on Windows).

--- a/src/server/state/file_tracker.cpp
+++ b/src/server/state/file_tracker.cpp
@@ -99,7 +99,7 @@ llvm::SmallVector<FileEvent> FileTracker::tick_cdb(bool force) {
         return {};
     }
 
-    // Diff ids and event ids share the single path pool.
+    // Diff ids and event ids share the single file table.
     FileEvent::CDBDelta delta;
     delta.added.assign(diff->added.begin(), diff->added.end());
     delta.removed.assign(diff->removed.begin(), diff->removed.end());

--- a/src/server/state/file_tracker.cpp
+++ b/src/server/state/file_tracker.cpp
@@ -170,19 +170,23 @@ kota::task<llvm::SmallVector<FileEvent>> FileTracker::tick_workspace() {
 
             auto it = baseline.find(path_id);
             if(it == baseline.end()) {
-                // First sight seeds the baseline silently.
+                // First sight seeds the baseline silently. The startup
+                // scan usually observed the file already, so the common
+                // seed is a shared-pair hit with no second read.
                 FileState state;
                 state.missing = !exists;
                 if(exists) {
-                    state.size = status.getSize();
-                    state.mtime_ns = fs::mtime_ns(status);
-                    state.hash = hash_file(path);
-                    if(state.hash == 0) {
-                        // Read failure (hash_file's sentinel): don't seed a
-                        // baseline that would later compare as a change.
-                        // Retry next tick.
+                    auto obs = workspace.file_table.observe_for(path_id,
+                                                                status.getSize(),
+                                                                fs::mtime_ns(status));
+                    if(!obs) {
+                        // Unreadable right now: don't seed a baseline that
+                        // would later compare as a change. Retry next tick.
                         continue;
                     }
+                    state.size = obs->size;
+                    state.mtime_ns = obs->mtime_ns;
+                    state.hash = obs->hash;
                 }
                 baseline.try_emplace(path_id, state);
                 continue;
@@ -206,8 +210,8 @@ kota::task<llvm::SmallVector<FileEvent>> FileTracker::tick_workspace() {
 
             // The stamp moved: only a confirmed content change counts, so
             // touches and checkouts of identical bytes stay silent.
-            auto hash = hash_file(path);
-            if(hash == 0) {
+            auto obs = workspace.file_table.observe_for(path_id, size, mtime_ns);
+            if(!obs) {
                 // The file stats fine but cannot be read right now (e.g. an
                 // antivirus scanner briefly holding a fresh file on Windows).
                 // No signal either way — leave the baseline untouched so the
@@ -215,8 +219,8 @@ kota::task<llvm::SmallVector<FileEvent>> FileTracker::tick_workspace() {
                 // emit nothing: a failed read must never count as a change.
                 continue;
             }
-            bool content_changed = state.missing || hash != state.hash;
-            state = FileState{.size = size, .mtime_ns = mtime_ns, .hash = hash};
+            bool content_changed = state.missing || obs->hash != state.hash;
+            state = FileState{.size = obs->size, .mtime_ns = obs->mtime_ns, .hash = obs->hash};
             if(content_changed) {
                 events.push_back(FileEvent::disk_changed(path_id));
                 changed += 1;

--- a/src/server/state/file_tracker.cpp
+++ b/src/server/state/file_tracker.cpp
@@ -164,7 +164,7 @@ kota::task<llvm::SmallVector<FileEvent>> FileTracker::tick_workspace() {
                 continue;
             }
 
-            auto path = workspace.path_pool.resolve(path_id);
+            auto path = workspace.file_table.resolve(path_id);
             llvm::sys::fs::file_status status;
             bool exists = !llvm::sys::fs::status(path, status);
 

--- a/src/server/state/file_tracker.cpp
+++ b/src/server/state/file_tracker.cpp
@@ -128,8 +128,8 @@ kota::task<llvm::SmallVector<FileEvent>> FileTracker::tick_workspace() {
 
     // Files that left the graph (e.g. a CDB reload rebuilt it) stop being
     // tracked; their baseline entries would otherwise be stat'd forever.
-    llvm::DenseSet<std::uint32_t> known(files.begin(), files.end());
-    llvm::SmallVector<std::uint32_t> gone;
+    llvm::DenseSet<Fid> known(files.begin(), files.end());
+    llvm::SmallVector<Fid> gone;
     for(auto& [path_id, state]: baseline) {
         if(!known.contains(path_id)) {
             gone.push_back(path_id);
@@ -242,7 +242,7 @@ kota::task<llvm::SmallVector<FileEvent>> FileTracker::tick_workspace() {
     // their baseline entries are pruned on the next sweep.
     if(workspace.context_epoch != epoch && !events.empty()) {
         auto current = workspace.dep_graph.all_files();
-        llvm::DenseSet<std::uint32_t> still_known(current.begin(), current.end());
+        llvm::DenseSet<Fid> still_known(current.begin(), current.end());
         llvm::erase_if(events, [&](const FileEvent& event) {
             return !still_known.contains(event.path_id);
         });

--- a/src/server/state/file_tracker.cpp
+++ b/src/server/state/file_tracker.cpp
@@ -185,6 +185,8 @@ kota::task<llvm::SmallVector<FileEvent>> FileTracker::tick_workspace() {
                     state.size = obs->size;
                     state.mtime_ns = obs->mtime_ns;
                     state.hash = obs->hash;
+                    state.uid_device = obs->uid_device;
+                    state.uid_file = obs->uid_file;
                 }
                 baseline.try_emplace(path_id, state);
                 continue;
@@ -202,7 +204,9 @@ kota::task<llvm::SmallVector<FileEvent>> FileTracker::tick_workspace() {
 
             auto size = status.getSize();
             auto mtime_ns = fs::mtime_ns(status);
-            if(!state.missing && state.size == size && state.mtime_ns == mtime_ns) {
+            auto uid = status.getUniqueID();
+            if(!state.missing && state.size == size && state.mtime_ns == mtime_ns &&
+               state.uid_device == uid.getDevice() && state.uid_file == uid.getFile()) {
                 continue;
             }
 
@@ -218,7 +222,11 @@ kota::task<llvm::SmallVector<FileEvent>> FileTracker::tick_workspace() {
                 continue;
             }
             bool content_changed = state.missing || obs->hash != state.hash;
-            state = FileState{.size = obs->size, .mtime_ns = obs->mtime_ns, .hash = obs->hash};
+            state = FileState{.size = obs->size,
+                              .mtime_ns = obs->mtime_ns,
+                              .hash = obs->hash,
+                              .uid_device = obs->uid_device,
+                              .uid_file = obs->uid_file};
             if(content_changed) {
                 events.push_back(FileEvent::disk_changed(path_id));
                 changed += 1;

--- a/src/server/state/file_tracker.h
+++ b/src/server/state/file_tracker.h
@@ -81,11 +81,15 @@ private:
 
     CDBStamp stat_cdb() const;
 
-    /// Last-known on-disk state of a tracked file.
+    /// Last-known on-disk state of a tracked file. The filesystem
+    /// identity is part of the stamp: a rename-over with a forged equal
+    /// size and mtime still changes the UniqueID.
     struct FileState {
         std::uint64_t size = 0;
         std::int64_t mtime_ns = 0;
         std::uint64_t hash = 0;
+        std::uint64_t uid_device = 0;
+        std::uint64_t uid_file = 0;
         bool missing = false;
     };
 

--- a/src/server/state/file_tracker.h
+++ b/src/server/state/file_tracker.h
@@ -106,7 +106,7 @@ private:
     bool has_pending = false;
 
     /// Workspace sweep baseline.
-    llvm::DenseMap<std::uint32_t, FileState> baseline;
+    llvm::DenseMap<Fid, FileState> baseline;
 
     /// True while a sweep is in flight (it suspends between batches);
     /// concurrent ticks are skipped instead of racing on the baseline.

--- a/src/server/state/invalidator.cpp
+++ b/src/server/state/invalidator.cpp
@@ -386,10 +386,10 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                 // follow. Rebuild the include graph and module map from
                 // scratch against the new database: entry additions,
                 // removals and flag changes all funnel into one uniform
-                // rescan instead of per-entry graph surgery. No ScanCache is
-                // retained anywhere: the cache's contract requires clearing
-                // it on every CDB change, and CDB changes are the only
-                // rescan trigger, so a persistent cache would never be warm.
+                // rescan instead of per-entry graph surgery. The rescan is
+                // still cheap: per-file scan results are content-keyed in
+                // the file table, so unchanged files re-resolve without a
+                // read or lex.
                 // TODO: this scan runs synchronously on the event loop (same
                 // cost as the startup scan); if it shows up on large
                 // projects, move it off the dispatch path.

--- a/src/server/state/invalidator.cpp
+++ b/src/server/state/invalidator.cpp
@@ -407,7 +407,6 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                 workspace.dep_graph = DependencyGraph();
                 scan_dependency_graph(workspace.cdb,
                                       workspace.dep_graph,
-                                      /*cache=*/nullptr,
                                       [this](llvm::StringRef path,
                                              std::vector<std::string>& append,
                                              std::vector<std::string>& remove) {

--- a/src/server/state/invalidator.cpp
+++ b/src/server/state/invalidator.cpp
@@ -8,26 +8,15 @@
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringMap.h"
-#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/xxhash.h"
 
 namespace clice {
-
-/// Default ReadFile: the real filesystem.
-static std::optional<std::string> read_from_disk(llvm::StringRef path) {
-    auto buffer = llvm::MemoryBuffer::getFile(path);
-    if(!buffer) {
-        return std::nullopt;
-    }
-    return std::string((*buffer)->getBuffer());
-}
 
 Invalidator::Invalidator(Workspace& workspace,
                          const SessionStore& store,
                          const ContextResolver& contexts,
-                         PCMFamily& pcm,
-                         ReadFile read_file) :
-    workspace(workspace), store(store), contexts(contexts), pcm(pcm),
-    read_file(read_file ? std::move(read_file) : ReadFile(read_from_disk)) {}
+                         PCMFamily& pcm) :
+    workspace(workspace), store(store), contexts(contexts), pcm(pcm) {}
 
 /// Batch effects may name the same file twice (two saves in one batch);
 /// execution must see each id once.
@@ -230,8 +219,9 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                 // the pull-side staleness check alone can miss when the
                 // rewrite lands within mtime granularity of the compile.
                 if(auto session = store.find(path_id)) {
-                    auto disk = read_file(workspace.file_table.resolve(path_id));
-                    if(!disk || *disk != session->text) {
+                    auto disk = workspace.file_table.current(path_id);
+                    if(!disk || disk->size != session->text.size() ||
+                       disk->hash != llvm::xxh3_64bits(session->text)) {
                         dirty.mark_ast_dirty.push_back(path_id);
                     }
                 }
@@ -249,7 +239,7 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                 // the queue's latency, while a close after saved edits must
                 // not serve rows for text that no longer exists. One disk
                 // read settles it; an unreadable file counts as changed.
-                auto disk = read_file(workspace.file_table.resolve(event.path_id));
+                auto disk = workspace.file_table.current(event.path_id);
                 if(!disk) {
                     // Deleted while it was open: the tracker skips open
                     // files, so this close is the first observation of the
@@ -263,7 +253,8 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                 }
                 auto shard_it = workspace.shards.find(event.path_id);
                 bool has_shard = shard_it != workspace.shards.end();
-                bool shard_current = has_shard && shard_it->second.matches_content(*disk);
+                bool shard_current =
+                    has_shard && shard_it->second.matches_content(disk->size, disk->hash);
                 // A module unit's PCM can be staler than the shard: an
                 // agent-mode reindex reads the rewritten disk while the
                 // artifact keeps the pre-change bytes. Its own deps

--- a/src/server/state/invalidator.cpp
+++ b/src/server/state/invalidator.cpp
@@ -230,7 +230,7 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                 // the pull-side staleness check alone can miss when the
                 // rewrite lands within mtime granularity of the compile.
                 if(auto session = store.find(path_id)) {
-                    auto disk = read_file(workspace.path_pool.resolve(path_id));
+                    auto disk = read_file(workspace.file_table.resolve(path_id));
                     if(!disk || *disk != session->text) {
                         dirty.mark_ast_dirty.push_back(path_id);
                     }
@@ -249,7 +249,7 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                 // the queue's latency, while a close after saved edits must
                 // not serve rows for text that no longer exists. One disk
                 // read settles it; an unreadable file counts as changed.
-                auto disk = read_file(workspace.path_pool.resolve(event.path_id));
+                auto disk = read_file(workspace.file_table.resolve(event.path_id));
                 if(!disk) {
                     // Deleted while it was open: the tracker skips open
                     // files, so this close is the first observation of the
@@ -271,7 +271,7 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                 // erases the entry.
                 auto pcm_it = workspace.pcm_cache.find(event.path_id);
                 bool pcm_stale = pcm_it != workspace.pcm_cache.end() &&
-                                 deps_changed(workspace.path_pool, pcm_it->second.deps);
+                                 deps_changed(workspace.file_table, pcm_it->second.deps);
                 // Disk is the truth again, and this close is the last
                 // chance to act on it: the DiskChanged path deliberately
                 // skips the rescan and the module/dependent cascades while

--- a/src/server/state/invalidator.cpp
+++ b/src/server/state/invalidator.cpp
@@ -20,7 +20,7 @@ Invalidator::Invalidator(Workspace& workspace,
 
 /// Batch effects may name the same file twice (two saves in one batch);
 /// execution must see each id once.
-static void dedup(llvm::SmallVector<std::uint32_t>& ids) {
+static void dedup(llvm::SmallVector<Fid>& ids) {
     llvm::sort(ids);
     ids.erase(llvm::unique(ids), ids.end());
 }
@@ -29,7 +29,7 @@ static void dedup(llvm::SmallVector<std::uint32_t>& ids) {
 /// AST, reindexes when closed — and does both for an index-only session
 /// (freshness clause 4): the buffer is the compile truth, but the serving
 /// rows are the shard's, and only a reindex refreshes those.
-void Invalidator::mark_dependent(std::uint32_t path_id, DirtySet& dirty) {
+void Invalidator::mark_dependent(Fid path_id, DirtySet& dirty) {
     if(auto session = store.find(path_id)) {
         dirty.mark_ast_dirty.push_back(path_id);
         if(session->serving == ServingMode::IndexOnly) {
@@ -40,7 +40,7 @@ void Invalidator::mark_dependent(std::uint32_t path_id, DirtySet& dirty) {
     }
 }
 
-void Invalidator::cascade_compile_graph(std::uint32_t path_id, DirtySet& dirty) {
+void Invalidator::cascade_compile_graph(Fid path_id, DirtySet& dirty) {
     if(!pcm.tracks(path_id)) {
         return;
     }
@@ -62,7 +62,7 @@ void Invalidator::provider_appeared(llvm::StringRef module_name, DirtySet& dirty
         if(PCMFamily::is_unresolved(id)) {
             continue;
         }
-        auto path_id = static_cast<std::uint32_t>(id.key);
+        auto path_id = Fid{static_cast<std::uint32_t>(id.key)};
         if(id.family == turun_family) {
             dirty.add_reindex_content_changed(path_id);
         } else if(id.family == ast_family) {
@@ -80,7 +80,7 @@ void Invalidator::provider_appeared(llvm::StringRef module_name, DirtySet& dirty
     }
 }
 
-void Invalidator::rescan_disk_state(std::uint32_t path_id, DirtySet& dirty) {
+void Invalidator::rescan_disk_state(Fid path_id, DirtySet& dirty) {
     auto old_module = workspace.path_to_module.lookup(path_id);
     workspace.rescan_after_save(path_id);
     auto it = workspace.path_to_module.find(path_id);
@@ -107,7 +107,7 @@ void Invalidator::rescan_disk_state(std::uint32_t path_id, DirtySet& dirty) {
     }
 }
 
-void Invalidator::cascade_disk_content_change(std::uint32_t path_id, DirtySet& dirty) {
+void Invalidator::cascade_disk_content_change(Fid path_id, DirtySet& dirty) {
     // The file's own self-containment may have changed; re-evaluate on its
     // next compile.
     dirty.reset_header_mode.push_back(path_id);
@@ -133,7 +133,7 @@ void Invalidator::cascade_disk_content_change(std::uint32_t path_id, DirtySet& d
     // staleness check filters TUs whose dependencies did not actually
     // change, and the idle/priority scheduling throttles the rest.
     // TODO: observe on large projects before adding debouncing.
-    auto split_dependents = [&](llvm::ArrayRef<std::uint32_t> roots) {
+    auto split_dependents = [&](llvm::ArrayRef<Fid> roots) {
         for(auto root: roots) {
             mark_dependent(root, dirty);
         }
@@ -260,10 +260,13 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                 // artifact keeps the pre-change bytes. Its own deps
                 // snapshot is the judge; checked before the cascade below
                 // erases the entry.
-                workspace.file_table.begin_wave();
-                auto pcm_it = workspace.pcm_cache.find(event.path_id);
-                bool pcm_stale = pcm_it != workspace.pcm_cache.end() &&
-                                 deps_changed(workspace.file_table, pcm_it->second.deps);
+                bool pcm_stale = false;
+                {
+                    auto wave = workspace.file_table.wave();
+                    auto pcm_it = workspace.pcm_cache.find(event.path_id);
+                    pcm_stale = pcm_it != workspace.pcm_cache.end() &&
+                                deps_changed(workspace.file_table, pcm_it->second.deps);
+                }
                 // Disk is the truth again, and this close is the last
                 // chance to act on it: the DiskChanged path deliberately
                 // skips the rescan and the module/dependent cascades while
@@ -397,7 +400,7 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                 // (direct_deps takes the list head) — not mere existence:
                 // a reload can move the selection to another provider
                 // while the old one's own entry stays unchanged.
-                llvm::StringMap<std::uint32_t> selected_provider;
+                llvm::StringMap<Fid> selected_provider;
                 for(auto& entry: workspace.dep_graph.modules()) {
                     if(!entry.getValue().empty()) {
                         selected_provider[entry.getKey()] = entry.getValue().front();
@@ -442,7 +445,7 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                 // see, whether it appeared, changed or vanished. PCH/PCM
                 // keys embed the canonical flags, so pull-side caches miss
                 // naturally.
-                auto invalidate_entry = [&](std::uint32_t path_id, bool keep_index) {
+                auto invalidate_entry = [&](Fid path_id, bool keep_index) {
                     if(store.find(path_id)) {
                         // The next compile re-resolves the command (added:
                         // first real entry replaces the guessed one;

--- a/src/server/state/invalidator.cpp
+++ b/src/server/state/invalidator.cpp
@@ -260,6 +260,7 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                 // artifact keeps the pre-change bytes. Its own deps
                 // snapshot is the judge; checked before the cascade below
                 // erases the entry.
+                workspace.file_table.begin_wave();
                 auto pcm_it = workspace.pcm_cache.find(event.path_id);
                 bool pcm_stale = pcm_it != workspace.pcm_cache.end() &&
                                  deps_changed(workspace.file_table, pcm_it->second.deps);

--- a/src/server/state/invalidator.h
+++ b/src/server/state/invalidator.h
@@ -209,8 +209,6 @@ public:
     /// Include edges changed: context choices may now be orphaned; run the
     /// context resolver's orphan cleanup.
     bool recheck_contexts = false;
-    /// Persist the workspace cache snapshot.
-    bool save_cache = false;
     /// Kick the background indexer's scheduler.
     bool reschedule_indexing = false;
 
@@ -219,7 +217,7 @@ public:
                reset_header_mode.empty() && force_revalidate.empty() &&
                reindex_content_changed.empty() && reindex_deps_only.empty() &&
                clear_reindex.empty() && drop_index.empty() && drop_context.empty() &&
-               !recheck_contexts && !save_cache && !reschedule_indexing;
+               !recheck_contexts && !reschedule_indexing;
     }
 };
 

--- a/src/server/state/invalidator.h
+++ b/src/server/state/invalidator.h
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <functional>
 #include <optional>
 #include <string>
 
@@ -247,17 +246,10 @@ public:
 /// not add ceremonial event kinds for exempt logic.
 class Invalidator {
 public:
-    /// Read a file's current on-disk content, or nullopt if unreadable.
-    /// Defaults to the real filesystem; unit tests inject file content
-    /// through it. Used by BufferSaved to detect a save hook or formatter
-    /// rewriting the file as it lands (disk ahead of the buffer).
-    using ReadFile = std::function<std::optional<std::string>(llvm::StringRef path)>;
-
     Invalidator(Workspace& workspace,
                 const SessionStore& store,
                 const ContextResolver& contexts,
-                PCMFamily& pcm,
-                ReadFile read_file = {});
+                PCMFamily& pcm);
 
     /// Fold a batch of events into one deduplicated effect set.
     DirtySet apply(llvm::ArrayRef<FileEvent> events);
@@ -294,7 +286,6 @@ private:
     const SessionStore& store;
     const ContextResolver& contexts;
     PCMFamily& pcm;
-    ReadFile read_file;
 
     /// Files whose disk content changed while their buffer was open. The
     /// DiskChanged case defers the dependent cascade (the buffer is the

--- a/src/server/state/invalidator.h
+++ b/src/server/state/invalidator.h
@@ -51,9 +51,9 @@ struct FileEvent {
     /// CDBChanged payload: the reload's per-file delta, as master path-pool
     /// ids. `changed` means the file kept an entry but its command differs.
     struct CDBDelta {
-        llvm::SmallVector<std::uint32_t, 0> added;
-        llvm::SmallVector<std::uint32_t, 0> removed;
-        llvm::SmallVector<std::uint32_t, 0> changed;
+        llvm::SmallVector<Fid, 0> added;
+        llvm::SmallVector<Fid, 0> removed;
+        llvm::SmallVector<Fid, 0> changed;
 
         bool empty() const {
             return added.empty() && removed.empty() && changed.empty();
@@ -61,33 +61,33 @@ struct FileEvent {
     };
 
     Kind kind;
-    std::uint32_t path_id = no_path_id;
+    Fid path_id;
     /// WorkerCrashed only: the crashed worker's lost documents.
-    llvm::SmallVector<std::uint32_t> paths;
+    llvm::SmallVector<Fid> paths;
     /// CDBChanged only: the reload delta.
     CDBDelta cdb;
 
-    static FileEvent buffer_opened(std::uint32_t path_id) {
+    static FileEvent buffer_opened(Fid path_id) {
         return {Kind::BufferOpened, path_id};
     }
 
-    static FileEvent buffer_edited(std::uint32_t path_id) {
+    static FileEvent buffer_edited(Fid path_id) {
         return {Kind::BufferEdited, path_id};
     }
 
-    static FileEvent buffer_saved(std::uint32_t path_id) {
+    static FileEvent buffer_saved(Fid path_id) {
         return {Kind::BufferSaved, path_id};
     }
 
-    static FileEvent buffer_closed(std::uint32_t path_id) {
+    static FileEvent buffer_closed(Fid path_id) {
         return {Kind::BufferClosed, path_id};
     }
 
-    static FileEvent disk_changed(std::uint32_t path_id) {
+    static FileEvent disk_changed(Fid path_id) {
         return {Kind::DiskChanged, path_id};
     }
 
-    static FileEvent disk_removed(std::uint32_t path_id) {
+    static FileEvent disk_removed(Fid path_id) {
         return {Kind::DiskRemoved, path_id};
     }
 
@@ -97,13 +97,13 @@ struct FileEvent {
         return event;
     }
 
-    static FileEvent worker_crashed(llvm::ArrayRef<std::uint32_t> lost_documents) {
+    static FileEvent worker_crashed(llvm::ArrayRef<Fid> lost_documents) {
         FileEvent event{Kind::WorkerCrashed};
         event.paths.assign(lost_documents.begin(), lost_documents.end());
         return event;
     }
 
-    static FileEvent document_evicted(std::uint32_t path_id) {
+    static FileEvent document_evicted(Fid path_id) {
         return {Kind::DocumentEvicted, path_id};
     }
 };
@@ -124,37 +124,37 @@ struct FileEvent {
 struct DirtySet {
     /// Compile inputs changed: ast_dirty + trial_done=false + forget the
     /// cached self-containment verdict.
-    llvm::SmallVector<std::uint32_t> mark_ast_dirty;
+    llvm::SmallVector<Fid> mark_ast_dirty;
     /// Built AST lost (worker crash) but compile inputs did not change:
     /// recompile only, without re-running the header trial or touching the
     /// self-containment verdict.
-    llvm::SmallVector<std::uint32_t> mark_lost;
+    llvm::SmallVector<Fid> mark_lost;
     /// Re-run the header trial only (trial_done=false); the AST itself is
     /// not stale.
-    llvm::SmallVector<std::uint32_t> reset_trial;
+    llvm::SmallVector<Fid> reset_trial;
     /// The header's content (or its preamble chain) changed: drop its
     /// persisted self-containment verdict so the next compile re-earns it.
     /// Executed by the context resolver, which owns the verdicts.
-    llvm::SmallVector<std::uint32_t> reset_header_mode;
+    llvm::SmallVector<Fid> reset_header_mode;
     /// Header sessions whose synthesized preamble embeds changed content:
     /// drop the chain snapshot's fast paths so every chain file is
     /// re-validated by hash, plus the mark_ast_dirty treatment.
-    llvm::SmallVector<std::uint32_t> force_revalidate;
+    llvm::SmallVector<Fid> force_revalidate;
     /// Closed files whose own content changed: their index rows describe
     /// text that no longer exists. Enqueue for background reindexing as
     /// ReindexReason::ContentChanged — queries skip these files'
     /// contributions until the reindex lands.
-    llvm::SmallVector<std::uint32_t> reindex_content_changed;
+    llvm::SmallVector<Fid> reindex_content_changed;
     /// Closed files enqueued only because a dependency changed: their own
     /// rows are positionally intact. Enqueue as ReindexReason::DepsOnly —
     /// queries keep serving the previous rows. A file in both lists is
     /// ContentChanged (the indexer's reason upgrade is absorbing).
-    llvm::SmallVector<std::uint32_t> reindex_deps_only;
+    llvm::SmallVector<Fid> reindex_deps_only;
 
     /// Files whose pending-reindex state must be discarded: a removed file
     /// has nothing left to reindex, and a stale ContentChanged reason would
     /// otherwise suppress its (deliberately still-serving) shard forever.
-    llvm::SmallVector<std::uint32_t> clear_reindex;
+    llvm::SmallVector<Fid> clear_reindex;
 
     /// The three reindex effect lists are kept disjoint per file, in event
     /// order: a batch can hold delete-then-recreate (atomic saves) as well
@@ -162,17 +162,17 @@ struct DirtySet {
     /// right as a fixed rule — the later event for a given file wins. All
     /// emission goes through these adders to keep that true by construction,
     /// letting the executor apply the lists in any order.
-    void add_reindex_content_changed(std::uint32_t path_id) {
+    void add_reindex_content_changed(Fid path_id) {
         erase_id(clear_reindex, path_id);
         reindex_content_changed.push_back(path_id);
     }
 
-    void add_reindex_deps_only(std::uint32_t path_id) {
+    void add_reindex_deps_only(Fid path_id) {
         erase_id(clear_reindex, path_id);
         reindex_deps_only.push_back(path_id);
     }
 
-    void add_clear_reindex(std::uint32_t path_id) {
+    void add_clear_reindex(Fid path_id) {
         erase_id(reindex_content_changed, path_id);
         erase_id(reindex_deps_only, path_id);
         // A removal retains the last-known index, so it also cancels an
@@ -187,7 +187,7 @@ struct DirtySet {
     }
 
 private:
-    static void erase_id(llvm::SmallVector<std::uint32_t>& ids, std::uint32_t path_id) {
+    static void erase_id(llvm::SmallVector<Fid>& ids, Fid path_id) {
         ids.erase(std::remove(ids.begin(), ids.end(), path_id), ids.end());
     }
 
@@ -199,13 +199,13 @@ public:
     /// the old-command rows serving, in this session and after a restart.
     /// Follows the later-event rule above: a later removal's clear cancels
     /// the drop, since the deleted file's last-known index keeps serving.
-    llvm::SmallVector<std::uint32_t> drop_index;
+    llvm::SmallVector<Fid> drop_index;
     /// Headers whose resolved context borrows a compile command that no
     /// longer exists in that form (the host's CDB entry changed): drop the
     /// context so the next use re-resolves. Content validation cannot see
     /// a flag change, so neither force_revalidate nor the deps snapshot
     /// covers this. Executed by the context resolver.
-    llvm::SmallVector<std::uint32_t> drop_context;
+    llvm::SmallVector<Fid> drop_context;
     /// Include edges changed: context choices may now be orphaned; run the
     /// context resolver's orphan cleanup.
     bool recheck_contexts = false;
@@ -257,7 +257,7 @@ private:
     /// name the rescan gave its first provider cascades to the consumers
     /// holding sentinel edges against it; a name the file stopped
     /// providing cascades through the provider's real node instead.
-    void rescan_disk_state(std::uint32_t path_id, DirtySet& dirty);
+    void rescan_disk_state(Fid path_id, DirtySet& dirty);
 
     /// The invalidation cascade for "this file's on-disk content is new":
     /// rescan the file's disk state, then split every affected file into
@@ -265,11 +265,11 @@ private:
     /// now holds the buffer) and DiskChanged on closed files (disk changed
     /// behind the server's back), and used verbatim — the two differ only
     /// in what the caller adds around it.
-    void cascade_disk_content_change(std::uint32_t path_id, DirtySet& dirty);
+    void cascade_disk_content_change(Fid path_id, DirtySet& dirty);
 
     /// Cascade a module unit's compile-graph invalidation (PCM caches,
     /// dependent module units), splitting dirtied units open/closed.
-    void cascade_compile_graph(std::uint32_t path_id, DirtySet& dirty);
+    void cascade_compile_graph(Fid path_id, DirtySet& dirty);
 
     /// A module name just gained its first provider: cascade through its
     /// sentinel node and route the dirtied consumers to recompiles and
@@ -278,7 +278,7 @@ private:
 
     /// See the definition: the open/closed/index-only split of a
     /// dependency invalidation.
-    void mark_dependent(std::uint32_t path_id, DirtySet& dirty);
+    void mark_dependent(Fid path_id, DirtySet& dirty);
 
     Workspace& workspace;
     const SessionStore& store;
@@ -291,7 +291,7 @@ private:
     /// so this set is the only surviving record of the debt. BufferSaved
     /// discharges it — the save's own cascade covers everything owed —
     /// and BufferClosed drains it.
-    llvm::DenseSet<std::uint32_t> disk_changed_while_open;
+    llvm::DenseSet<Fid> disk_changed_while_open;
 };
 
 }  // namespace clice

--- a/src/server/state/session.h
+++ b/src/server/state/session.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "server/state/quarantine.h"
+#include "vfs/file_table.h"
 
 #include "kota/ipc/lsp/position.h"
 
@@ -58,7 +59,7 @@ enum class ServingMode : std::uint8_t {
 /// NEVER leak to Workspace or other Sessions.
 struct Session {
     /// Path ID of this file in FileTable.  Set on creation, never changes.
-    std::uint32_t path_id = 0;
+    Fid path_id;
 
     /// LSP document version, incremented by the client on each edit.
     int version = 0;

--- a/src/server/state/session.h
+++ b/src/server/state/session.h
@@ -57,7 +57,7 @@ enum class ServingMode : std::uint8_t {
 /// the AST family's projection (see server/state/ast_projection.h) and
 /// NEVER leak to Workspace or other Sessions.
 struct Session {
-    /// Path ID of this file in PathPool.  Set on creation, never changes.
+    /// Path ID of this file in FileTable.  Set on creation, never changes.
     std::uint32_t path_id = 0;
 
     /// LSP document version, incremented by the client on each edit.

--- a/src/server/state/session_store.cpp
+++ b/src/server/state/session_store.cpp
@@ -13,12 +13,12 @@ namespace clice {
 
 namespace lsp = kota::ipc::lsp;
 
-std::shared_ptr<Session> SessionStore::find(std::uint32_t path_id) const {
+std::shared_ptr<Session> SessionStore::find(Fid path_id) const {
     auto it = sessions.find(path_id);
     return it != sessions.end() ? it->second : nullptr;
 }
 
-std::shared_ptr<Session> SessionStore::open(std::uint32_t path_id) {
+std::shared_ptr<Session> SessionStore::open(Fid path_id) {
     auto it = sessions.find(path_id);
     if(it != sessions.end()) {
         it->second->generation++;
@@ -29,7 +29,7 @@ std::shared_ptr<Session> SessionStore::open(std::uint32_t path_id) {
     return session;
 }
 
-void SessionStore::close(std::uint32_t path_id) {
+void SessionStore::close(Fid path_id) {
     auto it = sessions.find(path_id);
     if(it != sessions.end()) {
         it->second->generation++;
@@ -37,7 +37,7 @@ void SessionStore::close(std::uint32_t path_id) {
     }
 }
 
-void SessionStore::for_each(llvm::function_ref<bool(std::uint32_t, const Session&)> visitor) const {
+void SessionStore::for_each(llvm::function_ref<bool(Fid, const Session&)> visitor) const {
     for(auto& [path_id, session]: sessions) {
         if(!session)
             continue;

--- a/src/server/state/session_store.h
+++ b/src/server/state/session_store.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "server/state/session.h"
+#include "vfs/file_table.h"
 
 #include "kota/ipc/lsp/protocol.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -29,22 +30,22 @@ namespace protocol = kota::ipc::protocol;
 /// Future work: this store does not yet bound the number of concurrently
 /// open sessions.
 struct SessionStore {
-    llvm::DenseMap<std::uint32_t, std::shared_ptr<Session>> sessions;
+    llvm::DenseMap<Fid, std::shared_ptr<Session>> sessions;
 
     /// Look up the open Session for a path_id, or nullptr if none.
-    std::shared_ptr<Session> find(std::uint32_t path_id) const;
+    std::shared_ptr<Session> find(Fid path_id) const;
 
     /// Open a fresh Session for a path_id. If one already exists its
     /// generation is bumped (superseding any in-flight compile) before it is
     /// replaced.
-    std::shared_ptr<Session> open(std::uint32_t path_id);
+    std::shared_ptr<Session> open(Fid path_id);
 
     /// Drop the Session for a path_id, bumping its generation first so a
     /// late-arriving compile result cannot resurrect stale state.
-    void close(std::uint32_t path_id);
+    void close(Fid path_id);
 
     /// Visit every open Session. The callback returns false to stop early.
-    void for_each(llvm::function_ref<bool(std::uint32_t, const Session&)> visitor) const;
+    void for_each(llvm::function_ref<bool(Fid, const Session&)> visitor) const;
 
     /// Apply a didOpen: install the initial buffer text, version and line
     /// starts, and bump the generation.

--- a/src/server/transport/agent_client.cpp
+++ b/src/server/transport/agent_client.cpp
@@ -95,7 +95,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
         auto filter = params.filter.value_or("all");
 
         ProjectFilesResult result;
-        llvm::DenseSet<std::uint32_t> seen;
+        llvm::DenseSet<Fid> seen;
 
         for(auto& entry: ws.cdb.entries()) {
             auto file_path = ws.file_table.resolve(entry.file);
@@ -168,13 +168,12 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
             if(direction == "includes" || direction == "both") {
                 auto includes = ws.dep_graph.get_all_includes(path_id);
                 for(auto inc_id: includes) {
-                    auto real_id = inc_id & DependencyGraph::PATH_ID_MASK;
-                    auto inc_path = ws.file_table.resolve(real_id);
+                    auto inc_path = ws.file_table.resolve(inc_id);
                     result.includes.push_back(DepEntry{.path = inc_path.str(), .depth = 1});
                 }
 
                 if(max_depth == 0 || max_depth > 1) {
-                    llvm::DenseSet<std::uint32_t> visited;
+                    llvm::DenseSet<Fid> visited;
                     visited.insert(path_id);
                     for(auto& dep: result.includes)
                         visited.insert(ws.file_table.intern(dep.path));
@@ -185,10 +184,9 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                         auto dep_id = ws.file_table.intern(result.includes[i].path);
                         auto sub = ws.dep_graph.get_all_includes(dep_id);
                         for(auto sub_id: sub) {
-                            auto real_id = sub_id & DependencyGraph::PATH_ID_MASK;
-                            if(!visited.insert(real_id).second)
+                            if(!visited.insert(sub_id).second)
                                 continue;
-                            auto sub_path = ws.file_table.resolve(real_id);
+                            auto sub_path = ws.file_table.resolve(sub_id);
                             result.includes.push_back(DepEntry{
                                 .path = sub_path.str(),
                                 .depth = result.includes[i].depth + 1,
@@ -206,7 +204,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                 }
 
                 if(max_depth == 0 || max_depth > 1) {
-                    llvm::DenseSet<std::uint32_t> visited;
+                    llvm::DenseSet<Fid> visited;
                     visited.insert(path_id);
                     for(auto& dep: result.includers) {
                         if(auto id = ws.file_table.find(dep.path))
@@ -254,7 +252,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
             }
 
             auto hosts = ws.dep_graph.find_host_sources(path_id);
-            llvm::DenseSet<std::uint32_t> seen;
+            llvm::DenseSet<Fid> seen;
             seen.insert(path_id);
             for(auto inc_id: direct_includers)
                 seen.insert(inc_id);
@@ -386,7 +384,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                     continue;
                 if(!is_document_level(symbol.kind))
                     continue;
-                if(!symbol.reference_files.contains(*path_id))
+                if(!symbol.reference_files.contains(path_id->raw))
                     continue;
 
                 merged_index.lookup(hash, RelationKind::Definition, [&](const index::Relation& r) {

--- a/src/server/transport/agent_client.cpp
+++ b/src/server/transport/agent_client.cpp
@@ -98,7 +98,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
         llvm::DenseSet<std::uint32_t> seen;
 
         for(auto& entry: ws.cdb.entries()) {
-            auto file_path = ws.path_pool.resolve(entry.file);
+            auto file_path = ws.file_table.resolve(entry.file);
             if(file_path.empty())
                 continue;
 
@@ -133,7 +133,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
             for(auto& [path_id, shard]: ws.shards) {
                 if(seen.contains(path_id))
                     continue;
-                auto path_str = ws.path_pool.resolve(path_id);
+                auto path_str = ws.file_table.resolve(path_id);
                 auto ext = llvm::sys::path::extension(path_str);
                 if(ext == ".h" || ext == ".hpp" || ext == ".hxx" || ext == ".hh") {
                     seen.insert(path_id);
@@ -155,7 +155,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
             auto& ws = srv.workspace;
             // find() applies the canonical spelling; a native uppercase-drive
             // path from an agentic client must hit the same ID.
-            auto pool_id = ws.path_pool.find(params.path);
+            auto pool_id = ws.file_table.find(params.path);
             if(!pool_id)
                 co_return FileDepsResult{.file = params.path};
             auto path_id = *pool_id;
@@ -169,7 +169,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                 auto includes = ws.dep_graph.get_all_includes(path_id);
                 for(auto inc_id: includes) {
                     auto real_id = inc_id & DependencyGraph::PATH_ID_MASK;
-                    auto inc_path = ws.path_pool.resolve(real_id);
+                    auto inc_path = ws.file_table.resolve(real_id);
                     result.includes.push_back(DepEntry{.path = inc_path.str(), .depth = 1});
                 }
 
@@ -177,18 +177,18 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                     llvm::DenseSet<std::uint32_t> visited;
                     visited.insert(path_id);
                     for(auto& dep: result.includes)
-                        visited.insert(ws.path_pool.intern(dep.path));
+                        visited.insert(ws.file_table.intern(dep.path));
 
                     for(std::size_t i = 0; i < result.includes.size(); ++i) {
                         if(max_depth > 0 && result.includes[i].depth >= max_depth)
                             continue;
-                        auto dep_id = ws.path_pool.intern(result.includes[i].path);
+                        auto dep_id = ws.file_table.intern(result.includes[i].path);
                         auto sub = ws.dep_graph.get_all_includes(dep_id);
                         for(auto sub_id: sub) {
                             auto real_id = sub_id & DependencyGraph::PATH_ID_MASK;
                             if(!visited.insert(real_id).second)
                                 continue;
-                            auto sub_path = ws.path_pool.resolve(real_id);
+                            auto sub_path = ws.file_table.resolve(real_id);
                             result.includes.push_back(DepEntry{
                                 .path = sub_path.str(),
                                 .depth = result.includes[i].depth + 1,
@@ -201,7 +201,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
             if(direction == "includers" || direction == "both") {
                 auto includers = ws.dep_graph.get_includers(path_id);
                 for(auto inc_id: includers) {
-                    auto inc_path = ws.path_pool.resolve(inc_id);
+                    auto inc_path = ws.file_table.resolve(inc_id);
                     result.includers.push_back(DepEntry{.path = inc_path.str(), .depth = 1});
                 }
 
@@ -209,21 +209,21 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                     llvm::DenseSet<std::uint32_t> visited;
                     visited.insert(path_id);
                     for(auto& dep: result.includers) {
-                        if(auto id = ws.path_pool.find(dep.path))
+                        if(auto id = ws.file_table.find(dep.path))
                             visited.insert(*id);
                     }
 
                     for(std::size_t i = 0; i < result.includers.size(); ++i) {
                         if(max_depth > 0 && result.includers[i].depth >= max_depth)
                             continue;
-                        auto dep_id = ws.path_pool.find(result.includers[i].path);
+                        auto dep_id = ws.file_table.find(result.includers[i].path);
                         if(!dep_id)
                             continue;
                         auto sub = ws.dep_graph.get_includers(*dep_id);
                         for(auto sub_id: sub) {
                             if(!visited.insert(sub_id).second)
                                 continue;
-                            auto sub_path = ws.path_pool.resolve(sub_id);
+                            auto sub_path = ws.file_table.resolve(sub_id);
                             result.includers.push_back(DepEntry{
                                 .path = sub_path.str(),
                                 .depth = result.includers[i].depth + 1,
@@ -241,7 +241,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                const ImpactAnalysisParams& params) -> RequestResult<ImpactAnalysisParams> {
             srv.pool.foreground_pulse();
             auto& ws = srv.workspace;
-            auto pool_id = ws.path_pool.find(params.path);
+            auto pool_id = ws.file_table.find(params.path);
             if(!pool_id)
                 co_return ImpactAnalysisResult{};
             auto path_id = *pool_id;
@@ -250,7 +250,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
 
             auto direct_includers = ws.dep_graph.get_includers(path_id);
             for(auto inc_id: direct_includers) {
-                result.direct_dependents.push_back(ws.path_pool.resolve(inc_id).str());
+                result.direct_dependents.push_back(ws.file_table.resolve(inc_id).str());
             }
 
             auto hosts = ws.dep_graph.find_host_sources(path_id);
@@ -260,7 +260,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                 seen.insert(inc_id);
             for(auto host_id: hosts) {
                 if(seen.insert(host_id).second)
-                    result.transitive_dependents.push_back(ws.path_pool.resolve(host_id).str());
+                    result.transitive_dependents.push_back(ws.file_table.resolve(host_id).str());
             }
 
             for(auto host_id: hosts) {
@@ -362,7 +362,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
 
             DocumentSymbolsResult result;
 
-            auto path_id = srv.workspace.path_pool.find(params.path);
+            auto path_id = srv.workspace.file_table.find(params.path);
             if(!path_id)
                 co_return result;
 

--- a/src/server/transport/agentic.cpp
+++ b/src/server/transport/agentic.cpp
@@ -32,7 +32,7 @@ static kota::task<> agentic_request(kota::ipc::JsonPeer& peer,
                                     const QueryOptions& opts) {
     auto method = opts.method.value_or("compileCommand");
     auto path = opts.path.value_or("");
-    // The server matches paths against its absolute path pool; resolve a
+    // The server matches paths against its absolute file table; resolve a
     // relative --path against this CLI's working directory before it ships.
     if(!path.empty() && !path::is_absolute(path)) {
         llvm::SmallString<256> abs(path);

--- a/src/server/transport/lsp_client.cpp
+++ b/src/server/transport/lsp_client.cpp
@@ -227,7 +227,7 @@ void LSPClient::register_lifecycle() {
         // still describe the current buffer are replayed: an edit during
         // the handshake marks the session dirty, and the next compile
         // pushes fresh results instead.
-        srv.sessions.for_each([this](std::uint32_t path_id, const Session& session) {
+        srv.sessions.for_each([this](Fid path_id, const Session& session) {
             auto projection = this->server.ast.projections.projection(path_id);
             if(projection && projection->output.has_value() &&
                this->server.ast.projections.current(path_id) &&
@@ -728,7 +728,7 @@ void LSPClient::register_extensions() {
             }
 
             stats.header_contexts = static_cast<std::uint32_t>(srv.contexts.header_contexts.size());
-            srv.sessions.for_each([&](std::uint32_t, const Session&) -> bool {
+            srv.sessions.for_each([&](Fid, const Session&) -> bool {
                 stats.sessions += 1;
                 return true;
             });

--- a/src/server/transport/lsp_client.cpp
+++ b/src/server/transport/lsp_client.cpp
@@ -93,7 +93,7 @@ void LSPClient::forward_notify_messages() {
 
 LSPClient::ResolvedDoc LSPClient::resolve_uri(const std::string& uri) {
     auto path = uri_to_path(uri);
-    auto path_id = this->server.workspace.path_pool.intern(path);
+    auto path_id = this->server.workspace.file_table.intern(path);
     return ResolvedDoc{std::move(path), path_id, this->server.find_session(path_id)};
 }
 
@@ -799,7 +799,7 @@ void LSPClient::push_output(const Session& session) {
     }
     auto& output = *projection->output;
 
-    auto file_path = std::string(server.workspace.path_pool.resolve(session.path_id));
+    auto file_path = std::string(server.workspace.file_table.resolve(session.path_id));
     auto uri = lsp::URI::from_file_path(file_path);
     std::string uri_str = uri.has_value() ? uri->str() : file_path;
 

--- a/src/server/transport/lsp_client.cpp
+++ b/src/server/transport/lsp_client.cpp
@@ -631,12 +631,12 @@ void LSPClient::register_extensions() {
             // The session reset lives inside switch_context (single owner,
             // synchronous, no cross-file cascade — exempt from the event
             // pipeline; see the Invalidator charter).
-            auto result = this->server.context_service.switch_context(path,
-                                                                      path_id,
-                                                                      session.get(),
-                                                                      context_path,
-                                                                      context_path_id,
-                                                                      params);
+            auto result = co_await this->server.context_service.switch_context(path,
+                                                                               path_id,
+                                                                               session.get(),
+                                                                               context_path,
+                                                                               context_path_id,
+                                                                               params);
             // A context choice asks for the context-pure AST view; the
             // merged index cannot give it (union rows). A rejected switch
             // (stale epoch, bad host) changed no context and owes none.

--- a/src/server/transport/lsp_client.cpp
+++ b/src/server/transport/lsp_client.cpp
@@ -112,7 +112,7 @@ void LSPClient::register_lifecycle() {
         if(init.root_uri.has_value()) {
             // Canonicalize so downstream prefix checks (cache_dir,
             // ${workspace} expansion, artifact detection) compare against
-            // the same spelling the path pool stores.
+            // the same spelling the file table stores.
             srv.workspace_root = uri_to_path(*init.root_uri);
             path::canonicalize(srv.workspace_root);
         }

--- a/src/server/transport/lsp_client.h
+++ b/src/server/transport/lsp_client.h
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "support/signal.h"
+#include "vfs/file_table.h"
 
 #include "kota/async/async.h"
 #include "kota/codec/json/json.h"
@@ -30,7 +31,7 @@ private:
     /// interned path_id → open session (null when the document is not open).
     struct ResolvedDoc {
         std::string path;
-        std::uint32_t path_id;
+        Fid path_id;
         std::shared_ptr<Session> session;
     };
 
@@ -93,7 +94,7 @@ private:
     /// landing for an already-published version means the text did not
     /// change, so the client's pulled results went stale without any
     /// didChange to make it re-pull — the push path sends refreshes.
-    llvm::DenseMap<std::uint32_t, int> published_versions;
+    llvm::DenseMap<Fid, int> published_versions;
 
     /// Subscription to compile outputs; disconnects on destruction.
     Signal<std::shared_ptr<Session>>::Connection output_conn;

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -495,12 +495,21 @@ void MasterServer::dispatch(llvm::ArrayRef<FileEvent> events) {
     // dropping the snapshot's fast paths forces deps_changed() to re-validate
     // every chain file by content hash; open sessions also recompile and
     // re-trial.
+    auto stamps = workspace.file_table.stamp_generation;
     for(auto path_id: dirty.force_revalidate) {
         contexts.invalidate_header_deps(path_id);
         if(auto session = sessions.find(path_id)) {
             ast.invalidate(path_id);
             session->trial_done = false;
         }
+    }
+    // Revoked stamps live on in the global blob's version table and the
+    // artifacts blob's dep records; both must rewrite, or a restart after
+    // a same-stat dependency edit re-adopts the dropped fast paths and
+    // judges the edited file fresh without a read.
+    if(workspace.file_table.stamp_generation != stamps) {
+        index_store.mark_global_dirty();
+        workspace.mark_artifacts_dirty();
     }
 
     // The header's borrowed compile command changed: its resolved context
@@ -528,13 +537,8 @@ void MasterServer::dispatch(llvm::ArrayRef<FileEvent> events) {
         pump.clear_pending(path_id);
     }
 
-    bool save = dirty.save_cache;
-    if(dirty.recheck_contexts) {
-        save |= context_service.drop_orphaned_choices(sessions);
-    }
-    if(save) {
+    if(dirty.recheck_contexts && context_service.drop_orphaned_choices(sessions)) {
         workspace.mark_contexts_dirty();
-        workspace.mark_artifacts_dirty();
     }
 
     // Not before the server is ready: document-sync events are accepted

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -237,7 +237,7 @@ void MasterServer::wire() {
     };
 
     pool.on_evicted = [this](const std::string& path, std::size_t worker_index) {
-        auto id = workspace.path_pool.find(path);
+        auto id = workspace.file_table.find(path);
         if(!id) {
             LOG_WARN("Evicted path not in pool: {}", path);
             return;
@@ -335,7 +335,7 @@ void MasterServer::settle_open_serving(std::shared_ptr<Session> session) {
 }
 
 void MasterServer::close_session(std::uint32_t path_id) {
-    auto path = workspace.path_pool.resolve(path_id);
+    auto path = workspace.file_table.resolve(path_id);
     // Route the eviction notification before dropping ownership:
     // notify_stateful uses the owner table to find the worker.
     pool.notify_stateful(path_id, worker::EvictParams{std::string(path)});
@@ -387,7 +387,7 @@ Admission MasterServer::index_admission(std::uint32_t server_path_id) const {
     if(session->serving != ServingMode::IndexOnly) {
         return index_open_files ? Admission::Admit : Admission::SkipAndSettle;
     }
-    auto file_path = workspace.path_pool.resolve(server_path_id);
+    auto file_path = workspace.file_table.resolve(server_path_id);
     if(auto disk = fs::read(file_path); !disk || *disk != session->text) {
         return Admission::SkipAndSettle;
     }
@@ -440,7 +440,7 @@ void MasterServer::on_agentic_query() {
         // keeps serving through the catch-up, while a stale or missing one
         // (a save that landed while its reindex slot was still skipped)
         // must not answer agents with the pre-save rows.
-        auto disk = fs::read(workspace.path_pool.resolve(path_id));
+        auto disk = fs::read(workspace.file_table.resolve(path_id));
         if(!disk) {
             continue;
         }

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -239,7 +239,8 @@ void MasterServer::wire() {
         // event to dispatch.
         if(!info.stateful)
             return;
-        dispatch(FileEvent::worker_crashed(info.lost_documents));
+        dispatch(FileEvent::worker_crashed(llvm::to_vector(
+            llvm::map_range(info.lost_documents, [](std::uint32_t id) { return Fid{id}; }))));
     };
 
     pool.on_evicted = [this](const std::string& path, std::size_t worker_index) {
@@ -254,7 +255,7 @@ void MasterServer::wire() {
         // Only the current owner's eviction counts: a stale copy left
         // behind by a probe reassignment says nothing about the document
         // the new owner still holds.
-        if(pool.remove_owner_from(*id, worker_index)) {
+        if(pool.remove_owner_from(id->raw, worker_index)) {
             dispatch(FileEvent::document_evicted(*id));
         } else {
             LOG_INFO("Ignoring eviction of {} from non-owner worker {}", path, worker_index);
@@ -270,20 +271,20 @@ void MasterServer::wire() {
 
     // The pump is serving-neutral; the session-side policy hooks live on
     // this class and are installed here.
-    pump.admission = [this](std::uint32_t path_id) {
+    pump.admission = [this](Fid path_id) {
         return index_admission(path_id);
     };
-    pump.on_attempt_settled = [this](std::uint32_t path_id) {
+    pump.on_attempt_settled = [this](Fid path_id) {
         index_attempt_settled(path_id);
     };
     index_rows_conn = pump.on_rows_changed.connect(
-        [this](llvm::ArrayRef<std::uint32_t> path_ids) { index_rows_changed(path_ids); });
+        [this](llvm::ArrayRef<Fid> path_ids) { index_rows_changed(path_ids); });
 
     // The AST family's pull-side staleness check found a dependency changed
     // on disk: route it through the same DiskChanged path the file
     // tracker's polling uses, so lazy detection and polling share one
     // invalidation cascade.
-    ast.on_stale = [this](std::uint32_t path_id) {
+    ast.on_stale = [this](Fid path_id) {
         dispatch(FileEvent::disk_changed(path_id));
     };
 }
@@ -293,11 +294,11 @@ void MasterServer::initialize(llvm::StringRef root) {
     initialize();
 }
 
-std::shared_ptr<Session> MasterServer::find_session(std::uint32_t path_id) {
+std::shared_ptr<Session> MasterServer::find_session(Fid path_id) {
     return sessions.find(path_id);
 }
 
-std::shared_ptr<Session> MasterServer::open_session(std::uint32_t path_id) {
+std::shared_ptr<Session> MasterServer::open_session(Fid path_id) {
     // A replaced live session (an editor resending didOpen) leaves a
     // projection describing the old session's compile; the fresh session
     // starts with none, exactly like the pre-projection world's fresh
@@ -340,12 +341,12 @@ void MasterServer::settle_open_serving(std::shared_ptr<Session> session) {
     }
 }
 
-void MasterServer::close_session(std::uint32_t path_id) {
+void MasterServer::close_session(Fid path_id) {
     auto path = workspace.file_table.resolve(path_id);
     // Route the eviction notification before dropping ownership:
     // notify_stateful uses the owner table to find the worker.
-    pool.notify_stateful(path_id, worker::EvictParams{std::string(path)});
-    pool.remove_owner(path_id);
+    pool.notify_stateful(path_id.raw, worker::EvictParams{std::string(path)});
+    pool.remove_owner(path_id.raw);
 
     // Retract the document's published diagnostics through the standard
     // output path: materialize an empty output and signal the transports
@@ -372,7 +373,7 @@ void MasterServer::close_session(std::uint32_t path_id) {
     LOG_DEBUG("didClose: {}", path);
 }
 
-Admission MasterServer::index_admission(std::uint32_t server_path_id) {
+Admission MasterServer::index_admission(Fid server_path_id) {
     // Open files whose session invests in an AST are skipped until an
     // agent shows up: the LSP side never reads their shards (the session
     // serves them), so indexing them is pure waste — but agents read disk
@@ -401,7 +402,7 @@ Admission MasterServer::index_admission(std::uint32_t server_path_id) {
     return Admission::Admit;
 }
 
-void MasterServer::index_attempt_settled(std::uint32_t server_path_id) {
+void MasterServer::index_attempt_settled(Fid server_path_id) {
     // The boost in settle_open_serving promised the index would serve the
     // cold session; an attempt that settles without a servable shard ends
     // that promise — escalate like the disabled-indexing branch, or the
@@ -416,16 +417,16 @@ void MasterServer::index_attempt_settled(std::uint32_t server_path_id) {
     }
 }
 
-bool MasterServer::serves_session_rows(std::uint32_t path_id) const {
+bool MasterServer::serves_session_rows(Fid path_id) const {
     auto session = sessions.find(path_id);
     return session && !ast.projections.index_current(path_id) && session->index_served;
 }
 
-void MasterServer::index_rows_changed(llvm::ArrayRef<std::uint32_t> path_ids) {
+void MasterServer::index_rows_changed(llvm::ArrayRef<Fid> path_ids) {
     // Sessions without a current file index serve these very rows
     // (freshness clause 4); index_served says the client pulled some of
     // them. Tell subscribers so those results get re-pulled.
-    if(llvm::any_of(path_ids, [&](std::uint32_t id) { return serves_session_rows(id); })) {
+    if(llvm::any_of(path_ids, [&](Fid id) { return serves_session_rows(id); })) {
         on_serving_rows_changed.emit();
     }
 }

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -26,6 +26,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
+#include "llvm/Support/xxhash.h"
 
 namespace clice {
 
@@ -366,7 +367,7 @@ void MasterServer::close_session(std::uint32_t path_id) {
     LOG_DEBUG("didClose: {}", path);
 }
 
-Admission MasterServer::index_admission(std::uint32_t server_path_id) const {
+Admission MasterServer::index_admission(std::uint32_t server_path_id) {
     // Open files whose session invests in an AST are skipped until an
     // agent shows up: the LSP side never reads their shards (the session
     // serves them), so indexing them is pure waste — but agents read disk
@@ -387,8 +388,9 @@ Admission MasterServer::index_admission(std::uint32_t server_path_id) const {
     if(session->serving != ServingMode::IndexOnly) {
         return index_open_files ? Admission::Admit : Admission::SkipAndSettle;
     }
-    auto file_path = workspace.file_table.resolve(server_path_id);
-    if(auto disk = fs::read(file_path); !disk || *disk != session->text) {
+    auto disk = workspace.file_table.current(server_path_id);
+    if(!disk || disk->size != session->text.size() ||
+       disk->hash != llvm::xxh3_64bits(session->text)) {
         return Admission::SkipAndSettle;
     }
     return Admission::Admit;
@@ -440,13 +442,13 @@ void MasterServer::on_agentic_query() {
         // keeps serving through the catch-up, while a stale or missing one
         // (a save that landed while its reindex slot was still skipped)
         // must not answer agents with the pre-save rows.
-        auto disk = fs::read(workspace.file_table.resolve(path_id));
+        auto disk = workspace.file_table.current(path_id);
         if(!disk) {
             continue;
         }
         auto shard_it = workspace.shards.find(path_id);
-        bool shard_current =
-            shard_it != workspace.shards.end() && shard_it->second.matches_content(*disk);
+        bool shard_current = shard_it != workspace.shards.end() &&
+                             shard_it->second.matches_content(disk->size, disk->hash);
         pump.enqueue(path_id,
                      shard_current ? ReindexReason::DepsOnly : ReindexReason::ContentChanged);
     }

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -57,6 +57,11 @@ MasterServer::MasterServer(kota::event_loop& loop, std::string self_path) :
     workspace.open_documents = [this] {
         return sessions.sessions.size();
     };
+    // Metadata marks (a PCH landing, a context switch) flush through the
+    // next save; the wiring schedules one soon after the first mark.
+    workspace.request_flush = [this] {
+        schedule_metadata_flush();
+    };
 
     logging::set_notify_hook([this](logging::NotifyLevel level, std::string_view message) {
         notify_log.push_back(NotifyMessage{level, std::string(message)});
@@ -528,7 +533,8 @@ void MasterServer::dispatch(llvm::ArrayRef<FileEvent> events) {
         save |= context_service.drop_orphaned_choices(sessions);
     }
     if(save) {
-        workspace.save_cache(contexts);
+        workspace.mark_contexts_dirty();
+        workspace.mark_artifacts_dirty();
     }
 
     // Not before the server is ready: document-sync events are accepted
@@ -566,12 +572,35 @@ kota::task<> MasterServer::shutdown_and_cleanup() {
         // standalone header's repair debt dies with this process.
         pump.claim_report(co_await index_store.save(pump.save_debt()));
     }
-    workspace.save_cache(contexts);
     co_await pool.stop();
     if(workspace.store) {
         workspace.store->shutdown();
     }
     lifecycle = ServerLifecycle::Exited;
+}
+
+void MasterServer::schedule_metadata_flush() {
+    if(metadata_flush_scheduled || lifecycle == ServerLifecycle::ShuttingDown ||
+       lifecycle == ServerLifecycle::Exited) {
+        return;
+    }
+    metadata_flush_scheduled = true;
+    bg_tasks.spawn(metadata_flush_task());
+}
+
+kota::task<> MasterServer::metadata_flush_task() {
+    // One loop turn of debounce coalesces a burst of marks into one save;
+    // the save itself batches whatever else is dirty by then. Marks
+    // arriving while the save runs re-schedule through request_flush, and
+    // a save that could not clear the flags (serialization or write
+    // failure) retries on the next spawn with this backoff.
+    co_await kota::sleep(std::chrono::milliseconds(50));
+    metadata_flush_scheduled = false;
+    pump.claim_report(co_await index_store.save(pump.save_debt()));
+    if(workspace.artifacts_dirty || workspace.contexts_dirty) {
+        co_await kota::sleep(std::chrono::seconds(5));
+        schedule_metadata_flush();
+    }
 }
 
 kota::task<> MasterServer::cache_checkpoint_task() {

--- a/src/server/transport/master_server.h
+++ b/src/server/transport/master_server.h
@@ -108,8 +108,8 @@ public:
 
     kota::task<> shutdown_and_cleanup();
 
-    std::shared_ptr<Session> find_session(std::uint32_t path_id);
-    std::shared_ptr<Session> open_session(std::uint32_t path_id);
+    std::shared_ptr<Session> find_session(Fid path_id);
+    std::shared_ptr<Session> open_session(Fid path_id);
 
     /// Settle a freshly opened index-only buffer: escalate one that
     /// already diverged from its shard, or boost the file's background
@@ -121,7 +121,7 @@ public:
     /// session's output + on_output signal; a transport whose client has
     /// not completed the handshake drops it (nothing was ever pushed, so
     /// there is nothing to clear).
-    void close_session(std::uint32_t path_id);
+    void close_session(Fid path_id);
 
     /// The single entry point for file events: fold the batch through the
     /// Invalidator, then execute the resulting effects against the mutable
@@ -248,23 +248,23 @@ private:
 
     /// Dispatch- and landing-time admission on one claimed pump file: the
     /// serving side's veto (open sessions, index-only disk divergence).
-    Admission index_admission(std::uint32_t server_path_id);
+    Admission index_admission(Fid server_path_id);
 
     /// An index attempt settled with no retry pending; a session waiting
     /// on the index with nothing servable will never be served by it —
     /// escalate instead of letting it answer empty forever.
-    void index_attempt_settled(std::uint32_t server_path_id);
+    void index_attempt_settled(Fid server_path_id);
 
     /// Whether an open session serves this file's project rows (freshness
     /// clause 4) and a client already pulled some of them — the emit
     /// condition of on_serving_rows_changed.
-    bool serves_session_rows(std::uint32_t path_id) const;
+    bool serves_session_rows(Fid path_id) const;
 
     /// Filter a store row-change report down to the sessions actually
     /// serving those rows and wake the transports.
-    void index_rows_changed(llvm::ArrayRef<std::uint32_t> path_ids);
+    void index_rows_changed(llvm::ArrayRef<Fid> path_ids);
 
-    Signal<llvm::ArrayRef<std::uint32_t>>::Connection index_rows_conn;
+    Signal<llvm::ArrayRef<Fid>>::Connection index_rows_conn;
 
     void load_workspace();
 

--- a/src/server/transport/master_server.h
+++ b/src/server/transport/master_server.h
@@ -248,7 +248,7 @@ private:
 
     /// Dispatch- and landing-time admission on one claimed pump file: the
     /// serving side's veto (open sessions, index-only disk divergence).
-    Admission index_admission(std::uint32_t server_path_id) const;
+    Admission index_admission(std::uint32_t server_path_id);
 
     /// An index attempt settled with no retry pending; a session waiting
     /// on the index with nothing servable will never be served by it —

--- a/src/server/transport/master_server.h
+++ b/src/server/transport/master_server.h
@@ -171,7 +171,7 @@ public:
     /// reuses them); the session-side policy — admission vetoes,
     /// unservable escalation, serving-row refresh — lives on this class
     /// and is installed into the pump's hooks by wire().
-    IndexStore index_store{loop, workspace};
+    IndexStore index_store{loop, workspace, contexts};
     TURunFamily turun{graph, workspace, contexts, pcm, index_store, pool};
     IndexPump pump{loop, workspace, turun, index_store, pool};
 
@@ -270,6 +270,13 @@ private:
 
     /// Periodically checkpoint the cache store manifest so last-accessed
     /// times survive crashes (the store itself is passive by design).
+    /// Schedule a save carrying dirty artifact/context metadata; no-op
+    /// when one is already scheduled or the server is shutting down (the
+    /// final shutdown save covers it).
+    void schedule_metadata_flush();
+    kota::task<> metadata_flush_task();
+    bool metadata_flush_scheduled = false;
+
     kota::task<> cache_checkpoint_task();
 
     /// Drop pch_cache metadata for blobs the store's LRU evicted from

--- a/src/support/cache_store.cpp
+++ b/src/support/cache_store.cpp
@@ -212,16 +212,6 @@ struct CacheStore::State {
     /// swept, and writes are a caller bug.
     bool read_only = false;
 
-    /// Dirty-writer marker state (see mark_writer_dirty): mark count of
-    /// this instance, whether the marker file currently exists, and
-    /// whether open() found a dead writer's marker.
-    std::uint64_t writer_marks = 0;
-    bool writer_marked = false;
-    bool dead_dirty = false;
-    /// Whether this session can discharge a dead writer's verification
-    /// debt (see open()); false hands the marker on at shutdown.
-    bool adopt_debt = true;
-
     /// First namespace directory scan that failed (permissions, IO):
     /// the affected namespace looks empty while its blobs exist, so
     /// readers must not mistake the store for empty.
@@ -282,14 +272,12 @@ CacheStore::~CacheStore() = default;
 
 std::expected<CacheStore, std::error_code> CacheStore::open(llvm::StringRef root,
                                                             std::uint32_t version,
-                                                            bool read_only,
-                                                            bool adopt_writer_debt) {
+                                                            bool read_only) {
     assert(!root.empty() && "cache root must not be empty");
 
     auto state = std::make_unique<State>();
     state->self_pid = static_cast<std::uint32_t>(llvm::sys::Process::getProcessId());
     state->read_only = read_only;
-    state->adopt_debt = adopt_writer_debt;
 
     auto parent = path::join(root, "cache");
     auto version_dir = std::format("v{}", version);
@@ -384,60 +372,14 @@ std::expected<CacheStore, std::error_code> CacheStore::open(llvm::StringRef root
 
     // The only crash residue are in-flight tmp files; committed blobs are
     // complete by construction (atomic rename).  Sweep tmp directories of
-    // instances that no longer exist — reading their dirty markers first:
-    // a dead writer that crashed between publishing a blob and persisting
-    // its metadata leaves one, and this session must then verify adopted
-    // records against blob content on first use.
+    // instances that no longer exist.
     auto tmp_parent = path::join(state->base, "tmp");
-    {
-        std::error_code iter_ec;
-        for(llvm::sys::fs::directory_iterator it(tmp_parent, iter_ec), end; it != end && !iter_ec;
-            it.increment(iter_ec)) {
-            std::uint32_t pid = 0;
-            auto name = llvm::sys::path::filename(it->path());
-            if(name.getAsInteger(10, pid) || pid == state->self_pid || is_pid_alive(pid)) {
-                continue;
-            }
-            if(llvm::sys::fs::exists(path::join(it->path(), "dirty"))) {
-                LOG_WARN(
-                    "CacheStore: instance {} died with unflushed blob metadata; "
-                    "verifying adopted records against blob content",
-                    pid);
-                state->dead_dirty = true;
-            }
-        }
-    }
     sweep_dead_pid_dirs(tmp_parent, state->self_pid);
 
     state->tmp_dir = path::join(tmp_parent, std::to_string(state->self_pid));
-    // This process has not written a marker yet, so one under its own pid
-    // is a crashed predecessor that recycled the pid — the scan above
-    // skipped it and the removal below would silently launder its debt.
-    if(llvm::sys::fs::exists(path::join(state->tmp_dir, "dirty"))) {
-        LOG_WARN(
-            "CacheStore: a previous instance reusing pid {} died with unflushed "
-            "blob metadata; verifying adopted records against blob content",
-            state->self_pid);
-        state->dead_dirty = true;
-    }
     fs::remove_all(state->tmp_dir);
     if(auto ec2 = llvm::sys::fs::create_directories(state->tmp_dir)) {
         return std::unexpected(ec2);
-    }
-
-    if(state->dead_dirty) {
-        // The dead writer's marker is consumed by the sweep above, but the
-        // verification debt it signals is only durable once the adopted
-        // records persist with their per-record flags — which takes a
-        // successful save. Carry the marker in this instance's own
-        // directory across that window, or a crash before the first save
-        // would launder the debt. An unsynced relay may not survive that
-        // crash either, so only a synced one counts as latched.
-        auto marker = path::join(state->tmp_dir, "dirty");
-        if(fs::write(marker, "1") && !sync_file(marker)) {
-            state->writer_marked = true;
-            state->writer_marks += 1;
-        }
     }
 
     return CacheStore(std::move(state));
@@ -688,8 +630,7 @@ CacheStore::PendingEntry CacheStore::begin_store_aux(llvm::StringRef ns, llvm::S
     return PendingEntry{ns.str(), key.str(), path::join(state->tmp_dir, tmp_name), /*aux=*/true};
 }
 
-std::expected<std::string, std::error_code> CacheStore::commit(PendingEntry pending,
-                                                               BlobBinding* binding) {
+std::expected<std::string, std::error_code> CacheStore::commit(PendingEntry pending) {
     if(pending.tmp_path.empty()) {
         return std::unexpected(std::make_error_code(std::errc::invalid_argument));
     }
@@ -699,25 +640,9 @@ std::expected<std::string, std::error_code> CacheStore::commit(PendingEntry pend
         return std::unexpected(ec);
     }
 
-    if(binding) {
-        // Capture the identity while the bytes are still private: reading
-        // the final path after the rename would race a concurrent
-        // replacer of the same key and bind its bytes into our record.
-        auto bytes = llvm::MemoryBuffer::getFile(pending.tmp_path);
-        if(!bytes) {
-            return std::unexpected(bytes.getError());
-        }
-        *binding = BlobBinding{.size = status.getSize(),
-                               .mtime_ns = fs::mtime_ns(status),
-                               .uid_device = status.getUniqueID().getDevice(),
-                               .uid_file = status.getUniqueID().getFile(),
-                               .hash = llvm::xxh3_64bits((*bytes)->getBuffer())};
-    }
-
     // Scratch blobs are cheap derivatives with no durability requirement;
     // they skip the fsync.
     bool durable;
-    bool deferred_metadata;
     {
         std::lock_guard guard(state->mutex);
         auto* ns_state = state->find_namespace(pending.ns);
@@ -725,7 +650,6 @@ std::expected<std::string, std::error_code> CacheStore::commit(PendingEntry pend
             return std::unexpected(std::make_error_code(std::errc::invalid_argument));
         }
         durable = ns_state->config.policy != CachePolicy::Scratch;
-        deferred_metadata = ns_state->config.deferred_metadata;
     }
 
     // fsync outside the lock so lookups are not blocked behind disk flushes.
@@ -733,12 +657,6 @@ std::expected<std::string, std::error_code> CacheStore::commit(PendingEntry pend
         if(auto ec = sync_file(pending.tmp_path)) {
             llvm::sys::fs::remove(pending.tmp_path);
             return std::unexpected(ec);
-        }
-        // The marker must be durable before the blob becomes visible: a
-        // crash right after the rename must read as "published without a
-        // metadata barrier".
-        if(deferred_metadata) {
-            mark_writer_dirty();
         }
     }
 
@@ -777,15 +695,6 @@ std::expected<std::string, std::error_code> CacheStore::commit(PendingEntry pend
                 llvm::sys::fs::remove(pending.tmp_path);
                 if(llvm::sys::fs::status(final_path, status)) {
                     return std::unexpected(result.error());
-                }
-                if(binding) {
-                    // The survivor's bytes are proven identical but its
-                    // inode and mtime are its own — a binding carrying the
-                    // dead tmp file's identity would read as stale forever.
-                    binding->size = status.getSize();
-                    binding->mtime_ns = fs::mtime_ns(status);
-                    binding->uid_device = status.getUniqueID().getDevice();
-                    binding->uid_file = status.getUniqueID().getFile();
                 }
             } else {
                 // The destination is stale — a rewritten mutable key
@@ -848,68 +757,6 @@ std::expected<std::string, std::error_code> CacheStore::commit(PendingEntry pend
 
     maybe_checkpoint();
     return final_path;
-}
-
-bool binding_stat_matches(llvm::StringRef path, const BlobBinding& binding) {
-    if(binding.size == 0 && binding.mtime_ns == 0) {
-        return false;
-    }
-    llvm::sys::fs::file_status status;
-    if(llvm::sys::fs::status(path, status)) {
-        return false;
-    }
-    // The UniqueID is the generation token only where it identifies the
-    // file (fs::stable_file_ids); elsewhere the mtime carries the check.
-    return status.getSize() == binding.size && fs::mtime_ns(status) == binding.mtime_ns &&
-           (!fs::stable_file_ids || (status.getUniqueID().getDevice() == binding.uid_device &&
-                                     status.getUniqueID().getFile() == binding.uid_file));
-}
-
-bool binding_content_matches(llvm::StringRef path, const BlobBinding& binding) {
-    auto bytes = llvm::MemoryBuffer::getFile(path);
-    return bytes && llvm::xxh3_64bits((*bytes)->getBuffer()) == binding.hash;
-}
-
-std::uint64_t CacheStore::mark_writer_dirty() {
-    std::lock_guard guard(state->mutex);
-    state->writer_marks += 1;
-    if(!state->writer_marked && !state->read_only) {
-        auto marker = path::join(state->tmp_dir, "dirty");
-        if(auto result = fs::write(marker, "1"); !result) {
-            LOG_WARN("CacheStore: cannot write dirty marker {}: {}",
-                     marker,
-                     result.error().message());
-        } else {
-            // Durable before the publication it covers, or a crash between
-            // the rename and the marker reaching disk goes unnoticed. An
-            // unsynced marker may not survive that crash, so failure here
-            // leaves the latch unset and the next commit retries.
-            if(auto ec = sync_file(marker)) {
-                LOG_WARN("CacheStore: cannot sync dirty marker {}: {}", marker, ec.message());
-            } else {
-                state->writer_marked = true;
-            }
-        }
-    }
-    return state->writer_marks;
-}
-
-void CacheStore::clear_writer_dirty(std::uint64_t upto) {
-    std::lock_guard guard(state->mutex);
-    if(!state->writer_marked || state->writer_marks != upto) {
-        return;
-    }
-    llvm::sys::fs::remove(path::join(state->tmp_dir, "dirty"));
-    state->writer_marked = false;
-}
-
-std::uint64_t CacheStore::writer_mark_count() const {
-    std::lock_guard guard(state->mutex);
-    return state->writer_marks;
-}
-
-bool CacheStore::dead_writer_dirty() const {
-    return state->dead_dirty;
 }
 
 void CacheStore::PendingEntry::remove_tmp() {
@@ -1122,24 +969,6 @@ void CacheStore::shutdown() {
     }
     state->checkpoint_locked();
 
-    // A session that latched a dead writer's debt but cannot persist it
-    // (read-only index database) hands the marker on: its tmp directory
-    // stays, reads as a dead instance's next time, and re-latches the
-    // debt there.
-    if(!state->adopt_debt && state->dead_dirty && state->writer_marked) {
-        for(auto& [name, ns_state]: state->namespaces) {
-            if(ns_state.config.policy == CachePolicy::Scratch) {
-                fs::remove_all(ns_state.dir);
-            }
-        }
-        return;
-    }
-
-    // The dirty marker dies with the tmp directory, deliberately: an
-    // orderly exit means every commit's bytes were fsynced whole, so the
-    // byte-level damage the marker's verify mode exists for cannot have
-    // happened — and metadata a failed final save left behind mismatches
-    // its blobs' stat bindings, which reads as a plain miss.
     fs::remove_all(state->tmp_dir);
     for(auto& [name, ns_state]: state->namespaces) {
         if(ns_state.config.policy == CachePolicy::Scratch) {

--- a/src/support/cache_store.cpp
+++ b/src/support/cache_store.cpp
@@ -218,6 +218,9 @@ struct CacheStore::State {
     std::uint64_t writer_marks = 0;
     bool writer_marked = false;
     bool dead_dirty = false;
+    /// Whether this session can discharge a dead writer's verification
+    /// debt (see open()); false hands the marker on at shutdown.
+    bool adopt_debt = true;
 
     /// First namespace directory scan that failed (permissions, IO):
     /// the affected namespace looks empty while its blobs exist, so
@@ -279,12 +282,14 @@ CacheStore::~CacheStore() = default;
 
 std::expected<CacheStore, std::error_code> CacheStore::open(llvm::StringRef root,
                                                             std::uint32_t version,
-                                                            bool read_only) {
+                                                            bool read_only,
+                                                            bool adopt_writer_debt) {
     assert(!root.empty() && "cache root must not be empty");
 
     auto state = std::make_unique<State>();
     state->self_pid = static_cast<std::uint32_t>(llvm::sys::Process::getProcessId());
     state->read_only = read_only;
+    state->adopt_debt = adopt_writer_debt;
 
     auto parent = path::join(root, "cache");
     auto version_dir = std::format("v{}", version);
@@ -426,10 +431,10 @@ std::expected<CacheStore, std::error_code> CacheStore::open(llvm::StringRef root
         // records persist with their per-record flags — which takes a
         // successful save. Carry the marker in this instance's own
         // directory across that window, or a crash before the first save
-        // would launder the debt.
+        // would launder the debt. An unsynced relay may not survive that
+        // crash either, so only a synced one counts as latched.
         auto marker = path::join(state->tmp_dir, "dirty");
-        if(fs::write(marker, "1")) {
-            sync_file(marker);
+        if(fs::write(marker, "1") && !sync_file(marker)) {
             state->writer_marked = true;
             state->writer_marks += 1;
         }
@@ -1114,6 +1119,19 @@ void CacheStore::shutdown() {
         return;
     }
     state->checkpoint_locked();
+
+    // A session that latched a dead writer's debt but cannot persist it
+    // (read-only index database) hands the marker on: its tmp directory
+    // stays, reads as a dead instance's next time, and re-latches the
+    // debt there.
+    if(!state->adopt_debt && state->dead_dirty && state->writer_marked) {
+        for(auto& [name, ns_state]: state->namespaces) {
+            if(ns_state.config.policy == CachePolicy::Scratch) {
+                fs::remove_all(ns_state.dir);
+            }
+        }
+        return;
+    }
 
     // The dirty marker dies with the tmp directory, deliberately: an
     // orderly exit means every commit's bytes were fsynced whole, so the

--- a/src/support/cache_store.cpp
+++ b/src/support/cache_store.cpp
@@ -858,9 +858,11 @@ bool binding_stat_matches(llvm::StringRef path, const BlobBinding& binding) {
     if(llvm::sys::fs::status(path, status)) {
         return false;
     }
+    // The UniqueID is the generation token only where it identifies the
+    // file (fs::stable_file_ids); elsewhere the mtime carries the check.
     return status.getSize() == binding.size && fs::mtime_ns(status) == binding.mtime_ns &&
-           status.getUniqueID().getDevice() == binding.uid_device &&
-           status.getUniqueID().getFile() == binding.uid_file;
+           (!fs::stable_file_ids || (status.getUniqueID().getDevice() == binding.uid_device &&
+                                     status.getUniqueID().getFile() == binding.uid_file));
 }
 
 bool binding_content_matches(llvm::StringRef path, const BlobBinding& binding) {

--- a/src/support/cache_store.cpp
+++ b/src/support/cache_store.cpp
@@ -181,7 +181,7 @@ struct CacheStore::State {
     struct Namespace {
         CacheNamespace config;
         /// Directory holding this namespace's blobs: `{base}/{name}` for
-        /// LRU/Persistent, `{base}/{name}/{pid}` for Scratch.
+        /// LRU, `{base}/{name}/{pid}` for Scratch.
         std::string dir;
         llvm::StringMap<Entry> entries;
         std::uint64_t total_size = 0;
@@ -211,11 +211,6 @@ struct CacheStore::State {
     /// Inspection mode (open's read_only): no directory is created or
     /// swept, and writes are a caller bug.
     bool read_only = false;
-
-    /// First namespace directory scan that failed (permissions, IO):
-    /// the affected namespace looks empty while its blobs exist, so
-    /// readers must not mistake the store for empty.
-    std::error_code scan_failure;
 
     /// Logical clock: strictly increasing per issued stamp so that LRU
     /// ordering is deterministic even within one millisecond.
@@ -511,10 +506,8 @@ void CacheStore::register_namespace(CacheNamespace ns) {
     }
     // A read-only open of a store whose namespace was never created is a
     // legitimately empty scan; any other failure hides existing blobs.
-    if(ec && !(state->read_only && ec == std::errc::no_such_file_or_directory) &&
-       !state->scan_failure) {
+    if(ec && !(state->read_only && ec == std::errc::no_such_file_or_directory)) {
         LOG_WARN("CacheStore: failed to scan namespace {}: {}", ns_state.dir, ec.message());
-        state->scan_failure = ec;
     }
 
     // Attach aux blobs to their entries. An aux without a primary is crash
@@ -697,11 +690,10 @@ std::expected<std::string, std::error_code> CacheStore::commit(PendingEntry pend
                     return std::unexpected(result.error());
                 }
             } else {
-                // The destination is stale — a rewritten mutable key
-                // (Persistent/Scratch) or an LRU blob whose content drifted
-                // from its key.  Remove it and retry; if the rename still
-                // fails, report the error instead of silently dropping the
-                // new data.
+                // The destination is stale — a rewritten Scratch key or an
+                // LRU blob whose content drifted from its key.  Remove it
+                // and retry; if the rename still fails, report the error
+                // instead of silently dropping the new data.
                 llvm::sys::fs::remove(final_path);
                 if(auto retry = fs::rename(pending.tmp_path, final_path); !retry) {
                     llvm::sys::fs::remove(pending.tmp_path);
@@ -815,36 +807,12 @@ std::size_t CacheStore::pending_tmp_files() const {
     return count;
 }
 
-void CacheStore::for_each_key(llvm::StringRef ns, llvm::function_ref<void(llvm::StringRef)> fn) {
-    llvm::SmallVector<std::string> keys;
-    {
-        std::lock_guard guard(state->mutex);
-        auto* ns_state = state->find_namespace(ns);
-        if(!ns_state) {
-            return;
-        }
-        keys.reserve(ns_state->entries.size());
-        for(auto& entry: ns_state->entries) {
-            keys.push_back(entry.first().str());
-        }
-    }
-
-    for(auto& key: keys) {
-        fn(key);
-    }
-}
-
 llvm::StringRef CacheStore::base_dir() const {
     return state->base;
 }
 
 bool CacheStore::read_only() const {
     return state->read_only;
-}
-
-std::error_code CacheStore::scan_error() const {
-    std::lock_guard guard(state->mutex);
-    return state->scan_failure;
 }
 
 void CacheStore::State::evict_locked(Namespace& ns, llvm::StringRef keep_key) {

--- a/src/support/cache_store.cpp
+++ b/src/support/cache_store.cpp
@@ -31,6 +31,7 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Process.h"
+#include "llvm/Support/xxhash.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace clice {
@@ -211,6 +212,13 @@ struct CacheStore::State {
     /// swept, and writes are a caller bug.
     bool read_only = false;
 
+    /// Dirty-writer marker state (see mark_writer_dirty): mark count of
+    /// this instance, whether the marker file currently exists, and
+    /// whether open() found a dead writer's marker.
+    std::uint64_t writer_marks = 0;
+    bool writer_marked = false;
+    bool dead_dirty = false;
+
     /// First namespace directory scan that failed (permissions, IO):
     /// the affected namespace looks empty while its blobs exist, so
     /// readers must not mistake the store for empty.
@@ -371,14 +379,49 @@ std::expected<CacheStore, std::error_code> CacheStore::open(llvm::StringRef root
 
     // The only crash residue are in-flight tmp files; committed blobs are
     // complete by construction (atomic rename).  Sweep tmp directories of
-    // instances that no longer exist.
+    // instances that no longer exist — reading their dirty markers first:
+    // a dead writer that crashed between publishing a blob and persisting
+    // its metadata leaves one, and this session must then verify adopted
+    // records against blob content on first use.
     auto tmp_parent = path::join(state->base, "tmp");
+    {
+        std::error_code iter_ec;
+        for(llvm::sys::fs::directory_iterator it(tmp_parent, iter_ec), end; it != end && !iter_ec;
+            it.increment(iter_ec)) {
+            std::uint32_t pid = 0;
+            auto name = llvm::sys::path::filename(it->path());
+            if(name.getAsInteger(10, pid) || pid == state->self_pid || is_pid_alive(pid)) {
+                continue;
+            }
+            if(llvm::sys::fs::exists(path::join(it->path(), "dirty"))) {
+                LOG_WARN("CacheStore: instance {} died with unflushed blob metadata; "
+                         "verifying adopted records against blob content",
+                         pid);
+                state->dead_dirty = true;
+            }
+        }
+    }
     sweep_dead_pid_dirs(tmp_parent, state->self_pid);
 
     state->tmp_dir = path::join(tmp_parent, std::to_string(state->self_pid));
     fs::remove_all(state->tmp_dir);
     if(auto ec2 = llvm::sys::fs::create_directories(state->tmp_dir)) {
         return std::unexpected(ec2);
+    }
+
+    if(state->dead_dirty) {
+        // The dead writer's marker is consumed by the sweep above, but the
+        // verification debt it signals is only durable once the adopted
+        // records persist with their per-record flags — which takes a
+        // successful save. Carry the marker in this instance's own
+        // directory across that window, or a crash before the first save
+        // would launder the debt.
+        auto marker = path::join(state->tmp_dir, "dirty");
+        if(fs::write(marker, "1")) {
+            sync_file(marker);
+            state->writer_marked = true;
+            state->writer_marks += 1;
+        }
     }
 
     return CacheStore(std::move(state));
@@ -629,7 +672,8 @@ CacheStore::PendingEntry CacheStore::begin_store_aux(llvm::StringRef ns, llvm::S
     return PendingEntry{ns.str(), key.str(), path::join(state->tmp_dir, tmp_name), /*aux=*/true};
 }
 
-std::expected<std::string, std::error_code> CacheStore::commit(PendingEntry pending) {
+std::expected<std::string, std::error_code> CacheStore::commit(PendingEntry pending,
+                                                               BlobBinding* binding) {
     if(pending.tmp_path.empty()) {
         return std::unexpected(std::make_error_code(std::errc::invalid_argument));
     }
@@ -637,6 +681,21 @@ std::expected<std::string, std::error_code> CacheStore::commit(PendingEntry pend
     llvm::sys::fs::file_status status;
     if(auto ec = llvm::sys::fs::status(pending.tmp_path, status)) {
         return std::unexpected(ec);
+    }
+
+    if(binding) {
+        // Capture the identity while the bytes are still private: reading
+        // the final path after the rename would race a concurrent
+        // replacer of the same key and bind its bytes into our record.
+        auto bytes = llvm::MemoryBuffer::getFile(pending.tmp_path);
+        if(!bytes) {
+            return std::unexpected(bytes.getError());
+        }
+        *binding = BlobBinding{.size = status.getSize(),
+                               .mtime_ns = fs::mtime_ns(status),
+                               .uid_device = status.getUniqueID().getDevice(),
+                               .uid_file = status.getUniqueID().getFile(),
+                               .hash = llvm::xxh3_64bits((*bytes)->getBuffer())};
     }
 
     // Scratch blobs are cheap derivatives with no durability requirement;
@@ -657,6 +716,10 @@ std::expected<std::string, std::error_code> CacheStore::commit(PendingEntry pend
             llvm::sys::fs::remove(pending.tmp_path);
             return std::unexpected(ec);
         }
+        // The marker must be durable before the blob becomes visible: a
+        // crash right after the rename must read as "published without a
+        // metadata barrier".
+        mark_writer_dirty();
     }
 
     std::string final_path;
@@ -694,6 +757,15 @@ std::expected<std::string, std::error_code> CacheStore::commit(PendingEntry pend
                 llvm::sys::fs::remove(pending.tmp_path);
                 if(llvm::sys::fs::status(final_path, status)) {
                     return std::unexpected(result.error());
+                }
+                if(binding) {
+                    // The survivor's bytes are proven identical but its
+                    // inode and mtime are its own — a binding carrying the
+                    // dead tmp file's identity would read as stale forever.
+                    binding->size = status.getSize();
+                    binding->mtime_ns = fs::mtime_ns(status);
+                    binding->uid_device = status.getUniqueID().getDevice();
+                    binding->uid_file = status.getUniqueID().getFile();
                 }
             } else {
                 // The destination is stale — a rewritten mutable key
@@ -756,6 +828,63 @@ std::expected<std::string, std::error_code> CacheStore::commit(PendingEntry pend
 
     maybe_checkpoint();
     return final_path;
+}
+
+bool binding_stat_matches(llvm::StringRef path, const BlobBinding& binding) {
+    if(binding.size == 0 && binding.mtime_ns == 0) {
+        return false;
+    }
+    llvm::sys::fs::file_status status;
+    if(llvm::sys::fs::status(path, status)) {
+        return false;
+    }
+    return status.getSize() == binding.size && fs::mtime_ns(status) == binding.mtime_ns &&
+           status.getUniqueID().getDevice() == binding.uid_device &&
+           status.getUniqueID().getFile() == binding.uid_file;
+}
+
+bool binding_content_matches(llvm::StringRef path, const BlobBinding& binding) {
+    auto bytes = llvm::MemoryBuffer::getFile(path);
+    return bytes && llvm::xxh3_64bits((*bytes)->getBuffer()) == binding.hash;
+}
+
+std::uint64_t CacheStore::mark_writer_dirty() {
+    std::lock_guard guard(state->mutex);
+    state->writer_marks += 1;
+    if(!state->writer_marked && !state->read_only) {
+        auto marker = path::join(state->tmp_dir, "dirty");
+        if(auto result = fs::write(marker, "1"); !result) {
+            LOG_WARN("CacheStore: cannot write dirty marker {}: {}",
+                     marker,
+                     result.error().message());
+        } else {
+            // Durable before the publication it covers, or a crash between
+            // the rename and the marker reaching disk goes unnoticed.
+            if(auto ec = sync_file(marker)) {
+                LOG_WARN("CacheStore: cannot sync dirty marker {}: {}", marker, ec.message());
+            }
+            state->writer_marked = true;
+        }
+    }
+    return state->writer_marks;
+}
+
+void CacheStore::clear_writer_dirty(std::uint64_t upto) {
+    std::lock_guard guard(state->mutex);
+    if(!state->writer_marked || state->writer_marks != upto) {
+        return;
+    }
+    llvm::sys::fs::remove(path::join(state->tmp_dir, "dirty"));
+    state->writer_marked = false;
+}
+
+std::uint64_t CacheStore::writer_mark_count() const {
+    std::lock_guard guard(state->mutex);
+    return state->writer_marks;
+}
+
+bool CacheStore::dead_writer_dirty() const {
+    return state->dead_dirty;
 }
 
 void CacheStore::PendingEntry::remove_tmp() {
@@ -968,6 +1097,11 @@ void CacheStore::shutdown() {
     }
     state->checkpoint_locked();
 
+    // The dirty marker dies with the tmp directory, deliberately: an
+    // orderly exit means every commit's bytes were fsynced whole, so the
+    // byte-level damage the marker's verify mode exists for cannot have
+    // happened — and metadata a failed final save left behind mismatches
+    // its blobs' stat bindings, which reads as a plain miss.
     fs::remove_all(state->tmp_dir);
     for(auto& [name, ns_state]: state->namespaces) {
         if(ns_state.config.policy == CachePolicy::Scratch) {

--- a/src/support/cache_store.cpp
+++ b/src/support/cache_store.cpp
@@ -405,6 +405,16 @@ std::expected<CacheStore, std::error_code> CacheStore::open(llvm::StringRef root
     sweep_dead_pid_dirs(tmp_parent, state->self_pid);
 
     state->tmp_dir = path::join(tmp_parent, std::to_string(state->self_pid));
+    // This process has not written a marker yet, so one under its own pid
+    // is a crashed predecessor that recycled the pid — the scan above
+    // skipped it and the removal below would silently launder its debt.
+    if(llvm::sys::fs::exists(path::join(state->tmp_dir, "dirty"))) {
+        LOG_WARN(
+            "CacheStore: a previous instance reusing pid {} died with unflushed "
+            "blob metadata; verifying adopted records against blob content",
+            state->self_pid);
+        state->dead_dirty = true;
+    }
     fs::remove_all(state->tmp_dir);
     if(auto ec2 = llvm::sys::fs::create_directories(state->tmp_dir)) {
         return std::unexpected(ec2);
@@ -702,6 +712,7 @@ std::expected<std::string, std::error_code> CacheStore::commit(PendingEntry pend
     // Scratch blobs are cheap derivatives with no durability requirement;
     // they skip the fsync.
     bool durable;
+    bool deferred_metadata;
     {
         std::lock_guard guard(state->mutex);
         auto* ns_state = state->find_namespace(pending.ns);
@@ -709,6 +720,7 @@ std::expected<std::string, std::error_code> CacheStore::commit(PendingEntry pend
             return std::unexpected(std::make_error_code(std::errc::invalid_argument));
         }
         durable = ns_state->config.policy != CachePolicy::Scratch;
+        deferred_metadata = ns_state->config.deferred_metadata;
     }
 
     // fsync outside the lock so lookups are not blocked behind disk flushes.
@@ -720,7 +732,9 @@ std::expected<std::string, std::error_code> CacheStore::commit(PendingEntry pend
         // The marker must be durable before the blob becomes visible: a
         // crash right after the rename must read as "published without a
         // metadata barrier".
-        mark_writer_dirty();
+        if(deferred_metadata) {
+            mark_writer_dirty();
+        }
     }
 
     std::string final_path;
@@ -860,11 +874,14 @@ std::uint64_t CacheStore::mark_writer_dirty() {
                      result.error().message());
         } else {
             // Durable before the publication it covers, or a crash between
-            // the rename and the marker reaching disk goes unnoticed.
+            // the rename and the marker reaching disk goes unnoticed. An
+            // unsynced marker may not survive that crash, so failure here
+            // leaves the latch unset and the next commit retries.
             if(auto ec = sync_file(marker)) {
                 LOG_WARN("CacheStore: cannot sync dirty marker {}: {}", marker, ec.message());
+            } else {
+                state->writer_marked = true;
             }
-            state->writer_marked = true;
         }
     }
     return state->writer_marks;

--- a/src/support/cache_store.cpp
+++ b/src/support/cache_store.cpp
@@ -31,8 +31,8 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Process.h"
-#include "llvm/Support/xxhash.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/xxhash.h"
 
 namespace clice {
 
@@ -394,9 +394,10 @@ std::expected<CacheStore, std::error_code> CacheStore::open(llvm::StringRef root
                 continue;
             }
             if(llvm::sys::fs::exists(path::join(it->path(), "dirty"))) {
-                LOG_WARN("CacheStore: instance {} died with unflushed blob metadata; "
-                         "verifying adopted records against blob content",
-                         pid);
+                LOG_WARN(
+                    "CacheStore: instance {} died with unflushed blob metadata; "
+                    "verifying adopted records against blob content",
+                    pid);
                 state->dead_dirty = true;
             }
         }

--- a/src/support/cache_store.h
+++ b/src/support/cache_store.h
@@ -50,6 +50,13 @@ struct CacheNamespace {
     /// Size budget for LRU namespaces; 0 means unlimited.
     /// Ignored for Persistent and Scratch.
     std::uint64_t max_bytes = 0;
+
+    /// The blobs' validity metadata lives outside this store (the index
+    /// database's artifacts blob) and is flushed after the fact: commits
+    /// here raise the writer-dirty marker until that metadata is durable.
+    /// Self-describing namespaces (the index database's own files) leave
+    /// it unset, or the marker could never clear while they keep writing.
+    bool deferred_metadata = false;
 };
 
 /// The identity of one committed blob, captured while the bytes were still

--- a/src/support/cache_store.h
+++ b/src/support/cache_store.h
@@ -19,10 +19,6 @@ enum class CachePolicy : std::uint8_t {
     /// artifacts (PCH, PCM).
     LRU,
 
-    /// Never evicted automatically, only via explicit invalidate():
-    /// data that is expensive to accumulate (index).
-    Persistent,
-
     /// Per-instance working files: not tracked in the manifest, not part
     /// of LRU.  Stored under a pid subdirectory; directories of dead pids
     /// are cleaned up when the namespace is registered.
@@ -48,7 +44,7 @@ struct CacheNamespace {
     CachePolicy policy = CachePolicy::LRU;
 
     /// Size budget for LRU namespaces; 0 means unlimited.
-    /// Ignored for Persistent and Scratch.
+    /// Ignored for Scratch.
     std::uint64_t max_bytes = 0;
 };
 
@@ -82,7 +78,7 @@ struct CacheNamespace {
 /// On-disk layout under `{root}/cache/v{version}/`:
 ///   manifest.json        last-accessed checkpoint (not a source of truth)
 ///   tmp/{pid}/           in-flight writes of one live instance
-///   {ns}/{key}{ext}      committed blobs (LRU / Persistent)
+///   {ns}/{key}{ext}      committed blobs (LRU)
 ///   {ns}/{pid}/{key}{ext}  Scratch blobs of one live instance
 ///
 /// A blob is complete iff it exists at its final path (atomic rename); the
@@ -218,13 +214,9 @@ public:
     /// new blob still cannot be published an error is returned.
     std::expected<std::string, std::error_code> commit(PendingEntry pending);
 
-    /// Remove a blob.  Primarily for Persistent namespaces, whose cleanup
-    /// is the caller's mark-and-sweep; LRU namespaces rarely need it.
+    /// Remove a blob before the LRU budget would get to it — retraction of
+    /// an artifact the owner has judged unusable (corrupt, invalidated).
     void invalidate(llvm::StringRef ns, llvm::StringRef key);
-
-    /// Enumerate all keys in a namespace (for caller-side mark-and-sweep).
-    /// Iterates over a snapshot, so fn may call back into the store.
-    void for_each_key(llvm::StringRef ns, llvm::function_ref<void(llvm::StringRef)> fn);
 
     /// Number of in-flight tmp blobs of this instance (files under
     /// `tmp/{pid}`). A settled server has zero: every PendingEntry either
@@ -252,13 +244,6 @@ public:
 
     /// Whether the store was opened in read-only inspection mode.
     bool read_only() const;
-
-    /// First namespace directory scan that failed since open (default
-    /// error_code when none did).  A failed scan makes the namespace look
-    /// empty while its blobs exist, so a reader that would report "no
-    /// data" must check this first.  A read-only open of a namespace that
-    /// was never created scans empty legitimately and is not a failure.
-    std::error_code scan_error() const;
 
     /// Atomically persist the manifest (key sizes and last-accessed times)
     /// if anything changed.  Also runs automatically every few commits;

--- a/src/support/cache_store.h
+++ b/src/support/cache_store.h
@@ -50,41 +50,7 @@ struct CacheNamespace {
     /// Size budget for LRU namespaces; 0 means unlimited.
     /// Ignored for Persistent and Scratch.
     std::uint64_t max_bytes = 0;
-
-    /// The blobs' validity metadata lives outside this store (the index
-    /// database's artifacts blob) and is flushed after the fact: commits
-    /// here raise the writer-dirty marker until that metadata is durable.
-    /// Self-describing namespaces (the index database's own files) leave
-    /// it unset, or the marker could never clear while they keep writing.
-    bool deferred_metadata = false;
 };
-
-/// The identity of one committed blob, captured while the bytes were still
-/// private (the tmp file, before the publishing rename — capturing from
-/// the final path would race a concurrent replacer of the same key). The
-/// rename preserves inode and mtime, so the values stay true afterwards:
-/// the stat triple is a cheap per-use freshness check, and — since every
-/// commit is a fresh tmp file — the UniqueID changes whenever the blob is
-/// republished, making it a free generation token that same-size same-tick
-/// rewrites cannot forge. `hash` (xxh3 of the bytes) is the deep anchor
-/// for whole-read consumers and post-crash verification.
-struct BlobBinding {
-    std::uint64_t size = 0;
-    std::int64_t mtime_ns = 0;
-    std::uint64_t uid_device = 0;
-    std::uint64_t uid_file = 0;
-    std::uint64_t hash = 0;
-};
-
-/// Whether the file at `path` still carries the binding's stat identity
-/// (size, mtime, UniqueID) — the cheap per-use check that the blob was not
-/// republished since the record was made. A zeroed binding (record from
-/// before the blob existed) never matches.
-bool binding_stat_matches(llvm::StringRef path, const BlobBinding& binding);
-
-/// Whether the file's bytes hash to the binding's. Reads the whole file;
-/// used for post-crash verification and whole-read consumers.
-bool binding_content_matches(llvm::StringRef path, const BlobBinding& binding);
 
 /// Content-addressed blob store with atomic writes, crash recovery and
 /// per-namespace lifecycle policies.
@@ -95,6 +61,23 @@ bool binding_content_matches(llvm::StringRef path, const BlobBinding& binding);
 /// filename-safe strings constructed by the caller (project convention:
 /// hex of llvm::xxh3_128bits, optionally with a readable prefix).
 /// Dependency tracking and staleness decisions are the caller's job.
+///
+/// FIXME: Whether several processes (a server plus a batch `clice lint`)
+/// may share one store read-write — and how blob metadata stays truthful
+/// if they do — is an undecided design question this layer does not
+/// answer. The exposure: PCH/PCM keys are not fully content-addressed (a
+/// dependency edit changes the bytes but not the key), and their validity
+/// metadata is flushed debounced by the owner, so a crash before the
+/// flush — or a concurrent writer republishing a key mid-session — can
+/// leave metadata that validates against its deps while describing bytes
+/// it never saw; clang's own PCH/PCM validation is the backstop. An
+/// earlier revision pinned each record to its blob's identity (size,
+/// mtime, UniqueID and xxh3, captured from the tmp file before the
+/// publishing rename) and revalidated it on every use, with per-writer
+/// durable dirty markers latching content-verification debt across
+/// crashes; it was backed out of PR #650 to keep the scope on the file
+/// table until the concurrency model is decided — see that PR's history
+/// to resurrect it.
 ///
 /// On-disk layout under `{root}/cache/v{version}/`:
 ///   manifest.json        last-accessed checkpoint (not a source of truth)
@@ -180,14 +163,9 @@ public:
     /// an older layout version) is live on must survive being inspected.
     /// Fails with `no_such_file_or_directory` when the versioned directory
     /// does not exist; only lookups and enumeration may be used.
-    /// `adopt_writer_debt` says this session can discharge a dead writer's
-    /// verification debt (it persists artifact metadata). A session that
-    /// cannot (read-only index database) still verifies adopted records
-    /// itself but hands the marker on at shutdown instead of clearing it.
     static std::expected<CacheStore, std::error_code> open(llvm::StringRef root,
                                                            std::uint32_t version,
-                                                           bool read_only = false,
-                                                           bool adopt_writer_debt = true);
+                                                           bool read_only = false);
 
     /// Drop self-ignore markers into `root` (created if missing): a
     /// `.gitignore` and a CACHEDIR.TAG. Sessions call this right after
@@ -238,36 +216,7 @@ public:
     /// is kept only when verified byte-identical to the new one; otherwise
     /// the stale destination is removed and the rename retried, and if the
     /// new blob still cannot be published an error is returned.
-    ///
-    /// `binding`, when set, receives the committed blob's identity (see
-    /// BlobBinding) — read and stat'ed from the tmp file before the
-    /// rename, or from the byte-identical survivor of a benign collision.
-    /// Durable commits also drop this writer's dirty marker first (see
-    /// mark_writer_dirty).
-    std::expected<std::string, std::error_code> commit(PendingEntry pending,
-                                                       BlobBinding* binding = nullptr);
-
-    /// Persist a durable "this writer has published blobs whose metadata
-    /// may not have reached the database yet" marker in this instance's
-    /// tmp directory, before the publication it covers. Cleared by
-    /// clear_writer_dirty once the metadata barrier completes; a crash in
-    /// between leaves the marker for the next open() to find. Returns the
-    /// mark count (see clear_writer_dirty).
-    std::uint64_t mark_writer_dirty();
-
-    /// Drop the dirty marker — but only when no publication happened since
-    /// the caller observed mark count `upto`: a blob committed while the
-    /// metadata barrier was in flight is not covered by it.
-    void clear_writer_dirty(std::uint64_t upto);
-
-    /// Marks issued so far (monotonic); pair with clear_writer_dirty.
-    std::uint64_t writer_mark_count() const;
-
-    /// Whether open() found the dirty marker of a dead writer: that
-    /// session crashed between publishing blobs and persisting their
-    /// metadata, so records adopted from the database must verify their
-    /// blob's content hash on first use.
-    bool dead_writer_dirty() const;
+    std::expected<std::string, std::error_code> commit(PendingEntry pending);
 
     /// Remove a blob.  Primarily for Persistent namespaces, whose cleanup
     /// is the caller's mark-and-sweep; LRU namespaces rarely need it.

--- a/src/support/cache_store.h
+++ b/src/support/cache_store.h
@@ -158,7 +158,7 @@ public:
     /// is created, swept or discarded — a store another process (possibly
     /// an older layout version) is live on must survive being inspected.
     /// Fails with `no_such_file_or_directory` when the versioned directory
-    /// does not exist; only lookups and enumeration may be used.
+    /// does not exist; only lookups may be used.
     static std::expected<CacheStore, std::error_code> open(llvm::StringRef root,
                                                            std::uint32_t version,
                                                            bool read_only = false);

--- a/src/support/cache_store.h
+++ b/src/support/cache_store.h
@@ -52,6 +52,33 @@ struct CacheNamespace {
     std::uint64_t max_bytes = 0;
 };
 
+/// The identity of one committed blob, captured while the bytes were still
+/// private (the tmp file, before the publishing rename — capturing from
+/// the final path would race a concurrent replacer of the same key). The
+/// rename preserves inode and mtime, so the values stay true afterwards:
+/// the stat triple is a cheap per-use freshness check, and — since every
+/// commit is a fresh tmp file — the UniqueID changes whenever the blob is
+/// republished, making it a free generation token that same-size same-tick
+/// rewrites cannot forge. `hash` (xxh3 of the bytes) is the deep anchor
+/// for whole-read consumers and post-crash verification.
+struct BlobBinding {
+    std::uint64_t size = 0;
+    std::int64_t mtime_ns = 0;
+    std::uint64_t uid_device = 0;
+    std::uint64_t uid_file = 0;
+    std::uint64_t hash = 0;
+};
+
+/// Whether the file at `path` still carries the binding's stat identity
+/// (size, mtime, UniqueID) — the cheap per-use check that the blob was not
+/// republished since the record was made. A zeroed binding (record from
+/// before the blob existed) never matches.
+bool binding_stat_matches(llvm::StringRef path, const BlobBinding& binding);
+
+/// Whether the file's bytes hash to the binding's. Reads the whole file;
+/// used for post-crash verification and whole-read consumers.
+bool binding_content_matches(llvm::StringRef path, const BlobBinding& binding);
+
 /// Content-addressed blob store with atomic writes, crash recovery and
 /// per-namespace lifecycle policies.
 ///
@@ -199,7 +226,36 @@ public:
     /// is kept only when verified byte-identical to the new one; otherwise
     /// the stale destination is removed and the rename retried, and if the
     /// new blob still cannot be published an error is returned.
-    std::expected<std::string, std::error_code> commit(PendingEntry pending);
+    ///
+    /// `binding`, when set, receives the committed blob's identity (see
+    /// BlobBinding) — read and stat'ed from the tmp file before the
+    /// rename, or from the byte-identical survivor of a benign collision.
+    /// Durable commits also drop this writer's dirty marker first (see
+    /// mark_writer_dirty).
+    std::expected<std::string, std::error_code> commit(PendingEntry pending,
+                                                       BlobBinding* binding = nullptr);
+
+    /// Persist a durable "this writer has published blobs whose metadata
+    /// may not have reached the database yet" marker in this instance's
+    /// tmp directory, before the publication it covers. Cleared by
+    /// clear_writer_dirty once the metadata barrier completes; a crash in
+    /// between leaves the marker for the next open() to find. Returns the
+    /// mark count (see clear_writer_dirty).
+    std::uint64_t mark_writer_dirty();
+
+    /// Drop the dirty marker — but only when no publication happened since
+    /// the caller observed mark count `upto`: a blob committed while the
+    /// metadata barrier was in flight is not covered by it.
+    void clear_writer_dirty(std::uint64_t upto);
+
+    /// Marks issued so far (monotonic); pair with clear_writer_dirty.
+    std::uint64_t writer_mark_count() const;
+
+    /// Whether open() found the dirty marker of a dead writer: that
+    /// session crashed between publishing blobs and persisting their
+    /// metadata, so records adopted from the database must verify their
+    /// blob's content hash on first use.
+    bool dead_writer_dirty() const;
 
     /// Remove a blob.  Primarily for Persistent namespaces, whose cleanup
     /// is the caller's mark-and-sweep; LRU namespaces rarely need it.

--- a/src/support/cache_store.h
+++ b/src/support/cache_store.h
@@ -180,9 +180,14 @@ public:
     /// an older layout version) is live on must survive being inspected.
     /// Fails with `no_such_file_or_directory` when the versioned directory
     /// does not exist; only lookups and enumeration may be used.
+    /// `adopt_writer_debt` says this session can discharge a dead writer's
+    /// verification debt (it persists artifact metadata). A session that
+    /// cannot (read-only index database) still verifies adopted records
+    /// itself but hands the marker on at shutdown instead of clearing it.
     static std::expected<CacheStore, std::error_code> open(llvm::StringRef root,
                                                            std::uint32_t version,
-                                                           bool read_only = false);
+                                                           bool read_only = false,
+                                                           bool adopt_writer_debt = true);
 
     /// Drop self-ignore markers into `root` (created if missing): a
     /// `.gitignore` and a CACHEDIR.TAG. Sessions call this right after

--- a/src/support/filesystem.h
+++ b/src/support/filesystem.h
@@ -110,6 +110,17 @@ inline std::int64_t mtime_ns(const llvm::sys::fs::file_status& status) {
 /// hash comparison instead.
 constexpr inline std::int64_t mtime_guard_ns = 2'000'000'000;
 
+/// Whether the filesystem's UniqueID identifies a file rather than a
+/// path. Windows file IDs are not file-stable everywhere (ReFS dev
+/// drives report path-derived values, and handle- and path-derived
+/// stats of one file can disagree), so identity-based staleness
+/// defenses are POSIX-only.
+#ifdef _WIN32
+constexpr inline bool stable_file_ids = false;
+#else
+constexpr inline bool stable_file_ids = true;
+#endif
+
 /// The newest mtime (ns) a file may carry and still be provably untouched
 /// since the reference moment `at_ms` (a build start, or "now" for
 /// content read on the spot).

--- a/src/syntax/completion.cpp
+++ b/src/syntax/completion.cpp
@@ -65,9 +65,8 @@ PreambleCompletionContext detect_completion_context(llvm::StringRef text, std::u
     return {CompletionContext::Import, prefix.str()};
 }
 
-std::vector<std::string>
-    complete_module_import(const llvm::DenseMap<std::uint32_t, std::string>& modules,
-                           llvm::StringRef prefix) {
+std::vector<std::string> complete_module_import(const llvm::DenseMap<Fid, std::string>& modules,
+                                                llvm::StringRef prefix) {
     std::vector<std::string> results;
     // FIXME: exclude the current file's own module name from results
     // (self-import is never valid). Needs the requesting path_id passed in.

--- a/src/syntax/completion.h
+++ b/src/syntax/completion.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 
+#include "vfs/file_table.h"
+
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringRef.h"
 
@@ -33,9 +35,8 @@ PreambleCompletionContext detect_completion_context(llvm::StringRef text, std::u
 /// Return module names matching a prefix, suitable for `import` completion.
 /// @param modules  Module name map (path_id → module name).
 /// @param prefix   Partially-typed module name to match against.
-std::vector<std::string>
-    complete_module_import(const llvm::DenseMap<std::uint32_t, std::string>& modules,
-                           llvm::StringRef prefix);
+std::vector<std::string> complete_module_import(const llvm::DenseMap<Fid, std::string>& modules,
+                                                llvm::StringRef prefix);
 
 /// Entry in the include path completion result.
 struct IncludeCandidate {

--- a/src/syntax/dependency_graph.cpp
+++ b/src/syntax/dependency_graph.cpp
@@ -22,14 +22,14 @@ namespace clice {
 
 // DependencyGraph implementation
 
-void DependencyGraph::add_module(llvm::StringRef module_name, std::uint32_t path_id) {
+void DependencyGraph::add_module(llvm::StringRef module_name, Fid path_id) {
     auto& ids = module_to_path[module_name];
     if(llvm::find(ids, path_id) == ids.end()) {
         ids.push_back(path_id);
     }
 }
 
-void DependencyGraph::update_module_decl(std::uint32_t path_id, llvm::StringRef module_name) {
+void DependencyGraph::update_module_decl(Fid path_id, llvm::StringRef module_name) {
     // Re-declaring the unchanged name is a no-op: providers are selected
     // by list order, so an erase-and-append would silently reselect
     // among a duplicated name's providers without any cascade.
@@ -46,7 +46,7 @@ void DependencyGraph::update_module_decl(std::uint32_t path_id, llvm::StringRef 
     }
 }
 
-llvm::ArrayRef<std::uint32_t> DependencyGraph::lookup_module(llvm::StringRef module_name) const {
+llvm::ArrayRef<Fid> DependencyGraph::lookup_module(llvm::StringRef module_name) const {
     auto it = module_to_path.find(module_name);
     if(it != module_to_path.end()) {
         return it->second;
@@ -54,19 +54,19 @@ llvm::ArrayRef<std::uint32_t> DependencyGraph::lookup_module(llvm::StringRef mod
     return {};
 }
 
-void DependencyGraph::set_includes(std::uint32_t path_id,
+void DependencyGraph::set_includes(Fid path_id,
                                    std::uint32_t config_id,
-                                   llvm::SmallVector<std::uint32_t> included_ids) {
+                                   llvm::SmallVector<IncludeEdge> included) {
     IncludeKey key{path_id, config_id};
-    includes[key] = std::move(included_ids);
+    includes[key] = std::move(included);
     auto& configs = file_configs[path_id];
     if(std::find(configs.begin(), configs.end(), config_id) == configs.end()) {
         configs.push_back(config_id);
     }
 }
 
-llvm::ArrayRef<std::uint32_t> DependencyGraph::get_includes(std::uint32_t path_id,
-                                                            std::uint32_t config_id) const {
+llvm::ArrayRef<IncludeEdge> DependencyGraph::get_includes(Fid path_id,
+                                                          std::uint32_t config_id) const {
     auto it = includes.find(IncludeKey{path_id, config_id});
     if(it != includes.end()) {
         return it->second;
@@ -74,9 +74,9 @@ llvm::ArrayRef<std::uint32_t> DependencyGraph::get_includes(std::uint32_t path_i
     return {};
 }
 
-llvm::SmallVector<std::uint32_t> DependencyGraph::get_all_includes(std::uint32_t path_id) const {
-    llvm::DenseMap<std::uint32_t, std::size_t> seen;  // raw_id -> index in result
-    llvm::SmallVector<std::uint32_t> result;
+llvm::SmallVector<Fid> DependencyGraph::get_all_includes(Fid path_id) const {
+    llvm::DenseSet<Fid> seen;
+    llvm::SmallVector<Fid> result;
 
     auto fc_it = file_configs.find(path_id);
     if(fc_it == file_configs.end()) {
@@ -86,14 +86,9 @@ llvm::SmallVector<std::uint32_t> DependencyGraph::get_all_includes(std::uint32_t
     for(auto config_id: fc_it->second) {
         auto it = includes.find(IncludeKey{path_id, config_id});
         if(it != includes.end()) {
-            for(auto id: it->second) {
-                auto raw_id = id & PATH_ID_MASK;
-                auto [sit, inserted] = seen.try_emplace(raw_id, result.size());
-                if(inserted) {
-                    result.push_back(id);
-                } else if(!(id & CONDITIONAL_FLAG)) {
-                    // Unconditional include wins over conditional.
-                    result[sit->second] = raw_id;
+            for(auto edge: it->second) {
+                if(seen.insert(edge.fid).second) {
+                    result.push_back(edge.fid);
                 }
             }
         }
@@ -101,8 +96,8 @@ llvm::SmallVector<std::uint32_t> DependencyGraph::get_all_includes(std::uint32_t
     return result;
 }
 
-llvm::SmallVector<std::uint32_t> DependencyGraph::all_files() const {
-    llvm::SmallVector<std::uint32_t> files;
+llvm::SmallVector<Fid> DependencyGraph::all_files() const {
+    llvm::SmallVector<Fid> files;
     files.reserve(file_configs.size() + reverse_includes.size());
     for(auto& [path_id, configs]: file_configs) {
         files.push_back(path_id);
@@ -131,7 +126,7 @@ std::size_t DependencyGraph::edge_count() const {
     return count;
 }
 
-void DependencyGraph::clear_includes(std::uint32_t path_id) {
+void DependencyGraph::clear_includes(Fid path_id) {
     llvm::SmallVector<IncludeKey> stale;
     for(auto& [key, ids]: includes) {
         if(key.path_id == path_id) {
@@ -147,9 +142,8 @@ void DependencyGraph::clear_includes(std::uint32_t path_id) {
 void DependencyGraph::build_reverse_map() {
     reverse_includes.clear();
     for(auto& [key, ids]: includes) {
-        for(auto flagged_id: ids) {
-            auto included_id = flagged_id & PATH_ID_MASK;
-            auto& vec = reverse_includes[included_id];
+        for(auto edge: ids) {
+            auto& vec = reverse_includes[edge.fid];
             if(llvm::find(vec, key.path_id) == vec.end()) {
                 vec.push_back(key.path_id);
             }
@@ -157,7 +151,7 @@ void DependencyGraph::build_reverse_map() {
     }
 }
 
-llvm::ArrayRef<std::uint32_t> DependencyGraph::get_includers(std::uint32_t path_id) const {
+llvm::ArrayRef<Fid> DependencyGraph::get_includers(Fid path_id) const {
     auto it = reverse_includes.find(path_id);
     if(it != reverse_includes.end()) {
         return it->second;
@@ -165,11 +159,10 @@ llvm::ArrayRef<std::uint32_t> DependencyGraph::get_includers(std::uint32_t path_
     return {};
 }
 
-llvm::SmallVector<std::uint32_t, 4>
-    DependencyGraph::find_host_sources(std::uint32_t header_path_id) const {
-    llvm::SmallVector<std::uint32_t, 4> result;
-    llvm::DenseSet<std::uint32_t> visited;
-    llvm::SmallVector<std::uint32_t, 16> queue;
+llvm::SmallVector<Fid, 4> DependencyGraph::find_host_sources(Fid header_path_id) const {
+    llvm::SmallVector<Fid, 4> result;
+    llvm::DenseSet<Fid> visited;
+    llvm::SmallVector<Fid, 16> queue;
 
     queue.push_back(header_path_id);
     visited.insert(header_path_id);
@@ -195,26 +188,23 @@ llvm::SmallVector<std::uint32_t, 4>
     return result;
 }
 
-std::vector<std::uint32_t> DependencyGraph::find_include_chain(std::uint32_t host_path_id,
-                                                               std::uint32_t target_path_id) const {
+std::vector<Fid> DependencyGraph::find_include_chain(Fid host_path_id, Fid target_path_id) const {
     if(host_path_id == target_path_id) {
         return {host_path_id};
     }
 
     // BFS: predecessor map for path reconstruction.
-    llvm::DenseMap<std::uint32_t, std::uint32_t> prev;
-    llvm::SmallVector<std::uint32_t, 16> queue;
+    llvm::DenseMap<Fid, Fid> prev;
+    llvm::SmallVector<Fid, 16> queue;
 
     prev[host_path_id] = host_path_id;
     queue.push_back(host_path_id);
 
     bool found = false;
     while(!queue.empty() && !found) {
-        llvm::SmallVector<std::uint32_t, 16> next_queue;
+        llvm::SmallVector<Fid, 16> next_queue;
         for(auto current: queue) {
-            auto includes_union = get_all_includes(current);
-            for(auto flagged_id: includes_union) {
-                auto child = flagged_id & PATH_ID_MASK;
+            for(auto child: get_all_includes(current)) {
                 if(prev.find(child) == prev.end()) {
                     prev[child] = current;
                     if(child == target_path_id) {
@@ -236,7 +226,7 @@ std::vector<std::uint32_t> DependencyGraph::find_include_chain(std::uint32_t hos
     }
 
     // Reconstruct path from target back to host.
-    std::vector<std::uint32_t> chain;
+    std::vector<Fid> chain;
     auto node = target_path_id;
     while(node != host_path_id) {
         chain.push_back(node);
@@ -254,7 +244,7 @@ namespace {
 /// Result of scanning a single file (returned from worker thread).
 struct FileScanResult {
     const char* path;  // Stable pointer from FileTable.
-    std::uint32_t path_id;
+    Fid path_id;
     std::uint32_t config_id;
     ScanResult scan_result;
     /// Same-source {stat, hash} of the bytes scanned — the cold-start
@@ -281,7 +271,7 @@ std::uint64_t hash_rendered_command(llvm::ArrayRef<const char*> rendered) {
 /// Scan a single file: read content + lexer scan.
 /// Runs on libuv worker thread via queue().
 /// @param path  Stable pointer from FileTable (must outlive the task).
-FileScanResult scan_file_worker(const char* path, std::uint32_t path_id, std::uint32_t config_id) {
+FileScanResult scan_file_worker(const char* path, Fid path_id, std::uint32_t config_id) {
     FileScanResult result;
     result.path = path;
     result.path_id = path_id;
@@ -310,7 +300,8 @@ FileScanResult scan_file_worker(const char* path, std::uint32_t path_id, std::ui
 /// scanned files resolves once; the memo dies with the scan, so it can
 /// never serve a stale filesystem.
 struct CachedInclude {
-    std::uint32_t path_id;
+    /// Invalid = the include is known-unresolvable under this config.
+    Fid path_id;
     unsigned found_dir_idx;
 };
 
@@ -464,9 +455,9 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
         LOG_INFO("Launched {} dir cache tasks (running in background)", pending_dir_tasks.size());
     }
 
-    // Track which files have been scanned (by path_id — cheaper than string hash).
+    // Track which files have been scanned (by fid — cheaper than string hash).
     // Value: found_dir_idx needed for #include_next.
-    llvm::DenseMap<std::uint32_t, unsigned> scanned_files;
+    llvm::DenseMap<Fid, unsigned> scanned_files;
 
     // Wave 0: all source files from CDB (entry file ids are pool ids).
     // Re-use the cached initial_wave when available.
@@ -490,7 +481,7 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
     // the read and the lex for every unchanged file, at the cost of one
     // stat. Recorded at discovery so the prefetch never races the check.
     std::vector<FileScanResult> pending_warm;
-    auto try_warm = [&](std::uint32_t path_id, std::uint32_t config_id) {
+    auto try_warm = [&](Fid path_id, std::uint32_t config_id) {
         auto path = file_table.resolve(path_id);
         llvm::sys::fs::file_status status;
         if(llvm::sys::fs::status(path, status)) {
@@ -540,7 +531,7 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
         std::vector<FileScanResult> scan_results = std::move(pending_warm);
         pending_warm.clear();
         std::size_t wave_cache_hits = scan_results.size();
-        llvm::DenseSet<std::uint32_t> settled;
+        llvm::DenseSet<Fid> settled;
         for(auto& r: scan_results) {
             settled.insert(r.path_id);
         }
@@ -750,8 +741,8 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
 
             report.includes_found += scan_result.scan_result.includes.size();
 
-            llvm::SmallVector<std::uint32_t> include_ids;
-            include_ids.reserve(scan_result.scan_result.includes.size());
+            llvm::SmallVector<IncludeEdge> include_edges;
+            include_edges.reserve(scan_result.scan_result.includes.size());
 
             for(auto& inc: scan_result.scan_result.includes) {
                 // For angled includes, resolution depends only on config (not includer dir).
@@ -768,7 +759,7 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                     if(cache_it != include_cache.end()) {
                         report.include_cache_hits++;
                         auto& cached = cache_it->second;
-                        if(cached.path_id == UINT32_MAX) {
+                        if(!cached.path_id.valid()) {
                             report.unresolved.push_back({
                                 std::move(inc.path),
                                 std::string(file_table.resolve(scan_result.path_id)),
@@ -778,16 +769,13 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                             continue;
                         }
                         report.includes_resolved++;
-                        // Jump directly to edge building with cached path_id.
-                        std::uint32_t flagged_id = cached.path_id;
                         if(inc.conditional) {
-                            flagged_id |= DependencyGraph::CONDITIONAL_FLAG;
                             report.conditional_edges++;
                         } else {
                             report.unconditional_edges++;
                         }
                         report.total_edges++;
-                        include_ids.push_back(flagged_id);
+                        include_edges.push_back({cached.path_id, inc.conditional});
                         if(scanned_files.try_emplace(cached.path_id, cached.found_dir_idx).second) {
                             next_wave.push_back(
                                 {cached.path_id, scan_result.config_id, cached.found_dir_idx});
@@ -811,7 +799,7 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                     std::chrono::duration_cast<std::chrono::microseconds>(r_t1 - r_t0).count();
                 if(!resolved.has_value()) {
                     if(cache_eligible) {
-                        include_cache.try_emplace(cache_key, CachedInclude{UINT32_MAX, 0});
+                        include_cache.try_emplace(cache_key, CachedInclude{{}, 0});
                     }
                     report.unresolved.push_back({
                         std::move(inc.path),
@@ -830,15 +818,13 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                                               CachedInclude{inc_path_id, resolved->found_dir_idx});
                 }
 
-                std::uint32_t flagged_id = inc_path_id;
                 if(inc.conditional) {
-                    flagged_id |= DependencyGraph::CONDITIONAL_FLAG;
                     report.conditional_edges++;
                 } else {
                     report.unconditional_edges++;
                 }
                 report.total_edges++;
-                include_ids.push_back(flagged_id);
+                include_edges.push_back({inc_path_id, inc.conditional});
 
                 if(scanned_files.try_emplace(inc_path_id, resolved->found_dir_idx).second) {
                     next_wave.push_back(
@@ -857,7 +843,9 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                 }
             }
 
-            graph.set_includes(scan_result.path_id, scan_result.config_id, std::move(include_ids));
+            graph.set_includes(scan_result.path_id,
+                               scan_result.config_id,
+                               std::move(include_edges));
         }
 
         report.dir_listings += wave_stat_counters.dir_listings;

--- a/src/syntax/dependency_graph.cpp
+++ b/src/syntax/dependency_graph.cpp
@@ -9,6 +9,8 @@
 #include "syntax/scan.h"
 #include "vfs/file_table.h"
 
+#include "llvm/Support/xxhash.h"
+
 #include "kota/async/async.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringSet.h"
@@ -264,6 +266,19 @@ struct FileScanResult {
     std::int64_t scan_us = 0;
 };
 
+/// Semantic identity of a rendered compile command, for keying
+/// configuration-dependent derivations (the module-decl backfill): dense
+/// config ids are CDB-local and unstable across reloads, the flags
+/// themselves are the meaning.
+std::uint64_t hash_rendered_command(llvm::ArrayRef<const char*> rendered) {
+    llvm::SmallString<512> joined;
+    for(auto* arg: rendered) {
+        joined.append(arg);
+        joined.push_back('\0');
+    }
+    return llvm::xxh3_64bits(joined);
+}
+
 /// Scan a single file: read content + lexer scan.
 /// Runs on libuv worker thread via queue().
 /// @param path  Stable pointer from FileTable (must outlive the task).
@@ -291,25 +306,25 @@ FileScanResult scan_file_worker(const char* path, std::uint32_t path_id, std::ui
     return result;
 }
 
+/// Per-scan angled-include resolution memo: (config_id bytes + header)
+/// -> {path_id, found_dir_idx}. A repeated angled include across the
+/// scanned files resolves once; the memo dies with the scan, so it can
+/// never serve a stale filesystem.
+struct CachedInclude {
+    std::uint32_t path_id;
+    unsigned found_dir_idx;
+};
+
 /// The async scan implementation that runs on a local event loop.
 kota::task<> scan_impl(CompilationDatabase& cdb,
                        DependencyGraph& graph,
                        ScanReport& report,
-                       ScanCache* ext_cache,
                        kota::event_loop& loop,
                        const RuleMatcher& rule_matcher) {
     auto& file_table = cdb.files();
     auto start_time = std::chrono::steady_clock::now();
 
-    // On warm runs (ext_cache populated from a previous scan), skip the expensive
-    // config extraction and wave-0 construction entirely.
-    const bool have_config_cache =
-        ext_cache && !ext_cache->configs.empty() && !ext_cache->initial_wave.empty();
-
-    // Use persistent cache storage when available, otherwise local temporaries.
-    llvm::DenseMap<std::uint32_t, SearchConfig> local_configs;
-    llvm::DenseMap<std::uint32_t, SearchConfig>& configs =
-        ext_cache ? ext_cache->configs : local_configs;
+    llvm::DenseMap<std::uint32_t, SearchConfig> configs;
 
     auto config_start = std::chrono::steady_clock::now();
 
@@ -344,13 +359,11 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
             if(inserted) {
                 group_refs.push_back({entry.file, applied, input, CommandSource::CDBExact});
             }
-            if(!have_config_cache) {
-                wave0.push_back({entry.file, it->second, /*found_dir_idx=*/0});
-            }
+            wave0.push_back({entry.file, it->second, /*found_dir_idx=*/0});
         }
     }
 
-    if(!have_config_cache) {
+    {
         // Pre-warm the toolchain cache: probes key by non-user-content
         // flags, so groups differing only in -D/-I collapse to the same
         // probe — N groups often yield just 1-2 subprocess calls.
@@ -378,13 +391,8 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
     report.config_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(config_end - config_start).count();
 
-    // Use external persistent cache when provided, otherwise create a local one.
-    DirListingCache local_dir_cache;
-    DirListingCache& dir_cache = ext_cache ? ext_cache->dir_cache : local_dir_cache;
-
-    llvm::StringMap<ScanCache::CachedInclude> local_include_cache;
-    llvm::StringMap<ScanCache::CachedInclude>& include_cache =
-        ext_cache ? ext_cache->include_cache : local_include_cache;
+    DirListingCache dir_cache;
+    llvm::StringMap<CachedInclude> include_cache;
 
     // Collect all unique search dirs and launch readdir tasks on the
     // thread pool.  Tasks start executing immediately but are NOT awaited
@@ -440,15 +448,7 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
 
     // Wave 0: all source files from CDB (entry file ids are pool ids).
     // Re-use the cached initial_wave when available.
-    std::vector<WaveEntry> current_wave;
-    if(have_config_cache) {
-        current_wave = ext_cache->initial_wave;
-    } else {
-        current_wave = std::move(wave0);
-        if(ext_cache) {
-            ext_cache->initial_wave = current_wave;
-        }
-    }
+    std::vector<WaveEntry> current_wave = std::move(wave0);
     for(auto& entry: current_wave) {
         scanned_files.try_emplace(entry.path_id, entry.found_dir_idx);
     }
@@ -463,6 +463,38 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
     // of the Phase 1 wait time for subsequent waves.
     std::vector<kota::task<FileScanResult, kota::error>> prefetch_tasks;
 
+    // Warm path through the shared table: a live stat the shared pair can
+    // vouch for pins the bytes' cached lexical scan — a rescan then skips
+    // the read and the lex for every unchanged file, at the cost of one
+    // stat. Recorded at discovery so the prefetch never races the check.
+    std::vector<FileScanResult> pending_warm;
+    auto try_warm = [&](std::uint32_t path_id, std::uint32_t config_id) {
+        auto path = file_table.resolve(path_id);
+        llvm::sys::fs::file_status status;
+        if(llvm::sys::fs::status(path, status)) {
+            return false;
+        }
+        auto size = status.getSize();
+        auto mtime_ns = fs::mtime_ns(status);
+        auto hash = file_table.cached_hash(path_id, size, mtime_ns);
+        if(!hash) {
+            return false;
+        }
+        auto it = file_table.scan_results.find({path_id, *hash});
+        if(it == file_table.scan_results.end()) {
+            return false;
+        }
+        pending_warm.push_back(
+            {.path = path.data(),
+             .path_id = path_id,
+             .config_id = config_id,
+             .scan_result = it->second,
+             .obs = {.size = size, .mtime_ns = mtime_ns, .hash = *hash, .paired = true,
+                     .reliable = true}});
+        report.scan_cache_hits++;
+        return true;
+    };
+
     // Pre-resolved search configs: built once after dir cache is populated,
     // then reused for all waves.  Eliminates StringMap lookups in Phase 2.
     llvm::DenseMap<std::uint32_t, ResolvedSearchConfig> resolved_configs;
@@ -474,26 +506,14 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
         // Files with a cached ScanResult skip I/O and lexing entirely.
         // For waves > 0, files discovered during the previous wave's Phase 2
         // already have running scan tasks in prefetch_tasks.
-        std::vector<FileScanResult> scan_results;
-        scan_results.reserve(current_wave.size());
-        std::size_t wave_cache_hits = 0;
-
-        // Collect cache hits first (applies to all waves).
-        for(auto& entry: current_wave) {
-            if(ext_cache) {
-                auto it = ext_cache->scan_results.find(entry.path_id);
-                if(it != ext_cache->scan_results.end()) {
-                    scan_results.push_back({file_table.resolve(entry.path_id).data(),
-                                            entry.path_id,
-                                            entry.config_id,
-                                            it->second,
-                                            false,
-                                            0,
-                                            0});
-                    report.scan_cache_hits++;
-                    wave_cache_hits++;
-                }
-            }
+        // Warm results recorded at discovery come first; waves 1+ own
+        // prefetch tasks for everything else.
+        std::vector<FileScanResult> scan_results = std::move(pending_warm);
+        pending_warm.clear();
+        std::size_t wave_cache_hits = scan_results.size();
+        llvm::DenseSet<std::uint32_t> settled;
+        for(auto& r: scan_results) {
+            settled.insert(r.path_id);
         }
 
         if(!prefetch_tasks.empty()) {
@@ -507,21 +527,19 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
             for(auto& r: *scan_outcome) {
                 if(!r.read_failed) {
                     file_table.observe(r.path_id, r.obs);
-                    if(ext_cache) {
-                        ext_cache->scan_results.try_emplace(r.path_id, r.scan_result);
-                    }
+                    file_table.scan_results.try_emplace({r.path_id, r.obs.hash}, r.scan_result);
                 }
                 scan_results.push_back(std::move(r));
             }
         } else {
-            // Wave 0 (or warm run with all cache hits): create scan tasks now.
+            // Wave 0 (or a wave whose discoveries were all warm): probe the
+            // warm path and create scan tasks for the rest now.
             std::vector<kota::task<FileScanResult, kota::error>> scan_tasks;
             scan_tasks.reserve(current_wave.size());
             for(auto& entry: current_wave) {
                 auto pid = entry.path_id;
                 auto cid = entry.config_id;
-                // Skip files already served from cache above.
-                if(ext_cache && ext_cache->scan_results.count(pid)) {
+                if(settled.contains(pid) || try_warm(pid, cid)) {
                     continue;
                 }
                 auto path = file_table.resolve(pid).data();
@@ -529,6 +547,9 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                     kota::queue([path, pid, cid]() { return scan_file_worker(path, pid, cid); },
                                 loop));
             }
+            wave_cache_hits += pending_warm.size();
+            std::move(pending_warm.begin(), pending_warm.end(), std::back_inserter(scan_results));
+            pending_warm.clear();
 
             // Optimization 1: await dir cache tasks concurrently with scan tasks.
             // Both sets of tasks run on the same thread pool.  By awaiting dir
@@ -558,9 +579,8 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                 for(auto& r: *scan_outcome) {
                     if(!r.read_failed) {
                         file_table.observe(r.path_id, r.obs);
-                        if(ext_cache) {
-                            ext_cache->scan_results.try_emplace(r.path_id, r.scan_result);
-                        }
+                        file_table.scan_results.try_emplace({r.path_id, r.obs.hash},
+                                                            r.scan_result);
                     }
                     scan_results.push_back(std::move(r));
                 }
@@ -648,24 +668,47 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                         input = cdb.input_kind(applied, file_path);
                     }
                     CommandRef ref{entry.file, applied, input, CommandSource::CDBExact};
-                    auto fallback = scan_module_decl(cdb.render(ref),
-                                                     cdb.config(ref.config).directory,
-                                                     /*content=*/{});
-                    if(!fallback.module_name.empty()) {
-                        scan_result.scan_result.module_name = std::move(fallback.module_name);
-                        scan_result.scan_result.is_interface_unit = fallback.is_interface_unit;
-                        // Update cache so warm runs don't re-trigger the
-                        // fallback — single-candidate files only: the cache
-                        // holds one result per path, and a multi-group
-                        // file's groups may resolve different names, so its
-                        // units must re-derive on every run.
-                        if(ext_cache && candidates.size() == 1) {
-                            auto cache_it = ext_cache->scan_results.find(scan_result.path_id);
-                            if(cache_it != ext_cache->scan_results.end()) {
-                                cache_it->second.module_name = scan_result.scan_result.module_name;
-                                cache_it->second.is_interface_unit =
-                                    scan_result.scan_result.is_interface_unit;
-                                cache_it->second.need_preprocess = false;
+                    auto rendered = cdb.render(ref);
+                    auto config_hash = hash_rendered_command(rendered);
+                    auto cached = file_table.module_decls.find(
+                        {scan_result.obs.hash, config_hash});
+                    if(cached != file_table.module_decls.end()) {
+                        if(!cached->second.name.empty()) {
+                            scan_result.scan_result.module_name = cached->second.name;
+                            scan_result.scan_result.is_interface_unit =
+                                cached->second.is_interface_unit;
+                        }
+                    } else if(auto observed = read_file_observed(scan_result.path)) {
+                        // The preprocessor must consume the bytes that
+                        // produced this scan. When the disk moved under the
+                        // scan, the whole result is rebuilt from the bytes
+                        // actually read — includes and module name out of
+                        // one version, never a chimera of two.
+                        if(observed->obs.hash != scan_result.obs.hash) {
+                            file_table.observe(scan_result.path_id, observed->obs);
+                            scan_result.scan_result =
+                                scan_quick(observed->content->getBuffer());
+                            scan_result.obs = observed->obs;
+                            file_table.scan_results.try_emplace(
+                                {scan_result.path_id, observed->obs.hash},
+                                scan_result.scan_result);
+                        }
+                        if(scan_result.scan_result.need_preprocess) {
+                            auto fallback =
+                                scan_module_decl(rendered,
+                                                 cdb.config(ref.config).directory,
+                                                 observed->content->getBuffer());
+                            // Negative results memoize too: preprocessing the
+                            // same bytes under the same flags again cannot
+                            // resolve differently.
+                            file_table.module_decls[{scan_result.obs.hash, config_hash}] = {
+                                fallback.module_name,
+                                fallback.is_interface_unit};
+                            if(!fallback.module_name.empty()) {
+                                scan_result.scan_result.module_name =
+                                    std::move(fallback.module_name);
+                                scan_result.scan_result.is_interface_unit =
+                                    fallback.is_interface_unit;
                             }
                         }
                     }
@@ -741,7 +784,7 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                 if(!resolved.has_value()) {
                     if(cache_eligible) {
                         include_cache.try_emplace(cache_key,
-                                                  ScanCache::CachedInclude{UINT32_MAX, 0});
+                                                  CachedInclude{UINT32_MAX, 0});
                     }
                     report.unresolved.push_back({
                         std::move(inc.path),
@@ -758,7 +801,7 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                 if(cache_eligible) {
                     include_cache.try_emplace(
                         cache_key,
-                        ScanCache::CachedInclude{inc_path_id, resolved->found_dir_idx});
+                        CachedInclude{inc_path_id, resolved->found_dir_idx});
                 }
 
                 std::uint32_t flagged_id = inc_path_id;
@@ -775,9 +818,9 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                     next_wave.push_back(
                         {inc_path_id, scan_result.config_id, resolved->found_dir_idx});
                     // Prefetch: start scanning this file immediately on the
-                    // thread pool so it's ready when the next wave begins.
-                    if(!ext_cache ||
-                       ext_cache->scan_results.find(inc_path_id) == ext_cache->scan_results.end()) {
+                    // thread pool so it's ready when the next wave begins —
+                    // unless the shared table already pins its scan.
+                    if(!try_warm(inc_path_id, scan_result.config_id)) {
                         auto inc_path = file_table.resolve(inc_path_id).data();
                         prefetch_tasks.push_back(kota::queue(
                             [inc_path, inc_path_id, cid = scan_result.config_id]() {
@@ -851,7 +894,6 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
 
 ScanReport scan_dependency_graph(CompilationDatabase& cdb,
                                  DependencyGraph& graph,
-                                 ScanCache* cache,
                                  const RuleMatcher& rule_matcher) {
     ScanReport report;
     if(cdb.entries().empty()) {
@@ -859,7 +901,7 @@ ScanReport scan_dependency_graph(CompilationDatabase& cdb,
     }
 
     kota::event_loop loop;
-    loop.schedule(scan_impl(cdb, graph, report, cache, loop, rule_matcher));
+    loop.schedule(scan_impl(cdb, graph, report, loop, rule_matcher));
     loop.run();
     return report;
 }

--- a/src/syntax/dependency_graph.cpp
+++ b/src/syntax/dependency_graph.cpp
@@ -7,6 +7,7 @@
 #include "support/logging.h"
 #include "syntax/include_resolver.h"
 #include "syntax/scan.h"
+#include "vfs/file_table.h"
 
 #include "kota/async/async.h"
 #include "llvm/ADT/DenseSet.h"
@@ -255,6 +256,9 @@ struct FileScanResult {
     std::uint32_t path_id;
     std::uint32_t config_id;
     ScanResult scan_result;
+    /// Same-source {stat, hash} of the bytes scanned — the cold-start
+    /// read doubles as the workspace's first disk observation.
+    DiskObservation obs;
     bool read_failed = false;
     std::int64_t read_us = 0;
     std::int64_t scan_us = 0;
@@ -270,24 +274,17 @@ FileScanResult scan_file_worker(const char* path, std::uint32_t path_id, std::ui
     result.config_id = config_id;
 
     auto t0 = std::chrono::steady_clock::now();
-    // Force read() instead of mmap: RequiresNullTerminator=true makes LLVM
-    // fall back to read() for page-aligned files, and IsVolatile=true forces
-    // read() unconditionally — bypassing mmap entirely.  This separates
-    // actual I/O cost from page-fault cost that was previously hidden inside
-    // the lexer timing.
-    auto buf = llvm::MemoryBuffer::getFile(result.path,
-                                           /*FileSize=*/-1,
-                                           /*RequiresNullTerminator=*/true,
-                                           /*IsVolatile=*/true);
+    auto observed = read_file_observed(path);
     auto t1 = std::chrono::steady_clock::now();
     result.read_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
 
-    if(!buf) {
+    if(!observed) {
         result.read_failed = true;
         return result;
     }
+    result.obs = observed->obs;
 
-    result.scan_result = scan_quick((*buf)->getBuffer());
+    result.scan_result = scan_quick(observed->content->getBuffer());
     auto t2 = std::chrono::steady_clock::now();
     result.scan_us = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
 
@@ -508,8 +505,11 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                 break;
             }
             for(auto& r: *scan_outcome) {
-                if(!r.read_failed && ext_cache) {
-                    ext_cache->scan_results.try_emplace(r.path_id, r.scan_result);
+                if(!r.read_failed) {
+                    file_table.observe(r.path_id, r.obs);
+                    if(ext_cache) {
+                        ext_cache->scan_results.try_emplace(r.path_id, r.scan_result);
+                    }
                 }
                 scan_results.push_back(std::move(r));
             }
@@ -556,8 +556,11 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                     break;
                 }
                 for(auto& r: *scan_outcome) {
-                    if(!r.read_failed && ext_cache) {
-                        ext_cache->scan_results.try_emplace(r.path_id, r.scan_result);
+                    if(!r.read_failed) {
+                        file_table.observe(r.path_id, r.obs);
+                        if(ext_cache) {
+                            ext_cache->scan_results.try_emplace(r.path_id, r.scan_result);
+                        }
                     }
                     scan_results.push_back(std::move(r));
                 }

--- a/src/syntax/dependency_graph.cpp
+++ b/src/syntax/dependency_graph.cpp
@@ -445,9 +445,10 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                     for(; !ec && di != llvm::sys::fs::directory_iterator(); di.increment(ec)) {
                         result.entries.insert(llvm::sys::path::filename(di->path()));
                     }
-                    // Same pre/post-stat + guard discipline as resolve_dir.
+                    // Same pre/post-stat + guard + complete-readdir
+                    // discipline as resolve_dir.
                     llvm::sys::fs::file_status post_status;
-                    if(pre_ok && !llvm::sys::fs::status(result.dir_path, post_status) &&
+                    if(pre_ok && !ec && !llvm::sys::fs::status(result.dir_path, post_status) &&
                        fs::mtime_ns(pre_status) == fs::mtime_ns(post_status)) {
                         auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                                           std::chrono::system_clock::now().time_since_epoch())

--- a/src/syntax/dependency_graph.cpp
+++ b/src/syntax/dependency_graph.cpp
@@ -392,6 +392,7 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
         std::chrono::duration_cast<std::chrono::milliseconds>(config_end - config_start).count();
 
     DirListingCache dir_cache;
+    dir_cache.shared = &file_table;
     llvm::StringMap<CachedInclude> include_cache;
 
     // Collect all unique search dirs and launch readdir tasks on the
@@ -403,11 +404,12 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
     struct DirEntry {
         std::string dir_path;
         llvm::StringSet<> entries;
+        std::int64_t reliable_mtime = 0;
     };
 
     std::vector<kota::task<DirEntry, kota::error>> pending_dir_tasks;
 
-    if(dir_cache.dirs.empty()) {
+    {
         llvm::StringSet<> unique_dirs;
         for(auto& [config_id, config]: configs) {
             for(auto& dir: config.dirs) {
@@ -425,15 +427,35 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
 
         pending_dir_tasks.reserve(unique_dirs.size());
         for(auto& entry: unique_dirs) {
+            // A listing the shared compartment can still vouch for skips
+            // the readdir; its one validation stat happens lazily at first
+            // use.
+            auto cached = file_table.dir_listings.find(entry.getKey());
+            if(cached != file_table.dir_listings.end() && cached->second.mtime_ns != 0) {
+                continue;
+            }
             auto dir_path = entry.getKey().str();
             pending_dir_tasks.push_back(kota::queue(
                 [dir_path = std::move(dir_path)]() -> DirEntry {
                     DirEntry result;
                     result.dir_path = dir_path;
+                    llvm::sys::fs::file_status pre_status;
+                    bool pre_ok = !llvm::sys::fs::status(result.dir_path, pre_status);
                     std::error_code ec;
                     llvm::sys::fs::directory_iterator di(result.dir_path, ec);
                     for(; !ec && di != llvm::sys::fs::directory_iterator(); di.increment(ec)) {
                         result.entries.insert(llvm::sys::path::filename(di->path()));
+                    }
+                    // Same pre/post-stat + guard discipline as resolve_dir.
+                    llvm::sys::fs::file_status post_status;
+                    if(pre_ok && !llvm::sys::fs::status(result.dir_path, post_status) &&
+                       fs::mtime_ns(pre_status) == fs::mtime_ns(post_status)) {
+                        auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                          std::chrono::system_clock::now().time_since_epoch())
+                                          .count();
+                        if(fs::mtime_ns(post_status) <= fs::stat_baseline_before_ns(now_ms)) {
+                            result.reliable_mtime = fs::mtime_ns(post_status);
+                        }
                     }
                     return result;
                 },
@@ -561,7 +583,10 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                 pending_dir_tasks.clear();
                 if(dir_outcome.has_value()) {
                     for(auto& entry: *dir_outcome) {
-                        dir_cache.dirs.try_emplace(entry.dir_path, std::move(entry.entries));
+                        auto& listing = file_table.dir_listings[entry.dir_path];
+                        listing.entries = std::move(entry.entries);
+                        listing.mtime_ns = entry.reliable_mtime;
+                        dir_cache.validated.insert(entry.dir_path);
                     }
                     LOG_INFO("Pre-populated dir cache: {} directories", dir_outcome->size());
                 }

--- a/src/syntax/dependency_graph.cpp
+++ b/src/syntax/dependency_graph.cpp
@@ -251,7 +251,7 @@ namespace {
 
 /// Result of scanning a single file (returned from worker thread).
 struct FileScanResult {
-    const char* path;  // Stable pointer from PathPool.
+    const char* path;  // Stable pointer from FileTable.
     std::uint32_t path_id;
     std::uint32_t config_id;
     ScanResult scan_result;
@@ -262,7 +262,7 @@ struct FileScanResult {
 
 /// Scan a single file: read content + lexer scan.
 /// Runs on libuv worker thread via queue().
-/// @param path  Stable pointer from PathPool (must outlive the task).
+/// @param path  Stable pointer from FileTable (must outlive the task).
 FileScanResult scan_file_worker(const char* path, std::uint32_t path_id, std::uint32_t config_id) {
     FileScanResult result;
     result.path = path;
@@ -301,7 +301,7 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                        ScanCache* ext_cache,
                        kota::event_loop& loop,
                        const RuleMatcher& rule_matcher) {
-    auto& path_pool = cdb.paths();
+    auto& file_table = cdb.files();
     auto start_time = std::chrono::steady_clock::now();
 
     // On warm runs (ext_cache populated from a previous scan), skip the expensive
@@ -330,7 +330,7 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
     {
         llvm::DenseMap<std::pair<std::uint32_t, const char*>, std::uint32_t> group_ids;
         for(auto& entry: cdb.entries()) {
-            auto file_path = path_pool.resolve(entry.file);
+            auto file_path = file_table.resolve(entry.file);
 
             // Apply per-file rules so that [[rules]]-modified -I/-isystem/-std
             // flags are reflected in the search config used by the scan.
@@ -411,7 +411,7 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
         }
         // Also prefetch parent directories of source files (for quoted include resolution).
         for(auto& entry: cdb.entries()) {
-            auto file_path = path_pool.resolve(entry.file);
+            auto file_path = file_table.resolve(entry.file);
             auto dir = llvm::sys::path::parent_path(file_path);
             if(!dir.empty()) {
                 unique_dirs.insert(dir);
@@ -486,7 +486,7 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
             if(ext_cache) {
                 auto it = ext_cache->scan_results.find(entry.path_id);
                 if(it != ext_cache->scan_results.end()) {
-                    scan_results.push_back({path_pool.resolve(entry.path_id).data(),
+                    scan_results.push_back({file_table.resolve(entry.path_id).data(),
                                             entry.path_id,
                                             entry.config_id,
                                             it->second,
@@ -524,7 +524,7 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                 if(ext_cache && ext_cache->scan_results.count(pid)) {
                     continue;
                 }
-                auto path = path_pool.resolve(pid).data();
+                auto path = file_table.resolve(pid).data();
                 scan_tasks.push_back(
                     kota::queue([path, pid, cid]() { return scan_file_worker(path, pid, cid); },
                                 loop));
@@ -697,7 +697,7 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                         if(cached.path_id == UINT32_MAX) {
                             report.unresolved.push_back({
                                 std::move(inc.path),
-                                std::string(path_pool.resolve(scan_result.path_id)),
+                                std::string(file_table.resolve(scan_result.path_id)),
                                 inc.is_angled,
                                 inc.conditional,
                             });
@@ -742,14 +742,14 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                     }
                     report.unresolved.push_back({
                         std::move(inc.path),
-                        std::string(path_pool.resolve(scan_result.path_id)),
+                        std::string(file_table.resolve(scan_result.path_id)),
                         inc.is_angled,
                         inc.conditional,
                     });
                     continue;
                 }
 
-                auto inc_path_id = path_pool.intern(resolved->path);
+                auto inc_path_id = file_table.intern(resolved->path);
                 report.includes_resolved++;
 
                 if(cache_eligible) {
@@ -775,7 +775,7 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                     // thread pool so it's ready when the next wave begins.
                     if(!ext_cache ||
                        ext_cache->scan_results.find(inc_path_id) == ext_cache->scan_results.end()) {
-                        auto inc_path = path_pool.resolve(inc_path_id).data();
+                        auto inc_path = file_table.resolve(inc_path_id).data();
                         prefetch_tasks.push_back(kota::queue(
                             [inc_path, inc_path_id, cid = scan_result.config_id]() {
                                 return scan_file_worker(inc_path, inc_path_id, cid);

--- a/src/syntax/dependency_graph.cpp
+++ b/src/syntax/dependency_graph.cpp
@@ -9,8 +9,6 @@
 #include "syntax/scan.h"
 #include "vfs/file_table.h"
 
-#include "llvm/Support/xxhash.h"
-
 #include "kota/async/async.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringSet.h"
@@ -18,6 +16,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/StringSaver.h"
+#include "llvm/Support/xxhash.h"
 
 namespace clice {
 
@@ -498,7 +497,8 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
         }
         auto size = status.getSize();
         auto mtime_ns = fs::mtime_ns(status);
-        auto hash = file_table.cached_hash(path_id, size, mtime_ns);
+        auto uid = status.getUniqueID();
+        auto hash = file_table.cached_hash(path_id, size, mtime_ns, uid.getDevice(), uid.getFile());
         if(!hash) {
             return false;
         }
@@ -506,13 +506,19 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
         if(it == file_table.scan_results.end()) {
             return false;
         }
-        pending_warm.push_back(
-            {.path = path.data(),
-             .path_id = path_id,
-             .config_id = config_id,
-             .scan_result = it->second,
-             .obs = {.size = size, .mtime_ns = mtime_ns, .hash = *hash, .paired = true,
-                     .reliable = true}});
+        pending_warm.push_back({
+            .path = path.data(),
+            .path_id = path_id,
+            .config_id = config_id,
+            .scan_result = it->second,
+            .obs = {.size = size,
+                    .mtime_ns = mtime_ns,
+                    .hash = *hash,
+                    .uid_device = uid.getDevice(),
+                    .uid_file = uid.getFile(),
+                    .paired = true,
+                    .reliable = true}
+        });
         report.scan_cache_hits++;
         return true;
     };
@@ -604,8 +610,7 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                 for(auto& r: *scan_outcome) {
                     if(!r.read_failed) {
                         file_table.observe(r.path_id, r.obs);
-                        file_table.scan_results.try_emplace({r.path_id, r.obs.hash},
-                                                            r.scan_result);
+                        file_table.scan_results.try_emplace({r.path_id, r.obs.hash}, r.scan_result);
                     }
                     scan_results.push_back(std::move(r));
                 }
@@ -695,8 +700,7 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                     CommandRef ref{entry.file, applied, input, CommandSource::CDBExact};
                     auto rendered = cdb.render(ref);
                     auto config_hash = hash_rendered_command(rendered);
-                    auto cached = file_table.module_decls.find(
-                        {scan_result.obs.hash, config_hash});
+                    auto cached = file_table.module_decls.find({scan_result.obs.hash, config_hash});
                     if(cached != file_table.module_decls.end()) {
                         if(!cached->second.name.empty()) {
                             scan_result.scan_result.module_name = cached->second.name;
@@ -711,18 +715,16 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                         // one version, never a chimera of two.
                         if(observed->obs.hash != scan_result.obs.hash) {
                             file_table.observe(scan_result.path_id, observed->obs);
-                            scan_result.scan_result =
-                                scan_quick(observed->content->getBuffer());
+                            scan_result.scan_result = scan_quick(observed->content->getBuffer());
                             scan_result.obs = observed->obs;
                             file_table.scan_results.try_emplace(
                                 {scan_result.path_id, observed->obs.hash},
                                 scan_result.scan_result);
                         }
                         if(scan_result.scan_result.need_preprocess) {
-                            auto fallback =
-                                scan_module_decl(rendered,
-                                                 cdb.config(ref.config).directory,
-                                                 observed->content->getBuffer());
+                            auto fallback = scan_module_decl(rendered,
+                                                             cdb.config(ref.config).directory,
+                                                             observed->content->getBuffer());
                             // Negative results memoize too: preprocessing the
                             // same bytes under the same flags again cannot
                             // resolve differently.
@@ -808,8 +810,7 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                     std::chrono::duration_cast<std::chrono::microseconds>(r_t1 - r_t0).count();
                 if(!resolved.has_value()) {
                     if(cache_eligible) {
-                        include_cache.try_emplace(cache_key,
-                                                  CachedInclude{UINT32_MAX, 0});
+                        include_cache.try_emplace(cache_key, CachedInclude{UINT32_MAX, 0});
                     }
                     report.unresolved.push_back({
                         std::move(inc.path),
@@ -824,9 +825,8 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
                 report.includes_resolved++;
 
                 if(cache_eligible) {
-                    include_cache.try_emplace(
-                        cache_key,
-                        CachedInclude{inc_path_id, resolved->found_dir_idx});
+                    include_cache.try_emplace(cache_key,
+                                              CachedInclude{inc_path_id, resolved->found_dir_idx});
                 }
 
                 std::uint32_t flagged_id = inc_path_id;

--- a/src/syntax/dependency_graph.h
+++ b/src/syntax/dependency_graph.h
@@ -6,9 +6,9 @@
 #include <vector>
 
 #include "command/command.h"
-#include "vfs/file_table.h"
 #include "syntax/include_resolver.h"
 #include "syntax/scan.h"
+#include "vfs/file_table.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"

--- a/src/syntax/dependency_graph.h
+++ b/src/syntax/dependency_graph.h
@@ -240,51 +240,6 @@ struct ScanReport {
     std::vector<UnresolvedInclude> unresolved;
 };
 
-/// Persistent cache that can be reused across successive scan calls.
-/// Holding onto this between incremental re-scans eliminates repeated
-/// readdir() calls, angled-include resolution, and file I/O on warm runs.
-///
-/// Thread safety: not thread-safe; callers must serialise scan calls.
-///
-/// Invalidation: callers must clear (or discard) this cache whenever the
-/// compilation database or filesystem state changes.
-///
-/// TODO: add a generation counter or single invalidate() method to prevent
-/// partial clearing from causing inconsistency between inter-dependent fields.
-struct ScanCache {
-    /// Directory listing cache: dir path → set of filenames.
-    DirListingCache dir_cache;
-
-    /// Angled-include resolution cache: (config_id bytes + header) → {path_id, found_dir_idx}.
-    /// path_id values are valid only for the FileTable used during the scan
-    /// that populated this cache.  If FileTable is reset between scans, clear
-    /// this cache too (or pass nullptr to scan_dependency_graph).
-    struct CachedInclude {
-        std::uint32_t path_id;
-        unsigned found_dir_idx;
-    };
-
-    llvm::StringMap<CachedInclude> include_cache;
-
-    /// Lexer scan result cache: path_id → ScanResult.
-    /// Populated on the first scan of each file.  On subsequent calls the
-    /// worker-thread file read and lexer scan are skipped entirely, making
-    /// warm-run Phase 1 effectively free.
-    /// Invalidate per-entry when a file changes on disk.
-    llvm::DenseMap<std::uint32_t, ScanResult> scan_results;
-
-    // Populated during the first scan and reused on all subsequent calls
-    // when the compilation database has not changed.
-
-    /// Per-config search configuration, keyed by dense config_id.
-    /// Each config_id corresponds to one unique CDB CompilationInfo group —
-    /// files with identical (directory, canonical flags, user-content flags).
-    llvm::DenseMap<std::uint32_t, SearchConfig> configs;
-
-    /// Pre-built initial wave (wave 0): all source files with their config IDs.
-    std::vector<WaveEntry> initial_wave;
-};
-
 /// Callback for per-file rule-based flag modification. Given a file path,
 /// populates `append`/`remove` with rule-configured arguments so they can be
 /// layered on top of the CDB command when extracting the search config.
@@ -295,17 +250,12 @@ using RuleMatcher = std::function<
 /// Internally creates a local event loop for async I/O (file reads via worker
 /// thread pool, stat calls via libuv). Blocks until the scan is complete.
 ///
-/// @param cache  Optional persistent cache. When non-null and pre-populated,
-///               avoids repeated readdir() and include-resolution work across
-///               successive calls.  FileTable must NOT be reset between calls
-///               when a persistent cache is used (path_id values must remain stable).
 /// @param rule_matcher  Optional callback applied per context group so that
 ///               `[[rules]]`-modified include/std flags are reflected in the
 ///               dependency graph (otherwise rule-affected files would have
 ///               stale resolution).
 ScanReport scan_dependency_graph(CompilationDatabase& cdb,
                                  DependencyGraph& graph,
-                                 ScanCache* cache = nullptr,
                                  const RuleMatcher& rule_matcher = {});
 
 }  // namespace clice

--- a/src/syntax/dependency_graph.h
+++ b/src/syntax/dependency_graph.h
@@ -19,17 +19,18 @@
 
 namespace clice {
 
+/// One include edge: the included file and whether the directive sits
+/// inside a preprocessor conditional (#if/#ifdef).
+struct IncludeEdge {
+    Fid fid;
+    bool conditional = false;
+};
+
 class DependencyGraph {
 public:
-    /// Conditional flag: bit 31 marks an include inside #ifdef/#if.
-    constexpr static std::uint32_t CONDITIONAL_FLAG = 0x80000000u;
-
-    /// Mask to extract the actual PathID from a flagged value.
-    constexpr static std::uint32_t PATH_ID_MASK = 0x7FFFFFFFu;
-
     /// Key for per-(file, SearchConfig) include storage.
     struct IncludeKey {
-        std::uint32_t path_id;
+        Fid path_id;
         std::uint32_t config_id;
 
         bool operator==(const IncludeKey&) const = default;
@@ -37,16 +38,16 @@ public:
 
     struct IncludeKeyInfo {
         static IncludeKey getEmptyKey() {
-            return {~0u, ~0u};
+            return {Fid{~0u}, ~0u};
         }
 
         static IncludeKey getTombstoneKey() {
-            return {~0u - 1, ~0u - 1};
+            return {Fid{~0u - 1}, ~0u - 1};
         }
 
         static unsigned getHashValue(const IncludeKey& key) {
             return llvm::DenseMapInfo<std::uint64_t>::getHashValue(
-                (std::uint64_t(key.path_id) << 32) | key.config_id);
+                (std::uint64_t(key.path_id.raw) << 32) | key.config_id);
         }
 
         static bool isEqual(const IncludeKey& lhs, const IncludeKey& rhs) {
@@ -54,56 +55,54 @@ public:
         }
     };
 
-    /// Register a module interface unit: module name -> PathID.
-    void add_module(llvm::StringRef module_name, std::uint32_t path_id);
+    /// Register a module interface unit: module name -> fid.
+    void add_module(llvm::StringRef module_name, Fid path_id);
 
     /// Re-register a file's module declaration after a save: the file
     /// leaves whatever module it declared before and, when `module_name`
     /// is non-empty, provides that one — so imports resolved between two
     /// full scans see the declaration the disk actually holds.
-    void update_module_decl(std::uint32_t path_id, llvm::StringRef module_name);
+    void update_module_decl(Fid path_id, llvm::StringRef module_name);
 
-    /// Look up all PathIDs that provide a given module (may have multiple candidates).
-    llvm::ArrayRef<std::uint32_t> lookup_module(llvm::StringRef module_name) const;
+    /// Look up all fids that provide a given module (may have multiple candidates).
+    llvm::ArrayRef<Fid> lookup_module(llvm::StringRef module_name) const;
 
     /// Set the direct include list for a (file, config) pair.
-    void set_includes(std::uint32_t path_id,
+    void set_includes(Fid path_id,
                       std::uint32_t config_id,
-                      llvm::SmallVector<std::uint32_t> included_ids);
+                      llvm::SmallVector<IncludeEdge> included);
 
     /// Get direct includes for a specific (file, config) pair.
-    llvm::ArrayRef<std::uint32_t> get_includes(std::uint32_t path_id,
-                                               std::uint32_t config_id) const;
+    llvm::ArrayRef<IncludeEdge> get_includes(Fid path_id, std::uint32_t config_id) const;
 
-    /// Get the union of includes across all configs for a file.
-    llvm::SmallVector<std::uint32_t> get_all_includes(std::uint32_t path_id) const;
+    /// Get the union of included fids across all configs for a file.
+    llvm::SmallVector<Fid> get_all_includes(Fid path_id) const;
 
     /// Erase every config's include list for a file. Incremental didSave
     /// rescans clear first, then re-add one list per configuration.
-    void clear_includes(std::uint32_t path_id);
+    void clear_includes(Fid path_id);
 
     /// Build the reverse include map from the forward includes.
     /// Must be called after all set_includes() calls are complete.
     void build_reverse_map();
 
     /// Get the direct includers of a file (files that directly include path_id).
-    llvm::ArrayRef<std::uint32_t> get_includers(std::uint32_t path_id) const;
+    llvm::ArrayRef<Fid> get_includers(Fid path_id) const;
 
     /// BFS upward through reverse edges to find all source files (roots)
     /// that transitively include header_path_id.
     /// Source files are those that have no includers (i.e. they are roots in the graph).
-    llvm::SmallVector<std::uint32_t, 4> find_host_sources(std::uint32_t header_path_id) const;
+    llvm::SmallVector<Fid, 4> find_host_sources(Fid header_path_id) const;
 
     /// BFS forward through include edges to find the shortest include chain
     /// from host_path_id to target_path_id.
     /// Returns [host, intermediate1, ..., target], or empty if no path exists.
-    std::vector<std::uint32_t> find_include_chain(std::uint32_t host_path_id,
-                                                  std::uint32_t target_path_id) const;
+    std::vector<Fid> find_include_chain(Fid host_path_id, Fid target_path_id) const;
 
     /// Every file the graph knows: files with include entries plus files
     /// that only appear as include targets. Sorted so callers scan in a
     /// deterministic order. Requires build_reverse_map() to be current.
-    llvm::SmallVector<std::uint32_t> all_files() const;
+    llvm::SmallVector<Fid> all_files() const;
 
     /// Number of files with include entries.
     std::size_t file_count() const;
@@ -114,8 +113,8 @@ public:
     /// Total number of include edges across all (file, config) pairs.
     std::size_t edge_count() const;
 
-    /// Access the module name -> PathID mapping.
-    const llvm::StringMap<llvm::SmallVector<std::uint32_t, 2>>& modules() const {
+    /// Access the module name -> fid mapping.
+    const llvm::StringMap<llvm::SmallVector<Fid, 2>>& modules() const {
         return module_to_path;
     }
 
@@ -124,7 +123,7 @@ public:
     /// set means module code exists somewhere: the scan gates treat the
     /// whole project as modular from that point, because per-file
     /// reachability approximations have irreducible blind spots.
-    void set_import_candidate(std::uint32_t path_id, bool has_import) {
+    void set_import_candidate(Fid path_id, bool has_import) {
         if(has_import) {
             import_candidates.insert(path_id);
         } else {
@@ -132,32 +131,31 @@ public:
         }
     }
 
-    const llvm::DenseSet<std::uint32_t>& import_candidate_files() const {
+    const llvm::DenseSet<Fid>& import_candidate_files() const {
         return import_candidates;
     }
 
 private:
-    /// Module name -> PathIDs (multiple candidates possible, e.g. different targets).
-    llvm::StringMap<llvm::SmallVector<std::uint32_t, 2>> module_to_path;
+    /// Module name -> fids (multiple candidates possible, e.g. different targets).
+    llvm::StringMap<llvm::SmallVector<Fid, 2>> module_to_path;
 
     /// See set_import_candidate().
-    llvm::DenseSet<std::uint32_t> import_candidates;
+    llvm::DenseSet<Fid> import_candidates;
 
-    /// (PathID, ConfigID) -> list of directly included PathIDs.
-    /// Each PathID may have bit 31 set to indicate conditional include.
-    llvm::DenseMap<IncludeKey, llvm::SmallVector<std::uint32_t>, IncludeKeyInfo> includes;
+    /// (fid, ConfigID) -> directly included files.
+    llvm::DenseMap<IncludeKey, llvm::SmallVector<IncludeEdge>, IncludeKeyInfo> includes;
 
     /// Track which files have any include entries (for file_count).
-    llvm::DenseMap<std::uint32_t, llvm::SmallVector<std::uint32_t>> file_configs;
+    llvm::DenseMap<Fid, llvm::SmallVector<std::uint32_t>> file_configs;
 
-    /// Reverse include map: PathID -> list of PathIDs that directly include it.
+    /// Reverse include map: fid -> files that directly include it.
     /// Populated by build_reverse_map().
-    llvm::DenseMap<std::uint32_t, llvm::SmallVector<std::uint32_t, 4>> reverse_includes;
+    llvm::DenseMap<Fid, llvm::SmallVector<Fid, 4>> reverse_includes;
 };
 
 /// A (file, search-config) pair used to track per-wave work items.
 struct WaveEntry {
-    std::uint32_t path_id;
+    Fid path_id;
     std::uint32_t config_id;
     /// Search dir index where this file was found. Used for #include_next.
     /// Source files (wave 0) use 0.

--- a/src/syntax/dependency_graph.h
+++ b/src/syntax/dependency_graph.h
@@ -6,7 +6,7 @@
 #include <vector>
 
 #include "command/command.h"
-#include "support/path_pool.h"
+#include "vfs/file_table.h"
 #include "syntax/include_resolver.h"
 #include "syntax/scan.h"
 
@@ -256,8 +256,8 @@ struct ScanCache {
     DirListingCache dir_cache;
 
     /// Angled-include resolution cache: (config_id bytes + header) → {path_id, found_dir_idx}.
-    /// path_id values are valid only for the PathPool used during the scan
-    /// that populated this cache.  If PathPool is reset between scans, clear
+    /// path_id values are valid only for the FileTable used during the scan
+    /// that populated this cache.  If FileTable is reset between scans, clear
     /// this cache too (or pass nullptr to scan_dependency_graph).
     struct CachedInclude {
         std::uint32_t path_id;
@@ -297,7 +297,7 @@ using RuleMatcher = std::function<
 ///
 /// @param cache  Optional persistent cache. When non-null and pre-populated,
 ///               avoids repeated readdir() and include-resolution work across
-///               successive calls.  PathPool must NOT be reset between calls
+///               successive calls.  FileTable must NOT be reset between calls
 ///               when a persistent cache is used (path_id values must remain stable).
 /// @param rule_matcher  Optional callback applied per context group so that
 ///               `[[rules]]`-modified include/std flags are reflected in the

--- a/src/syntax/include_resolver.cpp
+++ b/src/syntax/include_resolver.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 
 #include "support/logging.h"
+#include "vfs/file_table.h"
 
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
@@ -12,12 +13,33 @@ namespace clice {
 const llvm::StringSet<>* resolve_dir(llvm::StringRef dir,
                                      DirListingCache& cache,
                                      StatCounters* counters) {
-    auto it = cache.dirs.find(dir);
-    if(it != cache.dirs.end()) {
+    if(auto it = cache.dirs.find(dir); it != cache.dirs.end()) {
         if(counters) {
             counters->dir_hits++;
         }
         return &it->second;
+    }
+
+    if(cache.shared) {
+        auto listing = cache.shared->dir_listings.find(dir);
+        if(listing != cache.shared->dir_listings.end()) {
+            // Validated once per operation: the directory's own mtime
+            // proves the listing current (entry creation and deletion bump
+            // it); later uses inside the operation trust the validation.
+            bool fresh = cache.validated.contains(dir);
+            if(!fresh && listing->second.mtime_ns != 0) {
+                llvm::sys::fs::file_status status;
+                fresh = !llvm::sys::fs::status(dir, status) &&
+                        fs::mtime_ns(status) == listing->second.mtime_ns;
+            }
+            if(fresh) {
+                cache.validated.insert(dir);
+                if(counters) {
+                    counters->dir_hits++;
+                }
+                return &listing->second.entries;
+            }
+        }
     }
 
     if(counters) {
@@ -25,6 +47,12 @@ const llvm::StringSet<>* resolve_dir(llvm::StringRef dir,
     }
 
     auto t0 = std::chrono::steady_clock::now();
+    // The pre/post-stat pairing discipline of file reads, on the
+    // directory: equal stats prove the listing describes this mtime, and
+    // an mtime inside the guard window must not be trusted across
+    // operations (a same-tick entry creation would be invisible).
+    llvm::sys::fs::file_status pre_status;
+    bool pre_ok = !llvm::sys::fs::status(dir, pre_status);
     llvm::StringSet<> entries;
     std::error_code ec;
     llvm::sys::fs::directory_iterator di(dir, ec);
@@ -37,6 +65,25 @@ const llvm::StringSet<>* resolve_dir(llvm::StringRef dir,
     auto t1 = std::chrono::steady_clock::now();
     if(counters) {
         counters->us += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+    }
+
+    if(cache.shared) {
+        std::int64_t reliable_mtime = 0;
+        llvm::sys::fs::file_status post_status;
+        if(pre_ok && !llvm::sys::fs::status(dir, post_status) &&
+           fs::mtime_ns(pre_status) == fs::mtime_ns(post_status)) {
+            auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                              std::chrono::system_clock::now().time_since_epoch())
+                              .count();
+            if(fs::mtime_ns(post_status) <= fs::stat_baseline_before_ns(now_ms)) {
+                reliable_mtime = fs::mtime_ns(post_status);
+            }
+        }
+        auto& listing = cache.shared->dir_listings[dir];
+        listing.entries = std::move(entries);
+        listing.mtime_ns = reliable_mtime;
+        cache.validated.insert(dir);
+        return &listing.entries;
     }
 
     auto [new_it, _] = cache.dirs.try_emplace(dir, std::move(entries));

--- a/src/syntax/include_resolver.cpp
+++ b/src/syntax/include_resolver.cpp
@@ -70,7 +70,10 @@ const llvm::StringSet<>* resolve_dir(llvm::StringRef dir,
     if(cache.shared) {
         std::int64_t reliable_mtime = 0;
         llvm::sys::fs::file_status post_status;
-        if(pre_ok && !llvm::sys::fs::status(dir, post_status) &&
+        // A failed or partial readdir (ec set) must not earn a trusted
+        // mtime: the incomplete listing would be reused until the
+        // directory itself changes.
+        if(pre_ok && !ec && !llvm::sys::fs::status(dir, post_status) &&
            fs::mtime_ns(pre_status) == fs::mtime_ns(post_status)) {
             auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                               std::chrono::system_clock::now().time_since_epoch())

--- a/src/syntax/include_resolver.h
+++ b/src/syntax/include_resolver.h
@@ -13,6 +13,8 @@
 
 namespace clice {
 
+struct FileTable;
+
 struct ResolveResult {
     /// The resolved absolute path (stack-allocated for paths < 256 chars).
     llvm::SmallString<256> path;
@@ -30,18 +32,25 @@ struct StatCounters {
     std::int64_t us = 0;           // Microseconds spent in filesystem ops.
 };
 
-/// Cache of directory listings for fast file existence checks.
-/// Instead of calling stat() for each candidate path, we list directory
-/// contents once via readdir() and do in-memory set lookups thereafter.
-/// This is dramatically faster on Windows where individual stat() calls
-/// are very expensive (~10x slower than Linux).
+/// Per-operation view over directory listings. Instead of calling stat()
+/// for each candidate path, directory contents are listed once via
+/// readdir() and checked with in-memory set lookups thereafter — this is
+/// dramatically faster on Windows where individual stat() calls are very
+/// expensive (~10x slower than Linux).
 ///
-/// TODO: add per-directory invalidation for incremental updates (currently
-/// the entire cache must be discarded when files change on disk).
+/// With `shared` set, listings live in the FileTable's directory
+/// compartment and survive the operation: the first use inside an
+/// operation validates a cached listing by the directory's own mtime (one
+/// stat instead of one readdir), later uses within the operation trust
+/// the validation (`validated`). Without it, `dirs` owns the listings and
+/// they die with the view — the standalone mode of tools and tests.
+///
 /// TODO: on case-insensitive filesystems (macOS HFS+/APFS, Windows NTFS),
 /// the readdir-based first-component optimization in resolve_include may
 /// produce false negatives when the #include casing differs from disk.
 struct DirListingCache {
+    FileTable* shared = nullptr;
+    llvm::StringSet<> validated;
     llvm::StringMap<llvm::StringSet<>> dirs;
 };
 

--- a/src/vfs/file_table.cpp
+++ b/src/vfs/file_table.cpp
@@ -1,0 +1,56 @@
+#include "vfs/file_table.h"
+
+#include <chrono>
+
+#include "llvm/ADT/ScopeExit.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/xxhash.h"
+
+namespace clice {
+
+std::optional<ObservedFile> read_file_observed(const char* path) {
+    auto fd = llvm::sys::fs::openNativeFileForRead(path);
+    if(!fd) {
+        llvm::consumeError(fd.takeError());
+        return std::nullopt;
+    }
+    auto close = llvm::make_scope_exit([&] { llvm::sys::fs::closeFile(*fd); });
+
+    llvm::sys::fs::file_status before;
+    bool have_before = !llvm::sys::fs::status(*fd, before);
+
+    // Force read() instead of mmap (IsVolatile): the bytes must be a
+    // snapshot taken between the two fstats — a mapped buffer would keep
+    // tracking the file after the post-fstat, unpairing hash and stat.
+    auto buf = llvm::MemoryBuffer::getOpenFile(*fd,
+                                               path,
+                                               /*FileSize=*/-1,
+                                               /*RequiresNullTerminator=*/true,
+                                               /*IsVolatile=*/true);
+    if(!buf) {
+        return std::nullopt;
+    }
+
+    ObservedFile result;
+    result.content = std::move(*buf);
+
+    llvm::sys::fs::file_status after;
+    bool have_after = !llvm::sys::fs::status(*fd, after);
+    result.obs.hash = llvm::xxh3_64bits(result.content->getBuffer());
+    if(!have_after) {
+        return result;
+    }
+    result.obs.size = after.getSize();
+    result.obs.mtime_ns = fs::mtime_ns(after);
+    result.obs.paired = have_before && before.getSize() == after.getSize() &&
+                        fs::mtime_ns(before) == result.obs.mtime_ns;
+
+    auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::system_clock::now().time_since_epoch())
+                      .count();
+    result.obs.reliable =
+        result.obs.paired && result.obs.mtime_ns <= fs::stat_baseline_before_ns(now_ms);
+    return result;
+}
+
+}  // namespace clice

--- a/src/vfs/file_table.cpp
+++ b/src/vfs/file_table.cpp
@@ -42,6 +42,8 @@ std::optional<ObservedFile> read_file_observed(const char* path) {
     }
     result.obs.size = after.getSize();
     result.obs.mtime_ns = fs::mtime_ns(after);
+    result.obs.uid_device = after.getUniqueID().getDevice();
+    result.obs.uid_file = after.getUniqueID().getFile();
     result.obs.paired = have_before && before.getSize() == after.getSize() &&
                         fs::mtime_ns(before) == result.obs.mtime_ns;
 

--- a/src/vfs/file_table.h
+++ b/src/vfs/file_table.h
@@ -392,6 +392,16 @@ struct FileTable {
     /// table changed under it.
     std::uint64_t stamp_generation = 0;
 
+    /// Bumped only when force_revalidate revokes stamps, and persisted in
+    /// both metadata blobs that carry them (the global blob's version
+    /// table, the artifacts blob's dep records). The blobs commit
+    /// non-atomically, so a crash can land a global recording a revocation
+    /// next to an artifacts blob that predates it — whose stamps
+    /// adopt_stamp would then restore into the revoked holes. Adoption is
+    /// gated on the artifacts blob being at least as revocation-current as
+    /// the loaded global.
+    std::uint64_t revocation_generation = 0;
+
     const FileVersion& version(VersionID vid) const {
         assert(vid.raw < versions.size());
         return versions[vid.raw];
@@ -502,6 +512,7 @@ struct FileTable {
         // the next session re-adopts trust this call just dropped.
         if(revoked) {
             stamp_generation += 1;
+            revocation_generation += 1;
         }
     }
 

--- a/src/vfs/file_table.h
+++ b/src/vfs/file_table.h
@@ -12,6 +12,7 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -346,6 +347,24 @@ struct FileTable {
     };
 
     llvm::DenseMap<std::pair<std::uint64_t, std::uint64_t>, ModuleDecl> module_decls;
+
+    /// Directory listings, validated by the directory's own mtime: POSIX
+    /// and Windows bump it on entry creation and deletion, so one stat per
+    /// operation proves a cached listing current — external generators
+    /// dropping files into include directories produce no event, making
+    /// the mtime the only anchor there is. mtime_ns == 0 means the listing
+    /// was taken inside the mtime-granularity guard window (or the stat
+    /// failed) and must not be trusted across operations; a listing
+    /// re-earns trust at the next readdir. Deliberate residual: a forged
+    /// (backdated) directory mtime defeats this — files have the content
+    /// hash as a second anchor, a directory's only deeper truth is the
+    /// readdir itself, and re-reading every use would mean not caching.
+    struct DirListing {
+        llvm::StringSet<> entries;
+        std::int64_t mtime_ns = 0;
+    };
+
+    llvm::StringMap<DirListing> dir_listings;
 
     /// Wave-scoped verdict memo: one top-level check operation (a
     /// deps_changed chain, an index need_update batch) opens a wave, and

--- a/src/vfs/file_table.h
+++ b/src/vfs/file_table.h
@@ -12,8 +12,8 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
-#include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/MemoryBuffer.h"
 
@@ -31,6 +31,10 @@ struct DiskObservation {
     std::uint64_t size = 0;
     std::int64_t mtime_ns = 0;
     std::uint64_t hash = 0;
+    /// Filesystem identity of the inode the bytes were read from
+    /// (fstat's UniqueID) — what binds a spelling to an entity.
+    std::uint64_t uid_device = 0;
+    std::uint64_t uid_file = 0;
     bool paired = false;
     bool reliable = false;
 };
@@ -71,6 +75,11 @@ std::optional<ObservedFile> read_file_observed(const char* path);
 /// are raw bytes; a non-UTF-8 path survives interning but breaks
 /// downstream where it is embedded into JSON (worker IPC, the agentic
 /// protocol) or percent-decoded by clients that interpret URIs as UTF-8.
+///
+/// FIXME: @rsp and NVCC option files are read during CDB parsing but
+/// never tracked here — editing one changes commands without touching
+/// compile_commands.json, so nothing notices until the CDB itself
+/// changes. Folding their paths into the CDB stamp is a follow-up.
 struct FileTable {
     llvm::BumpPtrAllocator allocator;
     llvm::SmallVector<llvm::StringRef> spellings;
@@ -110,21 +119,80 @@ struct FileTable {
         return it->second;
     }
 
-    /// Last reliable same-source {stat, hash} pair per fid: the shared
-    /// baseline every consumer's staleness check draws from and repairs.
-    /// Consumer-specific observation state (what a consumer has *seen*,
-    /// e.g. the tracker's last-reported baseline) stays with the
-    /// consumer — sharing it would swallow events.
+    /// Entities: on-disk files merged by filesystem UniqueID, the way
+    /// clang's FileManager merges FileEntries — hardlinked or symlinked
+    /// spellings of one file share the content-derived facts below. A
+    /// fid's binding to an entity is itself stat-verified: every
+    /// observation carries the UniqueID its stat returned, and a mismatch
+    /// rebinds (editors save via tmp+rename, so a spelling changes inode
+    /// on every save). Consumer-specific observation state (what a
+    /// consumer has *seen*, e.g. the tracker's last-reported baseline)
+    /// stays with the consumer and per fid — shared, a save through one
+    /// hardlink spelling would swallow the other spelling's change event.
+    ///
+    /// FIXME: UniqueID reliability on network filesystems is inherited
+    /// from clang's known limitation — some report unstable or colliding
+    /// ids, which here degrades to spurious rebinds (extra reads), never
+    /// wrong hashes (the first read through a rebound fid re-earns trust).
+    llvm::DenseMap<std::pair<std::uint64_t, std::uint64_t>, std::uint32_t> entity_ids;
+
+    struct EntityBinding {
+        std::uint32_t entity = ~0u;
+
+        /// A read through THIS fid confirmed the binding. Until then the
+        /// entity's pair is withheld from the fid: a recycled inode can
+        /// hand an unrelated new file an existing entity with an
+        /// equal-looking stat, and inheriting its pair would serve the
+        /// old file's hash for the new file's bytes.
+        bool earned = false;
+    };
+
+    llvm::DenseMap<std::uint32_t, EntityBinding> bindings;
+
+    /// Last reliable same-source {stat, hash} pair per entity: the shared
+    /// baseline every consumer's staleness check draws from and repairs —
+    /// computed once, shared by every spelling of the file.
     llvm::DenseMap<std::uint32_t, DiskObservation> disk_states;
 
-    /// The cached hash of exactly this (size, mtime), or nullopt when
-    /// someone must read. Equality against the shared pair, never a
-    /// watermark: the hash is "the hash of the bytes that had this
-    /// stat", nothing else.
+    /// The entity for a filesystem identity, allocating on first sight.
+    /// `fresh` reports allocation — a fid binding to a brand-new entity
+    /// has nothing to wrongly inherit.
+    std::uint32_t intern_entity(std::uint64_t uid_device, std::uint64_t uid_file, bool& fresh) {
+        auto [it, inserted] = entity_ids.try_emplace({uid_device, uid_file},
+                                                     static_cast<std::uint32_t>(entity_ids.size()));
+        fresh = inserted;
+        return it->second;
+    }
+
+    /// Re-verify (and if needed re-establish) the fid's entity binding
+    /// against the identity a live stat just returned. Returns the
+    /// binding; `earned` is false until a read through this fid confirms
+    /// it (see EntityBinding).
+    EntityBinding& bind(std::uint32_t fid, std::uint64_t uid_device, std::uint64_t uid_file) {
+        bool fresh = false;
+        auto entity = intern_entity(uid_device, uid_file, fresh);
+        auto& binding = bindings[fid];
+        if(binding.entity != entity) {
+            binding.entity = entity;
+            binding.earned = fresh;
+        }
+        return binding;
+    }
+
+    /// The cached hash of exactly this (size, mtime) at exactly this
+    /// filesystem identity, or nullopt when someone must read. Equality
+    /// against the shared pair, never a watermark: the hash is "the hash
+    /// of the bytes that had this stat", nothing else.
     std::optional<std::uint64_t> cached_hash(std::uint32_t fid,
                                              std::uint64_t size,
-                                             std::int64_t mtime_ns) const {
-        auto it = disk_states.find(fid);
+                                             std::int64_t mtime_ns,
+                                             std::uint64_t uid_device,
+                                             std::uint64_t uid_file) {
+        auto& binding = bind(fid, uid_device, uid_file);
+        if(!binding.earned) {
+            return std::nullopt;
+        }
+        auto it = disk_states.find(binding.entity);
         if(it == disk_states.end()) {
             return std::nullopt;
         }
@@ -136,11 +204,15 @@ struct FileTable {
     }
 
     /// Record a same-source read (the scan worker's, or one made through
-    /// read()) as the fid's shared pair. Unpaired reads carry a true
-    /// hash but no stat proof, so they never enter.
+    /// read()) as the entity's shared pair; the read also earns the fid
+    /// its binding. Unpaired reads carry a true hash but no stat proof,
+    /// so they never become the pair.
     void observe(std::uint32_t fid, const DiskObservation& obs) {
+        bool fresh = false;
+        auto entity = intern_entity(obs.uid_device, obs.uid_file, fresh);
+        bindings[fid] = {entity, true};
         if(obs.reliable) {
-            disk_states[fid] = obs;
+            disk_states[entity] = obs;
         }
     }
 
@@ -163,22 +235,26 @@ struct FileTable {
         if(llvm::sys::fs::status(resolve(fid), status)) {
             return std::nullopt;
         }
-        return observe_for(fid, status.getSize(), fs::mtime_ns(status));
+        return observe_for(fid, status);
     }
 
     /// The two-layer primitive: a same-source observation for a live
     /// stat the caller just took — the shared pair when it matches by
-    /// equality, else a real read (which repairs the pair for every
-    /// later consumer; its observation may describe a newer stat than
-    /// the caller's, which is then simply newer truth). nullopt =
-    /// unreadable right now.
+    /// equality (and the filesystem identity confirms the binding), else
+    /// a real read (which repairs the pair for every later consumer; its
+    /// observation may describe a newer stat than the caller's, which is
+    /// then simply newer truth). nullopt = unreadable right now.
     std::optional<DiskObservation> observe_for(std::uint32_t fid,
-                                               std::uint64_t size,
-                                               std::int64_t mtime_ns) {
-        if(auto hash = cached_hash(fid, size, mtime_ns)) {
+                                               const llvm::sys::fs::file_status& status) {
+        auto size = status.getSize();
+        auto mtime_ns = fs::mtime_ns(status);
+        auto uid = status.getUniqueID();
+        if(auto hash = cached_hash(fid, size, mtime_ns, uid.getDevice(), uid.getFile())) {
             return DiskObservation{.size = size,
                                    .mtime_ns = mtime_ns,
                                    .hash = *hash,
+                                   .uid_device = uid.getDevice(),
+                                   .uid_file = uid.getFile(),
                                    .paired = true,
                                    .reliable = true};
         }
@@ -247,12 +323,21 @@ struct FileTable {
         if(version.mtime_ns != 0 || version.content_hash == 0) {
             return;
         }
-        if(auto hash = cached_hash(version.fid, size, mtime_ns);
-           hash && *hash == version.content_hash) {
-            version.size = size;
-            version.mtime_ns = mtime_ns;
-            stamp_generation += 1;
+        // Corroborate through the fid's earned binding: no live stat is in
+        // hand here, so an unverified or missing binding simply declines
+        // the stamp and the first check earns it by reading.
+        auto binding = bindings.find(version.fid);
+        if(binding == bindings.end() || !binding->second.earned) {
+            return;
         }
+        auto pair = disk_states.find(binding->second.entity);
+        if(pair == disk_states.end() || pair->second.size != size ||
+           pair->second.mtime_ns != mtime_ns || pair->second.hash != version.content_hash) {
+            return;
+        }
+        version.size = size;
+        version.mtime_ns = mtime_ns;
+        stamp_generation += 1;
     }
 
     /// Adopt a stamp persisted by an earlier session — it was earned under
@@ -276,7 +361,11 @@ struct FileTable {
     /// reading, and verdicts already memoized in the current wave, which
     /// would bypass the forced point entirely.
     void force_revalidate(std::uint32_t fid) {
-        disk_states.erase(fid);
+        // Entity-level: dropping only a fid-scoped anchor would leave the
+        // pair reachable through a hardlinked spelling of the same file.
+        if(auto binding = bindings.find(fid); binding != bindings.end()) {
+            disk_states.erase(binding->second.entity);
+        }
         for(auto& [vid, version]: versions) {
             if(version.fid == fid) {
                 version.size = 0;
@@ -313,26 +402,14 @@ struct FileTable {
 
     /// The scan of exactly these bytes, whose hash the caller proved to be
     /// `content_hash` (a paired read), computed on first sight.
-    const ScanResult& scan_of(std::uint32_t fid, std::uint64_t content_hash,
+    const ScanResult& scan_of(std::uint32_t fid,
+                              std::uint64_t content_hash,
                               llvm::StringRef content) {
         auto [it, inserted] = scan_results.try_emplace({fid, content_hash});
         if(inserted) {
             it->second = scan_quick(content);
         }
         return it->second;
-    }
-
-    /// The cached scan for a live stat of the file, when the shared pair
-    /// proves which bytes the stat describes — the zero-IO warm path of a
-    /// rescan. nullptr = someone must read and lex.
-    const ScanResult* cached_scan(std::uint32_t fid, std::uint64_t size,
-                                  std::int64_t mtime_ns) const {
-        auto hash = cached_hash(fid, size, mtime_ns);
-        if(!hash) {
-            return nullptr;
-        }
-        auto it = scan_results.find({fid, *hash});
-        return it == scan_results.end() ? nullptr : &it->second;
     }
 
     /// A module declaration hidden behind preprocessor conditionals,
@@ -415,7 +492,7 @@ private:
             return Verdict::Stale;
         }
 
-        auto obs = observe_for(version.fid, size, mtime_ns);
+        auto obs = observe_for(version.fid, status);
         if(!obs) {
             return Verdict::Unreadable;
         }

--- a/src/vfs/file_table.h
+++ b/src/vfs/file_table.h
@@ -491,6 +491,22 @@ struct FileTable {
     }
 
 private:
+    /// Whether a stat-equality fast path may stand for this fid: once the
+    /// session has learned the file's identity (an earned binding), the
+    /// live stat must still carry it — a rename-over with a forged equal
+    /// stat changes the UniqueID and must fall through to a read. A fid
+    /// with no earned binding keeps cross-session trust: adopted stamps
+    /// serve the cold start before any read has happened.
+    bool stamp_identity_holds(std::uint32_t fid, const llvm::sys::fs::file_status& status) const {
+        auto binding = bindings.find(fid);
+        if(binding == bindings.end() || !binding->second.earned) {
+            return true;
+        }
+        auto uid = status.getUniqueID();
+        auto entity = entity_ids.find({uid.getDevice(), uid.getFile()});
+        return entity != entity_ids.end() && entity->second == binding->second.entity;
+    }
+
     Verdict check_version_uncached(std::uint32_t vid) {
         auto it = versions.find(vid);
         assert(it != versions.end());
@@ -502,7 +518,8 @@ private:
         }
         auto size = status.getSize();
         auto mtime_ns = fs::mtime_ns(status);
-        if(version.mtime_ns != 0 && version.size == size && version.mtime_ns == mtime_ns) {
+        if(version.mtime_ns != 0 && version.size == size && version.mtime_ns == mtime_ns &&
+           stamp_identity_holds(version.fid, status)) {
             return Verdict::Fresh;
         }
 

--- a/src/vfs/file_table.h
+++ b/src/vfs/file_table.h
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <format>
 #include <memory>
 #include <optional>
 
@@ -45,6 +46,89 @@ struct ObservedFile {
     std::unique_ptr<llvm::MemoryBuffer> content;
 };
 
+/// A file id: the FileTable's compact handle for one interned path
+/// spelling. A distinct type so fids, version ids and other integers
+/// cannot mix silently. Default-constructed = invalid ("no file").
+struct Fid {
+    std::uint32_t raw = ~0u;
+
+    constexpr bool valid() const {
+        return raw != ~0u;
+    }
+
+    friend constexpr auto operator<=>(Fid, Fid) = default;
+};
+
+/// A version id: the FileTable's handle for one (file, content hash)
+/// pair. Default-constructed = invalid ("no version").
+struct VersionID {
+    std::uint32_t raw = ~0u;
+
+    constexpr bool valid() const {
+        return raw != ~0u;
+    }
+
+    friend constexpr auto operator<=>(VersionID, VersionID) = default;
+};
+
+}  // namespace clice
+
+template <>
+struct llvm::DenseMapInfo<clice::Fid> {
+    static clice::Fid getEmptyKey() {
+        return {DenseMapInfo<std::uint32_t>::getEmptyKey()};
+    }
+
+    static clice::Fid getTombstoneKey() {
+        return {DenseMapInfo<std::uint32_t>::getTombstoneKey()};
+    }
+
+    static unsigned getHashValue(clice::Fid fid) {
+        return DenseMapInfo<std::uint32_t>::getHashValue(fid.raw);
+    }
+
+    static bool isEqual(clice::Fid lhs, clice::Fid rhs) {
+        return lhs == rhs;
+    }
+};
+
+template <>
+struct llvm::DenseMapInfo<clice::VersionID> {
+    static clice::VersionID getEmptyKey() {
+        return {DenseMapInfo<std::uint32_t>::getEmptyKey()};
+    }
+
+    static clice::VersionID getTombstoneKey() {
+        return {DenseMapInfo<std::uint32_t>::getTombstoneKey()};
+    }
+
+    static unsigned getHashValue(clice::VersionID vid) {
+        return DenseMapInfo<std::uint32_t>::getHashValue(vid.raw);
+    }
+
+    static bool isEqual(clice::VersionID lhs, clice::VersionID rhs) {
+        return lhs == rhs;
+    }
+};
+
+/// Ids appear directly in log messages and test-failure output; format
+/// as the raw id.
+template <>
+struct std::formatter<clice::Fid> : std::formatter<std::uint32_t> {
+    auto format(clice::Fid fid, auto& ctx) const {
+        return std::formatter<std::uint32_t>::format(fid.raw, ctx);
+    }
+};
+
+template <>
+struct std::formatter<clice::VersionID> : std::formatter<std::uint32_t> {
+    auto format(clice::VersionID vid, auto& ctx) const {
+        return std::formatter<std::uint32_t>::format(vid.raw, ctx);
+    }
+};
+
+namespace clice {
+
 /// Read a file and hash its bytes under the pairing discipline: open a
 /// handle, fstat it, read through it, fstat again. Equal fstats prove
 /// the stat describes the bytes (an in-place write racing the read moves
@@ -83,13 +167,14 @@ std::optional<ObservedFile> read_file_observed(const char* path);
 struct FileTable {
     llvm::BumpPtrAllocator allocator;
     llvm::SmallVector<llvm::StringRef> spellings;
-    llvm::StringMap<std::uint32_t> ids;
+    llvm::StringMap<Fid> ids;
 
-    std::uint32_t intern(llvm::StringRef path) {
+    Fid intern(llvm::StringRef path) {
         llvm::SmallString<256> storage;
         path = path::canonical(path, storage);
 
-        auto [it, inserted] = ids.try_emplace(path, spellings.size());
+        auto [it, inserted] =
+            ids.try_emplace(path, Fid{static_cast<std::uint32_t>(spellings.size())});
         if(inserted) {
             // Allocate with null terminator so that resolve().data() is safe
             // to use as const char* (e.g. in MemoryBuffer::getFile which calls strlen).
@@ -102,14 +187,14 @@ struct FileTable {
         return it->second;
     }
 
-    llvm::StringRef resolve(std::uint32_t fid) const {
-        assert(fid < spellings.size());
-        return spellings[fid];
+    llvm::StringRef resolve(Fid fid) const {
+        assert(fid.raw < spellings.size());
+        return spellings[fid.raw];
     }
 
     /// Look up a path without interning it, applying the same
     /// normalization as intern().
-    std::optional<std::uint32_t> find(llvm::StringRef path) const {
+    std::optional<Fid> find(llvm::StringRef path) const {
         llvm::SmallString<256> storage;
         path = path::canonical(path, storage);
         auto it = ids.find(path);
@@ -150,7 +235,7 @@ struct FileTable {
         bool earned = false;
     };
 
-    llvm::DenseMap<std::uint32_t, EntityBinding> bindings;
+    llvm::DenseMap<Fid, EntityBinding> bindings;
 
     /// Last reliable same-source {stat, hash} pair per entity: the shared
     /// baseline every consumer's staleness check draws from and repairs —
@@ -162,33 +247,24 @@ struct FileTable {
     /// spelling is its own entity and the observed id is ignored:
     /// hardlinks stay unmerged, and replace detection falls back to the
     /// stat pair — the pre-entity behavior.
-    static std::pair<std::uint64_t, std::uint64_t> entity_key(std::uint32_t fid,
+    static std::pair<std::uint64_t, std::uint64_t> entity_key(Fid fid,
                                                               std::uint64_t uid_device,
                                                               std::uint64_t uid_file) {
         if constexpr(!fs::stable_file_ids) {
-            return {~0ull, fid};
+            return {~0ull, fid.raw};
         }
         return {uid_device, uid_file};
-    }
-
-    /// The entity for a filesystem identity, allocating on first sight.
-    /// `fresh` reports allocation — a fid binding to a brand-new entity
-    /// has nothing to wrongly inherit.
-    std::uint32_t intern_entity(std::uint64_t uid_device, std::uint64_t uid_file, bool& fresh) {
-        auto [it, inserted] = entity_ids.try_emplace({uid_device, uid_file},
-                                                     static_cast<std::uint32_t>(entity_ids.size()));
-        fresh = inserted;
-        return it->second;
     }
 
     /// Re-verify (and if needed re-establish) the fid's entity binding
     /// against the identity a live stat just returned. Returns the
     /// binding; `earned` is false until a read through this fid confirms
-    /// it (see EntityBinding).
-    EntityBinding& bind(std::uint32_t fid, std::uint64_t uid_device, std::uint64_t uid_file) {
-        bool fresh = false;
-        auto [key_device, key_file] = entity_key(fid, uid_device, uid_file);
-        auto entity = intern_entity(key_device, key_file, fresh);
+    /// it (see EntityBinding). A fid binding to a brand-new entity has
+    /// nothing to wrongly inherit, so it is born earned.
+    EntityBinding& bind(Fid fid, std::uint64_t uid_device, std::uint64_t uid_file) {
+        auto [it, fresh] = entity_ids.try_emplace(entity_key(fid, uid_device, uid_file),
+                                                  static_cast<std::uint32_t>(entity_ids.size()));
+        auto entity = it->second;
         auto& binding = bindings[fid];
         if(binding.entity != entity) {
             binding.entity = entity;
@@ -201,7 +277,7 @@ struct FileTable {
     /// filesystem identity, or nullopt when someone must read. Equality
     /// against the shared pair, never a watermark: the hash is "the hash
     /// of the bytes that had this stat", nothing else.
-    std::optional<std::uint64_t> cached_hash(std::uint32_t fid,
+    std::optional<std::uint64_t> cached_hash(Fid fid,
                                              std::uint64_t size,
                                              std::int64_t mtime_ns,
                                              std::uint64_t uid_device,
@@ -225,20 +301,18 @@ struct FileTable {
     /// read()) as the entity's shared pair; the read also earns the fid
     /// its binding. Unpaired reads carry a true hash but no stat proof,
     /// so they never become the pair.
-    void observe(std::uint32_t fid, const DiskObservation& obs) {
-        bool fresh = false;
-        auto [key_device, key_file] = entity_key(fid, obs.uid_device, obs.uid_file);
-        auto entity = intern_entity(key_device, key_file, fresh);
-        bindings[fid] = {.entity = entity, .earned = true};
+    void observe(Fid fid, const DiskObservation& obs) {
+        auto& binding = bind(fid, obs.uid_device, obs.uid_file);
+        binding.earned = true;
         if(obs.reliable) {
-            disk_states[entity] = obs;
+            disk_states[binding.entity] = obs;
         }
     }
 
     /// Read the file under the pairing discipline and refresh the shared
     /// pair. nullopt = unreadable right now (the pair is left untouched;
     /// what a failed read means is the caller's policy).
-    std::optional<DiskObservation> read(std::uint32_t fid) {
+    std::optional<DiskObservation> read(Fid fid) {
         auto observed = read_file_observed(resolve(fid).data());
         if(!observed) {
             return std::nullopt;
@@ -249,7 +323,7 @@ struct FileTable {
 
     /// Stat the file and produce a same-source observation of its
     /// current content. nullopt = missing or unreadable.
-    std::optional<DiskObservation> current(std::uint32_t fid) {
+    std::optional<DiskObservation> current(Fid fid) {
         llvm::sys::fs::file_status status;
         if(llvm::sys::fs::status(resolve(fid), status)) {
             return std::nullopt;
@@ -263,8 +337,7 @@ struct FileTable {
     /// a real read (which repairs the pair for every later consumer; its
     /// observation may describe a newer stat than the caller's, which is
     /// then simply newer truth). nullopt = unreadable right now.
-    std::optional<DiskObservation> observe_for(std::uint32_t fid,
-                                               const llvm::sys::fs::file_status& status) {
+    std::optional<DiskObservation> observe_for(Fid fid, const llvm::sys::fs::file_status& status) {
         auto size = status.getSize();
         auto mtime_ns = fs::mtime_ns(status);
         auto uid = status.getUniqueID();
@@ -289,21 +362,29 @@ struct FileTable {
     /// falls through to the hash comparison, which repairs the fast path
     /// in place — once, for every consumer of the version.
     struct FileVersion {
-        std::uint32_t fid = 0;
+        Fid fid;
         std::uint64_t content_hash = 0;
         std::uint64_t size = 0;
         std::int64_t mtime_ns = 0;
     };
 
-    /// Version table. Ids are monotonic and never reused — persisted
-    /// index manifests stay resolvable against any later table (or are
-    /// detected as stale). Within a session the table is append-only:
-    /// persistence garbage-collects unreferenced versions from the blob it
-    /// writes, never from memory, so a version one consumer stops
-    /// referencing can still anchor another consumer's staleness check.
-    llvm::DenseMap<std::uint32_t, FileVersion> versions;
-    llvm::DenseMap<std::pair<std::uint32_t, std::uint64_t>, std::uint32_t> version_ids;
-    std::uint32_t next_version_id = 0;
+    /// Version table, indexed by VersionID. Ids are monotonic and never
+    /// reused — persisted index manifests stay resolvable against any
+    /// later table (or are detected as stale). Within a session the table
+    /// is append-only: persistence garbage-collects unreferenced versions
+    /// from the blob it writes, never from memory, so a version one
+    /// consumer stops referencing can still anchor another consumer's
+    /// staleness check. Adopting a persisted table (load_global) leaves
+    /// the garbage-collected ids as holes — records with an invalid fid
+    /// that nothing references; knows_version tells them apart.
+    llvm::SmallVector<FileVersion> versions;
+    llvm::DenseMap<std::pair<Fid, std::uint64_t>, VersionID> version_ids;
+
+    /// Whether the id names a live version (in range and not a hole left
+    /// by adopting a garbage-collected persisted table).
+    bool knows_version(VersionID vid) const {
+        return vid.raw < versions.size() && versions[vid.raw].fid.valid();
+    }
 
     /// Bumped whenever a version's stat fast path is written (stamped at
     /// capture or repaired by a check) or revoked (force_revalidate).
@@ -311,20 +392,19 @@ struct FileTable {
     /// table changed under it.
     std::uint64_t stamp_generation = 0;
 
-    const FileVersion& version(std::uint32_t vid) const {
-        auto it = versions.find(vid);
-        assert(it != versions.end());
-        return it->second;
+    const FileVersion& version(VersionID vid) const {
+        assert(vid.raw < versions.size());
+        return versions[vid.raw];
     }
 
     /// The version id for (fid, content hash), interning a new record on
     /// first sight.
-    std::uint32_t intern_version(std::uint32_t fid, std::uint64_t content_hash) {
-        auto [it, inserted] = version_ids.try_emplace({fid, content_hash}, next_version_id);
+    VersionID intern_version(Fid fid, std::uint64_t content_hash) {
+        auto [it, inserted] =
+            version_ids.try_emplace({fid, content_hash},
+                                    VersionID{static_cast<std::uint32_t>(versions.size())});
         if(inserted) {
-            versions.try_emplace(next_version_id,
-                                 FileVersion{.fid = fid, .content_hash = content_hash});
-            next_version_id += 1;
+            versions.push_back(FileVersion{.fid = fid, .content_hash = content_hash});
         }
         return it->second;
     }
@@ -337,14 +417,13 @@ struct FileTable {
     /// path would then judge them fresh forever. An already-stamped version
     /// keeps its stamp (it was earned the same way; concurrent captures of
     /// one version must not regress each other).
-    void try_stamp(std::uint32_t vid,
+    void try_stamp(VersionID vid,
                    std::uint64_t size,
                    std::int64_t mtime_ns,
                    std::uint64_t uid_device,
                    std::uint64_t uid_file) {
-        auto it = versions.find(vid);
-        assert(it != versions.end());
-        auto& version = it->second;
+        assert(vid.raw < versions.size());
+        auto& version = versions[vid.raw];
         if(version.mtime_ns != 0 || version.content_hash == 0) {
             return;
         }
@@ -376,10 +455,9 @@ struct FileTable {
     /// try_stamp's corroboration discipline back then, which is what makes
     /// it trustworthy without a live pair now. Only fills a hole: a stamp
     /// earned this session describes the same bytes at least as recently.
-    void adopt_stamp(std::uint32_t vid, std::uint64_t size, std::int64_t mtime_ns) {
-        auto it = versions.find(vid);
-        assert(it != versions.end());
-        auto& version = it->second;
+    void adopt_stamp(VersionID vid, std::uint64_t size, std::int64_t mtime_ns) {
+        assert(vid.raw < versions.size());
+        auto& version = versions[vid.raw];
         if(version.mtime_ns == 0 && version.content_hash != 0 && mtime_ns != 0) {
             version.size = size;
             version.mtime_ns = mtime_ns;
@@ -392,7 +470,7 @@ struct FileTable {
     /// stat fast paths, the shared pair a check would consult instead of
     /// reading, and verdicts already memoized in the current wave, which
     /// would bypass the forced point entirely.
-    void force_revalidate(std::uint32_t fid) {
+    void force_revalidate(Fid fid) {
         // Entity-level: dropping only fid-scoped anchors would leave the
         // pair — and the version stamps of a hardlinked spelling of the
         // same file — vouching for bytes this call says to re-read.
@@ -402,7 +480,11 @@ struct FileTable {
             disk_states.erase(entity);
         }
         bool revoked = false;
-        for(auto& [vid, version]: versions) {
+        for(std::uint32_t i = 0; i < versions.size(); i += 1) {
+            auto& version = versions[i];
+            if(!version.fid.valid()) {
+                continue;
+            }
             bool same_file = version.fid == fid;
             if(!same_file && entity != ~0u) {
                 auto alias = bindings.find(version.fid);
@@ -412,7 +494,7 @@ struct FileTable {
                 revoked = revoked || version.mtime_ns != 0;
                 version.size = 0;
                 version.mtime_ns = 0;
-                wave_verdicts.erase(vid);
+                wave_verdicts.erase(VersionID{i});
             }
         }
         // Revocation is stamp movement like any other: persisted stamps
@@ -446,13 +528,11 @@ struct FileTable {
     /// before the persisted id space loads) never allocates ids. Raw
     /// results only — the module-name backfill below is configuration
     /// output and must not enter a content-keyed slot.
-    llvm::DenseMap<std::pair<std::uint32_t, std::uint64_t>, ScanResult> scan_results;
+    llvm::DenseMap<std::pair<Fid, std::uint64_t>, ScanResult> scan_results;
 
     /// The scan of exactly these bytes, whose hash the caller proved to be
     /// `content_hash` (a paired read), computed on first sight.
-    const ScanResult& scan_of(std::uint32_t fid,
-                              std::uint64_t content_hash,
-                              llvm::StringRef content) {
+    const ScanResult& scan_of(Fid fid, std::uint64_t content_hash, llvm::StringRef content) {
         auto [it, inserted] = scan_results.try_emplace({fid, content_hash});
         if(inserted) {
             it->second = scan_quick(content);
@@ -492,16 +572,40 @@ struct FileTable {
     llvm::StringMap<DirListing> dir_listings;
 
     /// Wave-scoped verdict memo: one top-level check operation (a
-    /// deps_changed chain, an index need_update batch) opens a wave, and
+    /// deps_changed chain, an index need_update batch) opens a Wave, and
     /// every version is settled at most once inside it. Within a wave, a
     /// version with no fast path is validated by a real read exactly once;
     /// the repair the read performs is what later waves' fast paths are
-    /// made of. A wave must not span a suspension point — a save landing
-    /// mid-wave would leave memoized verdicts describing the old disk.
-    llvm::DenseMap<std::uint32_t, Verdict> wave_verdicts;
+    /// made of.
+    llvm::DenseMap<VersionID, Verdict> wave_verdicts;
+    bool wave_open = false;
 
-    void begin_wave() {
-        wave_verdicts.clear();
+    /// RAII scope of one memo wave: verdicts live exactly as long as the
+    /// guard, so a memo of one operation can never leak into the next.
+    /// Waves do not nest, and a wave must not span a suspension point —
+    /// a save landing mid-wave would leave memoized verdicts describing
+    /// the old disk.
+    class [[nodiscard]] Wave {
+    public:
+        explicit Wave(FileTable& table) : table(table) {
+            assert(!table.wave_open && "waves do not nest");
+            table.wave_open = true;
+        }
+
+        ~Wave() {
+            table.wave_verdicts.clear();
+            table.wave_open = false;
+        }
+
+        Wave(const Wave&) = delete;
+        Wave& operator=(const Wave&) = delete;
+
+    private:
+        FileTable& table;
+    };
+
+    Wave wave() {
+        return Wave(*this);
     }
 
     /// The unified two-layer staleness check: stat equality against the
@@ -509,7 +613,8 @@ struct FileTable {
     /// compartment (feeding both compartments), comparing the bytes'
     /// hash against the version's and repairing the fast path on a
     /// match. Memoized within the current wave.
-    Verdict check_version(std::uint32_t vid) {
+    Verdict check_version(VersionID vid) {
+        assert(wave_open && "check_version outside a Wave");
         if(auto it = wave_verdicts.find(vid); it != wave_verdicts.end()) {
             return it->second;
         }
@@ -525,7 +630,7 @@ private:
     /// stat changes the UniqueID and must fall through to a read. A fid
     /// with no earned binding keeps cross-session trust: adopted stamps
     /// serve the cold start before any read has happened.
-    bool stamp_identity_holds(std::uint32_t fid, const llvm::sys::fs::file_status& status) const {
+    bool stamp_identity_holds(Fid fid, const llvm::sys::fs::file_status& status) const {
         auto binding = bindings.find(fid);
         if(binding == bindings.end() || !binding->second.earned) {
             return true;
@@ -535,10 +640,9 @@ private:
         return entity != entity_ids.end() && entity->second == binding->second.entity;
     }
 
-    Verdict check_version_uncached(std::uint32_t vid) {
-        auto it = versions.find(vid);
-        assert(it != versions.end());
-        auto& version = it->second;
+    Verdict check_version_uncached(VersionID vid) {
+        assert(vid.raw < versions.size());
+        auto& version = versions[vid.raw];
 
         llvm::sys::fs::file_status status;
         if(llvm::sys::fs::status(resolve(version.fid), status)) {

--- a/src/vfs/file_table.h
+++ b/src/vfs/file_table.h
@@ -6,6 +6,7 @@
 #include <optional>
 
 #include "support/filesystem.h"
+#include "syntax/scan.h"
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallString.h"
@@ -297,6 +298,54 @@ struct FileTable {
         /// The file exists but cannot be read right now.
         Unreadable,
     };
+
+    /// The lexical scan of a version's bytes: scan_quick is a pure
+    /// function of the content, so the result is pinned by the version
+    /// identity (fid, content hash) and every consumer at that version
+    /// shares one lex — the startup scan feeds it, didSave rescans and
+    /// CDB-reload rescans hit it when only the stat moved. Keyed by the
+    /// identity pair rather than a version id so the scan (which runs
+    /// before the persisted id space loads) never allocates ids. Raw
+    /// results only — the module-name backfill below is configuration
+    /// output and must not enter a content-keyed slot.
+    llvm::DenseMap<std::pair<std::uint32_t, std::uint64_t>, ScanResult> scan_results;
+
+    /// The scan of exactly these bytes, whose hash the caller proved to be
+    /// `content_hash` (a paired read), computed on first sight.
+    const ScanResult& scan_of(std::uint32_t fid, std::uint64_t content_hash,
+                              llvm::StringRef content) {
+        auto [it, inserted] = scan_results.try_emplace({fid, content_hash});
+        if(inserted) {
+            it->second = scan_quick(content);
+        }
+        return it->second;
+    }
+
+    /// The cached scan for a live stat of the file, when the shared pair
+    /// proves which bytes the stat describes — the zero-IO warm path of a
+    /// rescan. nullptr = someone must read and lex.
+    const ScanResult* cached_scan(std::uint32_t fid, std::uint64_t size,
+                                  std::int64_t mtime_ns) const {
+        auto hash = cached_hash(fid, size, mtime_ns);
+        if(!hash) {
+            return nullptr;
+        }
+        auto it = scan_results.find({fid, *hash});
+        return it == scan_results.end() ? nullptr : &it->second;
+    }
+
+    /// A module declaration hidden behind preprocessor conditionals,
+    /// resolved by a real preprocessor run under one compile
+    /// configuration: keyed by (content hash, semantic hash of the
+    /// rendered command) — the same bytes legitimately resolve differently
+    /// under different flag sets, and dense config ids are CDB-local
+    /// (multiple CDBs share this table).
+    struct ModuleDecl {
+        std::string name;
+        bool is_interface_unit = false;
+    };
+
+    llvm::DenseMap<std::pair<std::uint64_t, std::uint64_t>, ModuleDecl> module_decls;
 
     /// Wave-scoped verdict memo: one top-level check operation (a
     /// deps_changed chain, an index need_update batch) opens a wave, and

--- a/src/vfs/file_table.h
+++ b/src/vfs/file_table.h
@@ -14,7 +14,10 @@
 
 namespace clice {
 
-/// Intern pool that maps file paths to compact uint32_t IDs.
+/// The master-side table of every file the workspace touches: a path
+/// spelling is interned once to a compact fid, and downstream code
+/// references files by fid. A fid names a spelling, not an on-disk
+/// file — case variants or links to one file are distinct fids.
 ///
 /// Paths are opaque byte strings interned in the canonical spelling of
 /// path::canonical, so on Windows the URI form VS Code sends
@@ -30,16 +33,16 @@ namespace clice {
 /// are raw bytes; a non-UTF-8 path survives interning but breaks
 /// downstream where it is embedded into JSON (worker IPC, the agentic
 /// protocol) or percent-decoded by clients that interpret URIs as UTF-8.
-struct PathPool {
+struct FileTable {
     llvm::BumpPtrAllocator allocator;
-    llvm::SmallVector<llvm::StringRef> paths;
-    llvm::StringMap<std::uint32_t> cache;
+    llvm::SmallVector<llvm::StringRef> spellings;
+    llvm::StringMap<std::uint32_t> ids;
 
     std::uint32_t intern(llvm::StringRef path) {
         llvm::SmallString<256> storage;
         path = path::canonical(path, storage);
 
-        auto [it, inserted] = cache.try_emplace(path, paths.size());
+        auto [it, inserted] = ids.try_emplace(path, spellings.size());
         if(inserted) {
             // Allocate with null terminator so that resolve().data() is safe
             // to use as const char* (e.g. in MemoryBuffer::getFile which calls strlen).
@@ -47,14 +50,14 @@ struct PathPool {
             char* buf = allocator.Allocate<char>(n + 1);
             std::copy(path.begin(), path.end(), buf);
             buf[n] = '\0';
-            paths.push_back(llvm::StringRef(buf, n));
+            spellings.push_back(llvm::StringRef(buf, n));
         }
         return it->second;
     }
 
-    llvm::StringRef resolve(std::uint32_t id) const {
-        assert(id < paths.size());
-        return paths[id];
+    llvm::StringRef resolve(std::uint32_t fid) const {
+        assert(fid < spellings.size());
+        return spellings[fid];
     }
 
     /// Look up a path without interning it, applying the same
@@ -62,8 +65,8 @@ struct PathPool {
     std::optional<std::uint32_t> find(llvm::StringRef path) const {
         llvm::SmallString<256> storage;
         path = path::canonical(path, storage);
-        auto it = cache.find(path);
-        if(it == cache.end()) {
+        auto it = ids.find(path);
+        if(it == ids.end()) {
             return std::nullopt;
         }
         return it->second;

--- a/src/vfs/file_table.h
+++ b/src/vfs/file_table.h
@@ -134,6 +134,9 @@ struct FileTable {
     /// from clang's known limitation — some report unstable or colliding
     /// ids, which here degrades to spurious rebinds (extra reads), never
     /// wrong hashes (the first read through a rebound fid re-earns trust).
+    /// On Windows the ids are not file-stable everywhere (see
+    /// fs::stable_file_ids), so entity merging is disabled there wholesale
+    /// via entity_key: identity-based defenses are POSIX-only.
     llvm::DenseMap<std::pair<std::uint64_t, std::uint64_t>, std::uint32_t> entity_ids;
 
     struct EntityBinding {
@@ -154,6 +157,20 @@ struct FileTable {
     /// computed once, shared by every spelling of the file.
     llvm::DenseMap<std::uint32_t, DiskObservation> disk_states;
 
+    /// The entity-map key for an identity observed through a fid. Where
+    /// file IDs are not file-stable (see fs::stable_file_ids), every
+    /// spelling is its own entity and the observed id is ignored:
+    /// hardlinks stay unmerged, and replace detection falls back to the
+    /// stat pair — the pre-entity behavior.
+    static std::pair<std::uint64_t, std::uint64_t> entity_key(std::uint32_t fid,
+                                                              std::uint64_t uid_device,
+                                                              std::uint64_t uid_file) {
+        if constexpr(!fs::stable_file_ids) {
+            return {~0ull, fid};
+        }
+        return {uid_device, uid_file};
+    }
+
     /// The entity for a filesystem identity, allocating on first sight.
     /// `fresh` reports allocation — a fid binding to a brand-new entity
     /// has nothing to wrongly inherit.
@@ -170,7 +187,8 @@ struct FileTable {
     /// it (see EntityBinding).
     EntityBinding& bind(std::uint32_t fid, std::uint64_t uid_device, std::uint64_t uid_file) {
         bool fresh = false;
-        auto entity = intern_entity(uid_device, uid_file, fresh);
+        auto [key_device, key_file] = entity_key(fid, uid_device, uid_file);
+        auto entity = intern_entity(key_device, key_file, fresh);
         auto& binding = bindings[fid];
         if(binding.entity != entity) {
             binding.entity = entity;
@@ -209,7 +227,8 @@ struct FileTable {
     /// so they never become the pair.
     void observe(std::uint32_t fid, const DiskObservation& obs) {
         bool fresh = false;
-        auto entity = intern_entity(obs.uid_device, obs.uid_file, fresh);
+        auto [key_device, key_file] = entity_key(fid, obs.uid_device, obs.uid_file);
+        auto entity = intern_entity(key_device, key_file, fresh);
         bindings[fid] = {.entity = entity, .earned = true};
         if(obs.reliable) {
             disk_states[entity] = obs;
@@ -287,8 +306,9 @@ struct FileTable {
     std::uint32_t next_version_id = 0;
 
     /// Bumped whenever a version's stat fast path is written (stamped at
-    /// capture or repaired by a check). Persistence compares it around an
-    /// operation to learn whether the table changed under it.
+    /// capture or repaired by a check) or revoked (force_revalidate).
+    /// Persistence compares it around an operation to learn whether the
+    /// table changed under it.
     std::uint64_t stamp_generation = 0;
 
     const FileVersion& version(std::uint32_t vid) const {
@@ -338,7 +358,7 @@ struct FileTable {
         // The live stat's identity must be the earned binding's: a
         // same-stat replace (new inode, forged size and mtime) would
         // otherwise corroborate through the replaced file's pair.
-        auto entity = entity_ids.find({uid_device, uid_file});
+        auto entity = entity_ids.find(entity_key(version.fid, uid_device, uid_file));
         if(entity == entity_ids.end() || entity->second != binding->second.entity) {
             return;
         }
@@ -381,6 +401,7 @@ struct FileTable {
             entity = binding->second.entity;
             disk_states.erase(entity);
         }
+        bool revoked = false;
         for(auto& [vid, version]: versions) {
             bool same_file = version.fid == fid;
             if(!same_file && entity != ~0u) {
@@ -388,10 +409,17 @@ struct FileTable {
                 same_file = alias != bindings.end() && alias->second.entity == entity;
             }
             if(same_file) {
+                revoked = revoked || version.mtime_ns != 0;
                 version.size = 0;
                 version.mtime_ns = 0;
                 wave_verdicts.erase(vid);
             }
+        }
+        // Revocation is stamp movement like any other: persisted stamps
+        // (the global blob, artifact dep records) must not outlive it, or
+        // the next session re-adopts trust this call just dropped.
+        if(revoked) {
+            stamp_generation += 1;
         }
     }
 
@@ -503,7 +531,7 @@ private:
             return true;
         }
         auto uid = status.getUniqueID();
-        auto entity = entity_ids.find({uid.getDevice(), uid.getFile()});
+        auto entity = entity_ids.find(entity_key(fid, uid.getDevice(), uid.getFile()));
         return entity != entity_ids.end() && entity->second == binding->second.entity;
     }
 

--- a/src/vfs/file_table.h
+++ b/src/vfs/file_table.h
@@ -182,6 +182,188 @@ struct FileTable {
         }
         return read(fid);
     }
+
+    /// A content version of a file: `content_hash` names the bytes (for
+    /// build artifacts, the bytes the build consumed — reported by the
+    /// worker, never replaced by a later disk read), and the stat is the
+    /// shared fast path proving the disk still holds them. Recorded only
+    /// when the file provably did not change since before the consuming
+    /// build started; mtime_ns == 0 means "no fast path" and a check
+    /// falls through to the hash comparison, which repairs the fast path
+    /// in place — once, for every consumer of the version.
+    struct FileVersion {
+        std::uint32_t fid = 0;
+        std::uint64_t content_hash = 0;
+        std::uint64_t size = 0;
+        std::int64_t mtime_ns = 0;
+    };
+
+    /// Version table. Ids are monotonic and never reused — persisted
+    /// index manifests stay resolvable against any later table (or are
+    /// detected as stale). Within a session the table is append-only:
+    /// persistence garbage-collects unreferenced versions from the blob it
+    /// writes, never from memory, so a version one consumer stops
+    /// referencing can still anchor another consumer's staleness check.
+    llvm::DenseMap<std::uint32_t, FileVersion> versions;
+    llvm::DenseMap<std::pair<std::uint32_t, std::uint64_t>, std::uint32_t> version_ids;
+    std::uint32_t next_version_id = 0;
+
+    /// Bumped whenever a version's stat fast path is written (stamped at
+    /// capture or repaired by a check). Persistence compares it around an
+    /// operation to learn whether the table changed under it.
+    std::uint64_t stamp_generation = 0;
+
+    const FileVersion& version(std::uint32_t vid) const {
+        auto it = versions.find(vid);
+        assert(it != versions.end());
+        return it->second;
+    }
+
+    /// The version id for (fid, content hash), interning a new record on
+    /// first sight.
+    std::uint32_t intern_version(std::uint32_t fid, std::uint64_t content_hash) {
+        auto [it, inserted] = version_ids.try_emplace({fid, content_hash}, next_version_id);
+        if(inserted) {
+            versions.try_emplace(next_version_id, FileVersion{fid, content_hash, 0, 0});
+            next_version_id += 1;
+        }
+        return it->second;
+    }
+
+    /// Give a version its stat fast path, but only corroborated: the shared
+    /// pair must prove the bytes at exactly this stat hash to the version's
+    /// content hash. A caller's own proof (e.g. "mtime predates the build")
+    /// is not enough — a same-stat rewrite forging the mtime would stamp a
+    /// stat describing bytes the consumer never saw, and the equality fast
+    /// path would then judge them fresh forever. An already-stamped version
+    /// keeps its stamp (it was earned the same way; concurrent captures of
+    /// one version must not regress each other).
+    void try_stamp(std::uint32_t vid, std::uint64_t size, std::int64_t mtime_ns) {
+        auto it = versions.find(vid);
+        assert(it != versions.end());
+        auto& version = it->second;
+        if(version.mtime_ns != 0 || version.content_hash == 0) {
+            return;
+        }
+        if(auto hash = cached_hash(version.fid, size, mtime_ns);
+           hash && *hash == version.content_hash) {
+            version.size = size;
+            version.mtime_ns = mtime_ns;
+            stamp_generation += 1;
+        }
+    }
+
+    /// Adopt a stamp persisted by an earlier session — it was earned under
+    /// try_stamp's corroboration discipline back then, which is what makes
+    /// it trustworthy without a live pair now. Only fills a hole: a stamp
+    /// earned this session describes the same bytes at least as recently.
+    void adopt_stamp(std::uint32_t vid, std::uint64_t size, std::int64_t mtime_ns) {
+        auto it = versions.find(vid);
+        assert(it != versions.end());
+        auto& version = it->second;
+        if(version.mtime_ns == 0 && version.content_hash != 0 && mtime_ns != 0) {
+            version.size = size;
+            version.mtime_ns = mtime_ns;
+        }
+    }
+
+    /// A save embedded this file's content into artifacts that will not be
+    /// re-read from disk (synthesized preambles): drop every trust anchor
+    /// so the next check of any of its versions performs a real read — the
+    /// stat fast paths, the shared pair a check would consult instead of
+    /// reading, and verdicts already memoized in the current wave, which
+    /// would bypass the forced point entirely.
+    void force_revalidate(std::uint32_t fid) {
+        disk_states.erase(fid);
+        for(auto& [vid, version]: versions) {
+            if(version.fid == fid) {
+                version.size = 0;
+                version.mtime_ns = 0;
+                wave_verdicts.erase(vid);
+            }
+        }
+    }
+
+    /// How one wave's check of a version came out. Policy-free facts;
+    /// what Missing or Unreadable *means* differs per consumer (see the
+    /// policy table in the plan) and stays with the caller.
+    enum class Verdict : std::uint8_t {
+        /// The disk provably holds the version's bytes.
+        Fresh,
+        /// The disk holds different bytes.
+        Stale,
+        /// The file does not exist now.
+        Missing,
+        /// The file exists but cannot be read right now.
+        Unreadable,
+    };
+
+    /// Wave-scoped verdict memo: one top-level check operation (a
+    /// deps_changed chain, an index need_update batch) opens a wave, and
+    /// every version is settled at most once inside it. Within a wave, a
+    /// version with no fast path is validated by a real read exactly once;
+    /// the repair the read performs is what later waves' fast paths are
+    /// made of. A wave must not span a suspension point — a save landing
+    /// mid-wave would leave memoized verdicts describing the old disk.
+    llvm::DenseMap<std::uint32_t, Verdict> wave_verdicts;
+
+    void begin_wave() {
+        wave_verdicts.clear();
+    }
+
+    /// The unified two-layer staleness check: stat equality against the
+    /// version's shared fast path, else a read through the disk-state
+    /// compartment (feeding both compartments), comparing the bytes'
+    /// hash against the version's and repairing the fast path on a
+    /// match. Memoized within the current wave.
+    Verdict check_version(std::uint32_t vid) {
+        if(auto it = wave_verdicts.find(vid); it != wave_verdicts.end()) {
+            return it->second;
+        }
+        auto verdict = check_version_uncached(vid);
+        wave_verdicts.try_emplace(vid, verdict);
+        return verdict;
+    }
+
+private:
+    Verdict check_version_uncached(std::uint32_t vid) {
+        auto it = versions.find(vid);
+        assert(it != versions.end());
+        auto& version = it->second;
+
+        llvm::sys::fs::file_status status;
+        if(llvm::sys::fs::status(resolve(version.fid), status)) {
+            return Verdict::Missing;
+        }
+        auto size = status.getSize();
+        auto mtime_ns = fs::mtime_ns(status);
+        if(version.mtime_ns != 0 && version.size == size && version.mtime_ns == mtime_ns) {
+            return Verdict::Fresh;
+        }
+
+        // No trusted hash to compare against: never fresh (0 is the
+        // consumed-hash sentinel for "the worker had no bytes to hash").
+        if(version.content_hash == 0) {
+            return Verdict::Stale;
+        }
+
+        auto obs = observe_for(version.fid, size, mtime_ns);
+        if(!obs) {
+            return Verdict::Unreadable;
+        }
+        if(obs->hash != version.content_hash) {
+            return Verdict::Stale;
+        }
+        // Touched but not modified — repair the fast path so the next
+        // check is a single stat again, for every consumer at once. An
+        // unpaired or guard-window observation must not become one.
+        if(obs->reliable) {
+            version.size = obs->size;
+            version.mtime_ns = obs->mtime_ns;
+            stamp_generation += 1;
+        }
+        return Verdict::Fresh;
+    }
 };
 
 }  // namespace clice

--- a/src/vfs/file_table.h
+++ b/src/vfs/file_table.h
@@ -95,7 +95,7 @@ struct FileTable {
             // to use as const char* (e.g. in MemoryBuffer::getFile which calls strlen).
             const std::size_t n = path.size();
             char* buf = allocator.Allocate<char>(n + 1);
-            std::copy(path.begin(), path.end(), buf);
+            std::ranges::copy(path, buf);
             buf[n] = '\0';
             spellings.push_back(llvm::StringRef(buf, n));
         }
@@ -210,7 +210,7 @@ struct FileTable {
     void observe(std::uint32_t fid, const DiskObservation& obs) {
         bool fresh = false;
         auto entity = intern_entity(obs.uid_device, obs.uid_file, fresh);
-        bindings[fid] = {entity, true};
+        bindings[fid] = {.entity = entity, .earned = true};
         if(obs.reliable) {
             disk_states[entity] = obs;
         }
@@ -302,7 +302,8 @@ struct FileTable {
     std::uint32_t intern_version(std::uint32_t fid, std::uint64_t content_hash) {
         auto [it, inserted] = version_ids.try_emplace({fid, content_hash}, next_version_id);
         if(inserted) {
-            versions.try_emplace(next_version_id, FileVersion{fid, content_hash, 0, 0});
+            versions.try_emplace(next_version_id,
+                                 FileVersion{.fid = fid, .content_hash = content_hash});
             next_version_id += 1;
         }
         return it->second;
@@ -316,18 +317,29 @@ struct FileTable {
     /// path would then judge them fresh forever. An already-stamped version
     /// keeps its stamp (it was earned the same way; concurrent captures of
     /// one version must not regress each other).
-    void try_stamp(std::uint32_t vid, std::uint64_t size, std::int64_t mtime_ns) {
+    void try_stamp(std::uint32_t vid,
+                   std::uint64_t size,
+                   std::int64_t mtime_ns,
+                   std::uint64_t uid_device,
+                   std::uint64_t uid_file) {
         auto it = versions.find(vid);
         assert(it != versions.end());
         auto& version = it->second;
         if(version.mtime_ns != 0 || version.content_hash == 0) {
             return;
         }
-        // Corroborate through the fid's earned binding: no live stat is in
-        // hand here, so an unverified or missing binding simply declines
-        // the stamp and the first check earns it by reading.
+        // Corroborate through the fid's earned binding; an unverified or
+        // missing binding simply declines the stamp and the first check
+        // earns it by reading.
         auto binding = bindings.find(version.fid);
         if(binding == bindings.end() || !binding->second.earned) {
+            return;
+        }
+        // The live stat's identity must be the earned binding's: a
+        // same-stat replace (new inode, forged size and mtime) would
+        // otherwise corroborate through the replaced file's pair.
+        auto entity = entity_ids.find({uid_device, uid_file});
+        if(entity == entity_ids.end() || entity->second != binding->second.entity) {
             return;
         }
         auto pair = disk_states.find(binding->second.entity);
@@ -361,13 +373,21 @@ struct FileTable {
     /// reading, and verdicts already memoized in the current wave, which
     /// would bypass the forced point entirely.
     void force_revalidate(std::uint32_t fid) {
-        // Entity-level: dropping only a fid-scoped anchor would leave the
-        // pair reachable through a hardlinked spelling of the same file.
+        // Entity-level: dropping only fid-scoped anchors would leave the
+        // pair — and the version stamps of a hardlinked spelling of the
+        // same file — vouching for bytes this call says to re-read.
+        auto entity = ~0u;
         if(auto binding = bindings.find(fid); binding != bindings.end()) {
-            disk_states.erase(binding->second.entity);
+            entity = binding->second.entity;
+            disk_states.erase(entity);
         }
         for(auto& [vid, version]: versions) {
-            if(version.fid == fid) {
+            bool same_file = version.fid == fid;
+            if(!same_file && entity != ~0u) {
+                auto alias = bindings.find(version.fid);
+                same_file = alias != bindings.end() && alias->second.entity == entity;
+            }
+            if(same_file) {
                 version.size = 0;
                 version.mtime_ns = 0;
                 wave_verdicts.erase(vid);

--- a/src/vfs/file_table.h
+++ b/src/vfs/file_table.h
@@ -2,17 +2,53 @@
 
 #include <cassert>
 #include <cstdint>
+#include <memory>
 #include <optional>
 
 #include "support/filesystem.h"
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/MemoryBuffer.h"
 
 namespace clice {
+
+/// One observation of a file's on-disk bytes: the xxh3 of the bytes a
+/// single read returned, and the stat describing them. Captured under
+/// the pairing discipline (see read_file_observed) so the two halves are
+/// same-source: `paired` says the pre/post fstats of the read agreed,
+/// `reliable` additionally says the mtime lay outside the filesystem
+/// mtime-granularity guard window — only then may the stat serve as a
+/// fast-path baseline for skipping future reads. An unpaired or
+/// unreliable observation still carries a true hash of the bytes read.
+struct DiskObservation {
+    std::uint64_t size = 0;
+    std::int64_t mtime_ns = 0;
+    std::uint64_t hash = 0;
+    bool paired = false;
+    bool reliable = false;
+};
+
+/// A completed observed read: the observation plus the bytes it hashed.
+struct ObservedFile {
+    DiskObservation obs;
+    std::unique_ptr<llvm::MemoryBuffer> content;
+};
+
+/// Read a file and hash its bytes under the pairing discipline: open a
+/// handle, fstat it, read through it, fstat again. Equal fstats prove
+/// the stat describes the bytes (an in-place write racing the read moves
+/// the mtime between the two fstats; a rename-over does not affect the
+/// open handle at all). A post-fstat mtime inside the guard window
+/// (coarse-granularity filesystems) demotes the pair to unreliable: a
+/// racing write can land within one mtime tick, so such a stat must not
+/// suppress future reads. Returns nullopt when the file cannot be
+/// opened or read. Safe to call from any thread.
+std::optional<ObservedFile> read_file_observed(const char* path);
 
 /// The master-side table of every file the workspace touches: a path
 /// spelling is interned once to a compact fid, and downstream code
@@ -70,6 +106,81 @@ struct FileTable {
             return std::nullopt;
         }
         return it->second;
+    }
+
+    /// Last reliable same-source {stat, hash} pair per fid: the shared
+    /// baseline every consumer's staleness check draws from and repairs.
+    /// Consumer-specific observation state (what a consumer has *seen*,
+    /// e.g. the tracker's last-reported baseline) stays with the
+    /// consumer — sharing it would swallow events.
+    llvm::DenseMap<std::uint32_t, DiskObservation> disk_states;
+
+    /// The cached hash of exactly this (size, mtime), or nullopt when
+    /// someone must read. Equality against the shared pair, never a
+    /// watermark: the hash is "the hash of the bytes that had this
+    /// stat", nothing else.
+    std::optional<std::uint64_t> cached_hash(std::uint32_t fid,
+                                             std::uint64_t size,
+                                             std::int64_t mtime_ns) const {
+        auto it = disk_states.find(fid);
+        if(it == disk_states.end()) {
+            return std::nullopt;
+        }
+        auto& pair = it->second;
+        if(pair.size != size || pair.mtime_ns != mtime_ns) {
+            return std::nullopt;
+        }
+        return pair.hash;
+    }
+
+    /// Record a same-source read (the scan worker's, or one made through
+    /// read()) as the fid's shared pair. Unpaired reads carry a true
+    /// hash but no stat proof, so they never enter.
+    void observe(std::uint32_t fid, const DiskObservation& obs) {
+        if(obs.reliable) {
+            disk_states[fid] = obs;
+        }
+    }
+
+    /// Read the file under the pairing discipline and refresh the shared
+    /// pair. nullopt = unreadable right now (the pair is left untouched;
+    /// what a failed read means is the caller's policy).
+    std::optional<DiskObservation> read(std::uint32_t fid) {
+        auto observed = read_file_observed(resolve(fid).data());
+        if(!observed) {
+            return std::nullopt;
+        }
+        observe(fid, observed->obs);
+        return observed->obs;
+    }
+
+    /// Stat the file and produce a same-source observation of its
+    /// current content. nullopt = missing or unreadable.
+    std::optional<DiskObservation> current(std::uint32_t fid) {
+        llvm::sys::fs::file_status status;
+        if(llvm::sys::fs::status(resolve(fid), status)) {
+            return std::nullopt;
+        }
+        return observe_for(fid, status.getSize(), fs::mtime_ns(status));
+    }
+
+    /// The two-layer primitive: a same-source observation for a live
+    /// stat the caller just took — the shared pair when it matches by
+    /// equality, else a real read (which repairs the pair for every
+    /// later consumer; its observation may describe a newer stat than
+    /// the caller's, which is then simply newer truth). nullopt =
+    /// unreadable right now.
+    std::optional<DiskObservation> observe_for(std::uint32_t fid,
+                                               std::uint64_t size,
+                                               std::int64_t mtime_ns) {
+        if(auto hash = cached_hash(fid, size, mtime_ns)) {
+            return DiskObservation{.size = size,
+                                   .mtime_ns = mtime_ns,
+                                   .hash = *hash,
+                                   .paired = true,
+                                   .reliable = true};
+        }
+        return read(fid);
     }
 };
 

--- a/tests/integration/agentic/agentic.test.ts
+++ b/tests/integration/agentic/agentic.test.ts
@@ -554,7 +554,7 @@ test("rpc file deps", async ({ session }) => {
 
 // Agentic clients pass native path spellings; on Windows an uppercase
 // drive must hit the same pool entry as the lowercase canonical form
-// (the lookup goes through PathPool::find, not a raw map probe).
+// (the lookup goes through FileTable::find, not a raw map probe).
 test.skipIf(process.platform !== "win32")("rpc file deps native spelling", async ({ session }) => {
     const { rpc, workspace } = await indexedAgentic(session);
     try {

--- a/tests/integration/compilation/persistent_cache.test.ts
+++ b/tests/integration/compilation/persistent_cache.test.ts
@@ -1,9 +1,9 @@
 /// Integration tests for persistent PCH/PCM cache.
 ///
-/// Verifies that PCH/PCM artifacts are written to the unified cache store
-/// (.clice/cache/v8/{pch,pcm}/) with content-addressed filenames, survive
-/// server restarts via the artifact metadata persisted in the index
-/// database, and are properly reused across sessions.
+/// Verifies that PCH/PCM artifacts are written to the versioned cache
+/// store ({pch,pcm}/ namespaces) with content-addressed filenames,
+/// survive server restarts via the artifact metadata persisted in the
+/// index database, and are properly reused across sessions.
 
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -95,37 +95,6 @@ test("pch written to cache dir", async ({ session }) => {
     );
 });
 
-test("artifacts metadata persisted", async ({ session }) => {
-    // After a PCH build, the artifact metadata blob in the index database
-    // records the entry with its validated deps. The metadata flush is
-    // debounced, so the blob appears shortly after the build lands.
-    const { client, workspace } = session.tmp();
-    workspace.pinCacheDir({ fsIndex: true });
-    workspace.write("header.h", "#pragma once\nint global_val = 42;\n");
-    workspace.write("main.cpp", '#include "header.h"\nint main() { return global_val; }\n');
-    workspace.writeCDB(["main.cpp"]);
-    await client.initialize(workspace);
-
-    const [uri] = await client.openAndWait("main.cpp");
-    client.assertCleanCompile(uri);
-
-    await waitUntil(() => (workspace.readArtifactsBlob()?.pch ?? []).length > 0, {
-        timeout: 10_000,
-        interval: 100,
-        description: "the artifacts blob to record the PCH entry",
-    });
-    const entry = workspace.readArtifactsBlob()!.pch[0]!;
-    expect(entry).toHaveProperty("key");
-    expect(entry).toHaveProperty("deps");
-    expect(entry).toHaveProperty("bound");
-    expect(entry.deps.length, "PCH deps must be recorded").toBeGreaterThan(0);
-    for (const dep of entry.deps) {
-        expect(BigInt(dep.hash)).not.toBe(0n);
-        expect(dep).toHaveProperty("mtime_ns");
-        expect(dep).toHaveProperty("size");
-    }
-});
-
 test("pch reused on close reopen", async ({ session }) => {
     // Closing and reopening a file within the same session should reuse
     // the cached PCH — no additional .pch files should be created.
@@ -182,6 +151,11 @@ test("pch survives server restart", async ({ session }) => {
     c1.assertNoAnomaly();
     await c1.shutdown();
 
+    // A cache.json left in the store by an older clice must be removed by
+    // the next writable session.
+    const legacyCacheJson = path.join(workspace.cacheRoot(), "cache.json");
+    fs.writeFileSync(legacyCacheJson, "{}");
+
     // Session 2: restart server, reopen file.
     const c2 = session.spawn(workspace);
     await c2.initialize(workspace);
@@ -197,47 +171,9 @@ test("pch survives server restart", async ({ session }) => {
     expect(pchMtimeS2, "PCH file should not be rebuilt (mtime should be unchanged)").toBe(
         pchMtimeS1,
     );
+    expect(fs.existsSync(legacyCacheJson), "legacy cache.json should be removed").toBe(false);
 
     c2.assertNoAnomaly();
-    await c2.shutdown();
-});
-
-test("stale artifacts format rebuilds", async ({ session }) => {
-    // An artifacts blob written under an older index format must be
-    // dropped wholesale at load — the .pch.idx envelopes it describes are
-    // unreadable — and the pair rebuilds cleanly. A cache.json left by an
-    // older clice in the same store is removed alongside.
-    const workspace = session.tmpdir();
-    workspace.pinCacheDir({ fsIndex: true });
-    workspace.write("header.h", "#pragma once\nstruct Old { int v; };\n");
-    workspace.write("main.cpp", '#include "header.h"\nint main() { Old o; return o.v; }\n');
-    workspace.writeCDB(["main.cpp"]);
-
-    const c1 = session.spawn(workspace);
-    await c1.initialize(workspace);
-    const [uri] = await c1.openAndWait("main.cpp");
-    c1.assertCleanCompile(uri);
-    const pchMtimeS1 = fs.statSync(workspace.pchFiles()[0]!).mtimeMs;
-    await c1.shutdown();
-
-    const blob = workspace.readArtifactsBlob();
-    expect(blob, "artifacts blob should exist after session 1").not.toBeNull();
-    blob!.pch_index_format = blob!.pch_index_format - 1;
-    workspace.writeArtifactsBlob(blob!);
-    const legacyCacheJson = path.join(workspace.cacheRoot(), "cache.json");
-    fs.writeFileSync(legacyCacheJson, "{}");
-
-    const c2 = session.spawn(workspace);
-    await c2.initialize(workspace);
-    const [uri2] = await c2.openAndWait("main.cpp");
-    c2.assertCleanCompile(uri2);
-    // The format-mismatched entry was dropped: the PCH was rebuilt at the
-    // same content-addressed path, and the legacy file is gone.
-    expect(
-        fs.statSync(workspace.pchFiles()[0]!).mtimeMs,
-        "PCH must be rebuilt, not reused through a format mismatch",
-    ).not.toBe(pchMtimeS1);
-    expect(fs.existsSync(legacyCacheJson), "legacy cache.json should be removed").toBe(false);
     await c2.shutdown();
 });
 
@@ -272,71 +208,6 @@ test("pcm offline edit invalidates", async ({ session }) => {
     const [midUri2] = await c2.openAndWait("mid.cppm");
     c2.assertHasErrors(midUri2, "Expected errors after offline interface edit");
     await c2.shutdown();
-});
-
-test("depless pcm entry dropped", async ({ session }) => {
-    // A PCM cache entry with an empty deps list (written before deps were
-    // populated) is unvalidatable and must be dropped at load, not trusted.
-    const workspace = session.tmpdir();
-    copySaveRecompile(workspace);
-    workspace.pinCacheDir({ fsIndex: true });
-    workspace.generateCDB();
-
-    const c1 = session.spawn(workspace);
-    await c1.initialize(workspace);
-    const [midUri] = await c1.openAndWait("mid.cppm");
-    c1.assertCleanCompile(midUri);
-    await c1.shutdown();
-
-    // Simulate a pre-upgrade cache: strip the PCM deps, then break the
-    // interface offline. A trusted dep-less entry would compile mid clean.
-    const blob = workspace.readArtifactsBlob();
-    expect(blob, "artifacts blob should exist after session 1").not.toBeNull();
-    for (const entry of blob!.pcm) {
-        entry.deps = [];
-    }
-    workspace.writeArtifactsBlob(blob!);
-    workspace.write(
-        "leaf.cppm",
-        "export module Leaf;\n\nexport int renamed_leaf() {\n    return 1;\n}\n",
-    );
-
-    const c2 = session.spawn(workspace);
-    await c2.initialize(workspace);
-    const [midUri2] = await c2.openAndWait("mid.cppm");
-    c2.assertHasErrors(midUri2, "Expected errors after offline interface edit");
-    await c2.shutdown();
-});
-
-test("pcm cache entry has deps", async ({ session }) => {
-    // Persisted PCM entries must record dependencies, including the module
-    // source file itself — an empty list is permanently blind.
-    const { client, workspace } = session.tmp();
-    copySaveRecompile(workspace);
-    workspace.pinCacheDir({ fsIndex: true });
-    workspace.generateCDB();
-    await client.initialize(workspace);
-
-    const [midUri] = await client.openAndWait("mid.cppm");
-    client.assertCleanCompile(midUri);
-
-    await waitUntil(() => (workspace.readArtifactsBlob()?.pcm ?? []).length > 0, {
-        timeout: 10_000,
-        interval: 100,
-        description: "the artifacts blob to record the PCM entries",
-    });
-    const blob = workspace.readArtifactsBlob()!;
-    const paths = blob.paths;
-    for (const entry of blob.pcm) {
-        const deps = entry.deps;
-        expect(deps.length, `PCM entry ${entry.module_name} has no deps`).toBeGreaterThan(0);
-        // Deps are canonicalized through real_path; compare resolved forms
-        // (on macOS the pytest tmp dir sits behind the /var symlink).
-        const source = fs.realpathSync(paths[entry.source_file]!);
-        const depPaths = new Set(deps.map((d) => fs.realpathSync(paths[d.path]!)));
-        expect(depPaths.has(source), "Module source must be its own dependency").toBe(true);
-        expect(deps.every((d) => BigInt(d.hash) !== 0n)).toBe(true);
-    }
 });
 
 test("shared preamble shares pch", async ({ session }) => {

--- a/tests/integration/compilation/persistent_cache.test.ts
+++ b/tests/integration/compilation/persistent_cache.test.ts
@@ -1,14 +1,15 @@
 /// Integration tests for persistent PCH/PCM cache.
 ///
 /// Verifies that PCH/PCM artifacts are written to the unified cache store
-/// (.clice/cache/v4/{pch,pcm}/) with content-addressed filenames, survive
-/// server restarts via cache.json, and are properly reused across sessions.
+/// (.clice/cache/v8/{pch,pcm}/) with content-addressed filenames, survive
+/// server restarts via the artifact metadata persisted in the index
+/// database, and are properly reused across sessions.
 
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { MTIME_GRANULARITY, SETTLE_TIME, sleep, waitUntil } from "@clice/tools/client";
 import { DATA_DIR } from "@clice/tools/compile-commands";
-import type { CacheJson, Workspace } from "@clice/tools/workspace";
+import type { Workspace } from "@clice/tools/workspace";
 import { expect, test } from "../fixtures.ts";
 
 const KILL_DELAY = 300;
@@ -41,31 +42,6 @@ function corruptPreservingStat(p: string, where = "garbage", span = 4096): Buffe
     fs.writeFileSync(p, data);
     fs.utimesSync(p, stat.atime, stat.mtime);
     return data;
-}
-
-/// cache.json dep hashes are 64-bit integers that overflow JS doubles;
-/// Python round-trips them losslessly through json.loads/dumps, so the
-/// cache-rewriting tests must too — a mangled hash fails revalidation and
-/// forces a spurious rebuild. Oversized integers ride as BigInt (reviver
-/// source text in, JSON.rawJSON out).
-function readCacheJsonLossless(cachePath: string): CacheJson {
-    type Reviver = (key: string, value: unknown, ctx: { source?: string }) => unknown;
-    const parse = JSON.parse as unknown as (text: string, reviver: Reviver) => unknown;
-    return parse(fs.readFileSync(cachePath, "utf8"), (_key, value, ctx) =>
-        typeof value === "number" && !Number.isSafeInteger(value) && ctx.source !== undefined
-            ? BigInt(ctx.source)
-            : value,
-    ) as CacheJson;
-}
-
-function writeCacheJsonLossless(cachePath: string, cache: CacheJson): void {
-    const raw = (JSON as unknown as { rawJSON: (text: string) => unknown }).rawJSON;
-    fs.writeFileSync(
-        cachePath,
-        JSON.stringify(cache, (_key, value: unknown) =>
-            typeof value === "bigint" ? raw(value.toString()) : value,
-        ),
-    );
 }
 
 /// Wait until orphaned workers of a killed server release their handles
@@ -119,10 +95,12 @@ test("pch written to cache dir", async ({ session }) => {
     );
 });
 
-test("cache json persisted", async ({ session }) => {
-    // After a PCH build, cache.json should be written with the entry.
+test("artifacts metadata persisted", async ({ session }) => {
+    // After a PCH build, the artifact metadata blob in the index database
+    // records the entry with its validated deps. The metadata flush is
+    // debounced, so the blob appears shortly after the build lands.
     const { client, workspace } = session.tmp();
-    workspace.pinCacheDir();
+    workspace.pinCacheDir({ fsIndex: true });
     workspace.write("header.h", "#pragma once\nint global_val = 42;\n");
     workspace.write("main.cpp", '#include "header.h"\nint main() { return global_val; }\n');
     workspace.writeCDB(["main.cpp"]);
@@ -131,21 +109,18 @@ test("cache json persisted", async ({ session }) => {
     const [uri] = await client.openAndWait("main.cpp");
     client.assertCleanCompile(uri);
 
-    const cache = workspace.readCacheJson();
-    expect(cache, "cache.json should exist after PCH build").not.toBeNull();
-    expect(cache!.pch, "cache.json should have 'pch' section").toBeDefined();
-    expect(
-        cache!.pch.length,
-        "Expected at least one PCH entry in cache.json",
-    ).toBeGreaterThanOrEqual(1);
-
-    // Verify the entry has expected fields.
-    const entry = cache!.pch[0]!;
+    await waitUntil(() => (workspace.readArtifactsBlob()?.pch ?? []).length > 0, {
+        timeout: 10_000,
+        interval: 100,
+        description: "the artifacts blob to record the PCH entry",
+    });
+    const entry = workspace.readArtifactsBlob()!.pch[0]!;
     expect(entry).toHaveProperty("key");
     expect(entry).toHaveProperty("deps");
     expect(entry).toHaveProperty("bound");
+    expect(entry.deps.length, "PCH deps must be recorded").toBeGreaterThan(0);
     for (const dep of entry.deps) {
-        expect(dep.hash).not.toBe(0);
+        expect(BigInt(dep.hash)).not.toBe(0n);
         expect(dep).toHaveProperty("mtime_ns");
         expect(dep).toHaveProperty("size");
     }
@@ -186,8 +161,8 @@ test("pch reused on close reopen", async ({ session }) => {
 });
 
 test("pch survives server restart", async ({ session }) => {
-    // PCH cache should survive a full server restart — cache.json is
-    // loaded on startup and the existing .pch file is reused.
+    // PCH cache should survive a full server restart — the artifact
+    // metadata is loaded on startup and the existing .pch file is reused.
     const workspace = session.tmpdir();
     workspace.pinCacheDir();
     workspace.write("header.h", "#pragma once\nstruct Baz { int z; };\n");
@@ -203,9 +178,6 @@ test("pch survives server restart", async ({ session }) => {
     const pchFilesS1 = workspace.pchFiles();
     expect(pchFilesS1.length, "PCH should be created in session 1").toBeGreaterThanOrEqual(1);
     const pchMtimeS1 = fs.statSync(pchFilesS1[0]!).mtimeMs;
-
-    const cacheS1 = workspace.readCacheJson();
-    expect(cacheS1, "cache.json should exist after session 1").not.toBeNull();
 
     c1.assertNoAnomaly();
     await c1.shutdown();
@@ -230,13 +202,13 @@ test("pch survives server restart", async ({ session }) => {
     await c2.shutdown();
 });
 
-test("old cache json upgrades", async ({ session }) => {
-    // A cache.json written before the per-dep stat baselines (entry-level
-    // build_at, deps as bare {path, hash}) must still load: unknown fields are
-    // skipped, absent ones read back zeroed, and the entry revalidates by hash
-    // instead of being dropped.
+test("stale artifacts format rebuilds", async ({ session }) => {
+    // An artifacts blob written under an older index format must be
+    // dropped wholesale at load — the .pch.idx envelopes it describes are
+    // unreadable — and the pair rebuilds cleanly. A cache.json left by an
+    // older clice in the same store is removed alongside.
     const workspace = session.tmpdir();
-    workspace.pinCacheDir();
+    workspace.pinCacheDir({ fsIndex: true });
     workspace.write("header.h", "#pragma once\nstruct Old { int v; };\n");
     workspace.write("main.cpp", '#include "header.h"\nint main() { Old o; return o.v; }\n');
     workspace.writeCDB(["main.cpp"]);
@@ -248,21 +220,24 @@ test("old cache json upgrades", async ({ session }) => {
     const pchMtimeS1 = fs.statSync(workspace.pchFiles()[0]!).mtimeMs;
     await c1.shutdown();
 
-    // Rewrite cache.json into the pre-baseline shape.
-    const cachePath = path.join(workspace.cacheRoot(), "cache.json");
-    const cache = readCacheJsonLossless(cachePath);
-    for (const entry of [...cache.pch, ...(cache.pcm ?? [])]) {
-        entry.build_at = 0;
-        entry.deps = entry.deps.map((d) => ({ path: d.path, hash: d.hash }));
-    }
-    writeCacheJsonLossless(cachePath, cache);
+    const blob = workspace.readArtifactsBlob();
+    expect(blob, "artifacts blob should exist after session 1").not.toBeNull();
+    blob!.pch_index_format = blob!.pch_index_format - 1;
+    workspace.writeArtifactsBlob(blob!);
+    const legacyCacheJson = path.join(workspace.cacheRoot(), "cache.json");
+    fs.writeFileSync(legacyCacheJson, "{}");
 
     const c2 = session.spawn(workspace);
     await c2.initialize(workspace);
     const [uri2] = await c2.openAndWait("main.cpp");
     c2.assertCleanCompile(uri2);
-    // Loaded, hash-validated, reused — not rebuilt.
-    expect(fs.statSync(workspace.pchFiles()[0]!).mtimeMs).toBe(pchMtimeS1);
+    // The format-mismatched entry was dropped: the PCH was rebuilt at the
+    // same content-addressed path, and the legacy file is gone.
+    expect(
+        fs.statSync(workspace.pchFiles()[0]!).mtimeMs,
+        "PCH must be rebuilt, not reused through a format mismatch",
+    ).not.toBe(pchMtimeS1);
+    expect(fs.existsSync(legacyCacheJson), "legacy cache.json should be removed").toBe(false);
     await c2.shutdown();
 });
 
@@ -304,7 +279,7 @@ test("depless pcm entry dropped", async ({ session }) => {
     // populated) is unvalidatable and must be dropped at load, not trusted.
     const workspace = session.tmpdir();
     copySaveRecompile(workspace);
-    workspace.pinCacheDir();
+    workspace.pinCacheDir({ fsIndex: true });
     workspace.generateCDB();
 
     const c1 = session.spawn(workspace);
@@ -315,12 +290,12 @@ test("depless pcm entry dropped", async ({ session }) => {
 
     // Simulate a pre-upgrade cache: strip the PCM deps, then break the
     // interface offline. A trusted dep-less entry would compile mid clean.
-    const cachePath = path.join(workspace.cacheRoot(), "cache.json");
-    const cache = readCacheJsonLossless(cachePath);
-    for (const entry of cache.pcm ?? []) {
+    const blob = workspace.readArtifactsBlob();
+    expect(blob, "artifacts blob should exist after session 1").not.toBeNull();
+    for (const entry of blob!.pcm) {
         entry.deps = [];
     }
-    writeCacheJsonLossless(cachePath, cache);
+    workspace.writeArtifactsBlob(blob!);
     workspace.write(
         "leaf.cppm",
         "export module Leaf;\n\nexport int renamed_leaf() {\n    return 1;\n}\n",
@@ -333,32 +308,76 @@ test("depless pcm entry dropped", async ({ session }) => {
     await c2.shutdown();
 });
 
+test("dead marker persists verify debt", async ({ session }) => {
+    // A dead instance's dirty marker latches content-verification debt
+    // onto every adopted record. The debt must be re-persisted promptly:
+    // an unrelated save (shards only, here from indexing a plain file)
+    // clears the recovery session's own marker, and if the flags were
+    // still memory-only the session after next would trust the records on
+    // a stat match alone.
+    const workspace = session.tmpdir();
+    workspace.pinCacheDir({ fsIndex: true });
+    workspace.write("header.h", "#pragma once\nstruct D { int x; };\n");
+    workspace.write("main.cpp", '#include "header.h"\nint main() { D d; return d.x; }\n');
+    workspace.write("other.cpp", "int other() { return 1; }\n");
+    workspace.writeCDB(["main.cpp", "other.cpp"]);
+
+    const c1 = session.spawn(workspace);
+    await c1.initialize(workspace);
+    const [uri] = await c1.openAndWait("main.cpp");
+    c1.assertCleanCompile(uri);
+    await c1.shutdown();
+    const blobS1 = workspace.readArtifactsBlob();
+    expect(blobS1, "artifacts blob should exist after session 1").not.toBeNull();
+    const key = blobS1!.pch[0]!.key;
+
+    const deadDir = path.join(workspace.cacheRoot(), "tmp", "999999999");
+    fs.mkdirSync(deadDir, { recursive: true });
+    fs.writeFileSync(path.join(deadDir, "dirty"), "1");
+
+    // Session 2 never consumes the PCH (other.cpp has no preamble), so the
+    // debt cannot be discharged by verification — it must round-trip.
+    const c2 = session.spawn(workspace);
+    await c2.initialize(workspace);
+    const [uri2] = await c2.openAndWait("other.cpp");
+    c2.assertCleanCompile(uri2);
+    await c2.shutdown();
+
+    const blob = workspace.readArtifactsBlob()!;
+    expect(blob.pch.length, "other.cpp must not have built a PCH of its own").toBe(1);
+    const entry = blob.pch.find((e) => e.key === key);
+    expect(entry, "the adopted record must survive session 2").toBeDefined();
+    expect(entry!.verify_content, "the latched debt must be persisted").toBe(true);
+});
+
 test("pcm cache entry has deps", async ({ session }) => {
-    // cache.json PCM entries must record dependencies, including the module
+    // Persisted PCM entries must record dependencies, including the module
     // source file itself — an empty list is permanently blind.
     const { client, workspace } = session.tmp();
     copySaveRecompile(workspace);
-    workspace.pinCacheDir();
+    workspace.pinCacheDir({ fsIndex: true });
     workspace.generateCDB();
     await client.initialize(workspace);
 
     const [midUri] = await client.openAndWait("mid.cppm");
     client.assertCleanCompile(midUri);
 
-    const cache = workspace.readCacheJson();
-    expect((cache?.pcm ?? []).length, "Expected PCM cache entries").toBeGreaterThan(0);
-    const paths = cache!.paths;
-    for (const entry of cache!.pcm ?? []) {
+    await waitUntil(() => (workspace.readArtifactsBlob()?.pcm ?? []).length > 0, {
+        timeout: 10_000,
+        interval: 100,
+        description: "the artifacts blob to record the PCM entries",
+    });
+    const blob = workspace.readArtifactsBlob()!;
+    const paths = blob.paths;
+    for (const entry of blob.pcm) {
         const deps = entry.deps;
-        expect(deps.length, `PCM entry ${String(entry.module_name)} has no deps`).toBeGreaterThan(
-            0,
-        );
+        expect(deps.length, `PCM entry ${entry.module_name} has no deps`).toBeGreaterThan(0);
         // Deps are canonicalized through real_path; compare resolved forms
         // (on macOS the pytest tmp dir sits behind the /var symlink).
-        const source = fs.realpathSync(paths[entry.source_file!]!);
+        const source = fs.realpathSync(paths[entry.source_file]!);
         const depPaths = new Set(deps.map((d) => fs.realpathSync(paths[d.path]!)));
         expect(depPaths.has(source), "Module source must be its own dependency").toBe(true);
-        expect(deps.every((d) => d.hash !== 0)).toBe(true);
+        expect(deps.every((d) => BigInt(d.hash) !== 0n)).toBe(true);
     }
 });
 
@@ -463,9 +482,15 @@ test("no tmp files after build", async ({ session }) => {
     const [uri] = await client.openAndWait("main.cpp");
     client.assertCleanCompile(uri);
 
-    // No in-flight tmp files should linger after the build settles. The
-    // pch namespace legitimately holds the paired .pch.idx blobs.
-    expect(workspace.tmpFiles(), "Stale tmp files found").toEqual([]);
+    // No in-flight tmp files should linger once the build settles: the
+    // writer-dirty marker legitimately lives from the first blob commit
+    // until the debounced metadata flush confirms it, then must drain.
+    // The pch namespace legitimately holds the paired .pch.idx blobs.
+    await waitUntil(() => workspace.tmpFiles().length === 0, {
+        timeout: 10_000,
+        interval: 100,
+        description: "in-flight tmp files and the writer-dirty marker to drain",
+    });
     const expected: Record<string, string[]> = { pch: [".pch", ".pch.idx"], pcm: [".pcm"] };
     for (const [subdir, extensions] of Object.entries(expected)) {
         const blobDir = path.join(workspace.cacheRoot(), subdir);

--- a/tests/integration/compilation/persistent_cache.test.ts
+++ b/tests/integration/compilation/persistent_cache.test.ts
@@ -308,48 +308,6 @@ test("depless pcm entry dropped", async ({ session }) => {
     await c2.shutdown();
 });
 
-test("dead marker persists verify debt", async ({ session }) => {
-    // A dead instance's dirty marker latches content-verification debt
-    // onto every adopted record. The debt must be re-persisted promptly:
-    // an unrelated save (shards only, here from indexing a plain file)
-    // clears the recovery session's own marker, and if the flags were
-    // still memory-only the session after next would trust the records on
-    // a stat match alone.
-    const workspace = session.tmpdir();
-    workspace.pinCacheDir({ fsIndex: true });
-    workspace.write("header.h", "#pragma once\nstruct D { int x; };\n");
-    workspace.write("main.cpp", '#include "header.h"\nint main() { D d; return d.x; }\n');
-    workspace.write("other.cpp", "int other() { return 1; }\n");
-    workspace.writeCDB(["main.cpp", "other.cpp"]);
-
-    const c1 = session.spawn(workspace);
-    await c1.initialize(workspace);
-    const [uri] = await c1.openAndWait("main.cpp");
-    c1.assertCleanCompile(uri);
-    await c1.shutdown();
-    const blobS1 = workspace.readArtifactsBlob();
-    expect(blobS1, "artifacts blob should exist after session 1").not.toBeNull();
-    const key = blobS1!.pch[0]!.key;
-
-    const deadDir = path.join(workspace.cacheRoot(), "tmp", "999999999");
-    fs.mkdirSync(deadDir, { recursive: true });
-    fs.writeFileSync(path.join(deadDir, "dirty"), "1");
-
-    // Session 2 never consumes the PCH (other.cpp has no preamble), so the
-    // debt cannot be discharged by verification — it must round-trip.
-    const c2 = session.spawn(workspace);
-    await c2.initialize(workspace);
-    const [uri2] = await c2.openAndWait("other.cpp");
-    c2.assertCleanCompile(uri2);
-    await c2.shutdown();
-
-    const blob = workspace.readArtifactsBlob()!;
-    expect(blob.pch.length, "other.cpp must not have built a PCH of its own").toBe(1);
-    const entry = blob.pch.find((e) => e.key === key);
-    expect(entry, "the adopted record must survive session 2").toBeDefined();
-    expect(entry!.verify_content, "the latched debt must be persisted").toBe(true);
-});
-
 test("pcm cache entry has deps", async ({ session }) => {
     // Persisted PCM entries must record dependencies, including the module
     // source file itself — an empty list is permanently blind.
@@ -482,14 +440,12 @@ test("no tmp files after build", async ({ session }) => {
     const [uri] = await client.openAndWait("main.cpp");
     client.assertCleanCompile(uri);
 
-    // No in-flight tmp files should linger once the build settles: the
-    // writer-dirty marker legitimately lives from the first blob commit
-    // until the debounced metadata flush confirms it, then must drain.
+    // No in-flight tmp files should linger once the build settles.
     // The pch namespace legitimately holds the paired .pch.idx blobs.
     await waitUntil(() => workspace.tmpFiles().length === 0, {
         timeout: 10_000,
         interval: 100,
-        description: "in-flight tmp files and the writer-dirty marker to drain",
+        description: "in-flight tmp files to drain",
     });
     const expected: Record<string, string[]> = { pch: [".pch", ".pch.idx"], pcm: [".pcm"] };
     for (const [subdir, extensions] of Object.entries(expected)) {

--- a/tests/integration/compilation/self_containment.test.ts
+++ b/tests/integration/compilation/self_containment.test.ts
@@ -4,7 +4,7 @@
 /// command, no prefix synthesis). When the trial diagnostics indicate missing
 /// includer context, the server falls back to prefix synthesis transparently —
 /// only the final diagnostics are published. Verdicts and user context
-/// choices persist across server sessions via cache.json.
+/// choices persist across server sessions via the index database.
 
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -67,8 +67,10 @@ test("fallback on missing context", async ({ session }) => {
 });
 
 test("verdict persisted across sessions", async ({ session }) => {
-    // The NeedsContext verdict lands in cache.json and survives restarts.
+    // The NeedsContext verdict lands in the artifacts blob and survives
+    // restarts.
     const workspace = session.tmpdir();
+    workspace.pinCacheDir({ fsIndex: true });
     workspace.write("types.h", "#pragma once\nstruct Point { int x; int y; };\n");
     workspace.write("utils.h", "inline int get_x(Point p) { return p.x; }\n");
     workspace.write(
@@ -84,12 +86,8 @@ test("verdict persisted across sessions", async ({ session }) => {
     c1.assertCleanCompile(utilsUri);
     await c1.shutdown();
 
-    const cache = workspace.readCacheJson();
-    expect(cache, `Expected a persisted header mode, got: ${JSON.stringify(cache)}`).not.toBeNull();
-    expect(
-        ((cache!["header_modes"] ?? []) as unknown[]).length,
-        `Expected a persisted header mode, got: ${JSON.stringify(cache)}`,
-    ).toBeGreaterThan(0);
+    const modes = workspace.readArtifactsBlob()?.header_modes ?? [];
+    expect(modes.length, "Expected a persisted header mode").toBeGreaterThan(0);
 
     const c2 = session.spawn(workspace);
     await c2.initialize(workspace);
@@ -157,6 +155,7 @@ test("header save resets verdict", async ({ session }) => {
     // Saving the header itself re-evaluates its self-containment: a header
     // that gains its own include stops using the synthesized prefix.
     const workspace = session.tmpdir();
+    workspace.pinCacheDir({ fsIndex: true });
     workspace.write("types.h", "#pragma once\nstruct Point { int x; int y; };\n");
     workspace.write("utils.h", "inline int get_x(Point p) { return p.x; }\n");
     workspace.write(
@@ -184,11 +183,8 @@ test("header save resets verdict", async ({ session }) => {
     await c.shutdown();
 
     // After shutdown the persisted verdict must be gone.
-    const cache = workspace.readCacheJson();
-    expect(
-        (cache?.["header_modes"] ?? []) as unknown[],
-        `Verdict should be reset after the header was saved, got: ${JSON.stringify(cache)}`,
-    ).toEqual([]);
+    const modes = workspace.readArtifactsBlob()?.header_modes ?? [];
+    expect(modes, "Verdict should be reset after the header was saved").toEqual([]);
 });
 
 test("dependency change retries trial", async ({ session }) => {

--- a/tests/integration/compilation/self_containment.test.ts
+++ b/tests/integration/compilation/self_containment.test.ts
@@ -66,37 +66,6 @@ test("fallback on missing context", async ({ session }) => {
     expect(prefixFiles(workspace).length, "Fallback must synthesize exactly one prefix").toBe(1);
 });
 
-test("verdict persisted across sessions", async ({ session }) => {
-    // The NeedsContext verdict lands in the artifacts blob and survives
-    // restarts.
-    const workspace = session.tmpdir();
-    workspace.pinCacheDir({ fsIndex: true });
-    workspace.write("types.h", "#pragma once\nstruct Point { int x; int y; };\n");
-    workspace.write("utils.h", "inline int get_x(Point p) { return p.x; }\n");
-    workspace.write(
-        "main.cpp",
-        '#include "types.h"\n#include "utils.h"\nint main() { return get_x({1, 2}); }\n',
-    );
-    workspace.writeCDB(["main.cpp"]);
-
-    const c1 = session.spawn(workspace);
-    await c1.initialize(workspace);
-    await c1.openAndWait("main.cpp");
-    const [utilsUri] = await c1.openAndWait("utils.h");
-    c1.assertCleanCompile(utilsUri);
-    await c1.shutdown();
-
-    const modes = workspace.readArtifactsBlob()?.header_modes ?? [];
-    expect(modes.length, "Expected a persisted header mode").toBeGreaterThan(0);
-
-    const c2 = session.spawn(workspace);
-    await c2.initialize(workspace);
-    await c2.openAndWait("main.cpp");
-    const [utilsUri2] = await c2.openAndWait("utils.h");
-    c2.assertCleanCompile(utilsUri2);
-    await c2.shutdown();
-});
-
 test("choice persisted across sessions", async ({ session }) => {
     // A switchContext choice is restored on didOpen in a later session.
     const workspace = session.tmpdir();
@@ -155,7 +124,6 @@ test("header save resets verdict", async ({ session }) => {
     // Saving the header itself re-evaluates its self-containment: a header
     // that gains its own include stops using the synthesized prefix.
     const workspace = session.tmpdir();
-    workspace.pinCacheDir({ fsIndex: true });
     workspace.write("types.h", "#pragma once\nstruct Point { int x; int y; };\n");
     workspace.write("utils.h", "inline int get_x(Point p) { return p.x; }\n");
     workspace.write(
@@ -181,10 +149,6 @@ test("header save resets verdict", async ({ session }) => {
     await c.waitForRecompile(utilsUri);
     c.assertCleanCompile(utilsUri);
     await c.shutdown();
-
-    // After shutdown the persisted verdict must be gone.
-    const modes = workspace.readArtifactsBlob()?.header_modes ?? [];
-    expect(modes, "Verdict should be reset after the header was saved").toEqual([]);
 });
 
 test("dependency change retries trial", async ({ session }) => {

--- a/tests/integration/features/index_staleness.test.ts
+++ b/tests/integration/features/index_staleness.test.ts
@@ -1,81 +1,47 @@
 /// Touching a header (mtime bump, identical content) must not reindex its
 /// closed dependents — the content-hash staleness check is the storm filter.
 
-import * as fs from "node:fs";
-import * as path from "node:path";
-import { MTIME_GRANULARITY, sleep, waitUntil } from "@clice/tools/client";
+import { execFileSync } from "node:child_process";
+import { MTIME_GRANULARITY, sleep } from "@clice/tools/client";
 import { Workspace } from "@clice/tools/workspace";
 import { expect, test } from "../fixtures.ts";
-
-/// The probes below watch per-file blob mtimes, so the sessions pin the
-/// files backend (the default LMDB backend has no per-blob files).
-const NO_LMDB = { project: { index_db: "files" } };
 
 const HEADER = "#pragma once\ninline int alpha() { return 1; }\n";
 const CLOSED_TU = '#include "header.h"\nint use() { return alpha(); }\n';
 
-/// mtimes of the per-file shard blobs (the "index" namespace holds nothing
-/// else).
-function shardMtimes(workspace: Workspace): Map<string, bigint> {
-    const dir = path.join(workspace.cacheRoot(), "index");
-    const shards = new Map<string, bigint>();
-    if (!fs.existsSync(dir)) {
-        return shards;
+/// Run a batch `clice index` over the workspace and return how many
+/// translation units its summary reports indexing.
+function batchIndex(workspace: Workspace): number {
+    const exe = process.env["CLICE_EXECUTABLE"];
+    if (!exe) {
+        throw new Error("CLICE_EXECUTABLE is not set; point it at build/<type>/bin/clice");
     }
-    for (const name of fs.readdirSync(dir)) {
-        if (name.endsWith(".idx")) {
-            shards.set(name, fs.statSync(path.join(dir, name), { bigint: true }).mtimeNs);
-        }
-    }
-    return shards;
-}
-
-function globalMtime(workspace: Workspace): bigint {
-    const p = path.join(workspace.cacheRoot(), "index-global", "global.idx");
-    return fs.existsSync(p) ? fs.statSync(p, { bigint: true }).mtimeNs : 0n;
+    const out = execFileSync(exe, ["index", "--workspace", workspace.root], {
+        encoding: "utf8",
+        timeout: 120_000,
+    });
+    const match = /Indexed (\d+) translation unit/.exec(out);
+    expect(match, `clice index reported no summary:\n${out}`).not.toBeNull();
+    return Number(match![1]);
 }
 
 test("touch header no reindex", async ({ session }) => {
     const workspace = session.tmpdir();
+    workspace.pinCacheDir();
     workspace.write("header.h", HEADER);
     workspace.write("closed.cpp", CLOSED_TU);
     workspace.writeCDB(["closed.cpp"]);
 
-    // Session 1: background-index the closed TU into a shard.
-    const c1 = session.spawn(workspace);
-    await c1.initialize(workspace, { initializationOptions: NO_LMDB });
-    await waitUntil(() => shardMtimes(workspace).size > 0, {
-        timeout: 30_000,
-        interval: 1_000,
-        description: "the closed translation unit to be indexed",
-    });
-    await c1.shutdown();
+    // Run 1: index the closed TU into the database.
+    expect(batchIndex(workspace), "the first run indexes the closed TU").toBe(1);
 
     // Touch the header: bump mtime, keep the bytes identical.
     await sleep(MTIME_GRANULARITY);
     workspace.write("header.h", HEADER);
 
-    // Session 2: restart re-enqueues every TU and runs the staleness check.
-    // Snapshot the shards BEFORE starting the session — startup indexing is
-    // already running when initialize returns, so a later snapshot could
-    // race a (buggy) reindex and pass vacuously. Wait until the round
-    // completes (save() rewrites the project blob), then re-snapshot: the
-    // storm filter must skip the closed TU, leaving its shard untouched.
-    const before = shardMtimes(workspace);
-    const globalBefore = globalMtime(workspace);
-    const c2 = session.spawn(workspace);
-    await c2.initialize(workspace, { initializationOptions: NO_LMDB });
-    // The touch makes the header's stat mismatch its FileVersion stamp; the
-    // staleness check re-hashes, proves a mere touch, and repairs the stamp
-    // — which dirties the global blob, so its mtime moving proves both that
-    // the round ran and that the repair persisted.
-    await waitUntil(() => globalMtime(workspace) !== globalBefore, {
-        timeout: 30_000,
-        interval: 1_000,
-        description: "the second session's indexing round to persist",
-    });
-    const after = shardMtimes(workspace);
-    await c2.shutdown();
-
-    expect(after, "a same-content touch must not reindex dependents").toEqual(before);
+    // Run 2: the load re-enqueues every TU and runs the staleness check.
+    // The touch makes the header's stat mismatch its FileVersion stamp;
+    // the check re-hashes, proves a mere touch, and the storm filter
+    // leaves the closed TU alone.
+    expect(batchIndex(workspace), "a same-content touch must not reindex dependents").toBe(0);
 });

--- a/tests/unit/command/cdb_diff_tests.cpp
+++ b/tests/unit/command/cdb_diff_tests.cpp
@@ -16,7 +16,7 @@ namespace ranges = std::ranges;
 
 /// path_id that `cdb` assigns to a file under the temp root.
 std::uint32_t id_of(CompilationDatabase& cdb, TempDir& tmp, llvm::StringRef rel) {
-    return cdb.paths().intern(path::join(tmp.root.str(), rel));
+    return cdb.files().intern(path::join(tmp.root.str(), rel));
 }
 
 bool contains(llvm::ArrayRef<std::uint32_t> list, std::uint32_t id) {
@@ -32,7 +32,8 @@ TEST_SUITE(ReloadDiff) {
 
 TEST_CASE(AddedEntry) {
     TempDir tmp;
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     auto cdb_path = tmp.path("compile_commands.json");
 
     write_json(tmp,
@@ -56,7 +57,8 @@ TEST_CASE(AddedEntry) {
 
 TEST_CASE(RemovedEntry) {
     TempDir tmp;
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     auto cdb_path = tmp.path("compile_commands.json");
 
     write_json(tmp,
@@ -80,7 +82,8 @@ TEST_CASE(RemovedEntry) {
 
 TEST_CASE(ChangedFlag) {
     TempDir tmp;
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     auto cdb_path = tmp.path("compile_commands.json");
 
     write_json(tmp,
@@ -103,7 +106,8 @@ TEST_CASE(ChangedFlag) {
 
 TEST_CASE(IdenticalReload) {
     TempDir tmp;
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     auto cdb_path = tmp.path("compile_commands.json");
 
     write_json(tmp,
@@ -121,7 +125,8 @@ TEST_CASE(ReorderNoDiff) {
     // A file's entries are compared as a set, so shuffling the JSON must not
     // register as a change — even when one file owns several entries.
     TempDir tmp;
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     auto cdb_path = tmp.path("compile_commands.json");
 
     write_json(tmp,
@@ -149,7 +154,8 @@ TEST_CASE(CodegenChangeIgnored) {
     // (Note: -O* is NOT codegen-only here — it defines __OPTIMIZE__ and is
     // kept, so an -O change does count; see OptLevelIsSemantic.)
     TempDir tmp;
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     auto cdb_path = tmp.path("compile_commands.json");
 
     write_json(tmp,
@@ -171,7 +177,8 @@ TEST_CASE(OptLevelIsSemantic) {
     // Anchors that -O* is semantic (defines __OPTIMIZE__), not codegen-only:
     // changing the optimization level must be reported as a change.
     TempDir tmp;
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     auto cdb_path = tmp.path("compile_commands.json");
 
     write_json(tmp,
@@ -195,7 +202,8 @@ TEST_CASE(OptLevelIsSemantic) {
 TEST_CASE(MultiEntryOneChanged) {
     // A file with several entries appears in `changed` once, not per entry.
     TempDir tmp;
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     auto cdb_path = tmp.path("compile_commands.json");
 
     write_json(tmp,
@@ -221,7 +229,8 @@ TEST_CASE(MultiEntryOneChanged) {
 TEST_CASE(FirstLoadAllAdded) {
     // Discovering a CDB for the first time: every file is `added`.
     TempDir tmp;
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     auto cdb_path = tmp.path("compile_commands.json");
 
     write_json(tmp,
@@ -242,7 +251,8 @@ TEST_CASE(CorruptKeepsEntries) {
     // A half-written / corrupt CDB must leave the loaded entries intact and
     // signal failure so the caller retries instead of seeing "no change".
     TempDir tmp;
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     auto cdb_path = tmp.path("compile_commands.json");
 
     write_json(tmp,
@@ -269,7 +279,8 @@ TEST_CASE(MissingFileFails) {
     // An unreadable file (deleted, or still locked by the generator) is a
     // failure, not an empty database: entries survive and the caller retries.
     TempDir tmp;
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     auto cdb_path = tmp.path("compile_commands.json");
 
     write_json(tmp,

--- a/tests/unit/command/cdb_diff_tests.cpp
+++ b/tests/unit/command/cdb_diff_tests.cpp
@@ -15,11 +15,11 @@ namespace {
 namespace ranges = std::ranges;
 
 /// path_id that `cdb` assigns to a file under the temp root.
-std::uint32_t id_of(CompilationDatabase& cdb, TempDir& tmp, llvm::StringRef rel) {
+Fid id_of(CompilationDatabase& cdb, TempDir& tmp, llvm::StringRef rel) {
     return cdb.files().intern(path::join(tmp.root.str(), rel));
 }
 
-bool contains(llvm::ArrayRef<std::uint32_t> list, std::uint32_t id) {
+bool contains(llvm::ArrayRef<Fid> list, Fid id) {
     return ranges::find(list, id) != list.end();
 }
 

--- a/tests/unit/command/command_tests.cpp
+++ b/tests/unit/command/command_tests.cpp
@@ -26,7 +26,7 @@ std::vector<const char*> render_fallback(CompilationDatabase& db,
                                          llvm::StringRef file,
                                          const CommandOptions& options = {}) {
     auto applied = db.apply_rules(db.fallback_config(file), options);
-    CommandRef ref{db.paths().intern(file),
+    CommandRef ref{db.files().intern(file),
                    applied,
                    db.input_kind(applied, file),
                    CommandSource::Fallback};
@@ -41,7 +41,8 @@ std::vector<const char*> render_fallback(CompilationDatabase& db,
 }
 
 void EXPECT_STRIP(llvm::StringRef argv, llvm::StringRef result) {
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     llvm::StringRef file = "main.cpp";
     database.add_command("fake/", file, argv);
     ASSERT_EQ(result, print_argv(render_entry(database, file)));
@@ -70,7 +71,8 @@ TEST_CASE(DefaultFilters) {
 };
 
 TEST_CASE(ConfigDedup) {
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command("fake", "test.cpp", "clang++ -std=c++23 test.cpp"sv);
     database.add_command("fake", "test2.cpp", "clang++ -std=c++23 test2.cpp"sv);
     database.add_command("fake", "test3.cpp", "clang++ -std=c++23 -DA test3.cpp"sv);
@@ -101,7 +103,8 @@ TEST_CASE(RemoveAppend) {
         "main.cpp",
     };
 
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command("/fake", "main.cpp", args);
 
     CommandOptions options;
@@ -140,7 +143,8 @@ TEST_CASE(AppendUnknownValue) {
     /// An appended option the table does not know keeps its separate value:
     /// an edit cannot name the entry input, so an input-classified token is
     /// really the option's value.
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command("/fake", "main.cpp", "clang++ main.cpp"sv);
 
     CommandOptions options;
@@ -153,7 +157,8 @@ TEST_CASE(AppendUnknownValue) {
 TEST_CASE(AppendBeforeSlot) {
     /// Appends insert before the input slot, so they always govern the
     /// compile — even when the CDB command carries flags after the input.
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command("/fake", "a.c", "clang -x c a.c -x none"sv);
 
     CommandOptions options;
@@ -168,7 +173,8 @@ TEST_CASE(AppendBeforeSlot) {
 
 TEST_CASE(SelectorHistoryRestored) {
     /// Removing the later selector re-exposes the earlier one.
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command("/fake", "a.c", "clang -x cuda -x c++ a.c"sv);
 
     auto base = database.candidate_entries("a.c").front().config;
@@ -184,7 +190,8 @@ TEST_CASE(SelectorHistoryRestored) {
 TEST_CASE(SelectorPositional) {
     /// -x only governs inputs after it: a trailing selector leaves the
     /// input to its extension, and removing the leading one restores it.
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command("/fake", "a.cu", "clang -x c++ a.cu -x c"sv);
 
     auto base = database.candidate_entries("a.cu").front().config;
@@ -206,7 +213,8 @@ TEST_CASE(PerFileClSelectors) {
     /// /Tc<file> and /Tp<file> pair a selector with one input: the entry's
     /// own selector rewrites to the equivalent global form, the other
     /// input vanishes with its selector.
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command("/fake", "/fake/alpha.c", "cl /Tc/fake/alpha.c /Tp/fake/beta.c /c"sv);
     database.add_command("/fake", "/fake/beta.c", "cl /Tc/fake/alpha.c /Tp/fake/beta.c /c"sv);
 
@@ -227,7 +235,8 @@ TEST_CASE(PerFileClSelectors) {
 };
 
 TEST_CASE(IdentityHashes) {
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command("/fake", "a.cpp", "clang++ -std=c++20 a.cpp"sv);
     database.add_command("/fake", "b.cpp", "clang++ -std=c++20 b.cpp"sv);
     database.add_command("/fake", "c.cpp", "clang++ -std=c++17 c.cpp"sv);
@@ -258,7 +267,8 @@ TEST_CASE(IdentityHashes) {
 };
 
 TEST_CASE(WrapperStripped) {
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command("/fake", "a.cpp", "ccache clang++ -std=c++20 a.cpp"sv);
     database.add_command("/fake", "b.cpp", "clang++ -std=c++20 b.cpp"sv);
 
@@ -277,7 +287,8 @@ TEST_CASE(WrapperStripped) {
 TEST_CASE(WrapperValueOptions) {
     /// A wrapper option's separate KEY=VAL value must not be mistaken for
     /// the compiler.
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command("/fake",
                          "a.cpp",
                          "ccache --set-config cache_dir=/tmp/cc clang++ -std=c++20 a.cpp"sv);
@@ -292,7 +303,8 @@ TEST_CASE(WrapperValueOptions) {
 
 TEST_CASE(WrapperCaseInsensitive) {
     /// Windows tools emit launcher spellings like CCACHE.EXE.
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command("/fake", "a.cpp", "CCACHE.EXE clang++ -std=c++20 a.cpp"sv);
 
     auto& a = database.candidate_entries("a.cpp").front();
@@ -304,7 +316,8 @@ TEST_CASE(WrapperCaseInsensitive) {
 TEST_CASE(InputKindNoExtension) {
     /// An extensionless file must yield a real (non-null) empty kind, not
     /// a null C string.
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command("/fake", "noext", "clang++ -std=c++20 noext"sv);
 
     auto& entry = database.candidate_entries("noext").front();
@@ -316,7 +329,8 @@ TEST_CASE(InputKindNoExtension) {
 TEST_CASE(ResponseFileExpansion) {
     TempDir tmp;
     tmp.touch("flags.rsp", "-std=c++23 -DFROM_RSP=1\n");
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command(tmp.root.str(), "main.cpp", "clang++ @flags.rsp main.cpp"sv);
 
     auto argv = print_argv(render_entry(database, "main.cpp"));
@@ -330,7 +344,8 @@ TEST_CASE(DriverModeFromRsp) {
     /// visibility (clang interprets the mode after expansion).
     TempDir tmp;
     tmp.touch("flags.rsp", "--driver-mode=cl /TP\n");
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command(tmp.root.str(), "main.cpp", "clang++ @flags.rsp main.cpp"sv);
 
     EXPECT_CONTAINS(print_argv(render_entry(database, "main.cpp")), "/TP");
@@ -339,7 +354,8 @@ TEST_CASE(DriverModeFromRsp) {
 TEST_CASE(PrependAfterBinary) {
     llvm::SmallVector args = {"clang++", "-DA", "main.cpp"};
 
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command("/fake", "main.cpp", args);
 
     CommandOptions options;
@@ -352,7 +368,8 @@ TEST_CASE(PrependAfterBinary) {
 };
 
 TEST_CASE(DefaultFallback) {
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
 
     /// C++ files get "clang++ -std=c++20 <file>".
     auto cpp_argv = render_fallback(database, "unknown.cpp");
@@ -389,7 +406,8 @@ TEST_CASE(DefaultFallback) {
 TEST_CASE(FallbackAppliesAppend) {
     /// Config rule appends must reach the synthesized fallback command:
     /// users without a CDB rely on them to supply include paths.
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     CommandOptions options;
     std::vector<std::string> append = {"-I/opt/include"};
     options.append = append;
@@ -404,7 +422,8 @@ TEST_CASE(FallbackAppliesAppend) {
 
 TEST_CASE(MultiCommand) {
     /// A file can have multiple compilation commands (e.g. different configs).
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command("fake", "main.cpp", "clang++ -std=c++17 main.cpp"sv);
     database.add_command("fake", "main.cpp", "clang++ -std=c++20 main.cpp"sv);
     database.add_command("fake", "other.cpp", "clang++ -std=c++23 other.cpp"sv);
@@ -430,23 +449,26 @@ TEST_CASE(MultiCommand) {
 TEST_CASE(CandidateOrderStable) {
     /// The default selection is content-decided: loading the same entries
     /// in a different order picks the same winner.
-    CompilationDatabase first;
+    FileTable file_table;
+    CompilationDatabase first{file_table};
     first.add_command("fake", "main.cpp", "clang++ -std=c++17 main.cpp"sv);
     first.add_command("fake", "main.cpp", "clang++ -std=c++20 main.cpp"sv);
 
-    CompilationDatabase second;
+    FileTable file_table2;
+    CompilationDatabase second{file_table2};
     second.add_command("fake", "main.cpp", "clang++ -std=c++20 main.cpp"sv);
     second.add_command("fake", "main.cpp", "clang++ -std=c++17 main.cpp"sv);
 
-    EXPECT_EQ(first.selected_hash(first.paths().intern("main.cpp")),
-              second.selected_hash(second.paths().intern("main.cpp")));
+    EXPECT_EQ(first.selected_hash(first.files().intern("main.cpp")),
+              second.selected_hash(second.files().intern("main.cpp")));
     EXPECT_EQ(print_argv(render_entry(first, "main.cpp")),
               print_argv(render_entry(second, "main.cpp")));
 };
 
 TEST_CASE(CodegenFilter) {
     /// Codegen-only options never reach the compile render.
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command(
         "fake",
         "main.cpp",
@@ -474,7 +496,8 @@ TEST_CASE(CodegenFilter) {
 };
 
 TEST_CASE(DependencyScanFilter) {
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command("fake",
                          "main.cpp",
                          "clang++ -std=c++20 -MD -MF main.d -MT main.o main.cpp"sv);
@@ -500,7 +523,8 @@ TEST_CASE(ModuleFilter) {
 };
 
 TEST_CASE(UserContentClassification) {
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command("fake", "a.cpp", "clang++ -std=c++20 -Wall -DA=1 -DFOO a.cpp"sv);
     database.add_command("fake", "b.cpp", "clang++ -std=c++20 -Wall -DB=2 b.cpp"sv);
 
@@ -522,7 +546,8 @@ TEST_CASE(UserContentClassification) {
 
 TEST_CASE(IncludePathAbsolutize) {
     /// Relative include paths absolutize against the entry directory.
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command("/project/build",
                          "main.cpp",
                          "clang++ -Iinclude -isystem sys/inc -iquote ../src main.cpp"sv);
@@ -544,7 +569,8 @@ TEST_CASE(IncludePathAbsolutize) {
     EXPECT_TRUE(has_path(result, "/project/"));
 
     /// Absolute paths are kept as-is.
-    CompilationDatabase database2;
+    FileTable file_table2;
+    CompilationDatabase database2{file_table2};
     database2.add_command("/project/build", "main.cpp", "clang++ -I/usr/include main.cpp"sv);
     EXPECT_TRUE(has_path(render_entry(database2, "main.cpp"), "/usr/include"));
 };
@@ -557,7 +583,8 @@ TEST_CASE(SemanticOptionsPreserved) {
 };
 
 TEST_CASE(ForcedLanguage) {
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command("fake", "a.h", "clang++ -x c++ a.h"sv);
     database.add_command("fake", "b.cpp", "clang++ b.cpp"sv);
 
@@ -588,7 +615,8 @@ TEST_CASE(LoadMixedFormats) {
     /// "arguments" array and "command" string can coexist in the same CDB.
     TempDir tmp;
     auto dir = json_escape(tmp.root);
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     auto count = load_json(database, R"([{"directory": ")" + dir + R"(", "file": "a.cpp",
           "arguments": ["clang++", "-std=c++20", "a.cpp"]},
          {"directory": ")" + dir + R"(", "file": "b.cpp",
@@ -603,7 +631,8 @@ TEST_CASE(RelativeDirectoryAnchored) {
     /// A relative CDB `directory` anchors to the CDB file's own location,
     /// both for resolving the entry's file and as the config's directory.
     TempDir tmp;
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     tmp.touch("compile_commands.json", R"([
         {"directory": "build", "file": "main.cpp",
          "arguments": ["clang++", "-std=c++20", "main.cpp"]}
@@ -631,7 +660,8 @@ TEST_CASE(RelativeLoadPathAnchored) {
     ASSERT_FALSE(bool(llvm::sys::fs::set_current_path(tmp.root)));
     auto restore = llvm::make_scope_exit([&] { llvm::sys::fs::set_current_path(saved_cwd); });
 
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     ASSERT_EQ(database.load("compile_commands.json").value_or(0), 1U);
 
     auto candidates = database.candidate_entries(path::join(tmp.root, "build", "main.cpp"));
@@ -644,7 +674,8 @@ TEST_CASE(LoadErrorRecovery) {
     /// Bad entries should be skipped; good entries still load.
     TempDir tmp;
     auto dir = json_escape(tmp.root);
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     auto count = load_json(database,
                            R"([{"file": "no_dir.cpp",
           "arguments": ["clang++", "no_dir.cpp"]},
@@ -671,7 +702,8 @@ TEST_CASE(LoadCudaHeader) {
     /// entries some build systems emit are skipped.
     TempDir tmp;
     auto dir = json_escape(tmp.root);
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     auto count = load_json(database, R"([{"directory": ")" + dir + R"(", "file": "kernels.cuh",
           "command": "nvcc -c kernels.cuh -o kernels.o"},
          {"directory": ")" + dir + R"(", "file": "app.rc",
@@ -685,7 +717,8 @@ TEST_CASE(LoadEmptyCommand) {
     /// Whitespace-only or empty "command" should not crash.
     TempDir tmp;
     auto dir = json_escape(tmp.root);
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     auto count = load_json(database,
                            R"([{"directory": ")" + dir + R"(", "file": "empty.cpp", "command": ""},
          {"directory": ")" + dir +
@@ -702,7 +735,8 @@ TEST_CASE(LoadReload) {
     /// Second load() replaces all entries from the first.
     TempDir tmp;
     auto dir = json_escape(tmp.root);
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
 
     auto file_a = tmp.path("a.cpp");
     auto file_b = tmp.path("b.cpp");
@@ -723,7 +757,8 @@ TEST_CASE(LoadCommandQuoting) {
     /// "command" string with spaces in paths and quoted defines.
     TempDir tmp;
     auto dir = json_escape(tmp.root);
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     auto count = load_json(database, R"([{"directory": ")" + dir + R"(", "file": "main.cpp",
           "command": "clang++ -std=c++20 \"-DMSG=hello world\" -I\"/path with spaces\" main.cpp"}])");
 
@@ -738,7 +773,8 @@ TEST_CASE(LoadRelativePath) {
     TempDir tmp;
     auto project = tmp.path("project/build");
     auto other = tmp.path("other/build");
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     auto count = load_json(database,
                            R"([{"directory": ")" + json_escape(project) +
                                R"(", "file": "src/main.cpp",
@@ -763,7 +799,8 @@ TEST_CASE(LoadDotSegments) {
     /// clang-reported (realpath'd) spellings match.
     TempDir tmp;
     auto build = tmp.path("project/build");
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     auto count = load_json(database,
                            R"([{"directory": ")" + json_escape(build) +
                                R"(", "file": "../src/./main.cpp",
@@ -774,7 +811,8 @@ TEST_CASE(LoadDotSegments) {
 };
 
 TEST_CASE(ResourceDir) {
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     database.add_command("/fake", "main.cpp", "clang++ -std=c++23 test.cpp"sv);
 
     auto& entry = database.candidate_entries("main.cpp").front();
@@ -795,7 +833,8 @@ TEST_CASE(ResourceDir) {
     EXPECT_EQ(has_resource_dir, !resource_dir().empty());
 
     /// A command carrying its own resource dir is not double-injected.
-    CompilationDatabase database2;
+    FileTable file_table2;
+    CompilationDatabase database2{file_table2};
     database2.add_command("/fake", "main.cpp", "clang++ -resource-dir /custom main.cpp"sv);
     auto& entry2 = database2.candidate_entries("main.cpp").front();
     CommandRef ref2{entry2.file,

--- a/tests/unit/command/nvcc_tests.cpp
+++ b/tests/unit/command/nvcc_tests.cpp
@@ -507,7 +507,8 @@ TEST_CASE(DryrunTopFallback) {
 TEST_CASE(CcbinAffectsKey) {
     /// -ccbin persists as an unknown probe token; two commands differing
     /// only in host compiler must not share a probe.
-    CompilationDatabase db;
+    FileTable file_table;
+    CompilationDatabase db{file_table};
     db.add_command("/tmp", "/tmp/a.cu", "nvcc -ccbin=/usr/bin/g++-12 -c /tmp/a.cu"sv);
     db.add_command("/tmp", "/tmp/b.cu", "nvcc -ccbin=/usr/bin/g++-13 -c /tmp/b.cu"sv);
 
@@ -520,7 +521,8 @@ TEST_CASE(CcbinAffectsKey) {
 }
 
 TEST_CASE(DatabaseTranslatesNVCC) {
-    CompilationDatabase db;
+    FileTable file_table;
+    CompilationDatabase db{file_table};
     std::vector<const char*> arguments = {"nvcc",
                                           "-forward-unknown-to-host-compiler",
                                           "-DMY_FLAG=1",
@@ -558,7 +560,8 @@ TEST_CASE(DatabaseTranslatesNVCC) {
 }
 
 TEST_CASE(RuleFlagsTranslated) {
-    CompilationDatabase db;
+    FileTable file_table;
+    CompilationDatabase db{file_table};
     std::vector<const char*> arguments = {"nvcc",
                                           "--generate-code=arch=compute_75,code=sm_75",
                                           "-c",
@@ -591,7 +594,8 @@ TEST_CASE(RuleFlagsTranslated) {
 }
 
 TEST_CASE(AppendOverridesBase) {
-    CompilationDatabase db;
+    FileTable file_table;
+    CompilationDatabase db{file_table};
     std::vector<const char*> arguments =
         {"nvcc", "-rdc=true", "-default-stream=per-thread", "-arch=sm_75", "-c", "/tmp/kern.cu"};
     db.add_command("/tmp", "/tmp/kern.cu", arguments);
@@ -644,7 +648,8 @@ TEST_CASE(AppendOverridesBase) {
 }
 
 TEST_CASE(ExtrasStayClangDialect) {
-    CompilationDatabase db;
+    FileTable file_table;
+    CompilationDatabase db{file_table};
     std::vector<const char*> arguments = {"nvcc", "-rdc=true", "-c", "/tmp/kern.cu"};
     db.add_command("/tmp", "/tmp/kern.cu", arguments);
 
@@ -664,7 +669,8 @@ TEST_CASE(ExtrasStayClangDialect) {
 }
 
 TEST_CASE(GencodeAppendAccumulates) {
-    CompilationDatabase db;
+    FileTable file_table;
+    CompilationDatabase db{file_table};
     std::vector<const char*> arguments = {"nvcc",
                                           "--generate-code=arch=compute_90,code=sm_90",
                                           "-c",
@@ -741,7 +747,8 @@ TEST_CASE(CollapseHonorsNegatives) {
 }
 
 TEST_CASE(WildcardRemoveClearsArch) {
-    CompilationDatabase db;
+    FileTable file_table;
+    CompilationDatabase db{file_table};
     std::vector<const char*> gencode = {"nvcc",
                                         "--generate-code=arch=compute_75,code=sm_75",
                                         "-c",
@@ -789,7 +796,8 @@ TEST_CASE(WildcardRemoveClearsArch) {
 }
 
 TEST_CASE(RemoveMatchesUnknownSpelling) {
-    CompilationDatabase db;
+    FileTable file_table;
+    CompilationDatabase db{file_table};
     std::vector<const char*> arguments = {"nvcc",
                                           "-ccbin=/usr/bin/g++-12",
                                           "-allow-unsupported-compiler",
@@ -816,7 +824,8 @@ TEST_CASE(RemoveMatchesUnknownSpelling) {
 }
 
 TEST_CASE(RemoveListAlternatives) {
-    CompilationDatabase db;
+    FileTable file_table;
+    CompilationDatabase db{file_table};
     std::vector<const char*> arguments = {"nvcc",
                                           "-ccbin=/usr/bin/g++-12",
                                           "-default-stream=per-thread",
@@ -844,7 +853,8 @@ TEST_CASE(RemoveListAlternatives) {
 }
 
 TEST_CASE(WildcardRemovesProbeValue) {
-    CompilationDatabase db;
+    FileTable file_table;
+    CompilationDatabase db{file_table};
     std::vector<const char*> arguments =
         {"nvcc", "-ccbin=/usr/bin/g++-12", "-target-dir", "sbsa-linux", "-c", "/tmp/kern.cu"};
     db.add_command("/tmp", "/tmp/kern.cu", arguments);

--- a/tests/unit/command/search_config_tests.cpp
+++ b/tests/unit/command/search_config_tests.cpp
@@ -12,7 +12,8 @@ TEST_SUITE(ExtractSearchConfig) {
 /// Normalize a raw argv through the database and extract from the
 /// structured command (the only extraction path).
 SearchConfig extract(llvm::ArrayRef<const char*> args, llvm::StringRef directory) {
-    CompilationDatabase db;
+    FileTable file_table;
+    CompilationDatabase db{file_table};
     db.add_command(directory, "main.cpp", args);
     auto& entry = db.candidate_entries("main.cpp").front();
     return extract_search_config(db.config(entry.config).args, directory);

--- a/tests/unit/command/toolchain_tests.cpp
+++ b/tests/unit/command/toolchain_tests.cpp
@@ -264,7 +264,8 @@ TEST_CASE(NVCCHostInput, skip = !(CIEnvironment && Linux)) {
 /// A database wrapping test entries — the unit tests' handle on the two
 /// toolchain layers.
 struct Fixture {
-    CompilationDatabase db;
+    FileTable file_table;
+    CompilationDatabase db{file_table};
 
     CommandRef add(llvm::StringRef directory,
                    llvm::StringRef file,
@@ -283,7 +284,8 @@ struct Fixture {
 };
 
 TEST_CASE(InitiallyEmpty) {
-    CompilationDatabase db;
+    FileTable file_table;
+    CompilationDatabase db{file_table};
     EXPECT_FALSE(db.toolchain().has_cache());
 }
 

--- a/tests/unit/compile/compilation_tests.cpp
+++ b/tests/unit/compile/compilation_tests.cpp
@@ -303,7 +303,8 @@ import mod_b;
 export int a_value() { return b_value() + 1; }
 )");
 
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
 
     auto render_entry = [&](llvm::StringRef file) {
         auto& entry = cdb.candidate_entries(file).front();

--- a/tests/unit/config/config_tests.cpp
+++ b/tests/unit/config/config_tests.cpp
@@ -667,13 +667,13 @@ TEST_CASE(JsonSchema) {
         EXPECT_EQ(minimum->get_uint().value_or(0), 1u);
     }
 
-    // index_db names the accepted backends, so editors flag a typo that
-    // open_database() would silently turn into LMDB.
-    const auto* index_db = find_property(*doc, "index_db");
-    ASSERT_TRUE(index_db != nullptr);
-    const auto* backends = index_db->get_object()->find("enum");
-    ASSERT_TRUE(backends != nullptr);
-    EXPECT_EQ(*backends, kota::codec::dyn::Value(kota::codec::dyn::Array{"lmdb", "files"}));
+    // Enum fields name their accepted values, so editors flag a typo that
+    // the lenient decode would silently turn into the default.
+    const auto* readonly = find_property(*doc, "readonly");
+    ASSERT_TRUE(readonly != nullptr);
+    const auto* modes = readonly->get_object()->find("enum");
+    ASSERT_TRUE(modes != nullptr);
+    EXPECT_EQ(*modes, kota::codec::dyn::Value(kota::codec::dyn::Array{"off", "on", "auto"}));
 
     // Root and every section body reject unknown properties, so editors
     // flag typos the way the strict decode pass does.

--- a/tests/unit/feature/feature_tests.cpp
+++ b/tests/unit/feature/feature_tests.cpp
@@ -41,8 +41,8 @@ TEST_CASE(RoundTripIdentity) {
     // Ingest of an emitted URI must intern to the same ID as the original
     // canonical path — including the client-style encoded-colon spelling.
     FileTable pool;
-    constexpr std::uint32_t bad = 0xFFFFFFFF;
-    auto ingest = [&](llvm::StringRef uri) -> std::uint32_t {
+    constexpr Fid bad{0xFFFFFFFF};
+    auto ingest = [&](llvm::StringRef uri) -> Fid {
         auto parsed = kota::ipc::lsp::URI::parse(std::string_view(uri.data(), uri.size()));
         if(!parsed.has_value()) {
             return bad;

--- a/tests/unit/feature/feature_tests.cpp
+++ b/tests/unit/feature/feature_tests.cpp
@@ -1,6 +1,6 @@
 #include "test/test.h"
 #include "feature/feature.h"
-#include "support/path_pool.h"
+#include "vfs/file_table.h"
 
 namespace clice::testing {
 
@@ -40,7 +40,7 @@ TEST_CASE(PlusStaysLiteral) {
 TEST_CASE(RoundTripIdentity) {
     // Ingest of an emitted URI must intern to the same ID as the original
     // canonical path — including the client-style encoded-colon spelling.
-    PathPool pool;
+    FileTable pool;
     constexpr std::uint32_t bad = 0xFFFFFFFF;
     auto ingest = [&](llvm::StringRef uri) -> std::uint32_t {
         auto parsed = kota::ipc::lsp::URI::parse(std::string_view(uri.data(), uri.size()));

--- a/tests/unit/index/database_tests.cpp
+++ b/tests/unit/index/database_tests.cpp
@@ -14,7 +14,6 @@ namespace clice::testing {
 namespace {
 
 constexpr std::uint32_t version = 1;
-constexpr llvm::StringLiteral backends[] = {"files", "lmdb"};
 
 /// Helper precondition check that survives NDEBUG builds; failures abort
 /// with a message instead of becoming UB on a bad expected access.
@@ -46,82 +45,75 @@ TEST_SUITE(IndexDatabase) {
 
 TEST_CASE(WriteReadRoundTrip) {
     TempDir tmp;
-    for(auto backend: backends) {
-        auto store = open_store(tmp, backend);
-        auto db = index::open_database(store, backend);
-        ASSERT_TRUE(db != nullptr);
+    auto store = open_store(tmp, "lmdb");
+    auto db = index::open_database(store);
+    ASSERT_TRUE(db != nullptr);
 
-        auto rejected = db->write({blob(index::IndexBlobKind::Shard, "a", large_value('a')),
-                                   blob(index::IndexBlobKind::Global, "global", "gg")},
-                                  {});
-        ASSERT_TRUE(rejected.empty());
-        // Reads serve the resident snapshot; committed writes become
-        // visible only after an advance (a no-op on the files backend).
-        ASSERT_TRUE(db->advance_read_snapshot().has_value());
-        db->retire_old_snapshot();
+    auto rejected = db->write({blob(index::IndexBlobKind::Shard, "a", large_value('a')),
+                               blob(index::IndexBlobKind::Global, "global", "gg")},
+                              {});
+    ASSERT_TRUE(rejected.empty());
+    // Reads serve the resident snapshot; committed writes become
+    // visible only after an advance.
+    ASSERT_TRUE(db->advance_read_snapshot().has_value());
+    db->retire_old_snapshot();
 
-        auto shard = db->read(index::IndexBlobKind::Shard, "a");
-        ASSERT_TRUE(bool(shard));
-        ASSERT_TRUE(shard.buffer->getBuffer() == large_value('a'));
-        ASSERT_TRUE(db->contains(index::IndexBlobKind::Global, "global"));
-        ASSERT_FALSE(db->contains(index::IndexBlobKind::Shard, "missing"));
-        ASSERT_FALSE(bool(db->read(index::IndexBlobKind::Shard, "missing")));
-    }
+    auto shard = db->read(index::IndexBlobKind::Shard, "a");
+    ASSERT_TRUE(bool(shard));
+    ASSERT_TRUE(shard.buffer->getBuffer() == large_value('a'));
+    ASSERT_TRUE(db->contains(index::IndexBlobKind::Global, "global"));
+    ASSERT_FALSE(db->contains(index::IndexBlobKind::Shard, "missing"));
+    ASSERT_FALSE(bool(db->read(index::IndexBlobKind::Shard, "missing")));
 }
 
 TEST_CASE(WriteRemoves) {
     TempDir tmp;
-    for(auto backend: backends) {
-        auto store = open_store(tmp, backend);
-        auto db = index::open_database(store, backend);
-        ASSERT_TRUE(db != nullptr);
+    auto store = open_store(tmp, "lmdb");
+    auto db = index::open_database(store);
+    ASSERT_TRUE(db != nullptr);
 
-        ASSERT_TRUE(db->write({blob(index::IndexBlobKind::Manifest, "m1", "one"),
-                               blob(index::IndexBlobKind::Manifest, "m2", "two")},
-                              {})
-                        .empty());
-        ASSERT_TRUE(db->write(
-                          {
-        },
-                          {{index::IndexBlobKind::Manifest, "m1"}})
-                        .empty());
-        ASSERT_TRUE(db->advance_read_snapshot().has_value());
-        db->retire_old_snapshot();
+    ASSERT_TRUE(db->write({blob(index::IndexBlobKind::Manifest, "m1", "one"),
+                           blob(index::IndexBlobKind::Manifest, "m2", "two")},
+                          {})
+                    .empty());
+    ASSERT_TRUE(db->write(
+                      {
+    },
+                      {{index::IndexBlobKind::Manifest, "m1"}})
+                    .empty());
+    ASSERT_TRUE(db->advance_read_snapshot().has_value());
+    db->retire_old_snapshot();
 
-        ASSERT_FALSE(db->contains(index::IndexBlobKind::Manifest, "m1"));
-        ASSERT_TRUE(db->contains(index::IndexBlobKind::Manifest, "m2"));
-    }
+    ASSERT_FALSE(db->contains(index::IndexBlobKind::Manifest, "m1"));
+    ASSERT_TRUE(db->contains(index::IndexBlobKind::Manifest, "m2"));
 }
 
 TEST_CASE(KindsAreIsolated) {
     TempDir tmp;
-    for(auto backend: backends) {
-        auto store = open_store(tmp, backend);
-        auto db = index::open_database(store, backend);
-        ASSERT_TRUE(db != nullptr);
+    auto store = open_store(tmp, "lmdb");
+    auto db = index::open_database(store);
+    ASSERT_TRUE(db != nullptr);
 
-        ASSERT_TRUE(db->write({blob(index::IndexBlobKind::Shard, "same", "shard"),
-                               blob(index::IndexBlobKind::Manifest, "same", "manifest")},
-                              {})
-                        .empty());
-        ASSERT_TRUE(db->advance_read_snapshot().has_value());
-        db->retire_old_snapshot();
+    ASSERT_TRUE(db->write({blob(index::IndexBlobKind::Shard, "same", "shard"),
+                           blob(index::IndexBlobKind::Manifest, "same", "manifest")},
+                          {})
+                    .empty());
+    ASSERT_TRUE(db->advance_read_snapshot().has_value());
+    db->retire_old_snapshot();
 
-        llvm::SmallVector<std::string> shard_keys;
-        db->for_each_key(index::IndexBlobKind::Shard,
-                         [&](llvm::StringRef key) { shard_keys.push_back(key.str()); });
-        ASSERT_TRUE(shard_keys.size() == 1);
-        ASSERT_TRUE(shard_keys.front() == "same");
-        ASSERT_TRUE(db->read(index::IndexBlobKind::Manifest, "same").buffer->getBuffer() ==
-                    "manifest");
-        ASSERT_FALSE(db->contains(index::IndexBlobKind::Global, "same"));
-    }
+    llvm::SmallVector<std::string> shard_keys;
+    db->for_each_key(index::IndexBlobKind::Shard,
+                     [&](llvm::StringRef key) { shard_keys.push_back(key.str()); });
+    ASSERT_TRUE(shard_keys.size() == 1);
+    ASSERT_TRUE(shard_keys.front() == "same");
+    ASSERT_TRUE(db->read(index::IndexBlobKind::Manifest, "same").buffer->getBuffer() == "manifest");
+    ASSERT_FALSE(db->contains(index::IndexBlobKind::Global, "same"));
 }
 
 TEST_CASE(SnapshotPinsUntilAdvance) {
     TempDir tmp;
     auto store = open_store(tmp, "lmdb");
-    auto db = index::open_database(store, "lmdb");
+    auto db = index::open_database(store);
     ASSERT_TRUE(db != nullptr);
 
     ASSERT_TRUE(db->write({blob(index::IndexBlobKind::Shard, "k", large_value('1'))}, {}).empty());
@@ -150,7 +142,7 @@ TEST_CASE(SnapshotPinsUntilAdvance) {
 TEST_CASE(SmallValuesCopiedAligned) {
     TempDir tmp;
     auto store = open_store(tmp, "lmdb");
-    auto db = index::open_database(store, "lmdb");
+    auto db = index::open_database(store);
     ASSERT_TRUE(db != nullptr);
 
     ASSERT_TRUE(db->write({blob(index::IndexBlobKind::Manifest, "small", "tiny"),
@@ -177,11 +169,11 @@ TEST_CASE(ReopenServesPersistedBlobs) {
     TempDir tmp;
     auto store = open_store(tmp, "lmdb");
     {
-        auto db = index::open_database(store, "lmdb");
+        auto db = index::open_database(store);
         ASSERT_TRUE(db != nullptr);
         ASSERT_TRUE(db->write({blob(index::IndexBlobKind::CDB, "cdb", "snapshot")}, {}).empty());
     }
-    auto db = index::open_database(store, "lmdb");
+    auto db = index::open_database(store);
     ASSERT_TRUE(db != nullptr);
     ASSERT_TRUE(db->read(index::IndexBlobKind::CDB, "cdb").buffer->getBuffer() == "snapshot");
 }
@@ -195,7 +187,7 @@ TEST_CASE(CorruptDatabaseRebuilds) {
         require(!ec, "writing garbage failed");
         os << "this is not an lmdb file, not even close, but long enough to map";
     }
-    auto db = index::open_database(store, "lmdb");
+    auto db = index::open_database(store);
     ASSERT_TRUE(db != nullptr);
     ASSERT_FALSE(db->contains(index::IndexBlobKind::CDB, "cdb"));
     ASSERT_TRUE(db->write({blob(index::IndexBlobKind::CDB, "cdb", "fresh")}, {}).empty());
@@ -204,7 +196,7 @@ TEST_CASE(CorruptDatabaseRebuilds) {
 TEST_CASE(DefaultOpenFileBounded) {
     TempDir tmp;
     auto store = open_store(tmp, "lmdb");
-    auto db = index::open_database(store, "lmdb");
+    auto db = index::open_database(store);
     ASSERT_TRUE(db != nullptr);
     ASSERT_TRUE(db->write({blob(index::IndexBlobKind::CDB, "cdb", "x")}, {}).empty());
 
@@ -251,27 +243,28 @@ TEST_CASE(FullMapFailsWholeBatchThenGrows) {
                 large_value('x'));
 }
 
-TEST_CASE(ReadOnlyWithoutDatabaseFallsBack) {
+TEST_CASE(ReadOnlyMissingDatabase) {
     TempDir tmp;
     { auto store = open_store(tmp, "empty"); }
     auto store = open_store(tmp, "empty", /*read_only=*/true);
-    // A reader before any LMDB writer ran gets the filesystem view (empty
-    // here) instead of failing on a missing index.mdb.
-    auto db = index::open_database(store, "lmdb");
-    ASSERT_TRUE(db != nullptr);
-    ASSERT_FALSE(db->contains(index::IndexBlobKind::Global, "global"));
+    // A reader before any writer ran has nothing to read: persistence is
+    // disabled rather than creating an index.mdb a read-only session must
+    // not leave behind.
+    auto db = index::open_database(store, /*read_only=*/true);
+    ASSERT_TRUE(db == nullptr);
+    ASSERT_FALSE(llvm::sys::fs::exists(path::join(store.base_dir(), "index.mdb")));
 }
 
 TEST_CASE(ReadOnlyServesExistingDatabase) {
     TempDir tmp;
     {
         auto store = open_store(tmp, "ws");
-        auto db = index::open_database(store, "lmdb");
+        auto db = index::open_database(store);
         ASSERT_TRUE(db != nullptr);
         ASSERT_TRUE(db->write({blob(index::IndexBlobKind::Global, "global", "gg")}, {}).empty());
     }
     auto store = open_store(tmp, "ws", /*read_only=*/true);
-    auto db = index::open_database(store, "lmdb");
+    auto db = index::open_database(store);
     ASSERT_TRUE(db != nullptr);
     ASSERT_TRUE(db->contains(index::IndexBlobKind::Global, "global"));
     ASSERT_TRUE(db->read(index::IndexBlobKind::Global, "global").buffer->getBuffer() == "gg");
@@ -281,13 +274,13 @@ TEST_CASE(CondemnedDatabaseDeletesOnClose) {
     TempDir tmp;
     auto store = open_store(tmp, "lmdb");
     {
-        auto db = index::open_database(store, "lmdb");
+        auto db = index::open_database(store);
         ASSERT_TRUE(db != nullptr);
         ASSERT_TRUE(db->write({blob(index::IndexBlobKind::CDB, "cdb", "bytes")}, {}).empty());
         db->condemn();
     }
     ASSERT_FALSE(llvm::sys::fs::exists(path::join(store.base_dir(), "index.mdb")));
-    auto db = index::open_database(store, "lmdb");
+    auto db = index::open_database(store);
     ASSERT_TRUE(db != nullptr);
     ASSERT_FALSE(db->contains(index::IndexBlobKind::CDB, "cdb"));
 }
@@ -295,7 +288,7 @@ TEST_CASE(CondemnedDatabaseDeletesOnClose) {
 TEST_CASE(OutstandingSnapshotsStack) {
     TempDir tmp;
     auto store = open_store(tmp, "lmdb");
-    auto db = index::open_database(store, "lmdb");
+    auto db = index::open_database(store);
     ASSERT_TRUE(db != nullptr);
 
     ASSERT_TRUE(db->write({blob(index::IndexBlobKind::Shard, "k", large_value('1'))}, {}).empty());
@@ -315,14 +308,6 @@ TEST_CASE(OutstandingSnapshotsStack) {
     ASSERT_TRUE(db->read(index::IndexBlobKind::Shard, "k").buffer->getBuffer() == large_value('3'));
     db->retire_old_snapshot();
     ASSERT_TRUE(db->read(index::IndexBlobKind::Shard, "k").buffer->getBuffer() == large_value('3'));
-}
-
-TEST_CASE(UnknownBackendFallsBackToLmdb) {
-    TempDir tmp;
-    auto store = open_store(tmp, "lmdb");
-    auto db = index::open_database(store, "bogus");
-    ASSERT_TRUE(db != nullptr);
-    ASSERT_TRUE(llvm::sys::fs::exists(path::join(store.base_dir(), "index.mdb")));
 }
 
 };  // TEST_SUITE(IndexDatabase)

--- a/tests/unit/index/index_query_tests.cpp
+++ b/tests/unit/index/index_query_tests.cpp
@@ -40,8 +40,8 @@ TURunFamily turun{graph, workspace, resolver, pcm, index_store, pool};
 IndexPump indexer{loop, workspace, turun, index_store, pool};
 clice::IndexQuery query{workspace, store, indexer, projections};
 
-std::uint32_t main_id = 0;
-std::uint32_t header_id = 0;
+Fid main_id;
+Fid header_id;
 
 /// Mirror of the indexer's merge over in-memory sources: project symbols,
 /// per-section shard blobs, and the TU manifest with its contributions —
@@ -52,7 +52,7 @@ void merge_into_workspace() {
     ASSERT_TRUE(view.loaded());
 
     auto& project = workspace.project_index;
-    llvm::SmallVector<std::uint32_t> file_ids_map;
+    llvm::SmallVector<Fid> file_ids_map;
     for(std::uint32_t i = 0; i < view.path_count(); i += 1) {
         file_ids_map.push_back(workspace.file_table.intern(view.path(i)));
     }
@@ -76,7 +76,7 @@ void merge_into_workspace() {
         }
     }
 
-    llvm::SmallVector<std::uint32_t> fv_of;
+    llvm::SmallVector<VersionID> fv_of;
     for(std::uint32_t i = 0; i < view.path_count(); i += 1) {
         auto hash = consumed[i] != 0 ? consumed[i] : view.path_hash(i);
         fv_of.push_back(workspace.file_table.intern_version(file_ids_map[i], hash));

--- a/tests/unit/index/index_query_tests.cpp
+++ b/tests/unit/index/index_query_tests.cpp
@@ -54,7 +54,7 @@ void merge_into_workspace() {
     auto& project = workspace.project_index;
     llvm::SmallVector<std::uint32_t> file_ids_map;
     for(std::uint32_t i = 0; i < view.path_count(); i += 1) {
-        file_ids_map.push_back(workspace.path_pool.intern(view.path(i)));
+        file_ids_map.push_back(workspace.file_table.intern(view.path(i)));
     }
     ASSERT_TRUE(project.merge(view, file_ids_map));
     main_id = file_ids_map[view.path_count() - 1];
@@ -102,7 +102,7 @@ void merge_into_workspace() {
 }
 
 std::string main_path() {
-    return std::string(workspace.path_pool.resolve(main_id));
+    return std::string(workspace.file_table.resolve(main_id));
 }
 
 TEST_CASE(DefinitionAcrossFiles) {

--- a/tests/unit/index/index_query_tests.cpp
+++ b/tests/unit/index/index_query_tests.cpp
@@ -35,7 +35,7 @@ ContextResolver resolver{workspace};
 TaskGraph graph{loop};
 PCMFamily pcm{graph, workspace, resolver, pool};
 ASTProjectionTable projections;
-IndexStore index_store{loop, workspace};
+IndexStore index_store{loop, workspace, resolver};
 TURunFamily turun{graph, workspace, resolver, pcm, index_store, pool};
 IndexPump indexer{loop, workspace, turun, index_store, pool};
 clice::IndexQuery query{workspace, store, indexer, projections};

--- a/tests/unit/index/index_query_tests.cpp
+++ b/tests/unit/index/index_query_tests.cpp
@@ -79,7 +79,7 @@ void merge_into_workspace() {
     llvm::SmallVector<std::uint32_t> fv_of;
     for(std::uint32_t i = 0; i < view.path_count(); i += 1) {
         auto hash = consumed[i] != 0 ? consumed[i] : view.path_hash(i);
-        fv_of.push_back(project.intern_file_version(file_ids_map[i], hash));
+        fv_of.push_back(workspace.file_table.intern_version(file_ids_map[i], hash));
     }
 
     index::TUManifest manifest;
@@ -93,7 +93,7 @@ void merge_into_workspace() {
                                             view.section_hash(section));
     }
 
-    for(auto path_id: project.apply_manifest(main_id, std::move(manifest))) {
+    for(auto path_id: project.apply_manifest(workspace.file_table, main_id, std::move(manifest))) {
         auto it = workspace.shards.find(path_id);
         if(it != workspace.shards.end()) {
             it->second.set_live(project.live_variants(path_id));

--- a/tests/unit/index/persisted_index_tests.cpp
+++ b/tests/unit/index/persisted_index_tests.cpp
@@ -18,7 +18,7 @@ TEST_CASE(ManifestRoundTrip) {
     index::TUManifest manifest;
     manifest.global_gen = 7;
     manifest.built_at = 1234567;
-    manifest.tu_fv = 300;
+    manifest.tu_fv = VersionID{300};
     // A root node, a multi-byte-varint line, and a parent that FOLLOWS its
     // child (the include graph resolves parent chains after appending).
     manifest.nodes = {
@@ -27,8 +27,8 @@ TEST_CASE(ManifestRoundTrip) {
         {302, 0,   12   },
     };
     manifest.contributions = {
-        {300, 0xdeadbeefdeadbeefull},
-        {302, 42                   },
+        {VersionID{300}, 0xdeadbeefdeadbeefull},
+        {VersionID{302}, 42                   },
     };
 
     llvm::SmallString<256> buf;
@@ -92,8 +92,8 @@ index::ProjectIndex build_project(clice::FileTable& pool,
     index::ProjectIndex project;
     auto path_id = pool.intern(path);
     auto fv = pool.intern_version(path_id, 0xabcd);
-    pool.versions.find(fv)->second.size = 100;
-    pool.versions.find(fv)->second.mtime_ns = 5555;
+    pool.versions[fv.raw].size = 100;
+    pool.versions[fv.raw].mtime_ns = 5555;
 
     index::TUManifest manifest;
     manifest.tu_fv = pool.intern_version(pool.intern(tu), 0x1111);
@@ -107,7 +107,7 @@ index::ProjectIndex build_project(clice::FileTable& pool,
 
     auto& symbol = project.symbols[42];
     symbol.name = "sym";
-    symbol.reference_files.add(path_id);
+    symbol.reference_files.add(path_id.raw);
     return project;
 }
 
@@ -128,13 +128,13 @@ TEST_CASE(GlobalRoundTripRemap) {
     clice::FileTable fresh;
     fresh.intern("/proj/opened-first.cpp");
     index::ProjectIndex loaded;
-    llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
+    llvm::DenseMap<VersionID, std::uint64_t> pins;
     ASSERT_TRUE(loaded.load_global(buf.str(), fresh, pins));
 
     auto id = fresh.find("/proj/used.h");
     ASSERT_TRUE(id.has_value());
-    ASSERT_TRUE(loaded.symbols[42].reference_files.contains(*id));
-    ASSERT_EQ(fresh.next_version_id, pool.next_version_id);
+    ASSERT_TRUE(loaded.symbols[42].reference_files.contains(id->raw));
+    ASSERT_EQ(fresh.versions.size(), pool.versions.size());
     ASSERT_EQ(loaded.global_generation, 9u);
 
     // The blob pins the TU's manifest at the stamp it was saved under.
@@ -163,7 +163,7 @@ TEST_CASE(GlobalCollectsGarbage) {
 
     clice::FileTable fresh;
     index::ProjectIndex loaded;
-    llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
+    llvm::DenseMap<VersionID, std::uint64_t> pins;
     ASSERT_TRUE(loaded.load_global(buf.str(), fresh, pins));
     ASSERT_FALSE(fresh.find("/proj/dead.h").has_value());
     ASSERT_TRUE(fresh.find("/proj/used.h").has_value());
@@ -178,7 +178,7 @@ TEST_CASE(GlobalVersionGate) {
 
     clice::FileTable pool;
     index::ProjectIndex loaded;
-    llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
+    llvm::DenseMap<VersionID, std::uint64_t> pins;
 
     auto stale = kota::codec::fbs::to_bytes(VersionOnly{});
     ASSERT_TRUE(stale.has_value());
@@ -230,7 +230,7 @@ TEST_CASE(GlobalBitmapPayloadGate) {
     };
 
     clice::FileTable pool;
-    llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
+    llvm::DenseMap<VersionID, std::uint64_t> pins;
     auto valid = kota::codec::fbs::to_bytes(mirror);
     ASSERT_TRUE(valid.has_value());
     index::ProjectIndex loaded;
@@ -277,7 +277,7 @@ TEST_CASE(UncoveredBitmapIdRejected) {
     mirror.sym_bitmaps = {index::write_bitmap(bits)};
 
     clice::FileTable pool;
-    llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
+    llvm::DenseMap<VersionID, std::uint64_t> pins;
     auto uncovered = kota::codec::fbs::to_bytes(mirror);
     ASSERT_TRUE(uncovered.has_value());
     index::ProjectIndex loaded;
@@ -308,7 +308,7 @@ TEST_CASE(GlobalDuplicateVersionsRejected) {
     mirror.fv_mtimes = {1, 2};
 
     clice::FileTable pool;
-    llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
+    llvm::DenseMap<VersionID, std::uint64_t> pins;
     auto dup_id = kota::codec::fbs::to_bytes(mirror);
     ASSERT_TRUE(dup_id.has_value());
     index::ProjectIndex loaded;
@@ -323,12 +323,17 @@ TEST_CASE(GlobalDuplicateVersionsRejected) {
     ASSERT_FALSE(loaded.load_global(bytes_of(*dup_pair), pool, pins));
 
     // The same path under two content hashes is the legitimate shape: two
-    // observed versions of one file.
+    // observed versions of one file. The table adopts the writer's id
+    // space up to its counter; garbage-collected ids stay behind as
+    // holes, not live versions.
     mirror.fv_hashes = {0x1, 0x2};
     auto distinct = kota::codec::fbs::to_bytes(mirror);
     ASSERT_TRUE(distinct.has_value());
     ASSERT_TRUE(loaded.load_global(bytes_of(*distinct), pool, pins));
-    ASSERT_EQ(pool.versions.size(), std::size_t(2));
+    ASSERT_EQ(pool.versions.size(), std::size_t(9));
+    ASSERT_TRUE(pool.knows_version(VersionID{7}));
+    ASSERT_TRUE(pool.knows_version(VersionID{8}));
+    ASSERT_FALSE(pool.knows_version(VersionID{0}));
 }
 
 TEST_CASE(GlobalBadCounterRejected) {
@@ -345,7 +350,7 @@ TEST_CASE(GlobalBadCounterRejected) {
     mirror.fv_mtimes = {1};
 
     clice::FileTable pool;
-    llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
+    llvm::DenseMap<VersionID, std::uint64_t> pins;
     auto ahead = kota::codec::fbs::to_bytes(mirror);
     ASSERT_TRUE(ahead.has_value());
     index::ProjectIndex loaded;
@@ -384,7 +389,7 @@ TEST_CASE(GlobalDuplicateSymbolRejected) {
     };
 
     clice::FileTable pool;
-    llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
+    llvm::DenseMap<VersionID, std::uint64_t> pins;
     auto dup = kota::codec::fbs::to_bytes(mirror);
     ASSERT_TRUE(dup.has_value());
     index::ProjectIndex loaded;
@@ -404,7 +409,7 @@ TEST_CASE(GlobalReservedKeysRejected) {
     // corrupt, and inserting it would corrupt (or assert in) the loader's
     // own containers.
     clice::FileTable pool;
-    llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
+    llvm::DenseMap<VersionID, std::uint64_t> pins;
     index::ProjectIndex loaded;
 
     {
@@ -452,7 +457,7 @@ TEST_CASE(GlobalReservedKeysRejected) {
 TEST_CASE(UnknownFileVersionsDetected) {
     clice::FileTable pool;
     index::ProjectIndex project;
-    auto known = pool.intern_version(0, 0x1);
+    auto known = pool.intern_version(Fid{0}, 0x1);
 
     index::TUManifest manifest;
     manifest.tu_fv = known;
@@ -461,7 +466,7 @@ TEST_CASE(UnknownFileVersionsDetected) {
     };
     ASSERT_TRUE(project.knows_file_versions(pool, manifest));
 
-    manifest.nodes.push_back({known + 1, ~0u, 2});
+    manifest.nodes.push_back({VersionID{known.raw + 1}, ~0u, 2});
     ASSERT_FALSE(project.knows_file_versions(pool, manifest));
 }
 

--- a/tests/unit/index/persisted_index_tests.cpp
+++ b/tests/unit/index/persisted_index_tests.cpp
@@ -89,19 +89,19 @@ TEST_CASE(ManifestVarintOverflowRejected) {
 index::ProjectIndex build_project(clice::FileTable& pool, llvm::StringRef path, llvm::StringRef tu) {
     index::ProjectIndex project;
     auto path_id = pool.intern(path);
-    auto fv = project.intern_file_version(path_id, 0xabcd);
-    project.file_versions.find(fv)->second.size = 100;
-    project.file_versions.find(fv)->second.mtime_ns = 5555;
+    auto fv = pool.intern_version(path_id, 0xabcd);
+    pool.versions.find(fv)->second.size = 100;
+    pool.versions.find(fv)->second.mtime_ns = 5555;
 
     index::TUManifest manifest;
-    manifest.tu_fv = project.intern_file_version(pool.intern(tu), 0x1111);
+    manifest.tu_fv = pool.intern_version(pool.intern(tu), 0x1111);
     manifest.nodes = {
         {fv, ~0u, 3}
     };
     manifest.contributions = {
         {fv, 777}
     };
-    project.apply_manifest(pool.intern(tu), std::move(manifest));
+    project.apply_manifest(pool, pool.intern(tu), std::move(manifest));
 
     auto& symbol = project.symbols[42];
     symbol.name = "sym";
@@ -132,16 +132,16 @@ TEST_CASE(GlobalRoundTripRemap) {
     auto id = fresh.find("/proj/used.h");
     ASSERT_TRUE(id.has_value());
     ASSERT_TRUE(loaded.symbols[42].reference_files.contains(*id));
-    ASSERT_EQ(loaded.next_fv_id, project.next_fv_id);
+    ASSERT_EQ(fresh.next_version_id, pool.next_version_id);
     ASSERT_EQ(loaded.global_generation, 9u);
 
     // The blob pins the TU's manifest at the stamp it was saved under.
     ASSERT_EQ(pins.size(), std::size_t(1));
     ASSERT_EQ(pins.find(manifest.tu_fv)->second, 9u);
 
-    auto fv_it = loaded.fv_ids.find({*id, std::uint64_t(0xabcd)});
-    ASSERT_TRUE(fv_it != loaded.fv_ids.end());
-    auto& record = loaded.file_versions.find(fv_it->second)->second;
+    auto fv_it = fresh.version_ids.find({*id, std::uint64_t(0xabcd)});
+    ASSERT_TRUE(fv_it != fresh.version_ids.end());
+    auto& record = fresh.version(fv_it->second);
     ASSERT_EQ(record.size, 100u);
     ASSERT_EQ(record.mtime_ns, 5555);
 }
@@ -149,15 +149,15 @@ TEST_CASE(GlobalRoundTripRemap) {
 TEST_CASE(GlobalCollectsGarbage) {
     clice::FileTable pool;
     auto project = build_project(pool, "/proj/used.h", "/proj/tu.cpp");
-    // Interned but referenced by no manifest — must not reach disk, and
-    // must be dropped from memory by the write.
+    // Interned but referenced by no manifest — must not reach disk. The
+    // shared table keeps it: other consumers may still anchor on it.
     auto dead_id = pool.intern("/proj/dead.h");
-    project.intern_file_version(dead_id, 0xdead);
+    pool.intern_version(dead_id, 0xdead);
 
     llvm::SmallString<1024> buf;
     llvm::raw_svector_ostream os(buf);
     project.serialize_global(os, pool);
-    ASSERT_FALSE(project.fv_ids.contains({dead_id, std::uint64_t(0xdead)}));
+    ASSERT_TRUE(pool.version_ids.contains({dead_id, std::uint64_t(0xdead)}));
 
     clice::FileTable fresh;
     index::ProjectIndex loaded;
@@ -257,7 +257,7 @@ TEST_CASE(GlobalBitmapPayloadGate) {
     clice::FileTable untouched;
     ASSERT_FALSE(rejecting.load_global(bytes_of(*corrupt), untouched, pins));
     ASSERT_TRUE(rejecting.symbols.empty());
-    ASSERT_TRUE(rejecting.file_versions.empty());
+    ASSERT_TRUE(untouched.versions.empty());
     ASSERT_FALSE(untouched.find("/proj/partial.h").has_value());
 }
 
@@ -311,7 +311,7 @@ TEST_CASE(GlobalDuplicateVersionsRejected) {
     ASSERT_TRUE(dup_id.has_value());
     index::ProjectIndex loaded;
     ASSERT_FALSE(loaded.load_global(bytes_of(*dup_id), pool, pins));
-    ASSERT_TRUE(loaded.file_versions.empty());
+    ASSERT_TRUE(pool.versions.empty());
 
     mirror.fv_ids = {7, 8};
     mirror.fv_paths = {"/proj/a.h", "/proj/a.h"};
@@ -326,7 +326,7 @@ TEST_CASE(GlobalDuplicateVersionsRejected) {
     auto distinct = kota::codec::fbs::to_bytes(mirror);
     ASSERT_TRUE(distinct.has_value());
     ASSERT_TRUE(loaded.load_global(bytes_of(*distinct), pool, pins));
-    ASSERT_EQ(loaded.file_versions.size(), std::size_t(2));
+    ASSERT_EQ(pool.versions.size(), std::size_t(2));
 }
 
 TEST_CASE(GlobalBadCounterRejected) {
@@ -443,23 +443,24 @@ TEST_CASE(GlobalReservedKeysRejected) {
         ASSERT_TRUE(bytes.has_value());
         ASSERT_FALSE(loaded.load_global(bytes_of(*bytes), pool, pins));
     }
-    ASSERT_TRUE(loaded.file_versions.empty());
+    ASSERT_TRUE(pool.versions.empty());
     ASSERT_TRUE(loaded.symbols.empty());
 }
 
 TEST_CASE(UnknownFileVersionsDetected) {
+    clice::FileTable pool;
     index::ProjectIndex project;
-    auto known = project.intern_file_version(0, 0x1);
+    auto known = pool.intern_version(0, 0x1);
 
     index::TUManifest manifest;
     manifest.tu_fv = known;
     manifest.nodes = {
         {known, ~0u, 1}
     };
-    ASSERT_TRUE(project.knows_file_versions(manifest));
+    ASSERT_TRUE(project.knows_file_versions(pool, manifest));
 
     manifest.nodes.push_back({known + 1, ~0u, 2});
-    ASSERT_FALSE(project.knows_file_versions(manifest));
+    ASSERT_FALSE(project.knows_file_versions(pool, manifest));
 }
 
 };  // TEST_SUITE(PersistedIndex)

--- a/tests/unit/index/persisted_index_tests.cpp
+++ b/tests/unit/index/persisted_index_tests.cpp
@@ -86,7 +86,9 @@ TEST_CASE(ManifestVarintOverflowRejected) {
 /// A project whose FileVersion for `path` is referenced by one manifest of
 /// `tu` (so garbage collection keeps it) and whose only symbol references
 /// `path` through `pool`.
-index::ProjectIndex build_project(clice::FileTable& pool, llvm::StringRef path, llvm::StringRef tu) {
+index::ProjectIndex build_project(clice::FileTable& pool,
+                                  llvm::StringRef path,
+                                  llvm::StringRef tu) {
     index::ProjectIndex project;
     auto path_id = pool.intern(path);
     auto fv = pool.intern_version(path_id, 0xabcd);

--- a/tests/unit/index/persisted_index_tests.cpp
+++ b/tests/unit/index/persisted_index_tests.cpp
@@ -86,7 +86,7 @@ TEST_CASE(ManifestVarintOverflowRejected) {
 /// A project whose FileVersion for `path` is referenced by one manifest of
 /// `tu` (so garbage collection keeps it) and whose only symbol references
 /// `path` through `pool`.
-index::ProjectIndex build_project(clice::PathPool& pool, llvm::StringRef path, llvm::StringRef tu) {
+index::ProjectIndex build_project(clice::FileTable& pool, llvm::StringRef path, llvm::StringRef tu) {
     index::ProjectIndex project;
     auto path_id = pool.intern(path);
     auto fv = project.intern_file_version(path_id, 0xabcd);
@@ -110,7 +110,7 @@ index::ProjectIndex build_project(clice::PathPool& pool, llvm::StringRef path, l
 }
 
 TEST_CASE(GlobalRoundTripRemap) {
-    clice::PathPool pool;
+    clice::FileTable pool;
     auto project = build_project(pool, "/proj/used.h", "/proj/tu.cpp");
     project.global_generation = 9;
     auto& manifest = project.manifests.find(pool.intern("/proj/tu.cpp"))->second;
@@ -123,7 +123,7 @@ TEST_CASE(GlobalRoundTripRemap) {
     // The next session interns other paths first, so the same file gets a
     // different pool id; both the FileVersion table and the loaded bitmap
     // must follow the path, not the id.
-    clice::PathPool fresh;
+    clice::FileTable fresh;
     fresh.intern("/proj/opened-first.cpp");
     index::ProjectIndex loaded;
     llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
@@ -147,7 +147,7 @@ TEST_CASE(GlobalRoundTripRemap) {
 }
 
 TEST_CASE(GlobalCollectsGarbage) {
-    clice::PathPool pool;
+    clice::FileTable pool;
     auto project = build_project(pool, "/proj/used.h", "/proj/tu.cpp");
     // Interned but referenced by no manifest — must not reach disk, and
     // must be dropped from memory by the write.
@@ -159,7 +159,7 @@ TEST_CASE(GlobalCollectsGarbage) {
     project.serialize_global(os, pool);
     ASSERT_FALSE(project.fv_ids.contains({dead_id, std::uint64_t(0xdead)}));
 
-    clice::PathPool fresh;
+    clice::FileTable fresh;
     index::ProjectIndex loaded;
     llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
     ASSERT_TRUE(loaded.load_global(buf.str(), fresh, pins));
@@ -174,7 +174,7 @@ TEST_CASE(GlobalVersionGate) {
         std::uint32_t format_version = 0;
     };
 
-    clice::PathPool pool;
+    clice::FileTable pool;
     index::ProjectIndex loaded;
     llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
 
@@ -227,7 +227,7 @@ TEST_CASE(GlobalBitmapPayloadGate) {
         {3, "/proj/ref.h"}
     };
 
-    clice::PathPool pool;
+    clice::FileTable pool;
     llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
     auto valid = kota::codec::fbs::to_bytes(mirror);
     ASSERT_TRUE(valid.has_value());
@@ -254,7 +254,7 @@ TEST_CASE(GlobalBitmapPayloadGate) {
     auto corrupt = kota::codec::fbs::to_bytes(mirror);
     ASSERT_TRUE(corrupt.has_value());
     index::ProjectIndex rejecting;
-    clice::PathPool untouched;
+    clice::FileTable untouched;
     ASSERT_FALSE(rejecting.load_global(bytes_of(*corrupt), untouched, pins));
     ASSERT_TRUE(rejecting.symbols.empty());
     ASSERT_TRUE(rejecting.file_versions.empty());
@@ -274,7 +274,7 @@ TEST_CASE(UncoveredBitmapIdRejected) {
     bits.add(3);
     mirror.sym_bitmaps = {index::write_bitmap(bits)};
 
-    clice::PathPool pool;
+    clice::FileTable pool;
     llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
     auto uncovered = kota::codec::fbs::to_bytes(mirror);
     ASSERT_TRUE(uncovered.has_value());
@@ -305,7 +305,7 @@ TEST_CASE(GlobalDuplicateVersionsRejected) {
     mirror.fv_sizes = {1, 2};
     mirror.fv_mtimes = {1, 2};
 
-    clice::PathPool pool;
+    clice::FileTable pool;
     llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
     auto dup_id = kota::codec::fbs::to_bytes(mirror);
     ASSERT_TRUE(dup_id.has_value());
@@ -342,7 +342,7 @@ TEST_CASE(GlobalBadCounterRejected) {
     mirror.fv_sizes = {1};
     mirror.fv_mtimes = {1};
 
-    clice::PathPool pool;
+    clice::FileTable pool;
     llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
     auto ahead = kota::codec::fbs::to_bytes(mirror);
     ASSERT_TRUE(ahead.has_value());
@@ -381,7 +381,7 @@ TEST_CASE(GlobalDuplicateSymbolRejected) {
         {3, "/proj/ref.h"}
     };
 
-    clice::PathPool pool;
+    clice::FileTable pool;
     llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
     auto dup = kota::codec::fbs::to_bytes(mirror);
     ASSERT_TRUE(dup.has_value());
@@ -401,7 +401,7 @@ TEST_CASE(GlobalReservedKeysRejected) {
     // tables, so the writer can never emit them; a blob carrying one is
     // corrupt, and inserting it would corrupt (or assert in) the loader's
     // own containers.
-    clice::PathPool pool;
+    clice::FileTable pool;
     llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
     index::ProjectIndex loaded;
 

--- a/tests/unit/index/persisted_index_tests.cpp
+++ b/tests/unit/index/persisted_index_tests.cpp
@@ -197,6 +197,7 @@ TEST_CASE(GlobalVersionGate) {
 struct GlobalBlobMirror {
     std::uint32_t format_version = 0;
     std::uint64_t generation = 0;
+    std::uint64_t revocation_generation = 0;
     std::uint32_t next_fv_id = 0;
     std::vector<std::uint32_t> fv_ids;
     std::vector<std::string> fv_paths;
@@ -370,6 +371,13 @@ TEST_CASE(GlobalBadCounterRejected) {
     auto reserved = kota::codec::fbs::to_bytes(mirror);
     ASSERT_TRUE(reserved.has_value());
     ASSERT_FALSE(loaded.load_global(bytes_of(*reserved), pool, pins));
+
+    // A garbage high-water mark far beyond any real table must reject
+    // before the id-space resize tries to allocate it.
+    mirror.next_fv_id = 0xf0000000;
+    auto oversized = kota::codec::fbs::to_bytes(mirror);
+    ASSERT_TRUE(oversized.has_value());
+    ASSERT_FALSE(loaded.load_global(bytes_of(*oversized), pool, pins));
 }
 
 TEST_CASE(GlobalDuplicateSymbolRejected) {

--- a/tests/unit/index/project_index_tests.cpp
+++ b/tests/unit/index/project_index_tests.cpp
@@ -145,20 +145,21 @@ TEST_CASE(MergeRejectsBadBitmap) {
 }
 
 TEST_CASE(FileVersionInterning) {
-    index::ProjectIndex project;
-    auto a = project.intern_file_version(7, 0x1111);
-    ASSERT_EQ(project.intern_file_version(7, 0x1111), a);
+    clice::FileTable pool;
+    auto a = pool.intern_version(7, 0x1111);
+    ASSERT_EQ(pool.intern_version(7, 0x1111), a);
 
-    auto b = project.intern_file_version(7, 0x2222);
+    auto b = pool.intern_version(7, 0x2222);
     ASSERT_TRUE(b != a);
-    ASSERT_EQ(project.file_versions.find(b)->second.path_id, 7u);
-    ASSERT_EQ(project.file_versions.find(b)->second.content_hash, 0x2222u);
+    ASSERT_EQ(pool.version(b).fid, 7u);
+    ASSERT_EQ(pool.version(b).content_hash, 0x2222u);
 }
 
 TEST_CASE(ManifestContributions) {
+    clice::FileTable pool;
     index::ProjectIndex project;
-    auto fv_a = project.intern_file_version(1, 0xa);
-    auto fv_b = project.intern_file_version(2, 0xb);
+    auto fv_a = pool.intern_version(1, 0xa);
+    auto fv_b = pool.intern_version(2, 0xb);
 
     auto manifest_for = [&](std::uint32_t tu_fv,
                             std::initializer_list<std::pair<std::uint32_t, std::uint64_t>> rows) {
@@ -168,11 +169,12 @@ TEST_CASE(ManifestContributions) {
         return manifest;
     };
 
-    auto tu1_fv = project.intern_file_version(10, 0x1);
-    auto tu2_fv = project.intern_file_version(11, 0x2);
+    auto tu1_fv = pool.intern_version(10, 0x1);
+    auto tu2_fv = pool.intern_version(11, 0x2);
 
     // TU 1 contributes h1 to file 1 and h2 to file 2.
-    auto affected = project.apply_manifest(10,
+    auto affected = project.apply_manifest(pool,
+                                           10,
                                            manifest_for(tu1_fv,
                                                         {
                                                             {fv_a, 100},
@@ -182,7 +184,8 @@ TEST_CASE(ManifestContributions) {
     ASSERT_EQ(project.live_variants(1).size(), std::size_t(1));
 
     // TU 2 shares file 1's variant: the live set does not grow.
-    project.apply_manifest(11,
+    project.apply_manifest(pool,
+                           11,
                            manifest_for(tu2_fv,
                                         {
                                             {fv_a, 100}
@@ -192,7 +195,8 @@ TEST_CASE(ManifestContributions) {
     // TU 1 re-indexes with a new variant for file 1 and drops file 2: both
     // hashes stay live on file 1 (TU 2 still holds the old one), file 2
     // loses its only contribution.
-    project.apply_manifest(10,
+    project.apply_manifest(pool,
+                           10,
                            manifest_for(tu1_fv,
                                         {
                                             {fv_a, 300}
@@ -200,12 +204,12 @@ TEST_CASE(ManifestContributions) {
     ASSERT_EQ(project.live_variants(1).size(), std::size_t(2));
     ASSERT_TRUE(project.live_variants(2).empty());
 
-    project.remove_manifest(11);
+    project.remove_manifest(pool, 11);
     auto live = project.live_variants(1);
     ASSERT_EQ(live.size(), std::size_t(1));
     ASSERT_EQ(live.front(), 300u);
 
-    project.remove_manifest(10);
+    project.remove_manifest(pool, 10);
     ASSERT_TRUE(project.contributions.empty());
 }
 
@@ -225,11 +229,11 @@ TEST_CASE(GlobalRoundTripWithRealMerge) {
 
     // A manifest referencing the main file keeps its FileVersion alive
     // through the write's garbage collection.
-    auto main_fv = project.intern_file_version(file_ids_map[view.path_count() - 1],
-                                               view.path_hash(view.path_count() - 1));
+    auto main_fv = pool.intern_version(file_ids_map[view.path_count() - 1],
+                                       view.path_hash(view.path_count() - 1));
     index::TUManifest manifest;
     manifest.tu_fv = main_fv;
-    project.apply_manifest(file_ids_map[view.path_count() - 1], std::move(manifest));
+    project.apply_manifest(pool, file_ids_map[view.path_count() - 1], std::move(manifest));
 
     llvm::SmallString<4096> buf;
     llvm::raw_svector_ostream os(buf);

--- a/tests/unit/index/project_index_tests.cpp
+++ b/tests/unit/index/project_index_tests.cpp
@@ -37,7 +37,7 @@ index::SymbolHash find_symbol(const index::ProjectIndex& project, llvm::StringRe
 
 /// The TU-local id -> pool id mapping merge() consumes, as Indexer::merge
 /// computes it.
-llvm::SmallVector<std::uint32_t> intern_paths(const index::TUIndex& view, clice::PathPool& pool) {
+llvm::SmallVector<std::uint32_t> intern_paths(const index::TUIndex& view, clice::FileTable& pool) {
     llvm::SmallVector<std::uint32_t> ids;
     for(std::uint32_t i = 0; i < view.path_count(); i += 1) {
         ids.push_back(pool.intern(view.path(i)));
@@ -60,7 +60,7 @@ TEST_CASE(MergeCollectsExternalSymbols) {
     )");
     ASSERT_TRUE(compile());
 
-    clice::PathPool pool;
+    clice::FileTable pool;
     index::ProjectIndex project;
     auto view = build_view();
     ASSERT_TRUE(view.loaded());
@@ -108,7 +108,7 @@ TEST_CASE(MergeRejectsBadBitmap) {
     ASSERT_TRUE(valid.has_value());
     auto valid_view = index::TUIndex::from_bytes(bytes_of(*valid));
     ASSERT_TRUE(valid_view.loaded());
-    clice::PathPool pool;
+    clice::FileTable pool;
     index::ProjectIndex accepting;
     ASSERT_TRUE(accepting.merge(valid_view, intern_paths(valid_view, pool)));
     ASSERT_EQ(find_symbol(accepting, "good_sym"), 42u);
@@ -216,7 +216,7 @@ TEST_CASE(GlobalRoundTripWithRealMerge) {
     )");
     ASSERT_TRUE(compile());
 
-    clice::PathPool pool;
+    clice::FileTable pool;
     index::ProjectIndex project;
     auto view = build_view();
     ASSERT_TRUE(view.loaded());
@@ -235,7 +235,7 @@ TEST_CASE(GlobalRoundTripWithRealMerge) {
     llvm::raw_svector_ostream os(buf);
     project.serialize_global(os, pool);
 
-    clice::PathPool fresh;
+    clice::FileTable fresh;
     index::ProjectIndex loaded;
     llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
     ASSERT_TRUE(loaded.load_global(buf.str(), fresh, pins));

--- a/tests/unit/index/project_index_tests.cpp
+++ b/tests/unit/index/project_index_tests.cpp
@@ -37,8 +37,8 @@ index::SymbolHash find_symbol(const index::ProjectIndex& project, llvm::StringRe
 
 /// The TU-local id -> pool id mapping merge() consumes, as Indexer::merge
 /// computes it.
-llvm::SmallVector<std::uint32_t> intern_paths(const index::TUIndex& view, clice::FileTable& pool) {
-    llvm::SmallVector<std::uint32_t> ids;
+llvm::SmallVector<Fid> intern_paths(const index::TUIndex& view, clice::FileTable& pool) {
+    llvm::SmallVector<Fid> ids;
     for(std::uint32_t i = 0; i < view.path_count(); i += 1) {
         ids.push_back(pool.intern(view.path(i)));
     }
@@ -146,70 +146,66 @@ TEST_CASE(MergeRejectsBadBitmap) {
 
 TEST_CASE(FileVersionInterning) {
     clice::FileTable pool;
-    auto a = pool.intern_version(7, 0x1111);
-    ASSERT_EQ(pool.intern_version(7, 0x1111), a);
+    auto a = pool.intern_version(Fid{7}, 0x1111);
+    ASSERT_EQ(pool.intern_version(Fid{7}, 0x1111), a);
 
-    auto b = pool.intern_version(7, 0x2222);
+    auto b = pool.intern_version(Fid{7}, 0x2222);
     ASSERT_TRUE(b != a);
-    ASSERT_EQ(pool.version(b).fid, 7u);
+    ASSERT_EQ(pool.version(b).fid.raw, 7u);
     ASSERT_EQ(pool.version(b).content_hash, 0x2222u);
 }
 
 TEST_CASE(ManifestContributions) {
     clice::FileTable pool;
     index::ProjectIndex project;
-    auto fv_a = pool.intern_version(1, 0xa);
-    auto fv_b = pool.intern_version(2, 0xb);
+    auto fv_a = pool.intern_version(Fid{1}, 0xa);
+    auto fv_b = pool.intern_version(Fid{2}, 0xb);
 
-    auto manifest_for = [&](std::uint32_t tu_fv,
-                            std::initializer_list<std::pair<std::uint32_t, std::uint64_t>> rows) {
+    auto manifest_for = [&](VersionID tu_fv,
+                            std::initializer_list<std::pair<VersionID, std::uint64_t>> rows) {
         index::TUManifest manifest;
         manifest.tu_fv = tu_fv;
         manifest.contributions = rows;
         return manifest;
     };
 
-    auto tu1_fv = pool.intern_version(10, 0x1);
-    auto tu2_fv = pool.intern_version(11, 0x2);
+    auto tu1_fv = pool.intern_version(Fid{10}, 0x1);
+    auto tu2_fv = pool.intern_version(Fid{11}, 0x2);
 
     // TU 1 contributes h1 to file 1 and h2 to file 2.
     auto affected = project.apply_manifest(pool,
-                                           10,
-                                           manifest_for(tu1_fv,
-                                                        {
-                                                            {fv_a, 100},
-                                                            {fv_b, 200}
-    }));
+                                           Fid{
+                                               10
+    },
+                                           manifest_for(tu1_fv, {{fv_a, 100}, {fv_b, 200}}));
     ASSERT_EQ(affected.size(), std::size_t(2));
-    ASSERT_EQ(project.live_variants(1).size(), std::size_t(1));
+    ASSERT_EQ(project.live_variants(Fid{1}).size(), std::size_t(1));
 
     // TU 2 shares file 1's variant: the live set does not grow.
     project.apply_manifest(pool,
-                           11,
-                           manifest_for(tu2_fv,
-                                        {
-                                            {fv_a, 100}
-    }));
-    ASSERT_EQ(project.live_variants(1).size(), std::size_t(1));
+                           Fid{
+                               11
+    },
+                           manifest_for(tu2_fv, {{fv_a, 100}}));
+    ASSERT_EQ(project.live_variants(Fid{1}).size(), std::size_t(1));
 
     // TU 1 re-indexes with a new variant for file 1 and drops file 2: both
     // hashes stay live on file 1 (TU 2 still holds the old one), file 2
     // loses its only contribution.
     project.apply_manifest(pool,
-                           10,
-                           manifest_for(tu1_fv,
-                                        {
-                                            {fv_a, 300}
-    }));
-    ASSERT_EQ(project.live_variants(1).size(), std::size_t(2));
-    ASSERT_TRUE(project.live_variants(2).empty());
+                           Fid{
+                               10
+    },
+                           manifest_for(tu1_fv, {{fv_a, 300}}));
+    ASSERT_EQ(project.live_variants(Fid{1}).size(), std::size_t(2));
+    ASSERT_TRUE(project.live_variants(Fid{2}).empty());
 
-    project.remove_manifest(pool, 11);
-    auto live = project.live_variants(1);
+    project.remove_manifest(pool, Fid{11});
+    auto live = project.live_variants(Fid{1});
     ASSERT_EQ(live.size(), std::size_t(1));
     ASSERT_EQ(live.front(), 300u);
 
-    project.remove_manifest(pool, 10);
+    project.remove_manifest(pool, Fid{10});
     ASSERT_TRUE(project.contributions.empty());
 }
 
@@ -241,7 +237,7 @@ TEST_CASE(GlobalRoundTripWithRealMerge) {
 
     clice::FileTable fresh;
     index::ProjectIndex loaded;
-    llvm::DenseMap<std::uint32_t, std::uint64_t> pins;
+    llvm::DenseMap<VersionID, std::uint64_t> pins;
     ASSERT_TRUE(loaded.load_global(buf.str(), fresh, pins));
 
     auto symbol = find_symbol(loaded, "global_value");
@@ -249,7 +245,7 @@ TEST_CASE(GlobalRoundTripWithRealMerge) {
     auto main_path = pool.resolve(file_ids_map[view.path_count() - 1]);
     auto fresh_id = fresh.find(main_path);
     ASSERT_TRUE(fresh_id.has_value());
-    ASSERT_TRUE(loaded.symbols[symbol].reference_files.contains(*fresh_id));
+    ASSERT_TRUE(loaded.symbols[symbol].reference_files.contains(fresh_id->raw));
 }
 
 };  // TEST_SUITE(ProjectIndex)

--- a/tests/unit/sched/ledger_tests.cpp
+++ b/tests/unit/sched/ledger_tests.cpp
@@ -20,41 +20,41 @@ TEST_CASE(content_absorbs_queued) {
     // Within one queued slot ContentChanged absorbs: a deps-only cascade
     // cannot downgrade a file whose own content already changed, and no
     // second slot is owed.
-    EXPECT_TRUE(ledger.record(1, ReindexReason::ContentChanged));
-    EXPECT_FALSE(ledger.record(1, ReindexReason::DepsOnly));
-    EXPECT_TRUE(ledger.pending_reason(1) == ReindexReason::ContentChanged);
+    EXPECT_TRUE(ledger.record(Fid{1}, ReindexReason::ContentChanged));
+    EXPECT_FALSE(ledger.record(Fid{1}, ReindexReason::DepsOnly));
+    EXPECT_TRUE(ledger.pending_reason(Fid{1}) == ReindexReason::ContentChanged);
 
-    EXPECT_FALSE(ledger.record(1, ReindexReason::ContentChanged));
-    EXPECT_TRUE(ledger.pending_reason(1) == ReindexReason::ContentChanged);
+    EXPECT_FALSE(ledger.record(Fid{1}, ReindexReason::ContentChanged));
+    EXPECT_TRUE(ledger.pending_reason(Fid{1}) == ReindexReason::ContentChanged);
 }
 
 TEST_CASE(consumed_pass_owns_debt) {
     // A deps-only recording after the slot was claimed is new debt of its
     // own kind: the in-flight pass owns the earlier content change, and
     // keeping ContentChanged would suppress the file's rows past it.
-    ledger.record(1, ReindexReason::ContentChanged);
-    auto claim = ledger.claim(1);
+    ledger.record(Fid{1}, ReindexReason::ContentChanged);
+    auto claim = ledger.claim(Fid{1});
     ASSERT_TRUE(claim.has_value());
 
-    EXPECT_TRUE(ledger.record(1, ReindexReason::DepsOnly));
-    EXPECT_TRUE(ledger.pending_reason(1) == ReindexReason::DepsOnly);
+    EXPECT_TRUE(ledger.record(Fid{1}, ReindexReason::DepsOnly));
+    EXPECT_TRUE(ledger.pending_reason(Fid{1}) == ReindexReason::DepsOnly);
 }
 
 TEST_CASE(settle_spares_newer_debt) {
     // A recording during the flight books newer debt; the older attempt's
     // settle must leave it standing, and only the newer claim clears it.
-    ledger.record(1, ReindexReason::ContentChanged);
-    auto old_claim = ledger.claim(1);
+    ledger.record(Fid{1}, ReindexReason::ContentChanged);
+    auto old_claim = ledger.claim(Fid{1});
     ASSERT_TRUE(old_claim.has_value());
-    ledger.record(1, ReindexReason::ContentChanged);
+    ledger.record(Fid{1}, ReindexReason::ContentChanged);
 
     ledger.settle(*old_claim);
-    EXPECT_TRUE(ledger.pending_reason(1).has_value());
+    EXPECT_TRUE(ledger.pending_reason(Fid{1}).has_value());
 
-    auto fresh = ledger.claim(1);
+    auto fresh = ledger.claim(Fid{1});
     ASSERT_TRUE(fresh.has_value());
     ledger.settle(*fresh);
-    EXPECT_FALSE(ledger.pending_reason(1).has_value());
+    EXPECT_FALSE(ledger.pending_reason(Fid{1}).has_value());
     EXPECT_TRUE(ledger.empty());
 }
 
@@ -62,19 +62,19 @@ TEST_CASE(deps_never_supersede) {
     // Only newer content supersedes an in-flight pass: its rows describe
     // text that no longer exists. A deps-only recording does not — the
     // rows are positionally right and the follow-up covers the drift.
-    ledger.record(1, ReindexReason::ContentChanged);
-    auto claim = ledger.claim(1);
+    ledger.record(Fid{1}, ReindexReason::ContentChanged);
+    auto claim = ledger.claim(Fid{1});
     ASSERT_TRUE(claim.has_value());
     EXPECT_FALSE(ledger.superseded(*claim));
 
-    ledger.record(1, ReindexReason::DepsOnly);
+    ledger.record(Fid{1}, ReindexReason::DepsOnly);
     EXPECT_FALSE(ledger.superseded(*claim));
 
-    ledger.record(1, ReindexReason::ContentChanged);
+    ledger.record(Fid{1}, ReindexReason::ContentChanged);
     EXPECT_TRUE(ledger.superseded(*claim));
 
     // A cleared entry (file removed) also lands nothing.
-    ledger.clear(1);
+    ledger.clear(Fid{1});
     EXPECT_TRUE(ledger.superseded(*claim));
 }
 
@@ -82,23 +82,23 @@ TEST_CASE(superseded_failure_spends_nothing) {
     // A failed dispatch of superseded bytes neither requeues nor spends
     // the fresh content's crash budget: the newer booking redoes the
     // work with a full budget of its own.
-    ledger.record(1, ReindexReason::ContentChanged);
-    auto stale = ledger.claim(1);
+    ledger.record(Fid{1}, ReindexReason::ContentChanged);
+    auto stale = ledger.claim(Fid{1});
     ASSERT_TRUE(stale.has_value());
-    ledger.record(1, ReindexReason::ContentChanged);
+    ledger.record(Fid{1}, ReindexReason::ContentChanged);
 
     EXPECT_TRUE(ledger.on_dispatch_failure(*stale, true).verdict == Verdict::Superseded);
 
     // The fresh claim still has the whole budget: `budget` crashes
     // requeue before the next one abandons.
     for(unsigned i = 0; i < budget; i += 1) {
-        auto claim = ledger.claim(1);
+        auto claim = ledger.claim(Fid{1});
         ASSERT_TRUE(claim.has_value());
         auto outcome = ledger.on_dispatch_failure(*claim, true);
         EXPECT_TRUE(outcome.verdict == Verdict::Requeued);
         EXPECT_TRUE(outcome.needs_slot);
     }
-    auto last = ledger.claim(1);
+    auto last = ledger.claim(Fid{1});
     ASSERT_TRUE(last.has_value());
     EXPECT_TRUE(ledger.on_dispatch_failure(*last, true).verdict == Verdict::GaveUp);
     EXPECT_TRUE(ledger.empty());
@@ -107,9 +107,9 @@ TEST_CASE(superseded_failure_spends_nothing) {
 TEST_CASE(preemption_needs_no_budget) {
     // Preemptions say nothing about the file: they requeue past any spent
     // budget — capping them would silently drop coverage.
-    ledger.record(1, ReindexReason::DepsOnly);
+    ledger.record(Fid{1}, ReindexReason::DepsOnly);
     for(int i = 0; i < 10; i += 1) {
-        auto claim = ledger.claim(1);
+        auto claim = ledger.claim(Fid{1});
         ASSERT_TRUE(claim.has_value());
         EXPECT_TRUE(ledger.on_dispatch_failure(*claim, false).verdict == Verdict::Requeued);
     }
@@ -119,22 +119,22 @@ TEST_CASE(requeue_carries_content) {
     // The requeue carries the debt class the dispatch was launched for: a
     // deps-only downgrade during the flight bet on the content pass
     // landing, and a failed pass leaves the edit uncovered.
-    ledger.record(1, ReindexReason::ContentChanged);
-    auto claim = ledger.claim(1);
+    ledger.record(Fid{1}, ReindexReason::ContentChanged);
+    auto claim = ledger.claim(Fid{1});
     ASSERT_TRUE(claim.has_value());
-    ledger.record(1, ReindexReason::DepsOnly);
-    EXPECT_TRUE(ledger.pending_reason(1) == ReindexReason::DepsOnly);
+    ledger.record(Fid{1}, ReindexReason::DepsOnly);
+    EXPECT_TRUE(ledger.pending_reason(Fid{1}) == ReindexReason::DepsOnly);
 
     EXPECT_TRUE(ledger.on_dispatch_failure(*claim, true).verdict == Verdict::Requeued);
-    EXPECT_TRUE(ledger.pending_reason(1) == ReindexReason::ContentChanged);
+    EXPECT_TRUE(ledger.pending_reason(Fid{1}) == ReindexReason::ContentChanged);
 }
 
 TEST_CASE(cleared_claim_drops) {
     // A file removed mid-flight has nothing to redo.
-    ledger.record(1, ReindexReason::ContentChanged);
-    auto claim = ledger.claim(1);
+    ledger.record(Fid{1}, ReindexReason::ContentChanged);
+    auto claim = ledger.claim(Fid{1});
     ASSERT_TRUE(claim.has_value());
-    ledger.clear(1);
+    ledger.clear(Fid{1});
     EXPECT_TRUE(ledger.on_dispatch_failure(*claim, true).verdict == Verdict::Dropped);
     EXPECT_TRUE(ledger.empty());
 }

--- a/tests/unit/sched/pcm_graph_integration_tests.cpp
+++ b/tests/unit/sched/pcm_graph_integration_tests.cpp
@@ -5,7 +5,7 @@
 #include "command/command.h"
 #include "compile/compilation.h"
 #include "sched/graph.h"
-#include "support/path_pool.h"
+#include "vfs/file_table.h"
 #include "syntax/dependency_graph.h"
 #include "syntax/scan.h"
 
@@ -86,7 +86,7 @@ DispatchFn make_dispatch(CompilationDatabase& cdb,
                          DependencyGraph& graph,
                          llvm::DenseMap<std::uint32_t, std::string>& pcm_paths) {
     return [&](std::uint32_t path_id, bool) -> kota::task<RoundOutcome> {
-        auto file_path = cdb.paths().resolve(path_id);
+        auto file_path = cdb.files().resolve(path_id);
         auto candidates = cdb.candidate_entries(file_path);
         if(candidates.empty()) {
             co_return RoundOutcome::Failed;
@@ -132,7 +132,7 @@ DispatchFn make_dispatch(CompilationDatabase& cdb,
 /// Build a resolve_fn that lazily scans module files for imports.
 ResolveFn make_resolver(CompilationDatabase& cdb, DependencyGraph& graph) {
     return [&](std::uint32_t path_id) -> llvm::SmallVector<std::uint32_t> {
-        auto file_path = cdb.paths().resolve(path_id);
+        auto file_path = cdb.files().resolve(path_id);
         auto candidates = cdb.candidate_entries(file_path);
         if(candidates.empty()) {
             return {};
@@ -159,7 +159,8 @@ ResolveFn make_resolver(CompilationDatabase& cdb, DependencyGraph& graph) {
 /// Helper to set up infra, compile a module, and verify all PCMs are produced.
 struct ModuleTestEnv {
     TempDir tmp;
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     DependencyGraph graph;
     llvm::DenseMap<std::uint32_t, std::string> pcm_paths;
 

--- a/tests/unit/sched/pcm_graph_integration_tests.cpp
+++ b/tests/unit/sched/pcm_graph_integration_tests.cpp
@@ -86,7 +86,7 @@ DispatchFn make_dispatch(CompilationDatabase& cdb,
                          DependencyGraph& graph,
                          llvm::DenseMap<std::uint32_t, std::string>& pcm_paths) {
     return [&](std::uint32_t path_id, bool) -> kota::task<RoundOutcome> {
-        auto file_path = cdb.files().resolve(path_id);
+        auto file_path = cdb.files().resolve(Fid{path_id});
         auto candidates = cdb.candidate_entries(file_path);
         if(candidates.empty()) {
             co_return RoundOutcome::Failed;
@@ -105,7 +105,7 @@ DispatchFn make_dispatch(CompilationDatabase& cdb,
         // Fill ALL available PCM paths (clang needs transitive deps too).
         for(auto& [pid, pcm_path]: pcm_paths) {
             for(auto& [mod_name, mod_ids]: graph.modules()) {
-                if(llvm::find(mod_ids, pid) != mod_ids.end()) {
+                if(llvm::find(mod_ids, Fid{pid}) != mod_ids.end()) {
                     cp.pcms.try_emplace(mod_name, pcm_path);
                     break;
                 }
@@ -132,7 +132,7 @@ DispatchFn make_dispatch(CompilationDatabase& cdb,
 /// Build a resolve_fn that lazily scans module files for imports.
 ResolveFn make_resolver(CompilationDatabase& cdb, DependencyGraph& graph) {
     return [&](std::uint32_t path_id) -> llvm::SmallVector<std::uint32_t> {
-        auto file_path = cdb.files().resolve(path_id);
+        auto file_path = cdb.files().resolve(Fid{path_id});
         auto candidates = cdb.candidate_entries(file_path);
         if(candidates.empty()) {
             return {};
@@ -149,7 +149,7 @@ ResolveFn make_resolver(CompilationDatabase& cdb, DependencyGraph& graph) {
         for(auto& mod_name: scan_result.modules) {
             auto mod_ids = graph.lookup_module(mod_name);
             if(!mod_ids.empty()) {
-                deps.push_back(mod_ids[0]);
+                deps.push_back(mod_ids[0].raw);
             }
         }
         return deps;
@@ -171,7 +171,7 @@ struct ModuleTestEnv {
 
     std::uint32_t lookup(llvm::StringRef mod_name) {
         auto ids = graph.lookup_module(mod_name);
-        return ids.empty() ? UINT32_MAX : ids[0];
+        return ids.empty() ? UINT32_MAX : ids[0].raw;
     }
 };
 
@@ -1131,7 +1131,7 @@ TEST_CASE(module_implementation_unit) {
         // Pass the built PCM so clang can resolve `module Greeter;`.
         for(auto& [pid, pcm_path]: env.pcm_paths) {
             for(auto& [mod_name, mod_ids]: env.graph.modules()) {
-                if(llvm::find(mod_ids, pid) != mod_ids.end()) {
+                if(llvm::find(mod_ids, Fid{pid}) != mod_ids.end()) {
                     cp.pcms.try_emplace(mod_name, pcm_path);
                     break;
                 }

--- a/tests/unit/sched/pcm_graph_integration_tests.cpp
+++ b/tests/unit/sched/pcm_graph_integration_tests.cpp
@@ -5,9 +5,9 @@
 #include "command/command.h"
 #include "compile/compilation.h"
 #include "sched/graph.h"
-#include "vfs/file_table.h"
 #include "syntax/dependency_graph.h"
 #include "syntax/scan.h"
+#include "vfs/file_table.h"
 
 namespace clice::testing {
 namespace {

--- a/tests/unit/server/ast_family_tests.cpp
+++ b/tests/unit/server/ast_family_tests.cpp
@@ -58,7 +58,7 @@ struct Stack {
     }
 
     std::shared_ptr<Session> open(llvm::StringRef path, std::string text) {
-        auto session = sessions.open(workspace.path_pool.intern(path));
+        auto session = sessions.open(workspace.file_table.intern(path));
         session->text = std::move(text);
         session->line_starts = kota::ipc::lsp::build_line_starts(session->text);
         return session;
@@ -837,7 +837,7 @@ TEST_CASE(PoisonPreambleBudget) {
 
     auto make_session = [&] {
         auto session = std::make_shared<Session>();
-        session->path_id = stack.workspace.path_pool.intern(src);
+        session->path_id = stack.workspace.file_table.intern(src);
         session->text = "#pragma clang __debug crash\n";
         return session;
     };
@@ -978,7 +978,7 @@ TEST_CASE(StaleDepsNoAdopt) {
 
     auto make_session = [&] {
         auto session = std::make_shared<Session>();
-        session->path_id = stack.workspace.path_pool.intern(src);
+        session->path_id = stack.workspace.file_table.intern(src);
         session->text = "#include \"dep.h\"\nint x;\n";
         return session;
     };

--- a/tests/unit/server/ast_family_tests.cpp
+++ b/tests/unit/server/ast_family_tests.cpp
@@ -64,8 +64,8 @@ struct Stack {
         return session;
     }
 
-    bool is_compiling(std::uint32_t path_id) const {
-        return graph.is_compiling({ast_family, path_id});
+    bool is_compiling(Fid path_id) const {
+        return graph.is_compiling({ast_family, path_id.raw});
     }
 
     void register_pch_store(TempDir& tmp) {
@@ -512,7 +512,8 @@ TEST_CASE(BufferImportRecorded) {
     // The sentinel edge survives the landing: a first provider's update
     // must reach this document's node.
     auto dirtied = stack.graph.update(PCMFamily::unresolved_node("m"));
-    EXPECT_TRUE(std::ranges::find(dirtied, NodeId{ast_family, session->path_id}) != dirtied.end());
+    EXPECT_TRUE(std::ranges::find(dirtied, NodeId{ast_family, session->path_id.raw}) !=
+                dirtied.end());
 
     logging::reset_anomaly_for_testing();
 }
@@ -557,7 +558,8 @@ TEST_CASE(IncludeImportRecorded) {
     EXPECT_TRUE(done);
 
     auto dirtied = stack.graph.update(PCMFamily::unresolved_node("m"));
-    EXPECT_TRUE(std::ranges::find(dirtied, NodeId{ast_family, session->path_id}) != dirtied.end());
+    EXPECT_TRUE(std::ranges::find(dirtied, NodeId{ast_family, session->path_id.raw}) !=
+                dirtied.end());
 
     logging::reset_anomaly_for_testing();
 }

--- a/tests/unit/server/context_resolver_tests.cpp
+++ b/tests/unit/server/context_resolver_tests.cpp
@@ -24,7 +24,7 @@ TEST_CASE(ChoiceNeedsSession) {
                   {tmp.root, path, {"-DSECOND"}}
     }));
 
-    auto file = workspace.path_pool.intern(path);
+    auto file = workspace.file_table.intern(path);
     auto candidates = workspace.cdb.candidate_entries(path);
     ASSERT_EQ(candidates.size(), 2u);
     // Pin the non-default candidate (candidate order is content-decided,
@@ -64,7 +64,7 @@ TEST_CASE(PinBaseSurvivesRules) {
                   {tmp.root, path, {"-DSECOND"}}
     }));
 
-    auto file = workspace.path_pool.intern(path);
+    auto file = workspace.file_table.intern(path);
     auto candidates = workspace.cdb.candidate_entries(path);
     ASSERT_EQ(candidates.size(), 2u);
     auto define_of = [&](ConfigID config) -> llvm::StringRef {
@@ -105,8 +105,8 @@ TEST_CASE(ValidateKeepsValidChoice) {
                   {tmp.root, tmp.path("host.cpp"), {}}
     }));
 
-    auto host = workspace.path_pool.intern(tmp.path("host.cpp"));
-    auto header = workspace.path_pool.intern(tmp.path("h.h"));
+    auto host = workspace.file_table.intern(tmp.path("host.cpp"));
+    auto header = workspace.file_table.intern(tmp.path("h.h"));
     workspace.dep_graph.set_includes(host, 0, {header});
     workspace.dep_graph.build_reverse_map();
     resolver.saved_contexts[header] = SavedContext{host, std::nullopt, ""};
@@ -130,9 +130,9 @@ TEST_CASE(ValidateDropsStaleChoice) {
                   {tmp.root, tmp.path("main.cpp"), {}}
     }));
 
-    auto host = workspace.path_pool.intern(tmp.path("host.cpp"));
-    auto header = workspace.path_pool.intern(tmp.path("h.h"));
-    auto main_file = workspace.path_pool.intern(tmp.path("main.cpp"));
+    auto host = workspace.file_table.intern(tmp.path("host.cpp"));
+    auto header = workspace.file_table.intern(tmp.path("h.h"));
+    auto main_file = workspace.file_table.intern(tmp.path("main.cpp"));
 
     // A host pin whose CDB entry disappeared while the server was down.
     resolver.saved_contexts[header] = SavedContext{host, std::nullopt, ""};
@@ -150,8 +150,8 @@ TEST_CASE(ValidateDropsStaleChoice) {
 TEST_CASE(InvalidateDropsBorrowed) {
     Workspace workspace;
     ContextResolver resolver(workspace);
-    auto borrowed = workspace.path_pool.intern("/proj/borrowed.h");
-    auto synthesized = workspace.path_pool.intern("/proj/synthesized.h");
+    auto borrowed = workspace.file_table.intern("/proj/borrowed.h");
+    auto synthesized = workspace.file_table.intern("/proj/synthesized.h");
 
     // A self-contained borrow tracks no chain deps: forcing re-validation
     // could never trigger anything, so invalidation drops it outright.

--- a/tests/unit/server/context_resolver_tests.cpp
+++ b/tests/unit/server/context_resolver_tests.cpp
@@ -35,7 +35,7 @@ TEST_CASE(ChoiceNeedsSession) {
     };
     auto pinned = candidates.back().config;
     resolver.saved_contexts[file] =
-        SavedContext{no_path_id, std::nullopt, workspace.cdb.entry_hash_hex(pinned)};
+        SavedContext{Fid{}, std::nullopt, workspace.cdb.entry_hash_hex(pinned)};
 
     // An open session honors the pinned CDB entry...
     auto session = store.open(file);
@@ -75,10 +75,8 @@ TEST_CASE(PinBaseSurvivesRules) {
 
     // A pin whose applied hash went stale (a rule edit since it was saved)
     // but whose base identity is recorded still selects its candidate...
-    resolver.saved_contexts[file] = SavedContext{no_path_id,
-                                                 std::nullopt,
-                                                 "0123456789abcdef",
-                                                 workspace.cdb.entry_hash_hex(pinned)};
+    resolver.saved_contexts[file] =
+        SavedContext{Fid{}, std::nullopt, "0123456789abcdef", workspace.cdb.entry_hash_hex(pinned)};
     auto session = store.open(file);
     std::string directory;
     std::vector<std::string> arguments;
@@ -86,7 +84,7 @@ TEST_CASE(PinBaseSurvivesRules) {
     ASSERT_TRUE(llvm::is_contained(arguments, define_of(pinned)));
 
     // ...while the same stale hash without a base falls back to the default.
-    resolver.saved_contexts[file] = SavedContext{no_path_id, std::nullopt, "0123456789abcdef", ""};
+    resolver.saved_contexts[file] = SavedContext{Fid{}, std::nullopt, "0123456789abcdef", ""};
     arguments.clear();
     resolver.resolve_command(path, directory, arguments, ContextUse::Editor);
     ASSERT_TRUE(llvm::is_contained(arguments, define_of(candidates.front().config)));
@@ -107,7 +105,7 @@ TEST_CASE(ValidateKeepsValidChoice) {
 
     auto host = workspace.file_table.intern(tmp.path("host.cpp"));
     auto header = workspace.file_table.intern(tmp.path("h.h"));
-    workspace.dep_graph.set_includes(host, 0, {header});
+    workspace.dep_graph.set_includes(host, 0, {{header}});
     workspace.dep_graph.build_reverse_map();
     resolver.saved_contexts[header] = SavedContext{host, std::nullopt, ""};
 
@@ -141,7 +139,7 @@ TEST_CASE(ValidateDropsStaleChoice) {
     ASSERT_FALSE(resolver.saved_contexts.contains(header));
 
     // A command pin whose hash matches no current CDB entry.
-    resolver.saved_contexts[main_file] = SavedContext{no_path_id, std::nullopt, "deadbeef"};
+    resolver.saved_contexts[main_file] = SavedContext{Fid{}, std::nullopt, "deadbeef"};
     auto main_session = store.open(main_file);
     resolver.validate_saved_context(main_session->path_id);
     ASSERT_FALSE(resolver.saved_contexts.contains(main_file));
@@ -160,17 +158,17 @@ TEST_CASE(InvalidateDropsBorrowed) {
     ASSERT_FALSE(resolver.header_contexts.contains(borrowed));
 
     // A synthesized context re-validates its chain by content hash: the
-    // shared version's fast path is dropped, the consumed hash stays.
+    // shared version's fast path is dropped, the consumed version stays.
     auto& context = resolver.header_contexts[synthesized];
-    context.deps.deps.push_back({.path_id = borrowed, .hash = 7});
     auto vid = workspace.file_table.intern_version(borrowed, 7);
+    context.deps.push_back({.path_id = borrowed, .version = vid});
     workspace.file_table.adopt_stamp(vid, 42, 123);
     ASSERT_EQ(workspace.file_table.version(vid).mtime_ns, 123);
     auto stamps = workspace.file_table.stamp_generation;
     resolver.invalidate_header_deps(synthesized);
     ASSERT_TRUE(resolver.header_contexts.contains(synthesized));
     ASSERT_EQ(workspace.file_table.version(vid).mtime_ns, 0);
-    ASSERT_EQ(resolver.header_contexts[synthesized].deps.deps[0].hash, 7u);
+    ASSERT_EQ(resolver.header_contexts[synthesized].deps[0].version, vid);
     // The revocation is stamp movement — what tells persistence the
     // dropped fast path must not survive in the global blob.
     ASSERT_TRUE(workspace.file_table.stamp_generation != stamps);
@@ -192,11 +190,11 @@ TEST_CASE(UnboundVerdictStaysLocal) {
     ASSERT_TRUE(resolver.header_mode(path, id) == HeaderMode::NeedsContext);
 
     std::vector<CacheModeEntry> slices;
-    resolver.dump_mode_slices(slices, [](std::uint32_t fid) { return fid; });
+    resolver.dump_mode_slices(slices, [](Fid fid) { return fid.raw; });
     ASSERT_TRUE(slices.empty());
 
     ContextResolver restarted(workspace);
-    slices.push_back({id, static_cast<std::uint32_t>(HeaderMode::NeedsContext), 0});
+    slices.push_back({id.raw, static_cast<std::uint32_t>(HeaderMode::NeedsContext), 0});
     restarted.load_mode_slices(slices, [&](std::uint32_t) -> llvm::StringRef { return path; });
     ASSERT_TRUE(restarted.header_mode(path, id) == HeaderMode::Unknown);
 }
@@ -215,7 +213,7 @@ TEST_CASE(ModeSliceContentGate) {
 
     resolver.record_header_mode(id, HeaderMode::NeedsContext, disk->hash);
     std::vector<CacheModeEntry> slices;
-    resolver.dump_mode_slices(slices, [](std::uint32_t fid) { return fid; });
+    resolver.dump_mode_slices(slices, [](Fid fid) { return fid.raw; });
     ASSERT_EQ(slices.size(), 1u);
 
     auto resolve = [&](std::uint32_t) -> llvm::StringRef {

--- a/tests/unit/server/context_resolver_tests.cpp
+++ b/tests/unit/server/context_resolver_tests.cpp
@@ -133,10 +133,13 @@ TEST_CASE(ValidateDropsStaleChoice) {
     auto main_file = workspace.file_table.intern(tmp.path("main.cpp"));
 
     // A host pin whose CDB entry disappeared while the server was down.
+    // The drop must dirty the contexts blob, or the stale choice
+    // resurrects from disk at the next start.
     resolver.saved_contexts[header] = SavedContext{host, std::nullopt, ""};
     auto header_session = store.open(header);
     resolver.validate_saved_context(header_session->path_id);
     ASSERT_FALSE(resolver.saved_contexts.contains(header));
+    ASSERT_TRUE(workspace.contexts_dirty);
 
     // A command pin whose hash matches no current CDB entry.
     resolver.saved_contexts[main_file] = SavedContext{Fid{}, std::nullopt, "deadbeef"};

--- a/tests/unit/server/context_resolver_tests.cpp
+++ b/tests/unit/server/context_resolver_tests.cpp
@@ -166,10 +166,100 @@ TEST_CASE(InvalidateDropsBorrowed) {
     auto vid = workspace.file_table.intern_version(borrowed, 7);
     workspace.file_table.adopt_stamp(vid, 42, 123);
     ASSERT_EQ(workspace.file_table.version(vid).mtime_ns, 123);
+    auto stamps = workspace.file_table.stamp_generation;
     resolver.invalidate_header_deps(synthesized);
     ASSERT_TRUE(resolver.header_contexts.contains(synthesized));
     ASSERT_EQ(workspace.file_table.version(vid).mtime_ns, 0);
     ASSERT_EQ(resolver.header_contexts[synthesized].deps.deps[0].hash, 7u);
+    // The revocation is stamp movement — what tells persistence the
+    // dropped fast path must not survive in the global blob.
+    ASSERT_TRUE(workspace.file_table.stamp_generation != stamps);
+}
+
+TEST_CASE(UnboundVerdictStaysLocal) {
+    // A NeedsContext verdict scored with no disk observation has no hash
+    // to validate on load: it serves this session but must neither
+    // persist nor, if found in a blob, bypass the content gate — the next
+    // session's bytes never earned it.
+    TempDir tmp;
+    Workspace workspace;
+    ContextResolver resolver(workspace);
+    tmp.touch("h.h", "int x;\n");
+    auto path = tmp.path("h.h");
+    auto id = workspace.file_table.intern(path);
+
+    resolver.record_header_mode(id, HeaderMode::NeedsContext);
+    ASSERT_TRUE(resolver.header_mode(path, id) == HeaderMode::NeedsContext);
+
+    std::vector<CacheModeEntry> slices;
+    resolver.dump_mode_slices(slices, [](std::uint32_t fid) { return fid; });
+    ASSERT_TRUE(slices.empty());
+
+    ContextResolver restarted(workspace);
+    slices.push_back({id, static_cast<std::uint32_t>(HeaderMode::NeedsContext), 0});
+    restarted.load_mode_slices(slices, [&](std::uint32_t) -> llvm::StringRef { return path; });
+    ASSERT_TRUE(restarted.header_mode(path, id) == HeaderMode::Unknown);
+}
+
+TEST_CASE(ModeSliceContentGate) {
+    // A content-bound verdict survives a restart only while the disk
+    // still holds the bytes it was scored on.
+    TempDir tmp;
+    Workspace workspace;
+    ContextResolver resolver(workspace);
+    tmp.touch("h.h", "int x;\n");
+    auto path = tmp.path("h.h");
+    auto id = workspace.file_table.intern(path);
+    auto disk = workspace.file_table.current(id);
+    ASSERT_TRUE(disk.has_value());
+
+    resolver.record_header_mode(id, HeaderMode::NeedsContext, disk->hash);
+    std::vector<CacheModeEntry> slices;
+    resolver.dump_mode_slices(slices, [](std::uint32_t fid) { return fid; });
+    ASSERT_EQ(slices.size(), 1u);
+
+    auto resolve = [&](std::uint32_t) -> llvm::StringRef {
+        return path;
+    };
+    ContextResolver same_disk(workspace);
+    same_disk.load_mode_slices(slices, resolve);
+    ASSERT_TRUE(same_disk.header_mode(path, id) == HeaderMode::NeedsContext);
+
+    tmp.touch("h.h", "int y;\n");
+    ContextResolver edited(workspace);
+    edited.load_mode_slices(slices, resolve);
+    ASSERT_TRUE(edited.header_mode(path, id) == HeaderMode::Unknown);
+}
+
+TEST_CASE(VerdictPersistenceMarksDirty) {
+    // The persisted mode slice and the artifacts blob move together: any
+    // transition of a content-bound NeedsContext — earned, downgraded by
+    // a trial, or reset by a dependency change — must rewrite the blob,
+    // or a restart resurrects the dropped verdict (the header's own hash
+    // still matches). Session-local transitions must not thrash it.
+    Workspace workspace;
+    ContextResolver resolver(workspace);
+    auto id = workspace.file_table.intern("/proj/h.h");
+
+    resolver.record_header_mode(id, HeaderMode::NeedsContext, 7);
+    ASSERT_TRUE(workspace.artifacts_dirty);
+
+    workspace.artifacts_dirty = false;
+    resolver.reset_header_mode(id);
+    ASSERT_TRUE(workspace.artifacts_dirty);
+
+    // Unbound verdicts and self-contained impressions are never persisted.
+    workspace.artifacts_dirty = false;
+    resolver.record_header_mode(id, HeaderMode::NeedsContext);
+    resolver.record_header_mode(id, HeaderMode::SelfContained);
+    resolver.reset_header_mode(id);
+    ASSERT_FALSE(workspace.artifacts_dirty);
+
+    // A trial downgrading a persisted verdict drops it from the blob.
+    resolver.record_header_mode(id, HeaderMode::NeedsContext, 7);
+    workspace.artifacts_dirty = false;
+    resolver.record_header_mode(id, HeaderMode::SelfContained);
+    ASSERT_TRUE(workspace.artifacts_dirty);
 }
 
 };  // TEST_SUITE(ContextResolver)

--- a/tests/unit/server/context_resolver_tests.cpp
+++ b/tests/unit/server/context_resolver_tests.cpp
@@ -160,14 +160,16 @@ TEST_CASE(InvalidateDropsBorrowed) {
     ASSERT_FALSE(resolver.header_contexts.contains(borrowed));
 
     // A synthesized context re-validates its chain by content hash: the
-    // fast paths are dropped, the consumed hash stays.
+    // shared version's fast path is dropped, the consumed hash stays.
     auto& context = resolver.header_contexts[synthesized];
-    context.deps.deps.push_back({.path_id = borrowed, .size = 42, .mtime_ns = 123, .hash = 7});
+    context.deps.deps.push_back({.path_id = borrowed, .hash = 7});
+    auto vid = workspace.file_table.intern_version(borrowed, 7);
+    workspace.file_table.adopt_stamp(vid, 42, 123);
+    ASSERT_EQ(workspace.file_table.version(vid).mtime_ns, 123);
     resolver.invalidate_header_deps(synthesized);
     ASSERT_TRUE(resolver.header_contexts.contains(synthesized));
-    auto& dep = resolver.header_contexts[synthesized].deps.deps[0];
-    ASSERT_EQ(dep.mtime_ns, 0);
-    ASSERT_EQ(dep.hash, 7u);
+    ASSERT_EQ(workspace.file_table.version(vid).mtime_ns, 0);
+    ASSERT_EQ(resolver.header_contexts[synthesized].deps.deps[0].hash, 7u);
 }
 
 };  // TEST_SUITE(ContextResolver)

--- a/tests/unit/server/deps_snapshot_tests.cpp
+++ b/tests/unit/server/deps_snapshot_tests.cpp
@@ -209,6 +209,11 @@ TEST_CASE(StalePairCannotStamp) {
 
     tmp.touch("dep.h", "int v2();\n");
     age_file(dep);
+    // Same-tick touches can age to a stat identical to the pair's on
+    // coarse-timestamp filesystems, and an equal-stat same-size rewrite
+    // is the accepted mtime residual — the premise here is a stat that
+    // does differ, so force it apart.
+    ASSERT_TRUE(set_file_mtime(dep, file_mtime_ns(dep) - 5'000'000'000));
     auto snap = capture_deps_snapshot(pool,
                                       {
                                           DepFile{dep, consumed_hash(dep)}

--- a/tests/unit/server/deps_snapshot_tests.cpp
+++ b/tests/unit/server/deps_snapshot_tests.cpp
@@ -3,6 +3,8 @@
 #include "sched/workspace.h"
 
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/xxhash.h"
 
 namespace clice::testing {
 namespace {
@@ -17,22 +19,86 @@ std::int64_t generous_build_at() {
            10'000;
 }
 
+/// The consumed hash a worker would report for the file's current bytes
+/// (0 = unreadable, which no test here expects).
+std::uint64_t consumed_hash(llvm::StringRef path) {
+    auto buf = llvm::MemoryBuffer::getFile(path);
+    return buf ? llvm::xxh3_64bits((*buf)->getBuffer()) : 0;
+}
+
+/// Rewind a file's mtime out of the mtime-granularity guard window, the
+/// way real project files predate a server start. A freshly touched file
+/// is deliberately untrusted (see read_file_observed), so tests exercising
+/// stamps and repairs must age their files first.
+void age_file(llvm::StringRef path) {
+    set_file_mtime(path, file_mtime_ns(path) - 10'000'000'000);
+}
+
+/// The shared stat fast path of the version a dep names (0 = none).
+std::int64_t stamp_of(FileTable& pool, const DepState& dep) {
+    return pool.version(pool.intern_version(dep.path_id, dep.hash)).mtime_ns;
+}
+
+bool changed(FileTable& pool, const DepsSnapshot& snap) {
+    pool.begin_wave();
+    return deps_changed(pool, snap);
+}
+
 TEST_SUITE(DepsSnapshot) {
 
 TEST_CASE(FreshWhenUntouched) {
     TempDir tmp;
     tmp.touch("dep.h", "int f();\n");
     auto dep = tmp.path("dep.h");
+    age_file(dep);
 
     FileTable pool;
     auto snap = capture_deps_snapshot(pool,
                                       {
-                                          DepFile{dep, hash_file(dep)}
+                                          DepFile{dep, consumed_hash(dep)}
     },
                                       generous_build_at());
     ASSERT_EQ(snap.deps.size(), 1u);
-    ASSERT_TRUE(snap.deps[0].mtime_ns != 0);
-    ASSERT_FALSE(deps_changed(pool, snap));
+    ASSERT_FALSE(changed(pool, snap));
+
+    // The passing check earned the version its stat fast path.
+    ASSERT_EQ(stamp_of(pool, snap.deps[0]), file_mtime_ns(dep));
+}
+
+TEST_CASE(ScanPairStampsAtCapture) {
+    // With the startup scan's read in the shared pair, the capture-time
+    // stat is corroborated and the fast path exists before any check.
+    TempDir tmp;
+    tmp.touch("dep.h", "int f();\n");
+    auto dep = tmp.path("dep.h");
+    age_file(dep);
+
+    FileTable pool;
+    pool.read(pool.intern(dep));
+    auto snap = capture_deps_snapshot(pool,
+                                      {
+                                          DepFile{dep, consumed_hash(dep)}
+    },
+                                      generous_build_at());
+    ASSERT_EQ(stamp_of(pool, snap.deps[0]), file_mtime_ns(dep));
+    ASSERT_FALSE(changed(pool, snap));
+}
+
+TEST_CASE(SnapshotsShareOneVersion) {
+    TempDir tmp;
+    tmp.touch("dep.h", "int f();\n");
+    auto dep = tmp.path("dep.h");
+    age_file(dep);
+
+    FileTable pool;
+    auto build_at = generous_build_at();
+    auto first = capture_deps_snapshot(pool, {DepFile{dep, consumed_hash(dep)}}, build_at);
+    auto second = capture_deps_snapshot(pool, {DepFile{dep, consumed_hash(dep)}}, build_at);
+    ASSERT_EQ(pool.versions.size(), 1u);
+
+    // A repair through one snapshot's check serves the other.
+    ASSERT_FALSE(changed(pool, first));
+    ASSERT_EQ(stamp_of(pool, second.deps[0]), file_mtime_ns(dep));
 }
 
 TEST_CASE(ImmediateEditDetected) {
@@ -45,11 +111,11 @@ TEST_CASE(ImmediateEditDetected) {
     FileTable pool;
     auto snap = capture_deps_snapshot(pool,
                                       {
-                                          DepFile{dep, hash_file(dep)}
+                                          DepFile{dep, consumed_hash(dep)}
     },
                                       generous_build_at());
     tmp.touch("dep.h", "int renamed();\n");
-    ASSERT_TRUE(deps_changed(pool, snap));
+    ASSERT_TRUE(changed(pool, snap));
 }
 
 TEST_CASE(BackdatedEditDetected) {
@@ -59,38 +125,44 @@ TEST_CASE(BackdatedEditDetected) {
     TempDir tmp;
     tmp.touch("dep.h", "int old_name();\n");
     auto dep = tmp.path("dep.h");
+    age_file(dep);
 
     FileTable pool;
+    pool.read(pool.intern(dep));
     auto snap = capture_deps_snapshot(pool,
                                       {
-                                          DepFile{dep, hash_file(dep)}
+                                          DepFile{dep, consumed_hash(dep)}
     },
                                       generous_build_at());
+    auto recorded_mtime = stamp_of(pool, snap.deps[0]);
+    ASSERT_TRUE(recorded_mtime != 0);
 
     tmp.touch("dep.h", "int new_name();\n");  // same length
-    set_file_mtime(dep, snap.deps[0].mtime_ns - 5'000'000'000);
-    ASSERT_TRUE(deps_changed(pool, snap));
+    set_file_mtime(dep, recorded_mtime - 5'000'000'000);
+    ASSERT_TRUE(changed(pool, snap));
 }
 
 TEST_CASE(TouchRepairsFastPath) {
     TempDir tmp;
     tmp.touch("dep.h", "int f();\n");
     auto dep = tmp.path("dep.h");
+    age_file(dep);
 
     FileTable pool;
+    pool.read(pool.intern(dep));
     auto snap = capture_deps_snapshot(pool,
                                       {
-                                          DepFile{dep, hash_file(dep)}
+                                          DepFile{dep, consumed_hash(dep)}
     },
                                       generous_build_at());
 
     // Rewrite identical bytes: the stat moves, the content does not.
     tmp.touch("dep.h", "int f();\n");
-    set_file_mtime(dep, snap.deps[0].mtime_ns + 5'000'000'000);
-    ASSERT_FALSE(deps_changed(pool, snap));
+    set_file_mtime(dep, stamp_of(pool, snap.deps[0]) + 5'000'000'000);
+    ASSERT_FALSE(changed(pool, snap));
 
     // The passing hash comparison repaired the fast path in place.
-    ASSERT_EQ(snap.deps[0].mtime_ns, file_mtime_ns(dep));
+    ASSERT_EQ(stamp_of(pool, snap.deps[0]), file_mtime_ns(dep));
 }
 
 TEST_CASE(PoisonedCaptureDetected) {
@@ -100,7 +172,7 @@ TEST_CASE(PoisonedCaptureDetected) {
     TempDir tmp;
     tmp.touch("dep.h", "int v1();\n");
     auto dep = tmp.path("dep.h");
-    auto consumed = hash_file(dep);
+    auto consumed = consumed_hash(dep);
 
     tmp.touch("dep.h", "int v2();\n");
     // build_at in the past: the file's mtime falls inside "modified during
@@ -111,27 +183,55 @@ TEST_CASE(PoisonedCaptureDetected) {
                                           DepFile{dep, consumed}
     },
                                       /*build_at=*/1);
-    ASSERT_EQ(snap.deps[0].mtime_ns, 0);
-    ASSERT_TRUE(deps_changed(pool, snap));
+    ASSERT_EQ(stamp_of(pool, snap.deps[0]), 0);
+    ASSERT_TRUE(changed(pool, snap));
+}
+
+TEST_CASE(StaleScanPairCannotStamp) {
+    // The pair describes bytes the scan read; after an edit the capture's
+    // live stat no longer matches the pair, so the stale hash cannot
+    // corroborate a stamp for the newly consumed version.
+    TempDir tmp;
+    tmp.touch("dep.h", "int v1();\n");
+    auto dep = tmp.path("dep.h");
+
+    FileTable pool;
+    age_file(dep);
+    pool.read(pool.intern(dep));
+
+    tmp.touch("dep.h", "int v2();\n");
+    age_file(dep);
+    auto snap = capture_deps_snapshot(pool,
+                                      {
+                                          DepFile{dep, consumed_hash(dep)}
+    },
+                                      generous_build_at());
+    ASSERT_EQ(stamp_of(pool, snap.deps[0]), 0);
+
+    // The first check reads, proves the consumed bytes and repairs.
+    ASSERT_FALSE(changed(pool, snap));
+    ASSERT_EQ(stamp_of(pool, snap.deps[0]), file_mtime_ns(dep));
 }
 
 TEST_CASE(NoBaselineConverges) {
-    // Same capture shape as above, but the disk still holds the consumed
-    // bytes: one hash comparison proves it and re-earns the fast path.
+    // Capture during the guard window, but the disk still holds the
+    // consumed bytes: one hash comparison proves it and earns the fast
+    // path.
     TempDir tmp;
     tmp.touch("dep.h", "int f();\n");
     auto dep = tmp.path("dep.h");
+    age_file(dep);
 
     FileTable pool;
     auto snap = capture_deps_snapshot(pool,
                                       {
-                                          DepFile{dep, hash_file(dep)}
+                                          DepFile{dep, consumed_hash(dep)}
     },
                                       /*build_at=*/1);
-    ASSERT_EQ(snap.deps[0].mtime_ns, 0);
+    ASSERT_EQ(stamp_of(pool, snap.deps[0]), 0);
 
-    ASSERT_FALSE(deps_changed(pool, snap));
-    ASSERT_EQ(snap.deps[0].mtime_ns, file_mtime_ns(dep));
+    ASSERT_FALSE(changed(pool, snap));
+    ASSERT_EQ(stamp_of(pool, snap.deps[0]), file_mtime_ns(dep));
 }
 
 TEST_CASE(MissingTransitions) {
@@ -147,11 +247,11 @@ TEST_CASE(MissingTransitions) {
     ASSERT_TRUE(snap.deps[0].missing);
 
     // Still missing: unchanged.
-    ASSERT_FALSE(deps_changed(pool, snap));
+    ASSERT_FALSE(changed(pool, snap));
 
     // Appearing is a change.
     tmp.touch("ghost.h", "int f();\n");
-    ASSERT_TRUE(deps_changed(pool, snap));
+    ASSERT_TRUE(changed(pool, snap));
 }
 
 TEST_CASE(RemovedAfterBuild) {
@@ -162,33 +262,62 @@ TEST_CASE(RemovedAfterBuild) {
     FileTable pool;
     auto snap = capture_deps_snapshot(pool,
                                       {
-                                          DepFile{dep, hash_file(dep)}
+                                          DepFile{dep, consumed_hash(dep)}
     },
                                       generous_build_at());
 
     fs::remove(dep);
-    ASSERT_TRUE(deps_changed(pool, snap));
+    ASSERT_TRUE(changed(pool, snap));
 }
 
 TEST_CASE(ForceRevalidateGoesByHash) {
     TempDir tmp;
     tmp.touch("dep.h", "int old_name();\n");
     auto dep = tmp.path("dep.h");
+    age_file(dep);
 
     FileTable pool;
+    pool.read(pool.intern(dep));
     auto snap = capture_deps_snapshot(pool,
                                       {
-                                          DepFile{dep, hash_file(dep)}
+                                          DepFile{dep, consumed_hash(dep)}
     },
                                       generous_build_at());
-    auto recorded_mtime = snap.deps[0].mtime_ns;
+    auto recorded_mtime = stamp_of(pool, snap.deps[0]);
+    ASSERT_TRUE(recorded_mtime != 0);
 
     // An edit that restores the recorded stat exactly would pass the fast
     // path; force_revalidate drops it, so the hash still catches the edit.
     tmp.touch("dep.h", "int new_name();\n");  // same length
     set_file_mtime(dep, recorded_mtime);
 
-    snap.force_revalidate();
+    snap.force_revalidate(pool);
+    ASSERT_TRUE(changed(pool, snap));
+}
+
+TEST_CASE(ForceRevalidatePurgesWaveMemo) {
+    // A force point inside a wave must not be bypassed by a verdict the
+    // wave already memoized.
+    TempDir tmp;
+    tmp.touch("dep.h", "int old_name();\n");
+    auto dep = tmp.path("dep.h");
+    age_file(dep);
+
+    FileTable pool;
+    pool.read(pool.intern(dep));
+    auto snap = capture_deps_snapshot(pool,
+                                      {
+                                          DepFile{dep, consumed_hash(dep)}
+    },
+                                      generous_build_at());
+    auto recorded_mtime = stamp_of(pool, snap.deps[0]);
+
+    pool.begin_wave();
+    ASSERT_FALSE(deps_changed(pool, snap));
+
+    tmp.touch("dep.h", "int new_name();\n");  // same length
+    set_file_mtime(dep, recorded_mtime);
+    snap.force_revalidate(pool);
     ASSERT_TRUE(deps_changed(pool, snap));
 }
 

--- a/tests/unit/server/deps_snapshot_tests.cpp
+++ b/tests/unit/server/deps_snapshot_tests.cpp
@@ -65,7 +65,7 @@ TEST_CASE(FreshWhenUntouched) {
     ASSERT_EQ(stamp_of(pool, snap.deps[0]), file_mtime_ns(dep));
 }
 
-TEST_CASE(ScanPairStampsAtCapture) {
+TEST_CASE(PairStampsAtCapture) {
     // With the startup scan's read in the shared pair, the capture-time
     // stat is corroborated and the fast path exists before any check.
     TempDir tmp;
@@ -195,7 +195,7 @@ TEST_CASE(PoisonedCaptureDetected) {
     ASSERT_TRUE(changed(pool, snap));
 }
 
-TEST_CASE(StaleScanPairCannotStamp) {
+TEST_CASE(StalePairCannotStamp) {
     // The pair describes bytes the scan read; after an edit the capture's
     // live stat no longer matches the pair, so the stale hash cannot
     // corroborate a stamp for the newly consumed version.
@@ -278,7 +278,7 @@ TEST_CASE(RemovedAfterBuild) {
     ASSERT_TRUE(changed(pool, snap));
 }
 
-TEST_CASE(ForceRevalidateGoesByHash) {
+TEST_CASE(RevalidateGoesByHash) {
     TempDir tmp;
     tmp.touch("dep.h", "int old_name();\n");
     auto dep = tmp.path("dep.h");
@@ -303,7 +303,7 @@ TEST_CASE(ForceRevalidateGoesByHash) {
     ASSERT_TRUE(changed(pool, snap));
 }
 
-TEST_CASE(ForceRevalidatePurgesWaveMemo) {
+TEST_CASE(RevalidatePurgesWaveMemo) {
     // A force point inside a wave must not be bypassed by a verdict the
     // wave already memoized.
     TempDir tmp;

--- a/tests/unit/server/deps_snapshot_tests.cpp
+++ b/tests/unit/server/deps_snapshot_tests.cpp
@@ -36,11 +36,11 @@ void age_file(llvm::StringRef path) {
 
 /// The shared stat fast path of the version a dep names (0 = none).
 std::int64_t stamp_of(FileTable& pool, const DepState& dep) {
-    return pool.version(pool.intern_version(dep.path_id, dep.hash)).mtime_ns;
+    return pool.version(dep.version).mtime_ns;
 }
 
 bool changed(FileTable& pool, const DepsSnapshot& snap) {
-    pool.begin_wave();
+    auto wave = pool.wave();
     return deps_changed(pool, snap);
 }
 
@@ -58,11 +58,11 @@ TEST_CASE(FreshWhenUntouched) {
                                           DepFile{dep, consumed_hash(dep)}
     },
                                       generous_build_at());
-    ASSERT_EQ(snap.deps.size(), 1u);
+    ASSERT_EQ(snap.size(), 1u);
     ASSERT_FALSE(changed(pool, snap));
 
     // The passing check earned the version its stat fast path.
-    ASSERT_EQ(stamp_of(pool, snap.deps[0]), file_mtime_ns(dep));
+    ASSERT_EQ(stamp_of(pool, snap[0]), file_mtime_ns(dep));
 }
 
 TEST_CASE(PairStampsAtCapture) {
@@ -80,7 +80,7 @@ TEST_CASE(PairStampsAtCapture) {
                                           DepFile{dep, consumed_hash(dep)}
     },
                                       generous_build_at());
-    ASSERT_EQ(stamp_of(pool, snap.deps[0]), file_mtime_ns(dep));
+    ASSERT_EQ(stamp_of(pool, snap[0]), file_mtime_ns(dep));
     ASSERT_FALSE(changed(pool, snap));
 }
 
@@ -106,7 +106,7 @@ TEST_CASE(SnapshotsShareOneVersion) {
 
     // A repair through one snapshot's check serves the other.
     ASSERT_FALSE(changed(pool, first));
-    ASSERT_EQ(stamp_of(pool, second.deps[0]), file_mtime_ns(dep));
+    ASSERT_EQ(stamp_of(pool, second[0]), file_mtime_ns(dep));
 }
 
 TEST_CASE(ImmediateEditDetected) {
@@ -142,7 +142,7 @@ TEST_CASE(BackdatedEditDetected) {
                                           DepFile{dep, consumed_hash(dep)}
     },
                                       generous_build_at());
-    auto recorded_mtime = stamp_of(pool, snap.deps[0]);
+    auto recorded_mtime = stamp_of(pool, snap[0]);
     ASSERT_TRUE(recorded_mtime != 0);
 
     tmp.touch("dep.h", "int new_name();\n");  // same length
@@ -166,11 +166,11 @@ TEST_CASE(TouchRepairsFastPath) {
 
     // Rewrite identical bytes: the stat moves, the content does not.
     tmp.touch("dep.h", "int f();\n");
-    ASSERT_TRUE(set_file_mtime(dep, stamp_of(pool, snap.deps[0]) + 5'000'000'000));
+    ASSERT_TRUE(set_file_mtime(dep, stamp_of(pool, snap[0]) + 5'000'000'000));
     ASSERT_FALSE(changed(pool, snap));
 
     // The passing hash comparison repaired the fast path in place.
-    ASSERT_EQ(stamp_of(pool, snap.deps[0]), file_mtime_ns(dep));
+    ASSERT_EQ(stamp_of(pool, snap[0]), file_mtime_ns(dep));
 }
 
 TEST_CASE(PoisonedCaptureDetected) {
@@ -191,7 +191,7 @@ TEST_CASE(PoisonedCaptureDetected) {
                                           DepFile{dep, consumed}
     },
                                       /*build_at=*/1);
-    ASSERT_EQ(stamp_of(pool, snap.deps[0]), 0);
+    ASSERT_EQ(stamp_of(pool, snap[0]), 0);
     ASSERT_TRUE(changed(pool, snap));
 }
 
@@ -214,11 +214,11 @@ TEST_CASE(StalePairCannotStamp) {
                                           DepFile{dep, consumed_hash(dep)}
     },
                                       generous_build_at());
-    ASSERT_EQ(stamp_of(pool, snap.deps[0]), 0);
+    ASSERT_EQ(stamp_of(pool, snap[0]), 0);
 
     // The first check reads, proves the consumed bytes and repairs.
     ASSERT_FALSE(changed(pool, snap));
-    ASSERT_EQ(stamp_of(pool, snap.deps[0]), file_mtime_ns(dep));
+    ASSERT_EQ(stamp_of(pool, snap[0]), file_mtime_ns(dep));
 }
 
 TEST_CASE(NoBaselineConverges) {
@@ -236,10 +236,10 @@ TEST_CASE(NoBaselineConverges) {
                                           DepFile{dep, consumed_hash(dep)}
     },
                                       /*build_at=*/1);
-    ASSERT_EQ(stamp_of(pool, snap.deps[0]), 0);
+    ASSERT_EQ(stamp_of(pool, snap[0]), 0);
 
     ASSERT_FALSE(changed(pool, snap));
-    ASSERT_EQ(stamp_of(pool, snap.deps[0]), file_mtime_ns(dep));
+    ASSERT_EQ(stamp_of(pool, snap[0]), file_mtime_ns(dep));
 }
 
 TEST_CASE(MissingTransitions) {
@@ -252,7 +252,7 @@ TEST_CASE(MissingTransitions) {
                                           DepFile{dep, 0}
     },
                                       generous_build_at());
-    ASSERT_TRUE(snap.deps[0].missing);
+    ASSERT_TRUE(snap[0].missing);
 
     // Still missing: unchanged.
     ASSERT_FALSE(changed(pool, snap));
@@ -291,7 +291,7 @@ TEST_CASE(RevalidateGoesByHash) {
                                           DepFile{dep, consumed_hash(dep)}
     },
                                       generous_build_at());
-    auto recorded_mtime = stamp_of(pool, snap.deps[0]);
+    auto recorded_mtime = stamp_of(pool, snap[0]);
     ASSERT_TRUE(recorded_mtime != 0);
 
     // An edit that restores the recorded stat exactly would pass the fast
@@ -299,7 +299,7 @@ TEST_CASE(RevalidateGoesByHash) {
     tmp.touch("dep.h", "int new_name();\n");  // same length
     ASSERT_TRUE(set_file_mtime(dep, recorded_mtime));
 
-    snap.force_revalidate(pool);
+    force_revalidate_deps(pool, snap);
     ASSERT_TRUE(changed(pool, snap));
 }
 
@@ -318,14 +318,14 @@ TEST_CASE(RevalidatePurgesWaveMemo) {
                                           DepFile{dep, consumed_hash(dep)}
     },
                                       generous_build_at());
-    auto recorded_mtime = stamp_of(pool, snap.deps[0]);
+    auto recorded_mtime = stamp_of(pool, snap[0]);
 
-    pool.begin_wave();
+    auto wave = pool.wave();
     ASSERT_FALSE(deps_changed(pool, snap));
 
     tmp.touch("dep.h", "int new_name();\n");  // same length
     ASSERT_TRUE(set_file_mtime(dep, recorded_mtime));
-    snap.force_revalidate(pool);
+    force_revalidate_deps(pool, snap);
     ASSERT_TRUE(deps_changed(pool, snap));
 }
 

--- a/tests/unit/server/deps_snapshot_tests.cpp
+++ b/tests/unit/server/deps_snapshot_tests.cpp
@@ -31,7 +31,7 @@ std::uint64_t consumed_hash(llvm::StringRef path) {
 /// is deliberately untrusted (see read_file_observed), so tests exercising
 /// stamps and repairs must age their files first.
 void age_file(llvm::StringRef path) {
-    set_file_mtime(path, file_mtime_ns(path) - 10'000'000'000);
+    EXPECT_TRUE(set_file_mtime(path, file_mtime_ns(path) - 10'000'000'000));
 }
 
 /// The shared stat fast path of the version a dep names (0 = none).
@@ -146,7 +146,7 @@ TEST_CASE(BackdatedEditDetected) {
     ASSERT_TRUE(recorded_mtime != 0);
 
     tmp.touch("dep.h", "int new_name();\n");  // same length
-    set_file_mtime(dep, recorded_mtime - 5'000'000'000);
+    ASSERT_TRUE(set_file_mtime(dep, recorded_mtime - 5'000'000'000));
     ASSERT_TRUE(changed(pool, snap));
 }
 
@@ -166,7 +166,7 @@ TEST_CASE(TouchRepairsFastPath) {
 
     // Rewrite identical bytes: the stat moves, the content does not.
     tmp.touch("dep.h", "int f();\n");
-    set_file_mtime(dep, stamp_of(pool, snap.deps[0]) + 5'000'000'000);
+    ASSERT_TRUE(set_file_mtime(dep, stamp_of(pool, snap.deps[0]) + 5'000'000'000));
     ASSERT_FALSE(changed(pool, snap));
 
     // The passing hash comparison repaired the fast path in place.
@@ -297,7 +297,7 @@ TEST_CASE(RevalidateGoesByHash) {
     // An edit that restores the recorded stat exactly would pass the fast
     // path; force_revalidate drops it, so the hash still catches the edit.
     tmp.touch("dep.h", "int new_name();\n");  // same length
-    set_file_mtime(dep, recorded_mtime);
+    ASSERT_TRUE(set_file_mtime(dep, recorded_mtime));
 
     snap.force_revalidate(pool);
     ASSERT_TRUE(changed(pool, snap));
@@ -324,7 +324,7 @@ TEST_CASE(RevalidatePurgesWaveMemo) {
     ASSERT_FALSE(deps_changed(pool, snap));
 
     tmp.touch("dep.h", "int new_name();\n");  // same length
-    set_file_mtime(dep, recorded_mtime);
+    ASSERT_TRUE(set_file_mtime(dep, recorded_mtime));
     snap.force_revalidate(pool);
     ASSERT_TRUE(deps_changed(pool, snap));
 }

--- a/tests/unit/server/deps_snapshot_tests.cpp
+++ b/tests/unit/server/deps_snapshot_tests.cpp
@@ -24,7 +24,7 @@ TEST_CASE(FreshWhenUntouched) {
     tmp.touch("dep.h", "int f();\n");
     auto dep = tmp.path("dep.h");
 
-    PathPool pool;
+    FileTable pool;
     auto snap = capture_deps_snapshot(pool,
                                       {
                                           DepFile{dep, hash_file(dep)}
@@ -42,7 +42,7 @@ TEST_CASE(ImmediateEditDetected) {
     tmp.touch("dep.h", "int value();\n");
     auto dep = tmp.path("dep.h");
 
-    PathPool pool;
+    FileTable pool;
     auto snap = capture_deps_snapshot(pool,
                                       {
                                           DepFile{dep, hash_file(dep)}
@@ -60,7 +60,7 @@ TEST_CASE(BackdatedEditDetected) {
     tmp.touch("dep.h", "int old_name();\n");
     auto dep = tmp.path("dep.h");
 
-    PathPool pool;
+    FileTable pool;
     auto snap = capture_deps_snapshot(pool,
                                       {
                                           DepFile{dep, hash_file(dep)}
@@ -77,7 +77,7 @@ TEST_CASE(TouchRepairsFastPath) {
     tmp.touch("dep.h", "int f();\n");
     auto dep = tmp.path("dep.h");
 
-    PathPool pool;
+    FileTable pool;
     auto snap = capture_deps_snapshot(pool,
                                       {
                                           DepFile{dep, hash_file(dep)}
@@ -105,7 +105,7 @@ TEST_CASE(PoisonedCaptureDetected) {
     tmp.touch("dep.h", "int v2();\n");
     // build_at in the past: the file's mtime falls inside "modified during
     // or after the build", so no fast path is recorded.
-    PathPool pool;
+    FileTable pool;
     auto snap = capture_deps_snapshot(pool,
                                       {
                                           DepFile{dep, consumed}
@@ -122,7 +122,7 @@ TEST_CASE(NoBaselineConverges) {
     tmp.touch("dep.h", "int f();\n");
     auto dep = tmp.path("dep.h");
 
-    PathPool pool;
+    FileTable pool;
     auto snap = capture_deps_snapshot(pool,
                                       {
                                           DepFile{dep, hash_file(dep)}
@@ -138,7 +138,7 @@ TEST_CASE(MissingTransitions) {
     TempDir tmp;
     auto dep = tmp.path("ghost.h");
 
-    PathPool pool;
+    FileTable pool;
     auto snap = capture_deps_snapshot(pool,
                                       {
                                           DepFile{dep, 0}
@@ -159,7 +159,7 @@ TEST_CASE(RemovedAfterBuild) {
     tmp.touch("dep.h", "int f();\n");
     auto dep = tmp.path("dep.h");
 
-    PathPool pool;
+    FileTable pool;
     auto snap = capture_deps_snapshot(pool,
                                       {
                                           DepFile{dep, hash_file(dep)}
@@ -175,7 +175,7 @@ TEST_CASE(ForceRevalidateGoesByHash) {
     tmp.touch("dep.h", "int old_name();\n");
     auto dep = tmp.path("dep.h");
 
-    PathPool pool;
+    FileTable pool;
     auto snap = capture_deps_snapshot(pool,
                                       {
                                           DepFile{dep, hash_file(dep)}

--- a/tests/unit/server/deps_snapshot_tests.cpp
+++ b/tests/unit/server/deps_snapshot_tests.cpp
@@ -92,8 +92,16 @@ TEST_CASE(SnapshotsShareOneVersion) {
 
     FileTable pool;
     auto build_at = generous_build_at();
-    auto first = capture_deps_snapshot(pool, {DepFile{dep, consumed_hash(dep)}}, build_at);
-    auto second = capture_deps_snapshot(pool, {DepFile{dep, consumed_hash(dep)}}, build_at);
+    auto first = capture_deps_snapshot(pool,
+                                       {
+                                           DepFile{dep, consumed_hash(dep)}
+    },
+                                       build_at);
+    auto second = capture_deps_snapshot(pool,
+                                        {
+                                            DepFile{dep, consumed_hash(dep)}
+    },
+                                        build_at);
     ASSERT_EQ(pool.versions.size(), 1u);
 
     // A repair through one snapshot's check serves the other.

--- a/tests/unit/server/file_tracker_tests.cpp
+++ b/tests/unit/server/file_tracker_tests.cpp
@@ -35,7 +35,7 @@ TEST_CASE(CDBTickDebounces) {
     ASSERT_EQ(events.size(), 1u);
     ASSERT_EQ(events[0].kind, FileEvent::Kind::CDBChanged);
     auto lib_id = workspace.file_table.intern(tmp.path("lib.cpp"));
-    ASSERT_EQ(events[0].cdb.added, llvm::SmallVector<std::uint32_t>{lib_id});
+    ASSERT_EQ(events[0].cdb.added, llvm::SmallVector<Fid>{lib_id});
     ASSERT_TRUE(events[0].cdb.removed.empty());
 
     // Settled: further ticks are quiet.
@@ -62,7 +62,7 @@ TEST_CASE(CDBTickForceImmediate) {
     auto events = tracker.tick_cdb(/*force=*/true);
     ASSERT_EQ(events.size(), 1u);
     auto main_id = workspace.file_table.intern(tmp.path("main.cpp"));
-    ASSERT_EQ(events[0].cdb.changed, llvm::SmallVector<std::uint32_t>{main_id});
+    ASSERT_EQ(events[0].cdb.changed, llvm::SmallVector<Fid>{main_id});
 }
 
 TEST_CASE(CDBTickDiscoversLate) {
@@ -82,7 +82,7 @@ TEST_CASE(CDBTickDiscoversLate) {
     auto events = tracker.tick_cdb(/*force=*/true);
     ASSERT_EQ(events.size(), 1u);
     auto main_id = workspace.file_table.intern(tmp.path("main.cpp"));
-    ASSERT_EQ(events[0].cdb.added, llvm::SmallVector<std::uint32_t>{main_id});
+    ASSERT_EQ(events[0].cdb.added, llvm::SmallVector<Fid>{main_id});
 }
 
 TEST_CASE(CDBTickDeleteRecreate) {
@@ -110,7 +110,7 @@ TEST_CASE(CDBTickDeleteRecreate) {
     auto events = tracker.tick_cdb(/*force=*/true);
     ASSERT_EQ(events.size(), 1u);
     auto main_id = workspace.file_table.intern(tmp.path("main.cpp"));
-    ASSERT_EQ(events[0].cdb.changed, llvm::SmallVector<std::uint32_t>{main_id});
+    ASSERT_EQ(events[0].cdb.changed, llvm::SmallVector<Fid>{main_id});
 }
 
 TEST_CASE(WorkspaceTickStateMachine) {
@@ -122,7 +122,7 @@ TEST_CASE(WorkspaceTickStateMachine) {
     SessionStore store;
     auto tu = workspace.file_table.intern(tmp.path("main.cpp"));
     auto header = workspace.file_table.intern(tmp.path("header.h"));
-    workspace.dep_graph.set_includes(tu, 0, {header});
+    workspace.dep_graph.set_includes(tu, 0, {{header}});
     workspace.dep_graph.build_reverse_map();
     FileTracker tracker(workspace, store, tmp.root.str().str());
 

--- a/tests/unit/server/file_tracker_tests.cpp
+++ b/tests/unit/server/file_tracker_tests.cpp
@@ -34,7 +34,7 @@ TEST_CASE(CDBTickDebounces) {
     auto events = tracker.tick_cdb();
     ASSERT_EQ(events.size(), 1u);
     ASSERT_EQ(events[0].kind, FileEvent::Kind::CDBChanged);
-    auto lib_id = workspace.path_pool.intern(tmp.path("lib.cpp"));
+    auto lib_id = workspace.file_table.intern(tmp.path("lib.cpp"));
     ASSERT_EQ(events[0].cdb.added, llvm::SmallVector<std::uint32_t>{lib_id});
     ASSERT_TRUE(events[0].cdb.removed.empty());
 
@@ -61,7 +61,7 @@ TEST_CASE(CDBTickForceImmediate) {
     }));
     auto events = tracker.tick_cdb(/*force=*/true);
     ASSERT_EQ(events.size(), 1u);
-    auto main_id = workspace.path_pool.intern(tmp.path("main.cpp"));
+    auto main_id = workspace.file_table.intern(tmp.path("main.cpp"));
     ASSERT_EQ(events[0].cdb.changed, llvm::SmallVector<std::uint32_t>{main_id});
 }
 
@@ -81,7 +81,7 @@ TEST_CASE(CDBTickDiscoversLate) {
     }));
     auto events = tracker.tick_cdb(/*force=*/true);
     ASSERT_EQ(events.size(), 1u);
-    auto main_id = workspace.path_pool.intern(tmp.path("main.cpp"));
+    auto main_id = workspace.file_table.intern(tmp.path("main.cpp"));
     ASSERT_EQ(events[0].cdb.added, llvm::SmallVector<std::uint32_t>{main_id});
 }
 
@@ -109,7 +109,7 @@ TEST_CASE(CDBTickDeleteRecreate) {
     }));
     auto events = tracker.tick_cdb(/*force=*/true);
     ASSERT_EQ(events.size(), 1u);
-    auto main_id = workspace.path_pool.intern(tmp.path("main.cpp"));
+    auto main_id = workspace.file_table.intern(tmp.path("main.cpp"));
     ASSERT_EQ(events[0].cdb.changed, llvm::SmallVector<std::uint32_t>{main_id});
 }
 
@@ -120,8 +120,8 @@ TEST_CASE(WorkspaceTickStateMachine) {
     kota::event_loop loop;
     Workspace workspace;
     SessionStore store;
-    auto tu = workspace.path_pool.intern(tmp.path("main.cpp"));
-    auto header = workspace.path_pool.intern(tmp.path("header.h"));
+    auto tu = workspace.file_table.intern(tmp.path("main.cpp"));
+    auto header = workspace.file_table.intern(tmp.path("header.h"));
     workspace.dep_graph.set_includes(tu, 0, {header});
     workspace.dep_graph.build_reverse_map();
     FileTracker tracker(workspace, store, tmp.root.str().str());
@@ -181,7 +181,7 @@ TEST_CASE(WorkspaceTickSkipsOpen) {
     kota::event_loop loop;
     Workspace workspace;
     SessionStore store;
-    auto header = workspace.path_pool.intern(tmp.path("header.h"));
+    auto header = workspace.file_table.intern(tmp.path("header.h"));
     workspace.dep_graph.set_includes(header, 0, {});
     workspace.dep_graph.build_reverse_map();
     store.open(header);

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -918,7 +918,7 @@ TEST_CASE(RejectsCorruptSection) {
     // fill empty names), and stray FileVersions would persist with the
     // next save.
     ASSERT_TRUE(workspace.project_index.symbols.empty());
-    ASSERT_TRUE(workspace.project_index.file_versions.empty());
+    ASSERT_TRUE(workspace.file_table.versions.empty());
 
     // The intact result still lands afterwards.
     merge(indexed.data.data(), indexed.data.size());
@@ -1241,6 +1241,10 @@ struct Indexed {
         tmp.touch("main.cpp", "#include \"dep.h\"\nint use() { return dep(); }\n");
         src = tmp.path("main.cpp");
         header = tmp.path("dep.h");
+        // Age the files out of the mtime guard window so the merge records
+        // stat stamps, the way real project files predate an index run.
+        set_file_mtime(src, file_mtime_ns(src) - 10'000'000'000);
+        set_file_mtime(header, file_mtime_ns(header) - 10'000'000'000);
         auto indexed = index_file(tmp, src);
         if(indexed.data.empty()) {
             return false;
@@ -1255,9 +1259,9 @@ TEST_CASE(TouchRepairsStamp) {
     ASSERT_TRUE(x.setup());
     ASSERT_FALSE(x.f.need_update(x.src));
 
-    // Same bytes, new mtime: the stat fast path misses, the hash proves a
-    // mere touch, and the stamp is repaired in place (dirtying the global
-    // blob so the repair persists).
+    // Same bytes, new mtime (still outside the guard window): the stat
+    // fast path misses, the hash proves a mere touch, and the stamp is
+    // repaired in place (dirtying the global blob so the repair persists).
     ASSERT_TRUE(set_file_mtime(x.header, file_mtime_ns(x.header) + 5'000'000'000));
     x.f.reset_global_dirty();
     x.f.clear_verdicts();
@@ -1627,8 +1631,8 @@ TEST_CASE(LoadRequeuesStaleManifest) {
         // standalone index no CDB sweep would ever rebuild.
         auto header_id = f.workspace.file_table.intern(header);
         std::uint32_t header_fv = ~0u;
-        for(auto& [fv, record]: f.workspace.project_index.file_versions) {
-            if(record.path_id == header_id) {
+        for(auto& [fv, record]: f.workspace.file_table.versions) {
+            if(record.fid == header_id) {
                 header_fv = fv;
             }
         }

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -352,7 +352,7 @@ TEST_CASE(MergeIgnoresDiskDrift) {
     ASSERT_FALSE(indexed.data.empty());
 
     merge(indexed.data.data(), indexed.data.size());
-    auto path_id = workspace.path_pool.intern(indexed.tu_path);
+    auto path_id = workspace.file_table.intern(indexed.tu_path);
     auto it = workspace.shards.find(path_id);
     ASSERT_TRUE(it != workspace.shards.end());
     ASSERT_EQ(it->second.content_hash(), llvm::xxh3_64bits("int value() { return 1; }\n"));
@@ -384,7 +384,7 @@ TEST_CASE(SaveCommitsDirtyShard) {
     ASSERT_FALSE(indexed.data.empty());
     merge(indexed.data.data(), indexed.data.size());
 
-    auto path_id = workspace.path_pool.intern(indexed.tu_path);
+    auto path_id = workspace.file_table.intern(indexed.tu_path);
     ASSERT_EQ(index_store.pending_shard_writes(), 1u);
 
     // Named body: a temporary lambda's captures die with the statement
@@ -464,7 +464,7 @@ TEST_CASE(SaveMigratesShardViews) {
     auto indexed = index_file(tmp, src);
     ASSERT_FALSE(indexed.data.empty());
     merge(indexed.data.data(), indexed.data.size());
-    auto path_id = workspace.path_pool.intern(indexed.tu_path);
+    auto path_id = workspace.file_table.intern(indexed.tu_path);
     auto before = workspace.shards.find(path_id);
     ASSERT_TRUE(before != workspace.shards.end());
     auto variants_before = before->second.variants();
@@ -554,13 +554,13 @@ TEST_CASE(GrowFailureShedsCleanShards) {
     // which need not equal the raw temp path byte-for-byte (Windows 8.3
     // names).
     spy->fail_key =
-        blob_key(workspace.path_pool.resolve(workspace.path_pool.intern(indexed_dirty.tu_path)));
+        blob_key(workspace.file_table.resolve(workspace.file_table.intern(indexed_dirty.tu_path)));
     workspace.index_db = std::move(spy);
 
     merge(indexed_clean.data.data(), indexed_clean.data.size());
     merge(indexed_dirty.data.data(), indexed_dirty.data.size());
-    auto clean_id = workspace.path_pool.intern(indexed_clean.tu_path);
-    auto dirty_id = workspace.path_pool.intern(indexed_dirty.tu_path);
+    auto clean_id = workspace.file_table.intern(indexed_clean.tu_path);
+    auto dirty_id = workspace.file_table.intern(indexed_dirty.tu_path);
 
     auto save_body = [&]() -> kota::task<> {
         co_await async_save();
@@ -583,7 +583,7 @@ TEST_CASE(MidSaveMergeKept) {
     auto indexed = index_file(tmp, src);
     ASSERT_FALSE(indexed.data.empty());
     merge(indexed.data.data(), indexed.data.size());
-    auto path_id = workspace.path_pool.intern(indexed.tu_path);
+    auto path_id = workspace.file_table.intern(indexed.tu_path);
 
     // Prepared before save() starts so the interleaved merge is purely an
     // in-memory event.
@@ -674,7 +674,7 @@ TEST_CASE(SharedHeaderVariants) {
     // one blob, each TU's contribution live.
     merge(a.data.data(), a.data.size());
     merge(b.data.data(), b.data.size());
-    auto header_id = workspace.path_pool.intern(tmp.path("shared.h"));
+    auto header_id = workspace.file_table.intern(tmp.path("shared.h"));
     auto& shard = workspace.shards[header_id];
     ASSERT_EQ(shard.variants().size(), std::size_t(2));
     ASSERT_EQ(workspace.project_index.contributions.lookup(header_id).size(), std::size_t(2));
@@ -707,8 +707,8 @@ TEST_CASE(HeaderRegenerationReplaces) {
     auto v1 = index_file(tmp, src);
     ASSERT_FALSE(v1.data.empty());
     merge(v1.data.data(), v1.data.size());
-    auto header_id = workspace.path_pool.intern(tmp.path("dep.h"));
-    auto tu_id = workspace.path_pool.intern(v1.tu_path);
+    auto header_id = workspace.file_table.intern(tmp.path("dep.h"));
+    auto tu_id = workspace.file_table.intern(v1.tu_path);
     auto old_hash = workspace.project_index.contributions.lookup(header_id).lookup(tu_id);
     ASSERT_TRUE(old_hash != 0);
 
@@ -747,7 +747,7 @@ TEST_CASE(SaveCompactsAndRetires) {
     ASSERT_FALSE(b.data.empty());
     merge(a.data.data(), a.data.size());
     merge(b.data.data(), b.data.size());
-    auto header_id = workspace.path_pool.intern(tmp.path("shared.h"));
+    auto header_id = workspace.file_table.intern(tmp.path("shared.h"));
     ASSERT_EQ(workspace.shards[header_id].variants().size(), std::size_t(2));
 
     auto save = [&] {
@@ -778,9 +778,9 @@ TEST_CASE(SaveCompactsAndRetires) {
     merge(a2.data.data(), a2.data.size());
     save();
     ASSERT_FALSE(workspace.shards.contains(header_id));
-    ASSERT_FALSE(pump.pending_reason(workspace.path_pool.intern(a2.tu_path)).has_value());
+    ASSERT_FALSE(pump.pending_reason(workspace.file_table.intern(a2.tu_path)).has_value());
     bool on_disk = false;
-    auto key = blob_key(workspace.path_pool.resolve(header_id));
+    auto key = blob_key(workspace.file_table.resolve(header_id));
     workspace.index_db->for_each_key(index::IndexBlobKind::Shard,
                                      [&](llvm::StringRef k) { on_disk |= k == key; });
     ASSERT_FALSE(on_disk);
@@ -801,7 +801,7 @@ TEST_CASE(SaveRetiresPinnedShard) {
     ASSERT_FALSE(b.data.empty());
     merge(a.data.data(), a.data.size());
     merge(b.data.data(), b.data.size());
-    auto header_id = workspace.path_pool.intern(tmp.path("pinned.h"));
+    auto header_id = workspace.file_table.intern(tmp.path("pinned.h"));
     ASSERT_EQ(workspace.shards[header_id].variants().size(), std::size_t(2));
 
     // The header moves to a new content generation and only pa catches up:
@@ -817,12 +817,12 @@ TEST_CASE(SaveRetiresPinnedShard) {
 
     // The rebuild re-enqueued pb; its pass then runs and fails, consuming
     // the slot — the state the retirement below must repair on its own.
-    pump.clear_pending(workspace.path_pool.intern(b.tu_path));
+    pump.clear_pending(workspace.file_table.intern(b.tu_path));
 
     // pa's index drops before pb reindexes: every stored variant is dead,
     // but pb's pinned hash keeps the live set nonempty. The save must
     // retire the shard rather than compact to an empty variant set.
-    drop_index(workspace.path_pool.intern(a2.tu_path));
+    drop_index(workspace.file_table.intern(a2.tu_path));
     auto body = [&]() -> kota::task<> {
         co_await async_save();
     };
@@ -832,7 +832,7 @@ TEST_CASE(SaveRetiresPinnedShard) {
 
     ASSERT_FALSE(workspace.shards.contains(header_id));
     bool on_disk = false;
-    auto key = blob_key(workspace.path_pool.resolve(header_id));
+    auto key = blob_key(workspace.file_table.resolve(header_id));
     workspace.index_db->for_each_key(index::IndexBlobKind::Shard,
                                      [&](llvm::StringRef k) { on_disk |= k == key; });
     ASSERT_FALSE(on_disk);
@@ -841,7 +841,7 @@ TEST_CASE(SaveRetiresPinnedShard) {
     // unservable; nothing else in this process would rebuild them (a
     // reverted header even reads fresh by hash), so the retirement must
     // re-enqueue pb itself.
-    ASSERT_TRUE(pump.pending_reason(workspace.path_pool.intern(b.tu_path)) ==
+    ASSERT_TRUE(pump.pending_reason(workspace.file_table.intern(b.tu_path)) ==
                 ReindexReason::ContentChanged);
 }
 
@@ -859,7 +859,7 @@ TEST_CASE(RebuildRequeuesPinnedOwner) {
     ASSERT_FALSE(b.data.empty());
     merge(a.data.data(), a.data.size());
     merge(b.data.data(), b.data.size());
-    auto b_tu = workspace.path_pool.intern(b.tu_path);
+    auto b_tu = workspace.file_table.intern(b.tu_path);
     ASSERT_FALSE(pump.pending_reason(b_tu).has_value());
 
     // The header moves to a new content generation and only ga catches up:
@@ -873,12 +873,12 @@ TEST_CASE(RebuildRequeuesPinnedOwner) {
     auto a2 = index_file(tmp, tmp.path("ga.cpp"));
     ASSERT_FALSE(a2.data.empty());
     merge(a2.data.data(), a2.data.size());
-    auto header_id = workspace.path_pool.intern(tmp.path("gen.h"));
+    auto header_id = workspace.file_table.intern(tmp.path("gen.h"));
     ASSERT_EQ(workspace.shards[header_id].variants().size(), std::size_t(1));
 
     ASSERT_TRUE(pump.pending_reason(b_tu) == ReindexReason::ContentChanged);
     // ga's own fresh pin is stored: the rebuild must not re-enqueue it.
-    ASSERT_FALSE(pump.pending_reason(workspace.path_pool.intern(a2.tu_path)).has_value());
+    ASSERT_FALSE(pump.pending_reason(workspace.file_table.intern(a2.tu_path)).has_value());
 }
 
 TEST_CASE(RejectsCorruptSection) {
@@ -909,8 +909,8 @@ TEST_CASE(RejectsCorruptSection) {
     // result — a manifest whose recorded versions all match the disk would
     // otherwise be judged fresh forever with the main file's rows missing.
     merge(corrupt.data(), corrupt.size());
-    auto tu_id = workspace.path_pool.intern(indexed.tu_path);
-    auto header_id = workspace.path_pool.intern(tmp.path("cor.h"));
+    auto tu_id = workspace.file_table.intern(indexed.tu_path);
+    auto header_id = workspace.file_table.intern(tmp.path("cor.h"));
     ASSERT_FALSE(workspace.project_index.manifests.contains(tu_id));
     ASSERT_FALSE(workspace.shards.contains(header_id));
     // No global trace either: symbol identities from an untrusted result
@@ -940,7 +940,7 @@ TEST_CASE(HashlessRemergeHits) {
     ASSERT_FALSE(wire.empty());
 
     merge(wire.data(), wire.size());
-    auto path_id = workspace.path_pool.intern(src);
+    auto path_id = workspace.file_table.intern(src);
     ASSERT_EQ(workspace.shards[path_id].variants().size(), std::size_t(1));
 
     // Re-merging the same rows must register as a hit, not append the
@@ -1104,8 +1104,8 @@ TEST_CASE(WriteCorruptionRebuildsDatabase) {
 
     ASSERT_TRUE(condemned);
     ASSERT_TRUE(workspace.index_db != nullptr);
-    auto clean_id = workspace.path_pool.intern(indexed_clean.tu_path);
-    auto dirty_id = workspace.path_pool.intern(indexed_dirty.tu_path);
+    auto clean_id = workspace.file_table.intern(indexed_clean.tu_path);
+    auto dirty_id = workspace.file_table.intern(indexed_dirty.tu_path);
     ASSERT_FALSE(workspace.shards.contains(clean_id));
     ASSERT_TRUE(workspace.shards.contains(dirty_id));
     ASSERT_TRUE(pump.pending_reason(clean_id) == ReindexReason::ContentChanged);
@@ -1186,7 +1186,7 @@ TEST_CASE(MigrationCorruptionRebuildsDatabase) {
     };
     save();
 
-    auto path_id = workspace.path_pool.intern(indexed.tu_path);
+    auto path_id = workspace.file_table.intern(indexed.tu_path);
     ASSERT_TRUE(condemned);
     ASSERT_TRUE(workspace.index_db != nullptr);
     ASSERT_FALSE(workspace.shards.contains(path_id));
@@ -1324,8 +1324,8 @@ TEST_CASE(LoadRestoresIndex) {
     open_store(tmp, f.workspace);
     f.load();
 
-    auto tu_id = f.workspace.path_pool.intern(src);
-    auto header_id = f.workspace.path_pool.intern(tmp.path("dep.h"));
+    auto tu_id = f.workspace.file_table.intern(src);
+    auto header_id = f.workspace.file_table.intern(tmp.path("dep.h"));
     ASSERT_TRUE(f.workspace.shards.contains(tu_id));
     ASSERT_TRUE(f.workspace.shards.contains(header_id));
     ASSERT_TRUE(f.workspace.project_index.contributions.lookup(header_id).contains(tu_id));
@@ -1352,7 +1352,7 @@ TEST_CASE(LoadHealsBrokenShard) {
         f.merge(indexed.data.data(), indexed.data.size());
         f.save();
         header_key = blob_key(
-            f.workspace.path_pool.resolve(f.workspace.path_pool.intern(tmp.path("dep.h"))));
+            f.workspace.file_table.resolve(f.workspace.file_table.intern(tmp.path("dep.h"))));
     }
 
     // Corrupt the header's blob and plant an orphan nothing references
@@ -1367,14 +1367,14 @@ TEST_CASE(LoadHealsBrokenShard) {
     // The header's rows are unservable, so its contributing TU's manifest
     // is dropped and the TU re-enqueued — no CDB entry would ever re-index
     // a header otherwise. The orphan is swept.
-    auto tu_id = f.workspace.path_pool.intern(src);
+    auto tu_id = f.workspace.file_table.intern(src);
     ASSERT_TRUE(f.workspace.project_index.manifests.empty());
     ASSERT_TRUE(f.pump.pending_reason(tu_id).has_value());
 
     // The dropped manifest also retired the TU's contribution to the
     // OTHER header: its loaded shard's live mask must follow, or it keeps
     // serving a variant nothing contributes any more.
-    auto extra_id = f.workspace.path_pool.intern(tmp.path("extra.h"));
+    auto extra_id = f.workspace.file_table.intern(tmp.path("extra.h"));
     auto extra_it = f.workspace.shards.find(extra_id);
     ASSERT_TRUE(extra_it != f.workspace.shards.end());
     ASSERT_TRUE(extra_it->second.has_dead_variants());
@@ -1410,8 +1410,8 @@ TEST_CASE(ReadOnlyLoadKeepsDisk) {
         f.merge(indexed.data.data(), indexed.data.size());
         f.save();
         header_key = blob_key(
-            f.workspace.path_pool.resolve(f.workspace.path_pool.intern(tmp.path("dep.h"))));
-        manifest_key = blob_key(f.workspace.path_pool.resolve(f.workspace.path_pool.intern(src)));
+            f.workspace.file_table.resolve(f.workspace.file_table.intern(tmp.path("dep.h"))));
+        manifest_key = blob_key(f.workspace.file_table.resolve(f.workspace.file_table.intern(src)));
     }
 
     tmp.touch("cache/cache/v1/index/" + header_key + ".idx", "corrupted beyond verification");
@@ -1423,7 +1423,7 @@ TEST_CASE(ReadOnlyLoadKeepsDisk) {
 
     // The in-memory sweeps still run: the unservable header drops its
     // contributing TU's manifest and re-enqueues the TU.
-    auto tu_id = f.workspace.path_pool.intern(src);
+    auto tu_id = f.workspace.file_table.intern(src);
     ASSERT_TRUE(f.workspace.project_index.manifests.empty());
     ASSERT_TRUE(f.pump.pending_reason(tu_id).has_value());
 
@@ -1457,7 +1457,7 @@ TEST_CASE(LoadHealsMissingVariant) {
         f.merge(indexed.data.data(), indexed.data.size());
         f.save();
         header_key = blob_key(
-            f.workspace.path_pool.resolve(f.workspace.path_pool.intern(tmp.path("dep.h"))));
+            f.workspace.file_table.resolve(f.workspace.file_table.intern(tmp.path("dep.h"))));
     }
 
     // Replace the header's blob with one that verifies but stores a variant
@@ -1473,7 +1473,7 @@ TEST_CASE(LoadHealsMissingVariant) {
     // set_live would silently drop the missing rows, so the shard is as
     // unservable as an unreadable one: the TU's manifest goes and the TU
     // re-enqueues.
-    auto tu_id = f.workspace.path_pool.intern(src);
+    auto tu_id = f.workspace.file_table.intern(src);
     ASSERT_TRUE(f.workspace.project_index.manifests.empty());
     ASSERT_TRUE(f.pump.pending_reason(tu_id).has_value());
 }
@@ -1493,11 +1493,11 @@ TEST_CASE(LoadHealsWrongGeneration) {
         ASSERT_FALSE(indexed.data.empty());
         f.merge(indexed.data.data(), indexed.data.size());
         f.save();
-        auto header_id = f.workspace.path_pool.intern(tmp.path("dep.h"));
-        auto tu_id = f.workspace.path_pool.intern(src);
+        auto header_id = f.workspace.file_table.intern(tmp.path("dep.h"));
+        auto tu_id = f.workspace.file_table.intern(src);
         rows_hash = f.workspace.project_index.contributions.lookup(header_id).lookup(tu_id);
         ASSERT_TRUE(rows_hash != 0);
-        header_key = blob_key(f.workspace.path_pool.resolve(header_id));
+        header_key = blob_key(f.workspace.file_table.resolve(header_id));
     }
 
     // Replace the header's blob with one from ANOTHER content generation
@@ -1511,7 +1511,7 @@ TEST_CASE(LoadHealsWrongGeneration) {
     open_store(tmp, f.workspace);
     f.load();
 
-    auto tu_id = f.workspace.path_pool.intern(src);
+    auto tu_id = f.workspace.file_table.intern(src);
     ASSERT_TRUE(f.workspace.project_index.manifests.empty());
     ASSERT_TRUE(f.pump.pending_reason(tu_id).has_value());
 }
@@ -1534,7 +1534,7 @@ TEST_CASE(LoadDropsNewerManifest) {
         // FileVersion it references is known and its shard variant stored
         // (a rows-only reindex), so only the stamp can tell that the
         // global's symbols never landed.
-        auto tu_id = f.workspace.path_pool.intern(src);
+        auto tu_id = f.workspace.file_table.intern(src);
         auto raced = f.workspace.project_index.manifests.find(tu_id)->second;
         raced.global_gen = f.workspace.project_index.global_generation + 1;
         std::string bytes;
@@ -1545,7 +1545,7 @@ TEST_CASE(LoadDropsNewerManifest) {
         f.workspace.index_db->write(
             {
                 {index::IndexBlobKind::Manifest,
-                 blob_key(f.workspace.path_pool.resolve(tu_id)),
+                 blob_key(f.workspace.file_table.resolve(tu_id)),
                  std::move(bytes)}
         },
             {});
@@ -1557,7 +1557,7 @@ TEST_CASE(LoadDropsNewerManifest) {
 
     // The raced manifest is dropped and its TU re-enqueued; the reindex
     // rewrites the manifest and the global together.
-    auto tu_id = f.workspace.path_pool.intern(src);
+    auto tu_id = f.workspace.file_table.intern(src);
     ASSERT_TRUE(f.workspace.project_index.manifests.empty());
     ASSERT_TRUE(f.pump.pending_reason(tu_id) == ReindexReason::ContentChanged);
 }
@@ -1580,7 +1580,7 @@ TEST_CASE(LoadDropsLostManifest) {
         // FileVersion still resolvable and its shard variant stored (a
         // reindex that changed rows or the include tree only). Only the
         // global's pin can tell it is not the manifest the save meant.
-        auto tu_id = f.workspace.path_pool.intern(src);
+        auto tu_id = f.workspace.file_table.intern(src);
         auto lost = f.workspace.project_index.manifests.find(tu_id)->second;
         lost.global_gen = f.workspace.project_index.global_generation - 1;
         std::string bytes;
@@ -1589,7 +1589,7 @@ TEST_CASE(LoadDropsLostManifest) {
         f.workspace.index_db->write(
             {
                 {index::IndexBlobKind::Manifest,
-                 blob_key(f.workspace.path_pool.resolve(tu_id)),
+                 blob_key(f.workspace.file_table.resolve(tu_id)),
                  std::move(bytes)}
         },
             {});
@@ -1601,7 +1601,7 @@ TEST_CASE(LoadDropsLostManifest) {
 
     // The mistamped manifest is dropped and the TU re-enqueued instead of
     // the previous reindex's dependency set and rows serving as current.
-    auto tu_id = f.workspace.path_pool.intern(src);
+    auto tu_id = f.workspace.file_table.intern(src);
     ASSERT_TRUE(f.workspace.project_index.manifests.empty());
     ASSERT_TRUE(f.pump.pending_reason(tu_id) == ReindexReason::ContentChanged);
 }
@@ -1625,7 +1625,7 @@ TEST_CASE(LoadRequeuesStaleManifest) {
         // dependency FileVersion the persisted global table never learned,
         // while the TU's own version is known — here for the header, whose
         // standalone index no CDB sweep would ever rebuild.
-        auto header_id = f.workspace.path_pool.intern(header);
+        auto header_id = f.workspace.file_table.intern(header);
         std::uint32_t header_fv = ~0u;
         for(auto& [fv, record]: f.workspace.project_index.file_versions) {
             if(record.path_id == header_id) {
@@ -1653,7 +1653,7 @@ TEST_CASE(LoadRequeuesStaleManifest) {
     // The unresolvable manifest is dropped and its TU re-enqueued instead
     // of losing its persisted index forever; the blob itself dies at the
     // first save (load defers cleanup off the startup event loop).
-    auto header_id = f.workspace.path_pool.intern(header);
+    auto header_id = f.workspace.file_table.intern(header);
     ASSERT_TRUE(f.pump.pending_reason(header_id) == ReindexReason::ContentChanged);
     ASSERT_FALSE(f.workspace.project_index.manifests.contains(header_id));
     auto save_body = [&]() -> kota::task<> {
@@ -1669,7 +1669,7 @@ TEST_CASE(LoadRequeuesStaleManifest) {
     ASSERT_FALSE(stale_alive);
 
     // The TU whose manifest resolved is untouched.
-    auto tu_id = f.workspace.path_pool.intern(src);
+    auto tu_id = f.workspace.file_table.intern(src);
     ASSERT_TRUE(f.workspace.project_index.manifests.contains(tu_id));
     ASSERT_FALSE(f.pump.pending_reason(tu_id).has_value());
 }
@@ -1689,7 +1689,7 @@ TEST_CASE(DeferredSweepYieldsToFreshWrite) {
         // The indexer keys blobs by the pool-canonical path, which need
         // not equal the raw temp path byte-for-byte (Windows 8.3 names).
         auto key =
-            blob_key(f.workspace.path_pool.resolve(f.workspace.path_pool.intern(indexed.tu_path)));
+            blob_key(f.workspace.file_table.resolve(f.workspace.file_table.intern(indexed.tu_path)));
         // Replace the persisted manifest with an unresolvable one: the
         // next load sweeps it — deferred into the first save — and the
         // TU's shard turns orphan, deferred too.
@@ -1719,7 +1719,7 @@ TEST_CASE(DeferredSweepYieldsToFreshWrite) {
     f.save();
 
     auto key =
-        blob_key(f.workspace.path_pool.resolve(f.workspace.path_pool.intern(indexed.tu_path)));
+        blob_key(f.workspace.file_table.resolve(f.workspace.file_table.intern(indexed.tu_path)));
     bool manifest_alive = false;
     f.workspace.index_db->for_each_key(index::IndexBlobKind::Manifest,
                                        [&](llvm::StringRef k) { manifest_alive |= k == key; });
@@ -1755,7 +1755,7 @@ TEST_CASE(LmdbLoadServesAcrossSaves) {
     IndexerFixture f;
     open_lmdb(f.workspace);
     ASSERT_TRUE(f.load());
-    auto path_id = f.workspace.path_pool.intern(src);
+    auto path_id = f.workspace.file_table.intern(src);
     ASSERT_TRUE(f.workspace.shards.contains(path_id));
 
     // The loaded shard borrows the open-time snapshot. A save that commits
@@ -1912,7 +1912,7 @@ TEST_CASE(CorruptShardCondemnsDatabase) {
     // The TU has no CDB entry, so nothing else records the debt: it is
     // re-enqueued before the adopted state unwinds, and the fresh
     // database's first save persists it as standalone debt.
-    ASSERT_TRUE(f.pump.pending_reason(f.workspace.path_pool.intern(tu_path)) ==
+    ASSERT_TRUE(f.pump.pending_reason(f.workspace.file_table.intern(tu_path)) ==
                 ReindexReason::ContentChanged);
     ASSERT_TRUE(f.workspace.index_db != nullptr);
     f.save();
@@ -2006,7 +2006,7 @@ TEST_CASE(DropIndexEvictsPersisted) {
 
         // The compile command changed: content freshness cannot see it, so
         // the TU's index is dropped wholesale and staleness flips at once.
-        f.drop_index(f.workspace.path_pool.intern(src));
+        f.drop_index(f.workspace.file_table.intern(src));
         ASSERT_TRUE(f.workspace.project_index.manifests.empty());
         ASSERT_TRUE(f.need_update(src));
         f.save();
@@ -2044,7 +2044,7 @@ TEST_CASE(OfflineCommandChangeReindexed) {
     f.workspace.cdb.add_command(tmp.root, src, llvm::StringRef("clang++ -DFOO=2 -c main.cpp"));
     f.load();
 
-    auto tu_id = f.workspace.path_pool.intern(src);
+    auto tu_id = f.workspace.file_table.intern(src);
     ASSERT_FALSE(f.workspace.project_index.manifests.contains(tu_id));
     ASSERT_TRUE(f.pump.pending_reason(tu_id) == ReindexReason::ContentChanged);
 }
@@ -2069,7 +2069,7 @@ TEST_CASE(UnchangedCommandKept) {
     f.workspace.cdb.add_command(tmp.root, src, llvm::StringRef("clang++ -DFOO=1 -c main.cpp"));
     f.load();
 
-    auto tu_id = f.workspace.path_pool.intern(src);
+    auto tu_id = f.workspace.file_table.intern(src);
     ASSERT_TRUE(f.workspace.project_index.manifests.contains(tu_id));
     ASSERT_FALSE(f.pump.pending_reason(tu_id).has_value());
 }
@@ -2095,7 +2095,7 @@ TEST_CASE(RemovedEntryKeepsIndex) {
     open_store(tmp, f.workspace);
     f.load();
 
-    auto tu_id = f.workspace.path_pool.intern(src);
+    auto tu_id = f.workspace.file_table.intern(src);
     ASSERT_TRUE(f.workspace.project_index.manifests.contains(tu_id));
     ASSERT_FALSE(f.pump.pending_reason(tu_id).has_value());
 }
@@ -2128,7 +2128,7 @@ TEST_CASE(RuleChangeReindexed) {
     f.workspace.config.finalize(tmp.root);
     f.load();
 
-    auto tu_id = f.workspace.path_pool.intern(src);
+    auto tu_id = f.workspace.file_table.intern(src);
     ASSERT_FALSE(f.workspace.project_index.manifests.contains(tu_id));
     ASSERT_TRUE(f.pump.pending_reason(tu_id) == ReindexReason::ContentChanged);
 }
@@ -2158,8 +2158,8 @@ TEST_CASE(HostChangeDropsHeader) {
     IndexerFixture f;
     open_store(tmp, f.workspace);
     f.workspace.cdb.add_command(tmp.root, src, llvm::StringRef("clang++ -DFOO=2 -c main.cpp"));
-    auto src_id = f.workspace.path_pool.intern(src);
-    auto header_id = f.workspace.path_pool.intern(header);
+    auto src_id = f.workspace.file_table.intern(src);
+    auto header_id = f.workspace.file_table.intern(header);
     f.workspace.dep_graph.set_includes(src_id, 0, {header_id});
     f.workspace.dep_graph.build_reverse_map();
     f.load();
@@ -2193,7 +2193,7 @@ TEST_CASE(HeaderRuleChangeReindexed) {
     f.workspace.config.finalize(tmp.root);
     f.load();
 
-    auto header_id = f.workspace.path_pool.intern(header);
+    auto header_id = f.workspace.file_table.intern(header);
     ASSERT_FALSE(f.workspace.project_index.manifests.contains(header_id));
     ASSERT_TRUE(f.pump.pending_reason(header_id) == ReindexReason::ContentChanged);
 }
@@ -2212,7 +2212,7 @@ TEST_CASE(RecordedHostChangeDrops) {
         auto indexed = index_file(tmp, header);
         ASSERT_FALSE(indexed.data.empty());
         ASSERT_TRUE(f.merge(indexed.data.data(), indexed.data.size()));
-        f.set_header_host(f.workspace.path_pool.intern(header), f.workspace.path_pool.intern(src));
+        f.set_header_host(f.workspace.file_table.intern(header), f.workspace.file_table.intern(src));
         f.save();
     }
 
@@ -2224,7 +2224,7 @@ TEST_CASE(RecordedHostChangeDrops) {
     f.workspace.cdb.add_command(tmp.root, src, llvm::StringRef("clang++ -DFOO=2 -c main.cpp"));
     f.load();
 
-    auto header_id = f.workspace.path_pool.intern(header);
+    auto header_id = f.workspace.file_table.intern(header);
     ASSERT_FALSE(f.workspace.project_index.manifests.contains(header_id));
     ASSERT_TRUE(f.pump.pending_reason(header_id) == ReindexReason::ContentChanged);
 }
@@ -2246,7 +2246,7 @@ TEST_CASE(PinnedHostKeepsHeader) {
         auto indexed = index_file(tmp, header);
         ASSERT_FALSE(indexed.data.empty());
         ASSERT_TRUE(f.merge(indexed.data.data(), indexed.data.size()));
-        f.set_header_host(f.workspace.path_pool.intern(header), f.workspace.path_pool.intern(src));
+        f.set_header_host(f.workspace.file_table.intern(header), f.workspace.file_table.intern(src));
         f.save();
     }
 
@@ -2257,9 +2257,9 @@ TEST_CASE(PinnedHostKeepsHeader) {
     open_store(tmp, f.workspace);
     f.workspace.cdb.add_command(tmp.root, src, llvm::StringRef("clang++ -c main.cpp"));
     f.workspace.cdb.add_command(tmp.root, other, llvm::StringRef("clang++ -DBAR=1 -c other.cpp"));
-    auto src_id = f.workspace.path_pool.intern(src);
-    auto other_id = f.workspace.path_pool.intern(other);
-    auto header_id = f.workspace.path_pool.intern(header);
+    auto src_id = f.workspace.file_table.intern(src);
+    auto other_id = f.workspace.file_table.intern(other);
+    auto header_id = f.workspace.file_table.intern(header);
     f.workspace.dep_graph.set_includes(src_id, 0, {header_id});
     f.workspace.dep_graph.set_includes(other_id, 0, {header_id});
     f.workspace.dep_graph.build_reverse_map();
@@ -2283,7 +2283,7 @@ TEST_CASE(UnreachableHostRebuilds) {
         auto indexed = index_file(tmp, header);
         ASSERT_FALSE(indexed.data.empty());
         ASSERT_TRUE(f.merge(indexed.data.data(), indexed.data.size()));
-        f.set_header_host(f.workspace.path_pool.intern(header), f.workspace.path_pool.intern(src));
+        f.set_header_host(f.workspace.file_table.intern(header), f.workspace.file_table.intern(src));
         f.save();
     }
 
@@ -2295,7 +2295,7 @@ TEST_CASE(UnreachableHostRebuilds) {
     f.workspace.cdb.add_command(tmp.root, src, llvm::StringRef("clang++ -c main.cpp"));
     f.load();
 
-    auto header_id = f.workspace.path_pool.intern(header);
+    auto header_id = f.workspace.file_table.intern(header);
     ASSERT_TRUE(f.workspace.project_index.manifests.contains(header_id));
     ASSERT_TRUE(f.pump.pending_reason(header_id) == ReindexReason::ContentChanged);
 }
@@ -2425,7 +2425,7 @@ TEST_CASE(DroppedHeaderDebtRetried) {
         auto indexed = index_file(tmp, header);
         ASSERT_FALSE(indexed.data.empty());
         ASSERT_TRUE(f.merge(indexed.data.data(), indexed.data.size()));
-        f.set_header_host(f.workspace.path_pool.intern(header), f.workspace.path_pool.intern(src));
+        f.set_header_host(f.workspace.file_table.intern(header), f.workspace.file_table.intern(src));
         f.save();
     }
 
@@ -2438,7 +2438,7 @@ TEST_CASE(DroppedHeaderDebtRetried) {
         open_store(tmp, f.workspace);
         f.workspace.cdb.add_command(tmp.root, src, llvm::StringRef("clang++ -DFOO=2 -c main.cpp"));
         f.load();
-        auto header_id = f.workspace.path_pool.intern(header);
+        auto header_id = f.workspace.file_table.intern(header);
         ASSERT_FALSE(f.workspace.project_index.manifests.contains(header_id));
         ASSERT_TRUE(f.pump.pending_reason(header_id) == ReindexReason::ContentChanged);
         f.save();
@@ -2449,7 +2449,7 @@ TEST_CASE(DroppedHeaderDebtRetried) {
     f.workspace.cdb.add_command(tmp.root, src, llvm::StringRef("clang++ -DFOO=2 -c main.cpp"));
     f.load();
 
-    auto header_id = f.workspace.path_pool.intern(header);
+    auto header_id = f.workspace.file_table.intern(header);
     ASSERT_FALSE(f.workspace.project_index.manifests.contains(header_id));
     ASSERT_TRUE(f.pump.pending_reason(header_id) == ReindexReason::ContentChanged);
 }
@@ -2468,7 +2468,7 @@ TEST_CASE(VanishedHeaderDebtDies) {
         auto indexed = index_file(tmp, header);
         ASSERT_FALSE(indexed.data.empty());
         ASSERT_TRUE(f.merge(indexed.data.data(), indexed.data.size()));
-        f.set_header_host(f.workspace.path_pool.intern(header), f.workspace.path_pool.intern(src));
+        f.set_header_host(f.workspace.file_table.intern(header), f.workspace.file_table.intern(src));
         f.save();
     }
 
@@ -2488,7 +2488,7 @@ TEST_CASE(VanishedHeaderDebtDies) {
     open_store(tmp, f.workspace);
     f.workspace.cdb.add_command(tmp.root, src, llvm::StringRef("clang++ -DFOO=2 -c main.cpp"));
     f.load();
-    ASSERT_FALSE(f.pump.pending_reason(f.workspace.path_pool.intern(header)).has_value());
+    ASSERT_FALSE(f.pump.pending_reason(f.workspace.file_table.intern(header)).has_value());
 }
 
 };  // TEST_SUITE(IndexerLoad)
@@ -2497,7 +2497,7 @@ TEST_SUITE(IndexerRequeue) {
 
 TEST_CASE(PreemptionKeepsBudget) {
     IndexerFixture f;
-    auto id = f.workspace.path_pool.intern("/proj/a.cpp");
+    auto id = f.workspace.file_table.intern("/proj/a.cpp");
     f.pump.enqueue(id, ReindexReason::ContentChanged);
 
     // A preemption under memory pressure requeues without spending the
@@ -2511,7 +2511,7 @@ TEST_CASE(PreemptionKeepsBudget) {
 
 TEST_CASE(CrashSpendsBudget) {
     IndexerFixture f;
-    auto id = f.workspace.path_pool.intern("/proj/poison.cpp");
+    auto id = f.workspace.file_table.intern("/proj/poison.cpp");
     f.pump.enqueue(id, ReindexReason::ContentChanged);
 
     for(unsigned i = 0; i < IndexerFixture::budget; ++i) {
@@ -2534,7 +2534,7 @@ TEST_CASE(CrashSpendsBudget) {
 
 TEST_CASE(StaleCrashKeepsBudget) {
     IndexerFixture f;
-    auto id = f.workspace.path_pool.intern("/proj/edited.cpp");
+    auto id = f.workspace.file_table.intern("/proj/edited.cpp");
     f.pump.enqueue(id, ReindexReason::ContentChanged);
     auto stale = f.ticket(id);
 
@@ -2550,7 +2550,7 @@ TEST_CASE(StaleCrashKeepsBudget) {
 
 TEST_CASE(DepsDowngradeKeepsDebt) {
     IndexerFixture f;
-    auto id = f.workspace.path_pool.intern("/proj/c.cpp");
+    auto id = f.workspace.file_table.intern("/proj/c.cpp");
     f.pump.enqueue(id, ReindexReason::ContentChanged);
     auto launch = f.ticket(id);
 
@@ -2569,7 +2569,7 @@ TEST_CASE(DepsDowngradeKeepsDebt) {
 
 TEST_CASE(GaveUpClearsDowngraded) {
     IndexerFixture f;
-    auto id = f.workspace.path_pool.intern("/proj/d.cpp");
+    auto id = f.workspace.file_table.intern("/proj/d.cpp");
     f.pump.enqueue(id, ReindexReason::ContentChanged);
     auto launch = f.ticket(id);
     f.set_attempts(id, IndexerFixture::budget);
@@ -2585,13 +2585,13 @@ TEST_CASE(GaveUpClearsDowngraded) {
 
 TEST_CASE(DroppedWithoutPending) {
     IndexerFixture f;
-    auto id = f.workspace.path_pool.intern("/proj/gone.cpp");
+    auto id = f.workspace.file_table.intern("/proj/gone.cpp");
     ASSERT_EQ(int(f.fail(id, /*crashed=*/true)), int(IndexerFixture::Verdict::Dropped));
 }
 
 TEST_CASE(AttemptWaitPerTicket) {
     IndexerFixture f;
-    auto id = f.workspace.path_pool.intern("/proj/waited.cpp");
+    auto id = f.workspace.file_table.intern("/proj/waited.cpp");
     f.pump.enqueue(id, ReindexReason::ContentChanged);
     auto launch = f.ticket(id);
 
@@ -2631,7 +2631,7 @@ TEST_CASE(AttemptWaitPerTicket) {
 
 TEST_CASE(ContentChangeResetsBudget) {
     IndexerFixture f;
-    auto id = f.workspace.path_pool.intern("/proj/fixed.cpp");
+    auto id = f.workspace.file_table.intern("/proj/fixed.cpp");
     f.pump.enqueue(id, ReindexReason::ContentChanged);
 
     ASSERT_EQ(int(f.fail(id, /*crashed=*/true)), int(IndexerFixture::Verdict::Requeued));
@@ -2654,9 +2654,9 @@ TEST_CASE(RoundSnapshotBoundary) {
     // the two rounds stays observable.
     f.workspace.config.project.enable_indexing.value = false;
 
-    auto a = f.workspace.path_pool.intern("/fake/a.cpp");
-    auto b = f.workspace.path_pool.intern("/fake/b.cpp");
-    auto c = f.workspace.path_pool.intern("/fake/c.cpp");
+    auto a = f.workspace.file_table.intern("/fake/a.cpp");
+    auto b = f.workspace.file_table.intern("/fake/b.cpp");
+    auto c = f.workspace.file_table.intern("/fake/c.cpp");
 
     f.pump.enqueue(a, ReindexReason::ContentChanged);
     f.pump.enqueue(b, ReindexReason::ContentChanged);
@@ -2696,8 +2696,8 @@ TEST_CASE(PauseResumesRound) {
     IndexerFixture f;
     f.workspace.config.project.enable_indexing.value = false;
 
-    auto a = f.workspace.path_pool.intern("/fake/a.cpp");
-    auto b = f.workspace.path_pool.intern("/fake/b.cpp");
+    auto a = f.workspace.file_table.intern("/fake/a.cpp");
+    auto b = f.workspace.file_table.intern("/fake/b.cpp");
     f.pump.enqueue(a, ReindexReason::ContentChanged);
     f.pump.enqueue(b, ReindexReason::ContentChanged);
 
@@ -2748,7 +2748,7 @@ TEST_CASE(MergeReportsRowsChanged) {
         [&](llvm::ArrayRef<std::uint32_t> ids) { notified.append(ids.begin(), ids.end()); });
     ASSERT_TRUE(f.merge(indexed.data.data(), indexed.data.size()));
 
-    ASSERT_TRUE(llvm::is_contained(notified, f.workspace.path_pool.intern(indexed.tu_path)));
+    ASSERT_TRUE(llvm::is_contained(notified, f.workspace.file_table.intern(indexed.tu_path)));
 }
 
 TEST_CASE(DropReportsServedRows) {
@@ -2764,8 +2764,8 @@ TEST_CASE(DropReportsServedRows) {
     ASSERT_FALSE(indexed.data.empty());
     ASSERT_TRUE(f.merge(indexed.data.data(), indexed.data.size()));
 
-    auto tu_id = f.workspace.path_pool.intern(indexed.tu_path);
-    auto header_id = f.workspace.path_pool.intern(tmp.path("dep.h"));
+    auto tu_id = f.workspace.file_table.intern(indexed.tu_path);
+    auto header_id = f.workspace.file_table.intern(tmp.path("dep.h"));
 
     llvm::SmallVector<std::uint32_t> notified;
     auto conn = f.pump.on_rows_changed.connect(
@@ -2799,7 +2799,7 @@ TEST_CASE(RetireReportsRowsChanged) {
     ASSERT_FALSE(second.data.empty());
     ASSERT_TRUE(f.merge(second.data.data(), second.data.size()));
 
-    auto header_id = f.workspace.path_pool.intern(tmp.path("dep.h"));
+    auto header_id = f.workspace.file_table.intern(tmp.path("dep.h"));
     ASSERT_TRUE(f.workspace.shards.contains(header_id));
 
     llvm::SmallVector<std::uint32_t> notified;
@@ -2826,7 +2826,7 @@ TEST_CASE(FailedStandaloneInSnapshot) {
         IndexerFixture f;
         open_store(tmp, f.workspace);
         f.workspace.cdb.add_command(tmp.root, src, llvm::StringRef("clang++ -c main.cpp"));
-        f.mark_failed(f.workspace.path_pool.intern(header));
+        f.mark_failed(f.workspace.file_table.intern(header));
         // Something dirty so the save writes at all; the snapshot rides
         // the same batch.
         auto indexed = index_file(tmp, src);
@@ -2839,7 +2839,7 @@ TEST_CASE(FailedStandaloneInSnapshot) {
     open_store(tmp, f.workspace);
     f.workspace.cdb.add_command(tmp.root, src, llvm::StringRef("clang++ -c main.cpp"));
     f.load();
-    ASSERT_TRUE(f.pump.pending_reason(f.workspace.path_pool.intern(header)) ==
+    ASSERT_TRUE(f.pump.pending_reason(f.workspace.file_table.intern(header)) ==
                 ReindexReason::ContentChanged);
 }
 
@@ -2896,7 +2896,7 @@ TEST_CASE(LateDebtShutdownRetry) {
     open_store(tmp, f.workspace);
     f.workspace.index_db = std::make_unique<CorruptOnWrite>();
 
-    f.mark_failed(f.workspace.path_pool.intern(tmp.path("dep.h")));
+    f.mark_failed(f.workspace.file_table.intern(tmp.path("dep.h")));
     auto indexed = index_file(tmp, tmp.path("main.cpp"));
     ASSERT_FALSE(indexed.data.empty());
     ASSERT_TRUE(f.merge(indexed.data.data(), indexed.data.size()));
@@ -2923,7 +2923,7 @@ TEST_CASE(LateDebtShutdownRetry) {
 TEST_CASE(DispatchDeferKeepsDebt) {
     IndexerFixture f;
     f.workspace.config.project.enable_indexing.value = false;
-    auto id = f.workspace.path_pool.intern("/fake/a.cpp");
+    auto id = f.workspace.file_table.intern("/fake/a.cpp");
     f.pump.enqueue(id, ReindexReason::ContentChanged);
 
     f.pump.admission = [](std::uint32_t) {
@@ -2953,7 +2953,7 @@ TEST_CASE(LandingVetoDropsResult) {
         src,
         std::format("clang++ -fsyntax-only -resource-dir {} -c {}", resource_dir(), src));
 
-    auto id = f.workspace.path_pool.intern(src);
+    auto id = f.workspace.file_table.intern(src);
     f.pump.enqueue(id, ReindexReason::ContentChanged);
 
     int asks = 0;
@@ -2991,7 +2991,7 @@ TEST_CASE(BoostRearmsIdleTimer) {
     f.workspace.config.project.enable_indexing.value = true;
     f.workspace.config.project.idle_timeout_ms.value = 60'000;
 
-    auto id = f.workspace.path_pool.intern("/fake/a.cpp");
+    auto id = f.workspace.file_table.intern("/fake/a.cpp");
     f.pump.enqueue(id, ReindexReason::ContentChanged);
     f.pump.schedule();
     f.pump.boost(id);
@@ -3044,7 +3044,7 @@ TEST_CASE(ModuleLintScanParity) {
     plan.tidy_params.checks = "-*,bugprone-integer-division";
     plan.tidy_params.extra_args = {"-DUSE_M"};
 
-    auto n_id = f.workspace.path_pool.intern(tmp.path("n.cppm"));
+    auto n_id = f.workspace.file_table.intern(tmp.path("n.cppm"));
     TURunFamily::Outcome outcome;
     bool done = false;
     auto body = [&]() -> kota::task<> {

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -46,7 +46,7 @@ struct IndexerFixture {
     ContextResolver contexts{workspace};
     TaskGraph graph{loop};
     PCMFamily pcm{graph, workspace, contexts, pool};
-    IndexStore index_store{loop, workspace};
+    IndexStore index_store{loop, workspace, contexts};
     TURunFamily turun{graph, workspace, contexts, pcm, index_store, pool};
     IndexPump pump{loop, workspace, turun, index_store, pool};
 

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -1692,8 +1692,8 @@ TEST_CASE(DeferredSweepYieldsToFreshWrite) {
         f.save();
         // The indexer keys blobs by the pool-canonical path, which need
         // not equal the raw temp path byte-for-byte (Windows 8.3 names).
-        auto key =
-            blob_key(f.workspace.file_table.resolve(f.workspace.file_table.intern(indexed.tu_path)));
+        auto key = blob_key(
+            f.workspace.file_table.resolve(f.workspace.file_table.intern(indexed.tu_path)));
         // Replace the persisted manifest with an unresolvable one: the
         // next load sweeps it — deferred into the first save — and the
         // TU's shard turns orphan, deferred too.
@@ -2216,7 +2216,8 @@ TEST_CASE(RecordedHostChangeDrops) {
         auto indexed = index_file(tmp, header);
         ASSERT_FALSE(indexed.data.empty());
         ASSERT_TRUE(f.merge(indexed.data.data(), indexed.data.size()));
-        f.set_header_host(f.workspace.file_table.intern(header), f.workspace.file_table.intern(src));
+        f.set_header_host(f.workspace.file_table.intern(header),
+                          f.workspace.file_table.intern(src));
         f.save();
     }
 
@@ -2250,7 +2251,8 @@ TEST_CASE(PinnedHostKeepsHeader) {
         auto indexed = index_file(tmp, header);
         ASSERT_FALSE(indexed.data.empty());
         ASSERT_TRUE(f.merge(indexed.data.data(), indexed.data.size()));
-        f.set_header_host(f.workspace.file_table.intern(header), f.workspace.file_table.intern(src));
+        f.set_header_host(f.workspace.file_table.intern(header),
+                          f.workspace.file_table.intern(src));
         f.save();
     }
 
@@ -2287,7 +2289,8 @@ TEST_CASE(UnreachableHostRebuilds) {
         auto indexed = index_file(tmp, header);
         ASSERT_FALSE(indexed.data.empty());
         ASSERT_TRUE(f.merge(indexed.data.data(), indexed.data.size()));
-        f.set_header_host(f.workspace.file_table.intern(header), f.workspace.file_table.intern(src));
+        f.set_header_host(f.workspace.file_table.intern(header),
+                          f.workspace.file_table.intern(src));
         f.save();
     }
 
@@ -2429,7 +2432,8 @@ TEST_CASE(DroppedHeaderDebtRetried) {
         auto indexed = index_file(tmp, header);
         ASSERT_FALSE(indexed.data.empty());
         ASSERT_TRUE(f.merge(indexed.data.data(), indexed.data.size()));
-        f.set_header_host(f.workspace.file_table.intern(header), f.workspace.file_table.intern(src));
+        f.set_header_host(f.workspace.file_table.intern(header),
+                          f.workspace.file_table.intern(src));
         f.save();
     }
 
@@ -2472,7 +2476,8 @@ TEST_CASE(VanishedHeaderDebtDies) {
         auto indexed = index_file(tmp, header);
         ASSERT_FALSE(indexed.data.empty());
         ASSERT_TRUE(f.merge(indexed.data.data(), indexed.data.size()));
-        f.set_header_host(f.workspace.file_table.intern(header), f.workspace.file_table.intern(src));
+        f.set_header_host(f.workspace.file_table.intern(header),
+                          f.workspace.file_table.intern(src));
         f.save();
     }
 

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -298,10 +298,21 @@ void open_store(TempDir& tmp, Workspace& workspace) {
     auto store = CacheStore::open(tmp.path("cache"), 1);
     ASSERT_TRUE(store.has_value());
     workspace.store.emplace(std::move(*store));
-    workspace.index_db = index::open_fs_database(*workspace.store);
+    workspace.index_db = index::open_lmdb_database(*workspace.store);
 }
 
-/// The storage key of a file's shard or manifest blob (the store's naming).
+/// Plant a blob between sessions (no fixture may be alive — the writer
+/// lock), as the residue of a crash or a foreign writer.
+void inject_blob(TempDir& tmp, index::IndexBlobKind kind, llvm::StringRef key, std::string bytes) {
+    auto store = CacheStore::open(tmp.path("cache"), 1);
+    ASSERT_TRUE(store.has_value());
+    auto db = index::open_lmdb_database(*store);
+    ASSERT_TRUE(db != nullptr);
+    index::BlobDatabase::Blob blob{kind, key.str(), std::move(bytes)};
+    ASSERT_TRUE(db->write(blob, {}).empty());
+}
+
+/// The storage key of a file's shard or manifest blob (the database's naming).
 std::string blob_key(llvm::StringRef path) {
     return std::format("{:016x}", llvm::xxh3_64bits(path));
 }
@@ -1199,32 +1210,6 @@ TEST_CASE(MigrationCorruptionRebuildsDatabase) {
     ASSERT_FALSE(index_store.has_unsaved_state());
 }
 
-TEST_CASE(WriteFailureStopsBatch) {
-    TempDir tmp;
-    open_store(tmp, workspace);
-    auto& db = *workspace.index_db;
-
-    // Wedge the manifest's destination with a non-empty directory so its
-    // commit fails while the shard before it lands.
-    tmp.touch("cache/cache/v1/index-manifest/k.idx/wedge");
-
-    auto failures = db.write(
-        {
-            {index::IndexBlobKind::Shard,    "k",      "shard bytes"   },
-            {index::IndexBlobKind::Manifest, "k",      "manifest bytes"},
-            {index::IndexBlobKind::Global,   "global", "global bytes"  },
-    },
-        {});
-
-    // The failure fails the rest of the batch: a global must never land
-    // above a manifest that did not.
-    ASSERT_EQ(failures.size(), 2u);
-    ASSERT_EQ(failures[0], 1u);
-    ASSERT_EQ(failures[1], 2u);
-    ASSERT_TRUE(db.contains(index::IndexBlobKind::Shard, "k"));
-    ASSERT_FALSE(db.contains(index::IndexBlobKind::Global, "global"));
-}
-
 };  // TEST_SUITE(IndexerMerge)
 
 TEST_SUITE(IndexerStaleness) {
@@ -1361,10 +1346,9 @@ TEST_CASE(LoadHealsBrokenShard) {
             f.workspace.file_table.resolve(f.workspace.file_table.intern(tmp.path("dep.h"))));
     }
 
-    // Corrupt the header's blob and plant an orphan nothing references
-    // (the store's layout is {root}/cache/v{N}, under the "cache" root).
-    tmp.touch("cache/cache/v1/index/" + header_key + ".idx", "corrupted beyond verification");
-    tmp.touch("cache/cache/v1/index/deadbeefdeadbeef.idx", "orphan");
+    // Corrupt the header's blob and plant an orphan nothing references.
+    inject_blob(tmp, index::IndexBlobKind::Shard, header_key, "corrupted beyond verification");
+    inject_blob(tmp, index::IndexBlobKind::Shard, "deadbeefdeadbeef", "orphan");
 
     IndexerFixture f;
     open_store(tmp, f.workspace);
@@ -1420,8 +1404,8 @@ TEST_CASE(ReadOnlyLoadKeepsDisk) {
         manifest_key = blob_key(f.workspace.file_table.resolve(f.workspace.file_table.intern(src)));
     }
 
-    tmp.touch("cache/cache/v1/index/" + header_key + ".idx", "corrupted beyond verification");
-    tmp.touch("cache/cache/v1/index/deadbeefdeadbeef.idx", "orphan");
+    inject_blob(tmp, index::IndexBlobKind::Shard, header_key, "corrupted beyond verification");
+    inject_blob(tmp, index::IndexBlobKind::Shard, "deadbeefdeadbeef", "orphan");
 
     IndexerFixture f;
     open_store(tmp, f.workspace);
@@ -1469,8 +1453,10 @@ TEST_CASE(LoadHealsMissingVariant) {
     // Replace the header's blob with one that verifies but stores a variant
     // no manifest contributed — the residue of a crash or failed write that
     // landed the manifest without its shard.
-    tmp.touch("cache/cache/v1/index/" + header_key + ".idx",
-              planted_blob("#pragma once\ninline int dep() { return 1; }\n", 0x1234));
+    inject_blob(tmp,
+                index::IndexBlobKind::Shard,
+                header_key,
+                planted_blob("#pragma once\ninline int dep() { return 1; }\n", 0x1234));
 
     IndexerFixture f;
     open_store(tmp, f.workspace);
@@ -1511,7 +1497,10 @@ TEST_CASE(LoadHealsWrongGeneration) {
     // the residue of a crash between shard and manifest writes. Every
     // recorded FileVersion matches the disk, so only the generation pin
     // can tell that positions would map through stale text.
-    tmp.touch("cache/cache/v1/index/" + header_key + ".idx", planted_blob("stale text", rows_hash));
+    inject_blob(tmp,
+                index::IndexBlobKind::Shard,
+                header_key,
+                planted_blob("stale text", rows_hash));
 
     IndexerFixture f;
     open_store(tmp, f.workspace);
@@ -2350,13 +2339,15 @@ TEST_CASE(CDBWriteFailureRetried) {
         }
 
         std::expected<std::uint64_t, std::string> advance_read_snapshot() override {
-            return 0;
+            return real->advance_read_snapshot();
         }
 
-        void retire_old_snapshot() override {}
+        void retire_old_snapshot() override {
+            real->retire_old_snapshot();
+        }
 
         std::expected<bool, std::string> grow() override {
-            return false;
+            return real->grow();
         }
     };
 
@@ -2500,6 +2491,202 @@ TEST_CASE(VanishedHeaderDebtDies) {
     f.workspace.cdb.add_command(tmp.root, src, llvm::StringRef("clang++ -DFOO=2 -c main.cpp"));
     f.load();
     ASSERT_FALSE(f.pump.pending_reason(f.workspace.file_table.intern(header)).has_value());
+}
+
+TEST_CASE(RevokedStampStaysRevoked) {
+    // The global and artifacts blobs commit non-atomically; a crash
+    // between the two writes of a revocation save leaves a global
+    // recording the revocation next to an artifacts blob predating it.
+    // Adopting the old blob's dep stamps would undo the revocation.
+    TempDir tmp;
+    tmp.touch("dep.h", "int x;\n");
+    auto dep_path = tmp.path("dep.h");
+    std::string stale_artifacts;
+
+    auto setup = [&](IndexerFixture& f) {
+        open_store(tmp, f.workspace);
+        f.workspace.store->register_namespace(
+            {.name = "pcm", .extension = ".pcm", .policy = CachePolicy::LRU});
+    };
+    auto dep_version = [&](IndexerFixture& f) {
+        return f.workspace.file_table.intern_version(f.workspace.file_table.intern(dep_path), 7);
+    };
+
+    {
+        IndexerFixture f;
+        setup(f);
+        auto pending = f.workspace.store->begin_store("pcm", "k");
+        ASSERT_TRUE(fs::write(pending.tmp_path, "pcm-bytes").has_value());
+        ASSERT_TRUE(f.workspace.store->commit(std::move(pending)).has_value());
+
+        auto dep_id = f.workspace.file_table.intern(dep_path);
+        auto vid = dep_version(f);
+        f.workspace.file_table.adopt_stamp(vid, 42, 123);
+        auto& st = f.workspace.pcm_cache[dep_id];
+        st.path = "dep.pcm";
+        st.key = "k";
+        st.deps.push_back({.path_id = dep_id, .version = vid});
+        f.workspace.mark_artifacts_dirty();
+        f.index_store.mark_global_dirty();
+        f.save();
+
+        auto blob = f.workspace.index_db->read(index::IndexBlobKind::Artifacts, "artifacts");
+        ASSERT_TRUE(bool(blob));
+        stale_artifacts = blob.buffer->getBuffer().str();
+    }
+
+    {
+        // Matching revocation generations adopt the persisted stamp...
+        IndexerFixture f;
+        setup(f);
+        f.load();
+        ASSERT_EQ(f.workspace.file_table.version(dep_version(f)).mtime_ns, std::int64_t(123));
+
+        // ...then revoke, persist both blobs, and put the pre-revocation
+        // artifacts blob back — the on-disk pair a mid-batch crash leaves.
+        f.workspace.file_table.force_revalidate(f.workspace.file_table.intern(dep_path));
+        f.workspace.mark_artifacts_dirty();
+        f.index_store.mark_global_dirty();
+        f.save();
+        index::BlobDatabase::Blob stale{index::IndexBlobKind::Artifacts,
+                                        "artifacts",
+                                        stale_artifacts};
+        ASSERT_TRUE(f.workspace.index_db->write(stale, {}).empty());
+    }
+
+    IndexerFixture f;
+    setup(f);
+    f.load();
+    ASSERT_EQ(f.workspace.file_table.version(dep_version(f)).mtime_ns, std::int64_t(0));
+}
+
+TEST_CASE(StaleFormatDropsPch) {
+    // A .pch.idx envelope written under an older index format is
+    // unreadable; the format gate drops every PCH entry at load so the
+    // pairs rebuild immediately, instead of the mismatch surfacing lazily
+    // on the first overlay query — which cannot trigger a rebuild.
+    TempDir tmp;
+    tmp.touch("dep.h", "int x;\n");
+    auto dep_path = tmp.path("dep.h");
+    std::string artifacts;
+
+    auto setup = [&](IndexerFixture& f) {
+        open_store(tmp, f.workspace);
+        f.workspace.store->register_namespace({.name = "pch",
+                                               .extension = ".pch",
+                                               .aux_extension = ".pch.idx",
+                                               .policy = CachePolicy::LRU});
+    };
+
+    {
+        IndexerFixture f;
+        setup(f);
+        auto pending = f.workspace.store->begin_store("pch", "k");
+        ASSERT_TRUE(fs::write(pending.tmp_path, "pch-bytes").has_value());
+        ASSERT_TRUE(f.workspace.store->commit(std::move(pending)).has_value());
+        auto aux = f.workspace.store->begin_store_aux("pch", "k");
+        ASSERT_TRUE(fs::write(aux.tmp_path, "idx-bytes").has_value());
+        ASSERT_TRUE(f.workspace.store->commit(std::move(aux)).has_value());
+
+        auto dep_id = f.workspace.file_table.intern(dep_path);
+        auto& st = f.workspace.pch_cache["k"];
+        st.path = "k.pch";
+        st.deps.push_back(
+            {.path_id = dep_id, .version = f.workspace.file_table.intern_version(dep_id, 7)});
+        f.workspace.mark_artifacts_dirty();
+        f.save();
+
+        auto blob = f.workspace.index_db->read(index::IndexBlobKind::Artifacts, "artifacts");
+        ASSERT_TRUE(bool(blob));
+        artifacts = blob.buffer->getBuffer().str();
+    }
+
+    {
+        // The premise: under the current format the entry loads.
+        IndexerFixture f;
+        setup(f);
+        f.load();
+        ASSERT_EQ(f.workspace.pch_cache.size(), std::size_t(1));
+
+        // Put back the blob as an older binary would have written it.
+        auto current = std::format("\"pch_index_format\":{}", index::index_format_version);
+        auto stale = std::format("\"pch_index_format\":{}", index::index_format_version - 1);
+        auto pos = artifacts.find(current);
+        ASSERT_TRUE(pos != std::string::npos);
+        artifacts.replace(pos, current.size(), stale);
+        index::BlobDatabase::Blob blob{index::IndexBlobKind::Artifacts, "artifacts", artifacts};
+        ASSERT_TRUE(f.workspace.index_db->write(blob, {}).empty());
+    }
+
+    IndexerFixture f;
+    setup(f);
+    f.load();
+    ASSERT_TRUE(f.workspace.pch_cache.empty());
+}
+
+TEST_CASE(DeplessPcmDropped) {
+    // A dep-less PCM entry is an unvalidatable snapshot (the key embeds
+    // no content): trusted, it would blindly serve a stale PCM after an
+    // offline edit. Load drops it so the module rebuilds once.
+    TempDir tmp;
+    tmp.touch("mod.cppm", "export module m;\n");
+    auto src = tmp.path("mod.cppm");
+
+    auto setup = [&](IndexerFixture& f) {
+        open_store(tmp, f.workspace);
+        f.workspace.store->register_namespace(
+            {.name = "pcm", .extension = ".pcm", .policy = CachePolicy::LRU});
+    };
+
+    {
+        IndexerFixture f;
+        setup(f);
+        auto pending = f.workspace.store->begin_store("pcm", "k");
+        ASSERT_TRUE(fs::write(pending.tmp_path, "pcm-bytes").has_value());
+        ASSERT_TRUE(f.workspace.store->commit(std::move(pending)).has_value());
+
+        auto& st = f.workspace.pcm_cache[f.workspace.file_table.intern(src)];
+        st.path = "m.pcm";
+        st.key = "k";
+        f.workspace.mark_artifacts_dirty();
+        f.save();
+
+        // The premise: the dep-less entry was persisted, so the tail
+        // assertion exercises the load-side drop, not a write-side skip.
+        auto blob = f.workspace.index_db->read(index::IndexBlobKind::Artifacts, "artifacts");
+        ASSERT_TRUE(bool(blob));
+        ASSERT_TRUE(blob.buffer->getBuffer().contains("\"key\":\"k\""));
+    }
+
+    IndexerFixture f;
+    setup(f);
+    f.load();
+    ASSERT_TRUE(f.workspace.pcm_cache.empty());
+}
+
+TEST_CASE(HeaderModePersisted) {
+    // The NeedsContext verdict rides the artifacts blob: a restart with
+    // unchanged disk content adopts it instead of re-running the trial.
+    TempDir tmp;
+    tmp.touch("utils.h", "inline int f();\n");
+    auto path = tmp.path("utils.h");
+
+    {
+        IndexerFixture f;
+        open_store(tmp, f.workspace);
+        auto id = f.workspace.file_table.intern(path);
+        auto disk = f.workspace.file_table.current(id);
+        ASSERT_TRUE(disk.has_value());
+        f.contexts.record_header_mode(id, HeaderMode::NeedsContext, disk->hash);
+        f.workspace.mark_artifacts_dirty();
+        f.save();
+    }
+
+    IndexerFixture f;
+    open_store(tmp, f.workspace);
+    f.load();
+    auto id = f.workspace.file_table.intern(path);
+    ASSERT_TRUE(f.contexts.header_mode(path, id) == HeaderMode::NeedsContext);
 }
 
 };  // TEST_SUITE(IndexerLoad)

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -1243,8 +1243,10 @@ struct Indexed {
         header = tmp.path("dep.h");
         // Age the files out of the mtime guard window so the merge records
         // stat stamps, the way real project files predate an index run.
-        set_file_mtime(src, file_mtime_ns(src) - 10'000'000'000);
-        set_file_mtime(header, file_mtime_ns(header) - 10'000'000'000);
+        if(!set_file_mtime(src, file_mtime_ns(src) - 10'000'000'000) ||
+           !set_file_mtime(header, file_mtime_ns(header) - 10'000'000'000)) {
+            return false;
+        }
         auto indexed = index_file(tmp, src);
         if(indexed.data.empty()) {
             return false;

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -77,50 +77,50 @@ struct IndexerFixture {
         return result.decoded;
     }
 
-    void drop_index(std::uint32_t id) {
+    void drop_index(Fid id) {
         pump.claim_report(index_store.drop_index(id));
     }
 
     /// Record a terminally failed attempt, as run_index_task's failure
     /// verdicts do.
-    void mark_failed(std::uint32_t id) {
+    void mark_failed(Fid id) {
         pump.failed_ids.insert(id);
     }
 
     /// Fail the entry's current dispatch: the launch ticket matches.
-    Verdict fail(std::uint32_t id, bool crashed) {
+    Verdict fail(Fid id, bool crashed) {
         return pump.note_dispatch_failure({id, ticket(id)}, crashed);
     }
 
     /// Fail a dispatch launched with an explicit (possibly stale) ticket.
-    Verdict fail_at(std::uint32_t id, std::uint64_t ticket, bool crashed) {
+    Verdict fail_at(Fid id, std::uint64_t ticket, bool crashed) {
         return pump.note_dispatch_failure({id, ticket}, crashed);
     }
 
-    std::uint64_t ticket(std::uint32_t id) {
+    std::uint64_t ticket(Fid id) {
         auto it = pump.ledger.entries.find(id);
         return it == pump.ledger.entries.end() ? std::numeric_limits<std::uint64_t>::max()
                                                : it->second.ticket;
     }
 
-    unsigned attempts(std::uint32_t id) {
+    unsigned attempts(Fid id) {
         auto it = pump.ledger.entries.find(id);
         return it == pump.ledger.entries.end() ? 0u : it->second.requeue_attempts;
     }
 
-    void set_attempts(std::uint32_t id, unsigned n) {
+    void set_attempts(Fid id, unsigned n) {
         pump.ledger.entries.find(id)->second.requeue_attempts = n;
     }
 
     /// Consume the queued slot as a dispatch would, so a later enqueue
     /// takes the fresh-slot (mid-flight) path.
-    void consume(std::uint32_t id) {
+    void consume(Fid id) {
         pump.ledger.queued.erase(id);
     }
 
     /// Complete an attempt for `ticket` on the loop, as run_index_task's
     /// tail does — waking waiters requires a running loop.
-    void settle(std::uint32_t id, std::uint64_t ticket) {
+    void settle(Fid id, std::uint64_t ticket) {
         auto body = [&]() -> kota::task<> {
             pump.settle_attempt_waits(id, ticket);
             co_return;
@@ -153,7 +153,7 @@ struct IndexerFixture {
 
     /// Record a standalone header's borrowed host, as the TURun round does
     /// after its merge lands (these tests merge worker results directly).
-    void set_header_host(std::uint32_t header_id, std::uint32_t host_id) {
+    void set_header_host(Fid header_id, Fid host_id) {
         index_store.record_header_host(header_id, host_id);
     }
 
@@ -326,7 +326,7 @@ bool load(bool read_only = false) {
     return fx.load(read_only);
 }
 
-void drop_index(std::uint32_t id) {
+void drop_index(Fid id) {
     fx.drop_index(id);
 }
 
@@ -1632,16 +1632,16 @@ TEST_CASE(LoadRequeuesStaleManifest) {
         // while the TU's own version is known — here for the header, whose
         // standalone index no CDB sweep would ever rebuild.
         auto header_id = f.workspace.file_table.intern(header);
-        std::uint32_t header_fv = ~0u;
-        for(auto& [fv, record]: f.workspace.file_table.versions) {
-            if(record.fid == header_id) {
-                header_fv = fv;
+        VersionID header_fv;
+        for(std::uint32_t fv = 0; fv < f.workspace.file_table.versions.size(); fv += 1) {
+            if(f.workspace.file_table.versions[fv].fid == header_id) {
+                header_fv = VersionID{fv};
             }
         }
-        ASSERT_TRUE(header_fv != ~0u);
+        ASSERT_TRUE(header_fv.valid());
         index::TUManifest stale;
         stale.tu_fv = header_fv;
-        stale.nodes.push_back({.fv = 9999});
+        stale.nodes.push_back({.fv = VersionID{9999}});
         std::string bytes;
         llvm::raw_string_ostream os(bytes);
         index::serialize_manifest(stale, os);
@@ -1700,8 +1700,8 @@ TEST_CASE(DeferredSweepYieldsToFreshWrite) {
         // next load sweeps it — deferred into the first save — and the
         // TU's shard turns orphan, deferred too.
         index::TUManifest stale;
-        stale.tu_fv = 999999;
-        stale.nodes.push_back({.fv = 9999});
+        stale.tu_fv = VersionID{999999};
+        stale.nodes.push_back({.fv = VersionID{9999}});
         std::string bytes;
         llvm::raw_string_ostream os(bytes);
         index::serialize_manifest(stale, os);
@@ -2166,7 +2166,7 @@ TEST_CASE(HostChangeDropsHeader) {
     f.workspace.cdb.add_command(tmp.root, src, llvm::StringRef("clang++ -DFOO=2 -c main.cpp"));
     auto src_id = f.workspace.file_table.intern(src);
     auto header_id = f.workspace.file_table.intern(header);
-    f.workspace.dep_graph.set_includes(src_id, 0, {header_id});
+    f.workspace.dep_graph.set_includes(src_id, 0, {{header_id}});
     f.workspace.dep_graph.build_reverse_map();
     f.load();
 
@@ -2268,8 +2268,8 @@ TEST_CASE(PinnedHostKeepsHeader) {
     auto src_id = f.workspace.file_table.intern(src);
     auto other_id = f.workspace.file_table.intern(other);
     auto header_id = f.workspace.file_table.intern(header);
-    f.workspace.dep_graph.set_includes(src_id, 0, {header_id});
-    f.workspace.dep_graph.set_includes(other_id, 0, {header_id});
+    f.workspace.dep_graph.set_includes(src_id, 0, {{header_id}});
+    f.workspace.dep_graph.set_includes(other_id, 0, {{header_id}});
     f.workspace.dep_graph.build_reverse_map();
     f.load();
 
@@ -2754,9 +2754,9 @@ TEST_CASE(MergeReportsRowsChanged) {
     auto indexed = index_file(tmp, tmp.path("main.cpp"));
     ASSERT_FALSE(indexed.data.empty());
 
-    llvm::SmallVector<std::uint32_t> notified;
+    llvm::SmallVector<Fid> notified;
     auto conn = f.pump.on_rows_changed.connect(
-        [&](llvm::ArrayRef<std::uint32_t> ids) { notified.append(ids.begin(), ids.end()); });
+        [&](llvm::ArrayRef<Fid> ids) { notified.append(ids.begin(), ids.end()); });
     ASSERT_TRUE(f.merge(indexed.data.data(), indexed.data.size()));
 
     ASSERT_TRUE(llvm::is_contained(notified, f.workspace.file_table.intern(indexed.tu_path)));
@@ -2778,9 +2778,9 @@ TEST_CASE(DropReportsServedRows) {
     auto tu_id = f.workspace.file_table.intern(indexed.tu_path);
     auto header_id = f.workspace.file_table.intern(tmp.path("dep.h"));
 
-    llvm::SmallVector<std::uint32_t> notified;
+    llvm::SmallVector<Fid> notified;
     auto conn = f.pump.on_rows_changed.connect(
-        [&](llvm::ArrayRef<std::uint32_t> ids) { notified.append(ids.begin(), ids.end()); });
+        [&](llvm::ArrayRef<Fid> ids) { notified.append(ids.begin(), ids.end()); });
     auto report = f.index_store.drop_index(tu_id);
     ASSERT_TRUE(llvm::is_contained(report.rows_changed(), tu_id));
     ASSERT_TRUE(llvm::is_contained(report.rows_changed(), header_id));
@@ -2813,9 +2813,9 @@ TEST_CASE(RetireReportsRowsChanged) {
     auto header_id = f.workspace.file_table.intern(tmp.path("dep.h"));
     ASSERT_TRUE(f.workspace.shards.contains(header_id));
 
-    llvm::SmallVector<std::uint32_t> notified;
+    llvm::SmallVector<Fid> notified;
     auto conn = f.pump.on_rows_changed.connect(
-        [&](llvm::ArrayRef<std::uint32_t> ids) { notified.append(ids.begin(), ids.end()); });
+        [&](llvm::ArrayRef<Fid> ids) { notified.append(ids.begin(), ids.end()); });
     f.save();
 
     ASSERT_FALSE(f.workspace.shards.contains(header_id));
@@ -2937,7 +2937,7 @@ TEST_CASE(DispatchDeferKeepsDebt) {
     auto id = f.workspace.file_table.intern("/fake/a.cpp");
     f.pump.enqueue(id, ReindexReason::ContentChanged);
 
-    f.pump.admission = [](std::uint32_t) {
+    f.pump.admission = [](Fid) {
         return Admission::Defer;
     };
     f.run_round();
@@ -2968,7 +2968,7 @@ TEST_CASE(LandingVetoDropsResult) {
     f.pump.enqueue(id, ReindexReason::ContentChanged);
 
     int asks = 0;
-    f.pump.admission = [&](std::uint32_t) {
+    f.pump.admission = [&](Fid) {
         asks += 1;
         // First ask = dispatch (admit); second = landing, where the
         // serving side has changed its mind.

--- a/tests/unit/server/invalidator_tests.cpp
+++ b/tests/unit/server/invalidator_tests.cpp
@@ -694,8 +694,9 @@ TEST_CASE(SaveUnreadableDiskDirties) {
     store.apply_open(*session, "int buffer;", 1);
 
     ContextResolver resolver(workspace);
-    // The file cannot be read back after the save: the disk state is
-    // unknown, which is treated as divergent (conservative).
+    // The file cannot be read back after the save (missing here; a
+    // present-but-unreadable file lands in the same nullopt): the disk
+    // state is unknown, which is treated as divergent (conservative).
     PCMHarness ph(workspace, resolver);
     Invalidator invalidator(workspace, store, resolver, ph.pcm);
     auto dirty = invalidator.apply(FileEvent::buffer_saved(saved));

--- a/tests/unit/server/invalidator_tests.cpp
+++ b/tests/unit/server/invalidator_tests.cpp
@@ -175,18 +175,19 @@ TEST_CASE(NoOpEventsNoEffects) {
 }
 
 TEST_CASE(SaveResetsTrialOnly) {
+    TempDir tmp;
+    tmp.touch("a.h", "int x;");
+
     Workspace workspace;
     SessionStore store;
-    auto saved = workspace.file_table.intern("/proj/a.h");
+    auto saved = workspace.file_table.intern(tmp.path("a.h"));
     auto session = store.open(saved);
     store.apply_open(*session, "int x;", 1);
 
     ContextResolver resolver(workspace);
     // A plain save: the disk holds exactly what the buffer holds.
     PCMHarness ph(workspace, resolver);
-    Invalidator invalidator(workspace, store, resolver, ph.pcm, [](llvm::StringRef) {
-        return std::optional<std::string>{"int x;"};
-    });
+    Invalidator invalidator(workspace, store, resolver, ph.pcm);
     auto dirty = invalidator.apply(FileEvent::buffer_saved(saved));
 
     // The saved file itself is not stale — its buffer was already current —
@@ -332,16 +333,17 @@ TEST_CASE(StaleReverseMapUnion) {
 }
 
 TEST_CASE(CloseWithoutShardReindexes) {
+    TempDir tmp;
+    tmp.touch("a.cpp", "int x;");
+
     Workspace workspace;
     SessionStore store;
-    auto closed = workspace.file_table.intern("/proj/a.cpp");
+    auto closed = workspace.file_table.intern(tmp.path("a.cpp"));
 
     ContextResolver resolver(workspace);
-    // The file exists on disk (injected read), it just was never indexed.
+    // The file exists on disk, it just was never indexed.
     PCMHarness ph(workspace, resolver);
-    Invalidator invalidator(workspace, store, resolver, ph.pcm, [](llvm::StringRef) {
-        return std::optional<std::string>("int x;");
-    });
+    Invalidator invalidator(workspace, store, resolver, ph.pcm);
     auto dirty = invalidator.apply(FileEvent::buffer_closed(closed));
 
     // No shard to compare against: nothing serves this file's rows anyway.
@@ -352,18 +354,19 @@ TEST_CASE(CloseWithoutShardReindexes) {
 }
 
 TEST_CASE(CloseCurrentShardDepsOnly) {
+    TempDir tmp;
+    tmp.touch("a.cpp", "int x;");
+
     Workspace workspace;
     SessionStore store;
-    auto closed = workspace.file_table.intern("/proj/a.cpp");
+    auto closed = workspace.file_table.intern(tmp.path("a.cpp"));
     workspace.shards[closed] = shard_of("int x;");
 
     ContextResolver resolver(workspace);
     // Disk matches the content the shard was built from: a browse-and-close
     // must not blank the file's rows for the reindex queue's latency.
     PCMHarness ph(workspace, resolver);
-    Invalidator invalidator(workspace, store, resolver, ph.pcm, [](llvm::StringRef) {
-        return std::optional<std::string>{"int x;"};
-    });
+    Invalidator invalidator(workspace, store, resolver, ph.pcm);
     auto dirty = invalidator.apply(FileEvent::buffer_closed(closed));
 
     ASSERT_EQ(dirty.reindex_deps_only, llvm::SmallVector<std::uint32_t>{closed});
@@ -371,18 +374,19 @@ TEST_CASE(CloseCurrentShardDepsOnly) {
 }
 
 TEST_CASE(CloseDivergentShardContentChanged) {
+    TempDir tmp;
+    tmp.touch("a.cpp", "int edited;");
+
     Workspace workspace;
     SessionStore store;
-    auto closed = workspace.file_table.intern("/proj/a.cpp");
+    auto closed = workspace.file_table.intern(tmp.path("a.cpp"));
     workspace.shards[closed] = shard_of("int x;");
 
     ContextResolver resolver(workspace);
     // Disk holds edits the shard never saw (saved while open): the shard's
     // rows describe text that no longer exists.
     PCMHarness ph(workspace, resolver);
-    Invalidator invalidator(workspace, store, resolver, ph.pcm, [](llvm::StringRef) {
-        return std::optional<std::string>{"int edited;"};
-    });
+    Invalidator invalidator(workspace, store, resolver, ph.pcm);
     auto dirty = invalidator.apply(FileEvent::buffer_closed(closed));
 
     ASSERT_EQ(dirty.reindex_content_changed, llvm::SmallVector<std::uint32_t>{closed});
@@ -393,9 +397,12 @@ TEST_CASE(CloseStaleModuleCascades) {
     // An external rewrite consumed while the interface was open skipped the
     // module cascade (buffer authoritative) and the tracker will not refire:
     // the close must deliver it, or importers keep the pre-change PCM.
+    TempDir tmp;
+    tmp.touch("m.cppm", "export module m;\nexport int v2();\n");
+
     Workspace workspace;
     SessionStore store;
-    auto mod = workspace.file_table.intern("/proj/m.cppm");
+    auto mod = workspace.file_table.intern(tmp.path("m.cppm"));
     auto user = workspace.file_table.intern("/proj/user.cpp");
     workspace.shards[mod] = shard_of("export module m;\nexport int v1();\n");
     workspace.pcm_cache[mod] = {
@@ -412,9 +419,7 @@ TEST_CASE(CloseStaleModuleCascades) {
             user
     },
         {{pcm_family, mod}});
-    Invalidator invalidator(workspace, store, resolver, ph.pcm, [](llvm::StringRef) {
-        return std::optional<std::string>{"export module m;\nexport int v2();\n"};
-    });
+    Invalidator invalidator(workspace, store, resolver, ph.pcm);
     auto dirty = invalidator.apply(FileEvent::buffer_closed(mod));
 
     EXPECT_TRUE(llvm::is_contained(dirty.reindex_content_changed, mod));
@@ -456,9 +461,12 @@ TEST_CASE(DeferredDiskChangeCascades) {
     // dependent cascade to the close, and an agent-mode reindex can
     // refresh the shard from the rewritten disk before then: a current
     // shard must not hide the recorded debt from the close.
+    TempDir tmp;
+    tmp.touch("h.h", "int rewritten;");
+
     Workspace workspace;
     SessionStore store;
-    auto header = workspace.file_table.intern("/proj/h.h");
+    auto header = workspace.file_table.intern(tmp.path("h.h"));
     auto tu = workspace.file_table.intern("/proj/a.cpp");
     workspace.dep_graph.set_includes(tu, 0, {header});
     workspace.dep_graph.build_reverse_map();
@@ -467,9 +475,7 @@ TEST_CASE(DeferredDiskChangeCascades) {
 
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
-    Invalidator invalidator(workspace, store, resolver, ph.pcm, [](llvm::StringRef) {
-        return std::optional<std::string>{"int rewritten;"};
-    });
+    Invalidator invalidator(workspace, store, resolver, ph.pcm);
 
     auto deferred = invalidator.apply(FileEvent::disk_changed(header));
     ASSERT_TRUE(deferred.reindex_deps_only.empty());
@@ -572,9 +578,12 @@ TEST_CASE(CloseStalePCMCascades) {
     // was open, so the shard is current — but the PCM consumed bytes the
     // disk no longer holds. The artifact's deps snapshot is the judge, and
     // the current shard keeps serving (deps-only).
+    TempDir tmp;
+    tmp.touch("m.cppm", "export module m;\nexport int v2();\n");
+
     Workspace workspace;
     SessionStore store;
-    auto mod = workspace.file_table.intern("/proj/m.cppm");
+    auto mod = workspace.file_table.intern(tmp.path("m.cppm"));
     auto user = workspace.file_table.intern("/proj/user.cpp");
     workspace.shards[mod] = shard_of("export module m;\nexport int v2();\n");
     workspace.pcm_cache[mod] = {
@@ -591,9 +600,7 @@ TEST_CASE(CloseStalePCMCascades) {
             user
     },
         {{pcm_family, mod}});
-    Invalidator invalidator(workspace, store, resolver, ph.pcm, [](llvm::StringRef) {
-        return std::optional<std::string>{"export module m;\nexport int v2();\n"};
-    });
+    Invalidator invalidator(workspace, store, resolver, ph.pcm);
     auto dirty = invalidator.apply(FileEvent::buffer_closed(mod));
 
     llvm::SmallVector<std::uint32_t> reindexed{mod, user};
@@ -658,18 +665,19 @@ TEST_CASE(BatchSavesDeduplicate) {
 }
 
 TEST_CASE(SaveDivergentDiskDirties) {
+    TempDir tmp;
+    tmp.touch("a.h", "int disk;");
+
     Workspace workspace;
     SessionStore store;
-    auto saved = workspace.file_table.intern("/proj/a.h");
+    auto saved = workspace.file_table.intern(tmp.path("a.h"));
     auto session = store.open(saved);
     store.apply_open(*session, "int buffer;", 1);
 
     ContextResolver resolver(workspace);
     // A save hook rewrote the file as it landed: disk != buffer.
     PCMHarness ph(workspace, resolver);
-    Invalidator invalidator(workspace, store, resolver, ph.pcm, [](llvm::StringRef) {
-        return std::optional<std::string>{"int disk;"};
-    });
+    Invalidator invalidator(workspace, store, resolver, ph.pcm);
     auto dirty = invalidator.apply(FileEvent::buffer_saved(saved));
 
     // The session recompiles so its deps snapshot re-validates against the
@@ -678,9 +686,10 @@ TEST_CASE(SaveDivergentDiskDirties) {
 }
 
 TEST_CASE(SaveUnreadableDiskDirties) {
+    TempDir tmp;
     Workspace workspace;
     SessionStore store;
-    auto saved = workspace.file_table.intern("/proj/a.h");
+    auto saved = workspace.file_table.intern(tmp.path("a.h"));
     auto session = store.open(saved);
     store.apply_open(*session, "int buffer;", 1);
 
@@ -688,9 +697,7 @@ TEST_CASE(SaveUnreadableDiskDirties) {
     // The file cannot be read back after the save: the disk state is
     // unknown, which is treated as divergent (conservative).
     PCMHarness ph(workspace, resolver);
-    Invalidator invalidator(workspace, store, resolver, ph.pcm, [](llvm::StringRef) {
-        return std::optional<std::string>{};
-    });
+    Invalidator invalidator(workspace, store, resolver, ph.pcm);
     auto dirty = invalidator.apply(FileEvent::buffer_saved(saved));
 
     ASSERT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<std::uint32_t>{saved});
@@ -837,15 +844,14 @@ TEST_CASE(EntryChangeThenRemoval) {
 }
 
 TEST_CASE(CloseOfDeletedFile) {
+    TempDir tmp;
     Workspace workspace;
     SessionStore store;
-    auto file = workspace.file_table.intern("/proj/gone.cpp");
+    auto file = workspace.file_table.intern(tmp.path("gone.cpp"));
     ContextResolver resolver(workspace);
     // Disk read fails: the file vanished while it was open.
     PCMHarness ph(workspace, resolver);
-    Invalidator invalidator(workspace, store, resolver, ph.pcm, [](llvm::StringRef) {
-        return std::optional<std::string>{};
-    });
+    Invalidator invalidator(workspace, store, resolver, ph.pcm);
 
     auto dirty = invalidator.apply(FileEvent::buffer_closed(file));
 

--- a/tests/unit/server/invalidator_tests.cpp
+++ b/tests/unit/server/invalidator_tests.cpp
@@ -86,8 +86,8 @@ TEST_CASE(NewProviderDirtiesImporters) {
 
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
-    ph.graph.declare({turun_family, closed}, {PCMFamily::unresolved_node("m")});
-    ph.graph.declare({ast_family, open}, {PCMFamily::unresolved_node("m")});
+    ph.graph.declare({turun_family, closed.raw}, {PCMFamily::unresolved_node("m")});
+    ph.graph.declare({ast_family, open.raw}, {PCMFamily::unresolved_node("m")});
     Invalidator invalidator(workspace, store, resolver, ph.pcm);
 
     FileEvent events[] = {FileEvent::disk_changed(iface)};
@@ -124,7 +124,7 @@ TEST_CASE(ReloadProviderCascades) {
 
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
-    ph.graph.declare({turun_family, retired}, {PCMFamily::unresolved_node("m")});
+    ph.graph.declare({turun_family, retired.raw}, {PCMFamily::unresolved_node("m")});
     Invalidator invalidator(workspace, store, resolver, ph.pcm);
 
     FileEvent::CDBDelta delta;
@@ -192,8 +192,8 @@ TEST_CASE(SaveResetsTrialOnly) {
 
     // The saved file itself is not stale — its buffer was already current —
     // only its self-containment verdict needs re-evaluation.
-    ASSERT_EQ(dirty.reset_trial, llvm::SmallVector<std::uint32_t>{saved});
-    ASSERT_EQ(dirty.reset_header_mode, llvm::SmallVector<std::uint32_t>{saved});
+    ASSERT_EQ(dirty.reset_trial, llvm::SmallVector<Fid>{saved});
+    ASSERT_EQ(dirty.reset_header_mode, llvm::SmallVector<Fid>{saved});
     ASSERT_TRUE(dirty.mark_ast_dirty.empty());
     ASSERT_TRUE(dirty.force_revalidate.empty());
     ASSERT_TRUE(dirty.recheck_contexts);
@@ -210,8 +210,8 @@ TEST_CASE(CascadeSplitsOpenClosed) {
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
     // The consumer edges build_deps declares in production — no rounds.
-    auto node = [](std::uint32_t pid) {
-        return NodeId{pcm_family, pid};
+    auto node = [](Fid pid) {
+        return NodeId{pcm_family, pid.raw};
     };
     ph.graph.declare(node(open_user), {node(mod)});
     ph.graph.declare(node(closed_user), {node(mod)});
@@ -223,8 +223,8 @@ TEST_CASE(CascadeSplitsOpenClosed) {
 
     // Cascade-dirtied module units split by session state: open buffers
     // recompile, closed files go back to the background indexer.
-    EXPECT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<std::uint32_t>{open_user});
-    llvm::SmallVector<std::uint32_t> reindexed{mod, closed_user};
+    EXPECT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<Fid>{open_user});
+    llvm::SmallVector<Fid> reindexed{mod, closed_user};
     llvm::sort(reindexed);
     EXPECT_EQ(dirty.reindex_deps_only, reindexed);
     EXPECT_TRUE(dirty.reindex_content_changed.empty());
@@ -253,14 +253,14 @@ TEST_CASE(ChainHitAndMiss) {
     // Every context embedding the saved file re-validates and drops its
     // verdict; a closed one additionally reindexes in the background — its
     // shard rows were built under the old chain.
-    llvm::SmallVector<std::uint32_t> revalidated{hit, closed};
+    llvm::SmallVector<Fid> revalidated{hit, closed};
     llvm::sort(revalidated);
     ASSERT_EQ(dirty.force_revalidate, revalidated);
-    llvm::SmallVector<std::uint32_t> reset{saved, hit, closed};
+    llvm::SmallVector<Fid> reset{saved, hit, closed};
     llvm::sort(reset);
     ASSERT_EQ(dirty.reset_header_mode, reset);
     // The closed header's own content did not change — only its chain did.
-    ASSERT_EQ(dirty.reindex_deps_only, llvm::SmallVector<std::uint32_t>{closed});
+    ASSERT_EQ(dirty.reindex_deps_only, llvm::SmallVector<Fid>{closed});
     ASSERT_TRUE(dirty.reindex_content_changed.empty());
 }
 
@@ -270,8 +270,8 @@ TEST_CASE(SaveMarksDependents) {
     auto header = workspace.file_table.intern("/proj/h.h");
     auto open_tu = workspace.file_table.intern("/proj/a.cpp");
     auto closed_tu = workspace.file_table.intern("/proj/b.cpp");
-    workspace.dep_graph.set_includes(open_tu, 0, {header});
-    workspace.dep_graph.set_includes(closed_tu, 0, {header});
+    workspace.dep_graph.set_includes(open_tu, 0, {{header}});
+    workspace.dep_graph.set_includes(closed_tu, 0, {{header}});
     workspace.dep_graph.build_reverse_map();
     store.open(open_tu);
 
@@ -283,8 +283,8 @@ TEST_CASE(SaveMarksDependents) {
     // Open dependents recompile, closed ones reindex; the old/new dependent
     // snapshots overlap fully here, so this also proves the dedup. A
     // dependent's own content did not change: deps-only.
-    ASSERT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<std::uint32_t>{open_tu});
-    ASSERT_EQ(dirty.reindex_deps_only, llvm::SmallVector<std::uint32_t>{closed_tu});
+    ASSERT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<Fid>{open_tu});
+    ASSERT_EQ(dirty.reindex_deps_only, llvm::SmallVector<Fid>{closed_tu});
     ASSERT_TRUE(dirty.reindex_content_changed.empty());
 }
 
@@ -294,8 +294,8 @@ TEST_CASE(TransitiveDependentsEnqueue) {
     auto header = workspace.file_table.intern("/proj/h.h");
     auto middle = workspace.file_table.intern("/proj/g.h");
     auto root = workspace.file_table.intern("/proj/c.cpp");
-    workspace.dep_graph.set_includes(middle, 0, {header});
-    workspace.dep_graph.set_includes(root, 0, {middle});
+    workspace.dep_graph.set_includes(middle, 0, {{header}});
+    workspace.dep_graph.set_includes(root, 0, {{middle}});
     workspace.dep_graph.build_reverse_map();
 
     ContextResolver resolver(workspace);
@@ -304,7 +304,7 @@ TEST_CASE(TransitiveDependentsEnqueue) {
     auto dirty = invalidator.apply(FileEvent::buffer_saved(header));
 
     // Only root TUs own index shards; the intermediate header is not one.
-    ASSERT_EQ(dirty.reindex_deps_only, llvm::SmallVector<std::uint32_t>{root});
+    ASSERT_EQ(dirty.reindex_deps_only, llvm::SmallVector<Fid>{root});
     ASSERT_TRUE(dirty.reindex_content_changed.empty());
     ASSERT_TRUE(dirty.mark_ast_dirty.empty());
 }
@@ -315,18 +315,18 @@ TEST_CASE(StaleReverseMapUnion) {
     auto header = workspace.file_table.intern("/proj/h.h");
     auto known = workspace.file_table.intern("/proj/a.cpp");
     auto unmapped = workspace.file_table.intern("/proj/b.cpp");
-    workspace.dep_graph.set_includes(known, 0, {header});
+    workspace.dep_graph.set_includes(known, 0, {{header}});
     workspace.dep_graph.build_reverse_map();
     // Edge added without rebuilding the reverse map: visible only after the
     // save's rescan rebuilds it. Both snapshots must contribute.
-    workspace.dep_graph.set_includes(unmapped, 0, {header});
+    workspace.dep_graph.set_includes(unmapped, 0, {{header}});
 
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
     Invalidator invalidator(workspace, store, resolver, ph.pcm);
     auto dirty = invalidator.apply(FileEvent::buffer_saved(header));
 
-    llvm::SmallVector<std::uint32_t> expected{known, unmapped};
+    llvm::SmallVector<Fid> expected{known, unmapped};
     llvm::sort(expected);
     ASSERT_EQ(dirty.reindex_deps_only, expected);
     ASSERT_TRUE(dirty.reindex_content_changed.empty());
@@ -347,7 +347,7 @@ TEST_CASE(CloseWithoutShardReindexes) {
     auto dirty = invalidator.apply(FileEvent::buffer_closed(closed));
 
     // No shard to compare against: nothing serves this file's rows anyway.
-    ASSERT_EQ(dirty.reindex_content_changed, llvm::SmallVector<std::uint32_t>{closed});
+    ASSERT_EQ(dirty.reindex_content_changed, llvm::SmallVector<Fid>{closed});
     ASSERT_TRUE(dirty.reindex_deps_only.empty());
     ASSERT_TRUE(dirty.reschedule_indexing);
     ASSERT_TRUE(dirty.mark_ast_dirty.empty());
@@ -369,7 +369,7 @@ TEST_CASE(CloseCurrentShardDepsOnly) {
     Invalidator invalidator(workspace, store, resolver, ph.pcm);
     auto dirty = invalidator.apply(FileEvent::buffer_closed(closed));
 
-    ASSERT_EQ(dirty.reindex_deps_only, llvm::SmallVector<std::uint32_t>{closed});
+    ASSERT_EQ(dirty.reindex_deps_only, llvm::SmallVector<Fid>{closed});
     ASSERT_TRUE(dirty.reindex_content_changed.empty());
 }
 
@@ -389,7 +389,7 @@ TEST_CASE(CloseDivergentShardContentChanged) {
     Invalidator invalidator(workspace, store, resolver, ph.pcm);
     auto dirty = invalidator.apply(FileEvent::buffer_closed(closed));
 
-    ASSERT_EQ(dirty.reindex_content_changed, llvm::SmallVector<std::uint32_t>{closed});
+    ASSERT_EQ(dirty.reindex_content_changed, llvm::SmallVector<Fid>{closed});
     ASSERT_TRUE(dirty.reindex_deps_only.empty());
 }
 
@@ -408,7 +408,7 @@ TEST_CASE(CloseStaleModuleCascades) {
     workspace.pcm_cache[mod] = {
         .path = "/cache/m.pcm",
         .key = "k",
-        .deps = {.deps = {DepState{.path_id = mod, .missing = true}}},
+        .deps = {DepState{.path_id = mod, .missing = true}},
     };
 
     ContextResolver resolver(workspace);
@@ -416,9 +416,9 @@ TEST_CASE(CloseStaleModuleCascades) {
     ph.graph.declare(
         {
             turun_family,
-            user
+            user.raw
     },
-        {{pcm_family, mod}});
+        {{pcm_family, mod.raw}});
     Invalidator invalidator(workspace, store, resolver, ph.pcm);
     auto dirty = invalidator.apply(FileEvent::buffer_closed(mod));
 
@@ -440,7 +440,7 @@ TEST_CASE(CloseRefreshesEdges) {
     auto file = workspace.file_table.intern(tmp.path("a.cpp"));
     auto old_header = workspace.file_table.intern("/proj/old.h");
     auto new_header = workspace.file_table.intern(tmp.path("new.h"));
-    workspace.dep_graph.set_includes(file, 0, {old_header});
+    workspace.dep_graph.set_includes(file, 0, {{old_header}});
     workspace.dep_graph.build_reverse_map();
 
     auto disk = llvm::MemoryBuffer::getFile(tmp.path("a.cpp"));
@@ -468,7 +468,7 @@ TEST_CASE(DeferredDiskChangeCascades) {
     SessionStore store;
     auto header = workspace.file_table.intern(tmp.path("h.h"));
     auto tu = workspace.file_table.intern("/proj/a.cpp");
-    workspace.dep_graph.set_includes(tu, 0, {header});
+    workspace.dep_graph.set_includes(tu, 0, {{header}});
     workspace.dep_graph.build_reverse_map();
     workspace.shards[header] = shard_of("int rewritten;");
     store.open(header);
@@ -506,7 +506,7 @@ TEST_CASE(CloseFirstProviderCascades) {
 
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
-    ph.graph.declare({turun_family, importer}, {PCMFamily::unresolved_node("m")});
+    ph.graph.declare({turun_family, importer.raw}, {PCMFamily::unresolved_node("m")});
     Invalidator invalidator(workspace, store, resolver, ph.pcm);
 
     auto dirty = invalidator.apply(FileEvent::buffer_closed(iface));
@@ -537,9 +537,9 @@ TEST_CASE(CloseProviderRenameCascades) {
     ph.graph.declare(
         {
             turun_family,
-            importer
+            importer.raw
     },
-        {{pcm_family, iface}});
+        {{pcm_family, iface.raw}});
     Invalidator invalidator(workspace, store, resolver, ph.pcm);
 
     auto dirty = invalidator.apply(FileEvent::buffer_closed(iface));
@@ -589,7 +589,8 @@ TEST_CASE(CloseStalePCMCascades) {
     workspace.pcm_cache[mod] = {
         .path = "/cache/m.pcm",
         .key = "k",
-        .deps = {.deps = {DepState{.path_id = mod, .hash = 1234}}},
+        .deps = {DepState{.path_id = mod,
+                          .version = workspace.file_table.intern_version(mod, 1234)}},
     };
 
     ContextResolver resolver(workspace);
@@ -597,13 +598,13 @@ TEST_CASE(CloseStalePCMCascades) {
     ph.graph.declare(
         {
             turun_family,
-            user
+            user.raw
     },
-        {{pcm_family, mod}});
+        {{pcm_family, mod.raw}});
     Invalidator invalidator(workspace, store, resolver, ph.pcm);
     auto dirty = invalidator.apply(FileEvent::buffer_closed(mod));
 
-    llvm::SmallVector<std::uint32_t> reindexed{mod, user};
+    llvm::SmallVector<Fid> reindexed{mod, user};
     llvm::sort(reindexed);
     EXPECT_EQ(dirty.reindex_deps_only, reindexed);
     EXPECT_TRUE(dirty.reindex_content_changed.empty());
@@ -621,10 +622,10 @@ TEST_CASE(CrashMarksLostDirty) {
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
     Invalidator invalidator(workspace, store, resolver, ph.pcm);
-    std::uint32_t lost[] = {first, second};
+    Fid lost[] = {first, second};
     auto dirty = invalidator.apply(FileEvent::worker_crashed(lost));
 
-    llvm::SmallVector<std::uint32_t> expected{first, second};
+    llvm::SmallVector<Fid> expected{first, second};
     llvm::sort(expected);
     ASSERT_EQ(dirty.mark_lost, expected);
     // A crash loses build products, not compile inputs: no trial reset.
@@ -644,7 +645,7 @@ TEST_CASE(EvictionMarksLost) {
     auto dirty = invalidator.apply(FileEvent::document_evicted(file));
 
     // Same loss as a crash, scoped to one document.
-    ASSERT_EQ(dirty.mark_lost, llvm::SmallVector<std::uint32_t>{file});
+    ASSERT_EQ(dirty.mark_lost, llvm::SmallVector<Fid>{file});
     ASSERT_TRUE(dirty.mark_ast_dirty.empty());
     ASSERT_TRUE(dirty.reset_trial.empty());
 }
@@ -661,7 +662,7 @@ TEST_CASE(BatchSavesDeduplicate) {
     FileEvent events[] = {FileEvent::buffer_saved(saved), FileEvent::buffer_saved(saved)};
     auto dirty = invalidator.apply(events);
 
-    ASSERT_EQ(dirty.reset_trial, llvm::SmallVector<std::uint32_t>{saved});
+    ASSERT_EQ(dirty.reset_trial, llvm::SmallVector<Fid>{saved});
 }
 
 TEST_CASE(SaveDivergentDiskDirties) {
@@ -682,7 +683,7 @@ TEST_CASE(SaveDivergentDiskDirties) {
 
     // The session recompiles so its deps snapshot re-validates against the
     // rewritten disk instead of describing a state that no longer exists.
-    ASSERT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<std::uint32_t>{saved});
+    ASSERT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<Fid>{saved});
 }
 
 TEST_CASE(SaveUnreadableDiskDirties) {
@@ -701,7 +702,7 @@ TEST_CASE(SaveUnreadableDiskDirties) {
     Invalidator invalidator(workspace, store, resolver, ph.pcm);
     auto dirty = invalidator.apply(FileEvent::buffer_saved(saved));
 
-    ASSERT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<std::uint32_t>{saved});
+    ASSERT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<Fid>{saved});
 }
 
 TEST_CASE(DiskChangeOpenMarksDirty) {
@@ -719,8 +720,8 @@ TEST_CASE(DiskChangeOpenMarksDirty) {
     // compile's deps validation judges the disk change, but no rescan and
     // no cascade. The file's shard describes the old disk, so its reindex
     // queues alongside (skipped while open-file indexing is off).
-    ASSERT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<std::uint32_t>{open_file});
-    ASSERT_EQ(dirty.reindex_content_changed, llvm::SmallVector<std::uint32_t>{open_file});
+    ASSERT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<Fid>{open_file});
+    ASSERT_EQ(dirty.reindex_content_changed, llvm::SmallVector<Fid>{open_file});
     ASSERT_TRUE(dirty.reindex_deps_only.empty());
     ASSERT_TRUE(dirty.reset_trial.empty());
     ASSERT_FALSE(dirty.recheck_contexts);
@@ -732,8 +733,8 @@ TEST_CASE(DiskChangeClosedCascades) {
     auto header = workspace.file_table.intern("/proj/h.h");
     auto open_tu = workspace.file_table.intern("/proj/a.cpp");
     auto closed_tu = workspace.file_table.intern("/proj/b.cpp");
-    workspace.dep_graph.set_includes(open_tu, 0, {header});
-    workspace.dep_graph.set_includes(closed_tu, 0, {header});
+    workspace.dep_graph.set_includes(open_tu, 0, {{header}});
+    workspace.dep_graph.set_includes(closed_tu, 0, {{header}});
     workspace.dep_graph.build_reverse_map();
     store.open(open_tu);
 
@@ -745,10 +746,10 @@ TEST_CASE(DiskChangeClosedCascades) {
     // A closed file's disk change cascades exactly like a save, plus the
     // file's own stale shard is refreshed. The changed file's own rows are
     // untrustworthy; its dependent only rebuilds semantics.
-    ASSERT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<std::uint32_t>{open_tu});
-    ASSERT_EQ(dirty.reindex_content_changed, llvm::SmallVector<std::uint32_t>{header});
-    ASSERT_EQ(dirty.reindex_deps_only, llvm::SmallVector<std::uint32_t>{closed_tu});
-    ASSERT_EQ(dirty.reset_trial, llvm::SmallVector<std::uint32_t>{header});
+    ASSERT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<Fid>{open_tu});
+    ASSERT_EQ(dirty.reindex_content_changed, llvm::SmallVector<Fid>{header});
+    ASSERT_EQ(dirty.reindex_deps_only, llvm::SmallVector<Fid>{closed_tu});
+    ASSERT_EQ(dirty.reset_trial, llvm::SmallVector<Fid>{header});
     ASSERT_TRUE(dirty.recheck_contexts);
     ASSERT_TRUE(dirty.reschedule_indexing);
 }
@@ -759,8 +760,8 @@ TEST_CASE(DiskRemovedScrubsSourceRole) {
     auto header = workspace.file_table.intern("/proj/h.h");
     auto removed_tu = workspace.file_table.intern("/proj/gone.cpp");
     auto other_tu = workspace.file_table.intern("/proj/kept.cpp");
-    workspace.dep_graph.set_includes(removed_tu, 0, {header});
-    workspace.dep_graph.set_includes(other_tu, 0, {header});
+    workspace.dep_graph.set_includes(removed_tu, 0, {{header}});
+    workspace.dep_graph.set_includes(other_tu, 0, {{header}});
     workspace.dep_graph.build_reverse_map();
     auto epoch = workspace.context_epoch;
 
@@ -771,7 +772,7 @@ TEST_CASE(DiskRemovedScrubsSourceRole) {
 
     // The removed file stops being an includer (and thus a host-source
     // candidate); surviving includers are untouched, shards are kept.
-    ASSERT_EQ(workspace.dep_graph.get_includers(header), llvm::ArrayRef<std::uint32_t>{other_tu});
+    ASSERT_EQ(workspace.dep_graph.get_includers(header), llvm::ArrayRef<Fid>{other_tu});
     ASSERT_TRUE(workspace.dep_graph.get_all_includes(removed_tu).empty());
     ASSERT_TRUE(dirty.recheck_contexts);
     ASSERT_TRUE(dirty.reindex_content_changed.empty());
@@ -781,7 +782,7 @@ TEST_CASE(DiskRemovedScrubsSourceRole) {
     // The removal clears any pending-reindex state recorded earlier (e.g. a
     // DiskChanged observed just before deletion): the shard keeps serving
     // and nothing is left to reindex.
-    ASSERT_EQ(dirty.clear_reindex, llvm::SmallVector<std::uint32_t>{removed_tu});
+    ASSERT_EQ(dirty.clear_reindex, llvm::SmallVector<Fid>{removed_tu});
 }
 
 TEST_CASE(RemoveRecreateBatchOrder) {
@@ -800,7 +801,7 @@ TEST_CASE(RemoveRecreateBatchOrder) {
         auto dirty = invalidator.apply(events);
         ASSERT_TRUE(llvm::find(dirty.reindex_content_changed, file) ==
                     dirty.reindex_content_changed.end());
-        ASSERT_EQ(dirty.clear_reindex, llvm::SmallVector<std::uint32_t>{file});
+        ASSERT_EQ(dirty.clear_reindex, llvm::SmallVector<Fid>{file});
     }
 
     // Delete then recreate (an editor's atomic save): the later change must
@@ -841,7 +842,7 @@ TEST_CASE(EntryChangeThenRemoval) {
     // surviving drop would mask the shard and let the next save retire it.
     ASSERT_TRUE(dirty.drop_index.empty());
     ASSERT_TRUE(dirty.reindex_content_changed.empty());
-    ASSERT_EQ(dirty.clear_reindex, llvm::SmallVector<std::uint32_t>{file});
+    ASSERT_EQ(dirty.clear_reindex, llvm::SmallVector<Fid>{file});
 }
 
 TEST_CASE(CloseOfDeletedFile) {
@@ -859,7 +860,7 @@ TEST_CASE(CloseOfDeletedFile) {
     // The close is the first observation of the removal (the tracker skips
     // open files): keep any shard serving, do not record ContentChanged,
     // do not enqueue a nonexistent file.
-    ASSERT_EQ(dirty.clear_reindex, llvm::SmallVector<std::uint32_t>{file});
+    ASSERT_EQ(dirty.clear_reindex, llvm::SmallVector<Fid>{file});
     ASSERT_TRUE(dirty.reindex_content_changed.empty());
     ASSERT_TRUE(dirty.reindex_deps_only.empty());
 }
@@ -887,9 +888,9 @@ TEST_CASE(CDBAddedScansAndEnqueues) {
 
     // The rescan resolved the new entry's includes; the new file reindexes.
     // A command change rewrites rows as thoroughly as an edit.
-    ASSERT_EQ(workspace.dep_graph.get_includers(header_id), llvm::ArrayRef<std::uint32_t>{main_id});
-    ASSERT_EQ(dirty.reindex_content_changed, llvm::SmallVector<std::uint32_t>{main_id});
-    ASSERT_EQ(dirty.drop_index, llvm::SmallVector<std::uint32_t>{main_id});
+    ASSERT_EQ(workspace.dep_graph.get_includers(header_id), llvm::ArrayRef<Fid>{main_id});
+    ASSERT_EQ(dirty.reindex_content_changed, llvm::SmallVector<Fid>{main_id});
+    ASSERT_EQ(dirty.drop_index, llvm::SmallVector<Fid>{main_id});
     ASSERT_TRUE(dirty.reindex_deps_only.empty());
     ASSERT_TRUE(dirty.recheck_contexts);
 }
@@ -921,8 +922,8 @@ TEST_CASE(CDBChangedSplitsOpenClosed) {
 
     // Flag changes recompile open files and reindex closed ones; the
     // pull-side cache keys (canonical flags) miss on their own.
-    ASSERT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<std::uint32_t>{open_id});
-    llvm::SmallVector<std::uint32_t> reindexed{open_id, closed_id};
+    ASSERT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<Fid>{open_id});
+    llvm::SmallVector<Fid> reindexed{open_id, closed_id};
     llvm::sort(reindexed);
     auto content_changed = dirty.reindex_content_changed;
     llvm::sort(content_changed);
@@ -957,9 +958,9 @@ TEST_CASE(CDBAddedOpenMarksDirty) {
     // The open file gained its first real entry: drop the guessed command
     // it was compiled with, and queue the reindex that builds its shard
     // under the real command once open-file indexing is on.
-    ASSERT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<std::uint32_t>{file});
-    ASSERT_EQ(dirty.reindex_content_changed, llvm::SmallVector<std::uint32_t>{file});
-    ASSERT_EQ(dirty.drop_index, llvm::SmallVector<std::uint32_t>{file});
+    ASSERT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<Fid>{file});
+    ASSERT_EQ(dirty.reindex_content_changed, llvm::SmallVector<Fid>{file});
+    ASSERT_EQ(dirty.drop_index, llvm::SmallVector<Fid>{file});
     ASSERT_TRUE(dirty.reindex_deps_only.empty());
 }
 
@@ -976,7 +977,7 @@ TEST_CASE(CDBChangedDropsHostedContext) {
     ContextResolver resolver(workspace);
     resolver.header_contexts[open_header].host_path_id = host;
     resolver.header_contexts[closed_header].host_path_id = host;
-    resolver.header_contexts[other_header].host_path_id = no_path_id;
+    resolver.header_contexts[other_header].host_path_id = Fid{};
     PCMHarness ph(workspace, resolver);
     Invalidator invalidator(workspace, store, resolver, ph.pcm);
     FileEvent::CDBDelta delta;
@@ -987,10 +988,10 @@ TEST_CASE(CDBChangedDropsHostedContext) {
     // open one recompiles, the closed one reindexes. Any standalone index
     // of theirs borrowed the changed command too, so it is dropped along
     // with the host's. Unrelated contexts are untouched.
-    llvm::SmallVector<std::uint32_t> dropped{open_header, closed_header};
+    llvm::SmallVector<Fid> dropped{open_header, closed_header};
     llvm::sort(dropped);
     ASSERT_EQ(dirty.drop_context, dropped);
-    llvm::SmallVector<std::uint32_t> evicted{host, open_header, closed_header};
+    llvm::SmallVector<Fid> evicted{host, open_header, closed_header};
     llvm::sort(evicted);
     auto drop = dirty.drop_index;
     llvm::sort(drop);
@@ -1010,8 +1011,8 @@ TEST_CASE(CDBChangedCascadesModule) {
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
     // The consumer edges build_deps declares in production — no rounds.
-    auto node = [](std::uint32_t pid) {
-        return NodeId{pcm_family, pid};
+    auto node = [](Fid pid) {
+        return NodeId{pcm_family, pid.raw};
     };
     ph.graph.declare(node(open_user), {node(mod)});
     ph.graph.declare(node(closed_user), {node(mod)});
@@ -1028,10 +1029,10 @@ TEST_CASE(CDBChangedCascadesModule) {
     // unit itself lands in both lists (its own entry changed AND the
     // cascade dirtied its PCM); the indexer's absorbing upgrade
     // resolves the overlap to ContentChanged.
-    EXPECT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<std::uint32_t>{open_user});
-    EXPECT_EQ(dirty.reindex_content_changed, llvm::SmallVector<std::uint32_t>{mod});
-    EXPECT_EQ(dirty.drop_index, llvm::SmallVector<std::uint32_t>{mod});
-    llvm::SmallVector<std::uint32_t> deps{mod, closed_user};
+    EXPECT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<Fid>{open_user});
+    EXPECT_EQ(dirty.reindex_content_changed, llvm::SmallVector<Fid>{mod});
+    EXPECT_EQ(dirty.drop_index, llvm::SmallVector<Fid>{mod});
+    llvm::SmallVector<Fid> deps{mod, closed_user};
     llvm::sort(deps);
     EXPECT_EQ(dirty.reindex_deps_only, deps);
 }
@@ -1042,8 +1043,8 @@ TEST_CASE(DiskRemovedReindexesIncluders) {
     auto header = workspace.file_table.intern("/proj/h.h");
     auto open_tu = workspace.file_table.intern("/proj/a.cpp");
     auto closed_tu = workspace.file_table.intern("/proj/b.cpp");
-    workspace.dep_graph.set_includes(open_tu, 0, {header});
-    workspace.dep_graph.set_includes(closed_tu, 0, {header});
+    workspace.dep_graph.set_includes(open_tu, 0, {{header}});
+    workspace.dep_graph.set_includes(closed_tu, 0, {{header}});
     workspace.dep_graph.build_reverse_map();
     store.open(open_tu);
 
@@ -1054,8 +1055,8 @@ TEST_CASE(DiskRemovedReindexesIncluders) {
 
     // Dependents now compile against a missing include: open ones
     // recompile, closed ones reindex.
-    ASSERT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<std::uint32_t>{open_tu});
-    ASSERT_EQ(dirty.reindex_deps_only, llvm::SmallVector<std::uint32_t>{closed_tu});
+    ASSERT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<Fid>{open_tu});
+    ASSERT_EQ(dirty.reindex_deps_only, llvm::SmallVector<Fid>{closed_tu});
     ASSERT_TRUE(dirty.reindex_content_changed.empty());
     ASSERT_TRUE(dirty.recheck_contexts);
 }
@@ -1071,7 +1072,7 @@ TEST_CASE(CDBRemovedDropsSourceRole) {
     // already been reloaded without it.
     auto gone_id = workspace.file_table.intern(tmp.path("gone.cpp"));
     auto header_id = workspace.file_table.intern(tmp.path("inc/h.h"));
-    workspace.dep_graph.set_includes(gone_id, 0, {header_id});
+    workspace.dep_graph.set_includes(gone_id, 0, {{header_id}});
     workspace.dep_graph.build_reverse_map();
     auto json = build_cdb_json({
         {tmp.root, tmp.path("kept.cpp"), {}}
@@ -1089,7 +1090,7 @@ TEST_CASE(CDBRemovedDropsSourceRole) {
     // The rebuild resolves includes from the surviving entries only. A
     // removed entry keeps its index — the last-known rows still serve.
     ASSERT_TRUE(workspace.dep_graph.get_all_includes(gone_id).empty());
-    ASSERT_EQ(workspace.dep_graph.get_includers(header_id), llvm::ArrayRef<std::uint32_t>{kept_id});
+    ASSERT_EQ(workspace.dep_graph.get_includers(header_id), llvm::ArrayRef<Fid>{kept_id});
     ASSERT_TRUE(dirty.drop_index.empty());
     ASSERT_TRUE(dirty.recheck_contexts);
 }
@@ -1120,7 +1121,7 @@ TEST_CASE(BatchDiskEventsDeduplicate) {
                           FileEvent::disk_changed(second)};
     auto dirty = invalidator.apply(events);
 
-    llvm::SmallVector<std::uint32_t> expected{first, second};
+    llvm::SmallVector<Fid> expected{first, second};
     llvm::sort(expected);
     ASSERT_EQ(dirty.reindex_content_changed, expected);
     ASSERT_TRUE(dirty.reindex_deps_only.empty());
@@ -1136,7 +1137,7 @@ TEST_CASE(SurvivingEdgeKeepsChoice) {
     ContextResolver resolver(workspace);
     auto host = workspace.file_table.intern("/proj/host.cpp");
     auto header = workspace.file_table.intern("/proj/h.h");
-    workspace.dep_graph.set_includes(host, 0, {header});
+    workspace.dep_graph.set_includes(host, 0, {{header}});
     workspace.dep_graph.build_reverse_map();
 
     auto session = store.open(header);
@@ -1182,7 +1183,7 @@ TEST_CASE(VanishedOccurrenceDropsChoice) {
     tmp.touch("h.h");
     auto host = workspace.file_table.intern(tmp.path("host.cpp"));
     auto header = workspace.file_table.intern(tmp.path("h.h"));
-    workspace.dep_graph.set_includes(host, 0, {header});
+    workspace.dep_graph.set_includes(host, 0, {{header}});
     workspace.dep_graph.build_reverse_map();
 
     store.open(header);

--- a/tests/unit/server/invalidator_tests.cpp
+++ b/tests/unit/server/invalidator_tests.cpp
@@ -79,9 +79,9 @@ TEST_CASE(NewProviderDirtiesImporters) {
 
     Workspace workspace;
     SessionStore store;
-    auto iface = workspace.path_pool.intern(tmp.path("m.cppm"));
-    auto closed = workspace.path_pool.intern("/proj/closed.cpp");
-    auto open = workspace.path_pool.intern("/proj/open.cpp");
+    auto iface = workspace.file_table.intern(tmp.path("m.cppm"));
+    auto closed = workspace.file_table.intern("/proj/closed.cpp");
+    auto open = workspace.file_table.intern("/proj/open.cpp");
     store.open(open);
 
     ContextResolver resolver(workspace);
@@ -119,8 +119,8 @@ TEST_CASE(ReloadProviderCascades) {
               build_cdb_json({
                   {tmp.root, tmp.path("m.cppm"), {}}
     }));
-    auto iface = workspace.path_pool.intern(tmp.path("m.cppm"));
-    auto retired = workspace.path_pool.intern(tmp.path("old.cpp"));
+    auto iface = workspace.file_table.intern(tmp.path("m.cppm"));
+    auto retired = workspace.file_table.intern(tmp.path("old.cpp"));
 
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
@@ -143,7 +143,7 @@ TEST_CASE(DiskRemovedDropsProvider) {
     // the candidate list and never be selected.
     Workspace workspace;
     SessionStore store;
-    auto iface = workspace.path_pool.intern("/proj/m.cppm");
+    auto iface = workspace.file_table.intern("/proj/m.cppm");
     workspace.dep_graph.add_module("m", iface);
     workspace.path_to_module[iface] = "m";
 
@@ -160,7 +160,7 @@ TEST_CASE(DiskRemovedDropsProvider) {
 TEST_CASE(NoOpEventsNoEffects) {
     Workspace workspace;
     SessionStore store;
-    auto file = workspace.path_pool.intern("/proj/a.cpp");
+    auto file = workspace.file_table.intern("/proj/a.cpp");
     store.open(file);
 
     ContextResolver resolver(workspace);
@@ -177,7 +177,7 @@ TEST_CASE(NoOpEventsNoEffects) {
 TEST_CASE(SaveResetsTrialOnly) {
     Workspace workspace;
     SessionStore store;
-    auto saved = workspace.path_pool.intern("/proj/a.h");
+    auto saved = workspace.file_table.intern("/proj/a.h");
     auto session = store.open(saved);
     store.apply_open(*session, "int x;", 1);
 
@@ -202,9 +202,9 @@ TEST_CASE(SaveResetsTrialOnly) {
 TEST_CASE(CascadeSplitsOpenClosed) {
     Workspace workspace;
     SessionStore store;
-    auto mod = workspace.path_pool.intern("/proj/m.cppm");
-    auto open_user = workspace.path_pool.intern("/proj/open_user.cppm");
-    auto closed_user = workspace.path_pool.intern("/proj/closed_user.cppm");
+    auto mod = workspace.file_table.intern("/proj/m.cppm");
+    auto open_user = workspace.file_table.intern("/proj/open_user.cppm");
+    auto closed_user = workspace.file_table.intern("/proj/closed_user.cppm");
 
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
@@ -232,12 +232,12 @@ TEST_CASE(CascadeSplitsOpenClosed) {
 TEST_CASE(ChainHitAndMiss) {
     Workspace workspace;
     SessionStore store;
-    auto saved = workspace.path_pool.intern("/proj/inner.h");
-    auto other = workspace.path_pool.intern("/proj/other.h");
-    auto hit = workspace.path_pool.intern("/proj/hit.h");
-    auto miss = workspace.path_pool.intern("/proj/miss.h");
+    auto saved = workspace.file_table.intern("/proj/inner.h");
+    auto other = workspace.file_table.intern("/proj/other.h");
+    auto hit = workspace.file_table.intern("/proj/hit.h");
+    auto miss = workspace.file_table.intern("/proj/miss.h");
 
-    auto closed = workspace.path_pool.intern("/proj/closed.h");
+    auto closed = workspace.file_table.intern("/proj/closed.h");
     store.open(hit);
     store.open(miss);
 
@@ -266,9 +266,9 @@ TEST_CASE(ChainHitAndMiss) {
 TEST_CASE(SaveMarksDependents) {
     Workspace workspace;
     SessionStore store;
-    auto header = workspace.path_pool.intern("/proj/h.h");
-    auto open_tu = workspace.path_pool.intern("/proj/a.cpp");
-    auto closed_tu = workspace.path_pool.intern("/proj/b.cpp");
+    auto header = workspace.file_table.intern("/proj/h.h");
+    auto open_tu = workspace.file_table.intern("/proj/a.cpp");
+    auto closed_tu = workspace.file_table.intern("/proj/b.cpp");
     workspace.dep_graph.set_includes(open_tu, 0, {header});
     workspace.dep_graph.set_includes(closed_tu, 0, {header});
     workspace.dep_graph.build_reverse_map();
@@ -290,9 +290,9 @@ TEST_CASE(SaveMarksDependents) {
 TEST_CASE(TransitiveDependentsEnqueue) {
     Workspace workspace;
     SessionStore store;
-    auto header = workspace.path_pool.intern("/proj/h.h");
-    auto middle = workspace.path_pool.intern("/proj/g.h");
-    auto root = workspace.path_pool.intern("/proj/c.cpp");
+    auto header = workspace.file_table.intern("/proj/h.h");
+    auto middle = workspace.file_table.intern("/proj/g.h");
+    auto root = workspace.file_table.intern("/proj/c.cpp");
     workspace.dep_graph.set_includes(middle, 0, {header});
     workspace.dep_graph.set_includes(root, 0, {middle});
     workspace.dep_graph.build_reverse_map();
@@ -311,9 +311,9 @@ TEST_CASE(TransitiveDependentsEnqueue) {
 TEST_CASE(StaleReverseMapUnion) {
     Workspace workspace;
     SessionStore store;
-    auto header = workspace.path_pool.intern("/proj/h.h");
-    auto known = workspace.path_pool.intern("/proj/a.cpp");
-    auto unmapped = workspace.path_pool.intern("/proj/b.cpp");
+    auto header = workspace.file_table.intern("/proj/h.h");
+    auto known = workspace.file_table.intern("/proj/a.cpp");
+    auto unmapped = workspace.file_table.intern("/proj/b.cpp");
     workspace.dep_graph.set_includes(known, 0, {header});
     workspace.dep_graph.build_reverse_map();
     // Edge added without rebuilding the reverse map: visible only after the
@@ -334,7 +334,7 @@ TEST_CASE(StaleReverseMapUnion) {
 TEST_CASE(CloseWithoutShardReindexes) {
     Workspace workspace;
     SessionStore store;
-    auto closed = workspace.path_pool.intern("/proj/a.cpp");
+    auto closed = workspace.file_table.intern("/proj/a.cpp");
 
     ContextResolver resolver(workspace);
     // The file exists on disk (injected read), it just was never indexed.
@@ -354,7 +354,7 @@ TEST_CASE(CloseWithoutShardReindexes) {
 TEST_CASE(CloseCurrentShardDepsOnly) {
     Workspace workspace;
     SessionStore store;
-    auto closed = workspace.path_pool.intern("/proj/a.cpp");
+    auto closed = workspace.file_table.intern("/proj/a.cpp");
     workspace.shards[closed] = shard_of("int x;");
 
     ContextResolver resolver(workspace);
@@ -373,7 +373,7 @@ TEST_CASE(CloseCurrentShardDepsOnly) {
 TEST_CASE(CloseDivergentShardContentChanged) {
     Workspace workspace;
     SessionStore store;
-    auto closed = workspace.path_pool.intern("/proj/a.cpp");
+    auto closed = workspace.file_table.intern("/proj/a.cpp");
     workspace.shards[closed] = shard_of("int x;");
 
     ContextResolver resolver(workspace);
@@ -395,8 +395,8 @@ TEST_CASE(CloseStaleModuleCascades) {
     // the close must deliver it, or importers keep the pre-change PCM.
     Workspace workspace;
     SessionStore store;
-    auto mod = workspace.path_pool.intern("/proj/m.cppm");
-    auto user = workspace.path_pool.intern("/proj/user.cpp");
+    auto mod = workspace.file_table.intern("/proj/m.cppm");
+    auto user = workspace.file_table.intern("/proj/user.cpp");
     workspace.shards[mod] = shard_of("export module m;\nexport int v1();\n");
     workspace.pcm_cache[mod] = {
         .path = "/cache/m.pcm",
@@ -432,9 +432,9 @@ TEST_CASE(CloseRefreshesEdges) {
 
     Workspace workspace;
     SessionStore store;
-    auto file = workspace.path_pool.intern(tmp.path("a.cpp"));
-    auto old_header = workspace.path_pool.intern("/proj/old.h");
-    auto new_header = workspace.path_pool.intern(tmp.path("new.h"));
+    auto file = workspace.file_table.intern(tmp.path("a.cpp"));
+    auto old_header = workspace.file_table.intern("/proj/old.h");
+    auto new_header = workspace.file_table.intern(tmp.path("new.h"));
     workspace.dep_graph.set_includes(file, 0, {old_header});
     workspace.dep_graph.build_reverse_map();
 
@@ -458,8 +458,8 @@ TEST_CASE(DeferredDiskChangeCascades) {
     // shard must not hide the recorded debt from the close.
     Workspace workspace;
     SessionStore store;
-    auto header = workspace.path_pool.intern("/proj/h.h");
-    auto tu = workspace.path_pool.intern("/proj/a.cpp");
+    auto header = workspace.file_table.intern("/proj/h.h");
+    auto tu = workspace.file_table.intern("/proj/a.cpp");
     workspace.dep_graph.set_includes(tu, 0, {header});
     workspace.dep_graph.build_reverse_map();
     workspace.shards[header] = shard_of("int rewritten;");
@@ -492,8 +492,8 @@ TEST_CASE(CloseFirstProviderCascades) {
 
     Workspace workspace;
     SessionStore store;
-    auto iface = workspace.path_pool.intern(tmp.path("m.cppm"));
-    auto importer = workspace.path_pool.intern("/proj/use.cpp");
+    auto iface = workspace.file_table.intern(tmp.path("m.cppm"));
+    auto importer = workspace.file_table.intern("/proj/use.cpp");
 
     auto disk = llvm::MemoryBuffer::getFile(tmp.path("m.cppm"));
     workspace.shards[iface] = shard_of((*disk)->getBuffer());
@@ -518,8 +518,8 @@ TEST_CASE(CloseProviderRenameCascades) {
 
     Workspace workspace;
     SessionStore store;
-    auto iface = workspace.path_pool.intern(tmp.path("m.cppm"));
-    auto importer = workspace.path_pool.intern("/proj/use.cpp");
+    auto iface = workspace.file_table.intern(tmp.path("m.cppm"));
+    auto importer = workspace.file_table.intern("/proj/use.cpp");
     workspace.path_to_module[iface] = "a";
     workspace.dep_graph.update_module_decl(iface, "a");
 
@@ -550,7 +550,7 @@ TEST_CASE(CloseKeepsGuardedProvider) {
 
     Workspace workspace;
     SessionStore store;
-    auto iface = workspace.path_pool.intern(tmp.path("m.cpp"));
+    auto iface = workspace.file_table.intern(tmp.path("m.cpp"));
     workspace.path_to_module[iface] = "m";
     workspace.dep_graph.update_module_decl(iface, "m");
 
@@ -574,8 +574,8 @@ TEST_CASE(CloseStalePCMCascades) {
     // the current shard keeps serving (deps-only).
     Workspace workspace;
     SessionStore store;
-    auto mod = workspace.path_pool.intern("/proj/m.cppm");
-    auto user = workspace.path_pool.intern("/proj/user.cpp");
+    auto mod = workspace.file_table.intern("/proj/m.cppm");
+    auto user = workspace.file_table.intern("/proj/user.cpp");
     workspace.shards[mod] = shard_of("export module m;\nexport int v2();\n");
     workspace.pcm_cache[mod] = {
         .path = "/cache/m.pcm",
@@ -606,8 +606,8 @@ TEST_CASE(CloseStalePCMCascades) {
 TEST_CASE(CrashMarksLostDirty) {
     Workspace workspace;
     SessionStore store;
-    auto first = workspace.path_pool.intern("/proj/a.cpp");
-    auto second = workspace.path_pool.intern("/proj/b.cpp");
+    auto first = workspace.file_table.intern("/proj/a.cpp");
+    auto second = workspace.file_table.intern("/proj/b.cpp");
     store.open(first);
     store.open(second);
 
@@ -628,7 +628,7 @@ TEST_CASE(CrashMarksLostDirty) {
 TEST_CASE(EvictionMarksLost) {
     Workspace workspace;
     SessionStore store;
-    auto file = workspace.path_pool.intern("/proj/a.cpp");
+    auto file = workspace.file_table.intern("/proj/a.cpp");
     store.open(file);
 
     ContextResolver resolver(workspace);
@@ -645,7 +645,7 @@ TEST_CASE(EvictionMarksLost) {
 TEST_CASE(BatchSavesDeduplicate) {
     Workspace workspace;
     SessionStore store;
-    auto saved = workspace.path_pool.intern("/proj/a.h");
+    auto saved = workspace.file_table.intern("/proj/a.h");
     store.open(saved);
 
     ContextResolver resolver(workspace);
@@ -660,7 +660,7 @@ TEST_CASE(BatchSavesDeduplicate) {
 TEST_CASE(SaveDivergentDiskDirties) {
     Workspace workspace;
     SessionStore store;
-    auto saved = workspace.path_pool.intern("/proj/a.h");
+    auto saved = workspace.file_table.intern("/proj/a.h");
     auto session = store.open(saved);
     store.apply_open(*session, "int buffer;", 1);
 
@@ -680,7 +680,7 @@ TEST_CASE(SaveDivergentDiskDirties) {
 TEST_CASE(SaveUnreadableDiskDirties) {
     Workspace workspace;
     SessionStore store;
-    auto saved = workspace.path_pool.intern("/proj/a.h");
+    auto saved = workspace.file_table.intern("/proj/a.h");
     auto session = store.open(saved);
     store.apply_open(*session, "int buffer;", 1);
 
@@ -699,7 +699,7 @@ TEST_CASE(SaveUnreadableDiskDirties) {
 TEST_CASE(DiskChangeOpenMarksDirty) {
     Workspace workspace;
     SessionStore store;
-    auto open_file = workspace.path_pool.intern("/proj/a.cpp");
+    auto open_file = workspace.file_table.intern("/proj/a.cpp");
     store.open(open_file);
 
     ContextResolver resolver(workspace);
@@ -721,9 +721,9 @@ TEST_CASE(DiskChangeOpenMarksDirty) {
 TEST_CASE(DiskChangeClosedCascades) {
     Workspace workspace;
     SessionStore store;
-    auto header = workspace.path_pool.intern("/proj/h.h");
-    auto open_tu = workspace.path_pool.intern("/proj/a.cpp");
-    auto closed_tu = workspace.path_pool.intern("/proj/b.cpp");
+    auto header = workspace.file_table.intern("/proj/h.h");
+    auto open_tu = workspace.file_table.intern("/proj/a.cpp");
+    auto closed_tu = workspace.file_table.intern("/proj/b.cpp");
     workspace.dep_graph.set_includes(open_tu, 0, {header});
     workspace.dep_graph.set_includes(closed_tu, 0, {header});
     workspace.dep_graph.build_reverse_map();
@@ -748,9 +748,9 @@ TEST_CASE(DiskChangeClosedCascades) {
 TEST_CASE(DiskRemovedScrubsSourceRole) {
     Workspace workspace;
     SessionStore store;
-    auto header = workspace.path_pool.intern("/proj/h.h");
-    auto removed_tu = workspace.path_pool.intern("/proj/gone.cpp");
-    auto other_tu = workspace.path_pool.intern("/proj/kept.cpp");
+    auto header = workspace.file_table.intern("/proj/h.h");
+    auto removed_tu = workspace.file_table.intern("/proj/gone.cpp");
+    auto other_tu = workspace.file_table.intern("/proj/kept.cpp");
     workspace.dep_graph.set_includes(removed_tu, 0, {header});
     workspace.dep_graph.set_includes(other_tu, 0, {header});
     workspace.dep_graph.build_reverse_map();
@@ -779,7 +779,7 @@ TEST_CASE(DiskRemovedScrubsSourceRole) {
 TEST_CASE(RemoveRecreateBatchOrder) {
     Workspace workspace;
     SessionStore store;
-    auto file = workspace.path_pool.intern("/proj/a.cpp");
+    auto file = workspace.file_table.intern("/proj/a.cpp");
     workspace.dep_graph.set_includes(file, 0, {});
     workspace.dep_graph.build_reverse_map();
     ContextResolver resolver(workspace);
@@ -818,7 +818,7 @@ TEST_CASE(EntryChangeThenRemoval) {
         {tmp.root, tmp.path("a.cpp"), {}}
     });
     write_cdb(tmp, workspace.cdb, json);
-    auto file = workspace.path_pool.intern(tmp.path("a.cpp"));
+    auto file = workspace.file_table.intern(tmp.path("a.cpp"));
 
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
@@ -839,7 +839,7 @@ TEST_CASE(EntryChangeThenRemoval) {
 TEST_CASE(CloseOfDeletedFile) {
     Workspace workspace;
     SessionStore store;
-    auto file = workspace.path_pool.intern("/proj/gone.cpp");
+    auto file = workspace.file_table.intern("/proj/gone.cpp");
     ContextResolver resolver(workspace);
     // Disk read fails: the file vanished while it was open.
     PCMHarness ph(workspace, resolver);
@@ -868,8 +868,8 @@ TEST_CASE(CDBAddedScansAndEnqueues) {
         {tmp.root, tmp.path("src/main.cpp"), {"-I", tmp.path("inc")}}
     });
     write_cdb(tmp, workspace.cdb, json);
-    auto main_id = workspace.path_pool.intern(tmp.path("src/main.cpp"));
-    auto header_id = workspace.path_pool.intern(tmp.path("inc/header.h"));
+    auto main_id = workspace.file_table.intern(tmp.path("src/main.cpp"));
+    auto header_id = workspace.file_table.intern(tmp.path("inc/header.h"));
 
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
@@ -899,8 +899,8 @@ TEST_CASE(CDBChangedSplitsOpenClosed) {
         {tmp.root, tmp.path("b.cpp"), {}}
     });
     write_cdb(tmp, workspace.cdb, json);
-    auto open_id = workspace.path_pool.intern(tmp.path("a.cpp"));
-    auto closed_id = workspace.path_pool.intern(tmp.path("b.cpp"));
+    auto open_id = workspace.file_table.intern(tmp.path("a.cpp"));
+    auto closed_id = workspace.file_table.intern(tmp.path("b.cpp"));
     store.open(open_id);
     workspace.shards[open_id];
     workspace.shards[closed_id];
@@ -937,7 +937,7 @@ TEST_CASE(CDBChangedSplitsOpenClosed) {
 TEST_CASE(CDBAddedOpenMarksDirty) {
     Workspace workspace;
     SessionStore store;
-    auto file = workspace.path_pool.intern("/proj/a.cpp");
+    auto file = workspace.file_table.intern("/proj/a.cpp");
     store.open(file);
 
     ContextResolver resolver(workspace);
@@ -959,10 +959,10 @@ TEST_CASE(CDBAddedOpenMarksDirty) {
 TEST_CASE(CDBChangedDropsHostedContext) {
     Workspace workspace;
     SessionStore store;
-    auto host = workspace.path_pool.intern("/proj/host.cpp");
-    auto open_header = workspace.path_pool.intern("/proj/open.h");
-    auto closed_header = workspace.path_pool.intern("/proj/closed.h");
-    auto other_header = workspace.path_pool.intern("/proj/other.h");
+    auto host = workspace.file_table.intern("/proj/host.cpp");
+    auto open_header = workspace.file_table.intern("/proj/open.h");
+    auto closed_header = workspace.file_table.intern("/proj/closed.h");
+    auto other_header = workspace.file_table.intern("/proj/other.h");
     store.open(open_header);
     workspace.shards[closed_header];
 
@@ -996,9 +996,9 @@ TEST_CASE(CDBChangedDropsHostedContext) {
 TEST_CASE(CDBChangedCascadesModule) {
     Workspace workspace;
     SessionStore store;
-    auto mod = workspace.path_pool.intern("/proj/m.cppm");
-    auto open_user = workspace.path_pool.intern("/proj/open_user.cppm");
-    auto closed_user = workspace.path_pool.intern("/proj/closed_user.cppm");
+    auto mod = workspace.file_table.intern("/proj/m.cppm");
+    auto open_user = workspace.file_table.intern("/proj/open_user.cppm");
+    auto closed_user = workspace.file_table.intern("/proj/closed_user.cppm");
 
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
@@ -1032,9 +1032,9 @@ TEST_CASE(CDBChangedCascadesModule) {
 TEST_CASE(DiskRemovedReindexesIncluders) {
     Workspace workspace;
     SessionStore store;
-    auto header = workspace.path_pool.intern("/proj/h.h");
-    auto open_tu = workspace.path_pool.intern("/proj/a.cpp");
-    auto closed_tu = workspace.path_pool.intern("/proj/b.cpp");
+    auto header = workspace.file_table.intern("/proj/h.h");
+    auto open_tu = workspace.file_table.intern("/proj/a.cpp");
+    auto closed_tu = workspace.file_table.intern("/proj/b.cpp");
     workspace.dep_graph.set_includes(open_tu, 0, {header});
     workspace.dep_graph.set_includes(closed_tu, 0, {header});
     workspace.dep_graph.build_reverse_map();
@@ -1062,15 +1062,15 @@ TEST_CASE(CDBRemovedDropsSourceRole) {
     SessionStore store;
     // The pre-reload graph still shows gone.cpp as an includer; the CDB has
     // already been reloaded without it.
-    auto gone_id = workspace.path_pool.intern(tmp.path("gone.cpp"));
-    auto header_id = workspace.path_pool.intern(tmp.path("inc/h.h"));
+    auto gone_id = workspace.file_table.intern(tmp.path("gone.cpp"));
+    auto header_id = workspace.file_table.intern(tmp.path("inc/h.h"));
     workspace.dep_graph.set_includes(gone_id, 0, {header_id});
     workspace.dep_graph.build_reverse_map();
     auto json = build_cdb_json({
         {tmp.root, tmp.path("kept.cpp"), {}}
     });
     write_cdb(tmp, workspace.cdb, json);
-    auto kept_id = workspace.path_pool.intern(tmp.path("kept.cpp"));
+    auto kept_id = workspace.file_table.intern(tmp.path("kept.cpp"));
 
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
@@ -1102,8 +1102,8 @@ TEST_CASE(CDBEmptyDeltaNoEffects) {
 TEST_CASE(BatchDiskEventsDeduplicate) {
     Workspace workspace;
     SessionStore store;
-    auto first = workspace.path_pool.intern("/proj/a.h");
-    auto second = workspace.path_pool.intern("/proj/b.h");
+    auto first = workspace.file_table.intern("/proj/a.h");
+    auto second = workspace.file_table.intern("/proj/b.h");
 
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
@@ -1127,8 +1127,8 @@ TEST_CASE(SurvivingEdgeKeepsChoice) {
     Workspace workspace;
     SessionStore store;
     ContextResolver resolver(workspace);
-    auto host = workspace.path_pool.intern("/proj/host.cpp");
-    auto header = workspace.path_pool.intern("/proj/h.h");
+    auto host = workspace.file_table.intern("/proj/host.cpp");
+    auto header = workspace.file_table.intern("/proj/h.h");
     workspace.dep_graph.set_includes(host, 0, {header});
     workspace.dep_graph.build_reverse_map();
 
@@ -1144,8 +1144,8 @@ TEST_CASE(RemovedEdgeDropsChoice) {
     Workspace workspace;
     SessionStore store;
     ContextResolver resolver(workspace);
-    auto host = workspace.path_pool.intern("/proj/host.cpp");
-    auto header = workspace.path_pool.intern("/proj/h.h");
+    auto host = workspace.file_table.intern("/proj/host.cpp");
+    auto header = workspace.file_table.intern("/proj/h.h");
     workspace.dep_graph.build_reverse_map();
 
     auto session = store.open(header);
@@ -1173,8 +1173,8 @@ TEST_CASE(VanishedOccurrenceDropsChoice) {
     // occurrence #1 no longer exists.
     tmp.touch("host.cpp", R"(#include "h.h")");
     tmp.touch("h.h");
-    auto host = workspace.path_pool.intern(tmp.path("host.cpp"));
-    auto header = workspace.path_pool.intern(tmp.path("h.h"));
+    auto host = workspace.file_table.intern(tmp.path("host.cpp"));
+    auto header = workspace.file_table.intern(tmp.path("h.h"));
     workspace.dep_graph.set_includes(host, 0, {header});
     workspace.dep_graph.build_reverse_map();
 

--- a/tests/unit/server/query_freshness_tests.cpp
+++ b/tests/unit/server/query_freshness_tests.cpp
@@ -53,7 +53,7 @@ void merge_into_workspace() {
 
     llvm::SmallVector<std::uint32_t> file_ids_map;
     for(std::uint32_t i = 0; i < view.path_count(); i += 1) {
-        file_ids_map.push_back(workspace.path_pool.intern(view.path(i)));
+        file_ids_map.push_back(workspace.file_table.intern(view.path(i)));
     }
     ASSERT_TRUE(workspace.project_index.merge(view, file_ids_map));
     main_id = file_ids_map[view.path_count() - 1];
@@ -88,7 +88,7 @@ std::vector<std::string> reference_files(index::SymbolHash hash) {
 }
 
 TEST_CASE(PendingReasonUpgrade) {
-    auto file = workspace.path_pool.intern("/proj/upgrade.cpp");
+    auto file = workspace.file_table.intern("/proj/upgrade.cpp");
     ASSERT_FALSE(indexer.pending_reason(file).has_value());
 
     indexer.enqueue(file, ReindexReason::DepsOnly);
@@ -134,7 +134,7 @@ TEST_CASE(PendingGateSplitsRows) {
 
     // Line-based resolution in the file works while its rows are current.
     agentic::ReadSymbolParams by_line;
-    by_line.path = std::string(workspace.path_pool.resolve(main_id));
+    by_line.path = std::string(workspace.file_table.resolve(main_id));
     by_line.line = 3;
     ASSERT_FALSE(agent_query.locate_symbols(by_line).empty());
 

--- a/tests/unit/server/query_freshness_tests.cpp
+++ b/tests/unit/server/query_freshness_tests.cpp
@@ -41,8 +41,8 @@ IndexPump indexer{loop, workspace, turun, index_store, pool};
 IndexQuery index_query{workspace, store, indexer, projections};
 IndexQuery agent_query{workspace, store, indexer, projections, {.disk_only = true}};
 
-std::uint32_t main_id = 0;
-std::uint32_t header_id = 0;
+Fid main_id;
+Fid header_id;
 
 /// Build an envelope from the added sources and merge it into the
 /// workspace, installing each section's blob verbatim as the file's shard.
@@ -51,7 +51,7 @@ void merge_into_workspace() {
     auto view = index::TUIndex::from_bytes(wire);
     ASSERT_TRUE(view.loaded());
 
-    llvm::SmallVector<std::uint32_t> file_ids_map;
+    llvm::SmallVector<Fid> file_ids_map;
     for(std::uint32_t i = 0; i < view.path_count(); i += 1) {
         file_ids_map.push_back(workspace.file_table.intern(view.path(i)));
     }
@@ -69,7 +69,7 @@ void merge_into_workspace() {
 }
 
 /// The symbol hash at an offset in a file's merged shard.
-index::SymbolHash symbol_at(std::uint32_t path_id, std::uint32_t offset) {
+index::SymbolHash symbol_at(Fid path_id, std::uint32_t offset) {
     index::SymbolHash result = 0;
     workspace.shards[path_id].lookup(offset, [&](const index::Occurrence& o) {
         result = o.target;

--- a/tests/unit/server/query_freshness_tests.cpp
+++ b/tests/unit/server/query_freshness_tests.cpp
@@ -35,7 +35,7 @@ ContextResolver resolver{workspace};
 TaskGraph graph{loop};
 PCMFamily pcm{graph, workspace, resolver, pool};
 ASTProjectionTable projections;
-IndexStore index_store{loop, workspace};
+IndexStore index_store{loop, workspace, resolver};
 TURunFamily turun{graph, workspace, resolver, pcm, index_store, pool};
 IndexPump indexer{loop, workspace, turun, index_store, pool};
 IndexQuery index_query{workspace, store, indexer, projections};

--- a/tests/unit/server/query_overlay_tests.cpp
+++ b/tests/unit/server/query_overlay_tests.cpp
@@ -68,7 +68,7 @@ void open_with_overlay(std::source_location location = std::source_location::cur
     st.state = nullptr;
 
     main_path = std::string(full_index.path(full_index.path_count() - 1));
-    auto path_id = workspace.path_pool.intern(main_path);
+    auto path_id = workspace.file_table.intern(main_path);
     session = session_store.open(path_id);
 
     auto it = sources.all_files.find(llvm::sys::path::filename(main_path));
@@ -114,7 +114,7 @@ std::string header_path(llvm::StringRef basename) {
 void merge_disk_index() {
     llvm::SmallVector<std::uint32_t> file_ids_map;
     for(std::uint32_t i = 0; i < full_index.path_count(); i += 1) {
-        file_ids_map.push_back(workspace.path_pool.intern(full_index.path(i)));
+        file_ids_map.push_back(workspace.file_table.intern(full_index.path(i)));
     }
     ASSERT_TRUE(workspace.project_index.merge(full_index, file_ids_map));
 
@@ -269,7 +269,7 @@ int main() { §(ref)⟦§(ref)foo⟧(); return 0; }
     // Opening the header makes its session authoritative: overlay rows
     // for it describe the disk snapshot and would map onto the edited
     // buffer at wrong lines, so they must vanish from results.
-    session_store.open(workspace.path_pool.intern(header_path("foo.h")));
+    session_store.open(workspace.file_table.intern(header_path("foo.h")));
 
     auto locations = index_query.query_relations(main_path,
                                                  position_of("ref"),
@@ -321,7 +321,7 @@ Derived instance;
 
     // Once derived.h is open, its session owns the type relations spelled
     // there; the overlay's disk-snapshot rows must stop contributing.
-    session_store.open(workspace.path_pool.intern(header_path("derived.h")));
+    session_store.open(workspace.file_table.intern(header_path("derived.h")));
     supertypes = index_query.find_supertypes(derived);
     EXPECT_EQ(supertypes.size(), 0);
 }
@@ -341,7 +341,7 @@ int main() { §(ref)⟦foo⟧(); return 0; }
     // The header's own disk content changed and awaits reindexing: its
     // overlay rows describe text that no longer exists (freshness
     // contract, clause 2), exactly like a shard contribution.
-    indexer.enqueue(workspace.path_pool.intern(header_path("foo.h")),
+    indexer.enqueue(workspace.file_table.intern(header_path("foo.h")),
                     ReindexReason::ContentChanged);
     EXPECT_FALSE(index_query.find_definition_location(hash_of("foo")).has_value());
 }
@@ -399,7 +399,7 @@ TEST_CASE(AsciiPreviewFromDisk) {
     llvm::StringRef text = "int value = 1;\nint other = value;\n";
     dir.touch("preview.cpp", text);
     auto path = dir.path("preview.cpp");
-    auto path_id = workspace.path_pool.intern(path);
+    auto path_id = workspace.file_table.intern(path);
 
     index::SymbolHash sym = 777;
     index::FileIndex rows;
@@ -457,7 +457,7 @@ int main() { return 0; }
     // file-local macro identities — its rows must stay scoped to the
     // file that built the blob.
     auto other_path = std::string(llvm::sys::path::parent_path(main_path)) + "/other.cpp";
-    auto other = session_store.open(workspace.path_pool.intern(other_path));
+    auto other = session_store.open(workspace.file_table.intern(other_path));
     other->text = session->text;
     other->line_starts = session->line_starts;
     auto& other_entry = projections.entries[other->path_id];
@@ -525,7 +525,7 @@ int main() { §(ref)⟦foo⟧(); return 0; }
     };
     relation.set_definition_range({0, 3});
     fake.relations[foo].push_back(relation);
-    auto header_id = workspace.path_pool.intern(header_path("foo.h"));
+    auto header_id = workspace.file_table.intern(header_path("foo.h"));
     std::string bytes;
     llvm::raw_string_ostream os(bytes);
     index::write_shard(fake, {}, "xxx\n", os);

--- a/tests/unit/server/query_overlay_tests.cpp
+++ b/tests/unit/server/query_overlay_tests.cpp
@@ -112,7 +112,7 @@ std::string header_path(llvm::StringRef basename) {
 /// Merge the full envelope into the workspace's disk index, installing
 /// each section's blob verbatim as background indexing would.
 void merge_disk_index() {
-    llvm::SmallVector<std::uint32_t> file_ids_map;
+    llvm::SmallVector<Fid> file_ids_map;
     for(std::uint32_t i = 0; i < full_index.path_count(); i += 1) {
         file_ids_map.push_back(workspace.file_table.intern(full_index.path(i)));
     }
@@ -426,7 +426,7 @@ TEST_CASE(AsciiPreviewFromDisk) {
         index::Shard::from_buffer(llvm::MemoryBuffer::getMemBufferCopy(bytes));
     ASSERT_TRUE(workspace.shards[path_id].ascii());
     workspace.project_index.symbols[sym].name = "value";
-    workspace.project_index.symbols[sym].reference_files.add(path_id);
+    workspace.project_index.symbols[sym].reference_files.add(path_id.raw);
 
     auto definition = agent_query.get_definition_text(sym);
     ASSERT_TRUE(definition.has_value());
@@ -531,7 +531,7 @@ int main() { §(ref)⟦foo⟧(); return 0; }
     index::write_shard(fake, {}, "xxx\n", os);
     workspace.shards[header_id] =
         index::Shard::from_buffer(llvm::MemoryBuffer::getMemBufferCopy(bytes));
-    workspace.project_index.symbols[foo].reference_files.add(header_id);
+    workspace.project_index.symbols[foo].reference_files.add(header_id.raw);
 
     auto def_loc = index_query.find_definition_location(foo);
     ASSERT_TRUE(def_loc.has_value());

--- a/tests/unit/server/query_overlay_tests.cpp
+++ b/tests/unit/server/query_overlay_tests.cpp
@@ -37,7 +37,7 @@ ContextResolver resolver{workspace};
 TaskGraph graph{loop};
 PCMFamily pcm{graph, workspace, resolver, pool};
 ASTProjectionTable projections;
-IndexStore index_store{loop, workspace};
+IndexStore index_store{loop, workspace, resolver};
 TURunFamily turun{graph, workspace, resolver, pcm, index_store, pool};
 IndexPump indexer{loop, workspace, turun, index_store, pool};
 IndexQuery index_query{workspace, session_store, indexer, projections};

--- a/tests/unit/server/rank_hosts_tests.cpp
+++ b/tests/unit/server/rank_hosts_tests.cpp
@@ -8,9 +8,9 @@ TEST_SUITE(RankHosts) {
 
 TEST_CASE(StemMatchWins) {
     Workspace ws;
-    auto header = ws.path_pool.intern("/proj/src/utils.h");
-    auto stem = ws.path_pool.intern("/other/utils.cpp");
-    auto same_dir = ws.path_pool.intern("/proj/src/main.cpp");
+    auto header = ws.file_table.intern("/proj/src/utils.h");
+    auto stem = ws.file_table.intern("/other/utils.cpp");
+    auto same_dir = ws.file_table.intern("/proj/src/main.cpp");
 
     auto ranked = ws.rank_hosts(header, {same_dir, stem});
     ASSERT_EQ(ranked.size(), 2u);
@@ -20,9 +20,9 @@ TEST_CASE(StemMatchWins) {
 
 TEST_CASE(SameDirBeatsProximity) {
     Workspace ws;
-    auto header = ws.path_pool.intern("/proj/src/utils.h");
-    auto same_dir = ws.path_pool.intern("/proj/src/zzz.cpp");
-    auto sibling_dir = ws.path_pool.intern("/proj/lib/aaa.cpp");
+    auto header = ws.file_table.intern("/proj/src/utils.h");
+    auto same_dir = ws.file_table.intern("/proj/src/zzz.cpp");
+    auto sibling_dir = ws.file_table.intern("/proj/lib/aaa.cpp");
 
     auto ranked = ws.rank_hosts(header, {sibling_dir, same_dir});
     ASSERT_EQ(ranked.size(), 2u);
@@ -31,16 +31,16 @@ TEST_CASE(SameDirBeatsProximity) {
 
 TEST_CASE(ProximityThenLexicographic) {
     Workspace ws;
-    auto header = ws.path_pool.intern("/proj/a/b/utils.h");
-    auto near = ws.path_pool.intern("/proj/a/main.cpp");
-    auto far = ws.path_pool.intern("/proj/x/main.cpp");
+    auto header = ws.file_table.intern("/proj/a/b/utils.h");
+    auto near = ws.file_table.intern("/proj/a/main.cpp");
+    auto far = ws.file_table.intern("/proj/x/main.cpp");
 
     auto ranked = ws.rank_hosts(header, {far, near});
     ASSERT_EQ(ranked.size(), 2u);
     EXPECT_EQ(ranked[0], near);
 
-    auto first = ws.path_pool.intern("/proj/x/aaa.cpp");
-    auto second = ws.path_pool.intern("/proj/x/bbb.cpp");
+    auto first = ws.file_table.intern("/proj/x/aaa.cpp");
+    auto second = ws.file_table.intern("/proj/x/bbb.cpp");
     auto tie = ws.rank_hosts(header, {second, first});
     ASSERT_EQ(tie.size(), 2u);
     EXPECT_EQ(tie[0], first);

--- a/tests/unit/server/session_store_tests.cpp
+++ b/tests/unit/server/session_store_tests.cpp
@@ -29,7 +29,7 @@ TEST_SUITE(SessionStore) {
 
 TEST_CASE(ApplyOpenInitializesBuffer) {
     SessionStore store;
-    auto session = store.open(1);
+    auto session = store.open(Fid{1});
     store.apply_open(*session, "int a;\nint b;\n", 3);
 
     ASSERT_EQ(session->version, 3);
@@ -40,7 +40,7 @@ TEST_CASE(ApplyOpenInitializesBuffer) {
 
 TEST_CASE(RangeReplace) {
     SessionStore store;
-    auto session = store.open(1);
+    auto session = store.open(Fid{1});
     store.apply_open(*session, "int a;\nint b;\n", 1);
 
     auto change = partial_change(1, 4, 1, 5, "value");
@@ -54,7 +54,7 @@ TEST_CASE(RangeReplace) {
 
 TEST_CASE(SequentialChangesFold) {
     SessionStore store;
-    auto session = store.open(1);
+    auto session = store.open(Fid{1});
     store.apply_open(*session, "ab\ncd\n", 1);
 
     // The second range addresses the buffer as left by the first change.
@@ -71,7 +71,7 @@ TEST_CASE(SequentialChangesFold) {
 
 TEST_CASE(WholeDocumentReplace) {
     SessionStore store;
-    auto session = store.open(1);
+    auto session = store.open(Fid{1});
     store.apply_open(*session, "old\n", 1);
 
     protocol::TextDocumentContentChangeEvent change =
@@ -84,7 +84,7 @@ TEST_CASE(WholeDocumentReplace) {
 
 TEST_CASE(InvertedRangeCollapsed) {
     SessionStore store;
-    auto session = store.open(1);
+    auto session = store.open(Fid{1});
     store.apply_open(*session, "ab\ncd\n", 1);
 
     // A range whose start lies after its end deletes nothing; the text is
@@ -98,7 +98,7 @@ TEST_CASE(InvertedRangeCollapsed) {
 
 TEST_CASE(SelectAllDeleteClamped) {
     SessionStore store;
-    auto session = store.open(1);
+    auto session = store.open(Fid{1});
     store.apply_open(*session, "int foo() { return 1; }\n", 1);
 
     // Several clients emit select-all-delete as an oversized range; per
@@ -114,7 +114,7 @@ TEST_CASE(SelectAllDeleteClamped) {
 
 TEST_CASE(InsertPastLastLine) {
     SessionStore store;
-    auto session = store.open(1);
+    auto session = store.open(Fid{1});
     store.apply_open(*session, "int a;\n", 1);
 
     // Line 1 (after the trailing newline) is the last line; line 2 clamps
@@ -128,7 +128,7 @@ TEST_CASE(InsertPastLastLine) {
 
 TEST_CASE(InsertPastLineEnd) {
     SessionStore store;
-    auto session = store.open(1);
+    auto session = store.open(Fid{1});
     store.apply_open(*session, "ab\ncd\n", 1);
 
     // A character beyond the line length clamps to the line end.
@@ -141,7 +141,7 @@ TEST_CASE(InsertPastLineEnd) {
 
 TEST_CASE(ClampedChangeFolds) {
     SessionStore store;
-    auto session = store.open(1);
+    auto session = store.open(Fid{1});
     store.apply_open(*session, "ab\ncd\n", 1);
 
     // The clamp for the second change must resolve against the buffer as
@@ -158,7 +158,7 @@ TEST_CASE(ClampedChangeFolds) {
 
 TEST_CASE(EmptyDocumentClamped) {
     SessionStore store;
-    auto session = store.open(1);
+    auto session = store.open(Fid{1});
     store.apply_open(*session, "", 1);
 
     auto change = partial_change(5, 3, 8, 0, "int x;");
@@ -170,7 +170,7 @@ TEST_CASE(EmptyDocumentClamped) {
 
 TEST_CASE(RangeEndPastEof) {
     SessionStore store;
-    auto session = store.open(1);
+    auto session = store.open(Fid{1});
     store.apply_open(*session, "int a;\nint b;\n", 1);
 
     // The end position sits on the last (empty) line but one character
@@ -184,32 +184,32 @@ TEST_CASE(RangeEndPastEof) {
 
 TEST_CASE(ReopenBumpsGeneration) {
     SessionStore store;
-    auto first = store.open(7);
+    auto first = store.open(Fid{7});
     first->generation = 5;
 
-    auto second = store.open(7);
+    auto second = store.open(Fid{7});
     ASSERT_EQ(first->generation, 6u);
     ASSERT_NE(first.get(), second.get());
-    ASSERT_EQ(store.find(7).get(), second.get());
+    ASSERT_EQ(store.find(Fid{7}).get(), second.get());
 }
 
 TEST_CASE(CloseBumpsGeneration) {
     SessionStore store;
-    auto session = store.open(7);
+    auto session = store.open(Fid{7});
     session->generation = 5;
 
-    store.close(7);
+    store.close(Fid{7});
     ASSERT_EQ(session->generation, 6u);
-    ASSERT_EQ(store.find(7), nullptr);
+    ASSERT_EQ(store.find(Fid{7}), nullptr);
 }
 
 TEST_CASE(ForEachVisitsAll) {
     SessionStore store;
-    store.open(1);
-    store.open(2);
+    store.open(Fid{1});
+    store.open(Fid{2});
 
     int visited = 0;
-    store.for_each([&](std::uint32_t, const Session&) -> bool {
+    store.for_each([&](Fid, const Session&) -> bool {
         ++visited;
         return true;
     });
@@ -217,7 +217,7 @@ TEST_CASE(ForEachVisitsAll) {
 
     // A false return stops the iteration early.
     visited = 0;
-    store.for_each([&](std::uint32_t, const Session&) -> bool {
+    store.for_each([&](Fid, const Session&) -> bool {
         ++visited;
         return false;
     });
@@ -229,7 +229,7 @@ TEST_CASE(QuarantineProbeOnEdit) {
     // that apply_change feeds real edits into it without resetting the
     // record — only a successful compile proves the document healthy.
     SessionStore store;
-    auto session = store.open(1);
+    auto session = store.open(Fid{1});
     store.apply_open(*session, "int a;\n", 1);
 
     session->quarantine.on_crash();
@@ -248,7 +248,7 @@ TEST_CASE(QuarantineProbeOnEdit) {
 
 TEST_CASE(NoopEditNoProbe) {
     SessionStore store;
-    auto session = store.open(1);
+    auto session = store.open(Fid{1});
     store.apply_open(*session, "int a;\n", 1);
     session->quarantine.on_crash();
     session->quarantine.on_crash();
@@ -279,7 +279,7 @@ TEST_CASE(NoopEditNoProbe) {
 
 TEST_CASE(ReopenClearsQuarantine) {
     SessionStore store;
-    auto session = store.open(1);
+    auto session = store.open(Fid{1});
     session->quarantine.on_crash();
     session->quarantine.on_crash();
 

--- a/tests/unit/support/cache_store_tests.cpp
+++ b/tests/unit/support/cache_store_tests.cpp
@@ -40,8 +40,11 @@ CacheStore open_store(const TempDir& tmp, std::uint32_t ver = version) {
 }
 
 void register_lru(CacheStore& store, std::uint64_t max_bytes = 0) {
-    store.register_namespace(
-        {.name = "pch", .extension = ".pch", .policy = CachePolicy::LRU, .max_bytes = max_bytes});
+    store.register_namespace({.name = "pch",
+                              .extension = ".pch",
+                              .policy = CachePolicy::LRU,
+                              .max_bytes = max_bytes,
+                              .deferred_metadata = true});
 }
 
 void register_paired(CacheStore& store, std::uint64_t max_bytes = 0) {
@@ -49,7 +52,8 @@ void register_paired(CacheStore& store, std::uint64_t max_bytes = 0) {
                               .extension = ".pch",
                               .aux_extension = ".pch.idx",
                               .policy = CachePolicy::LRU,
-                              .max_bytes = max_bytes});
+                              .max_bytes = max_bytes,
+                              .deferred_metadata = true});
 }
 
 /// Run a full two-phase aux write with the given content.
@@ -129,6 +133,20 @@ TEST_CASE(DirtyMarkerLifecycle) {
 
     store.clear_writer_dirty(store.writer_mark_count());
     ASSERT_FALSE(llvm::sys::fs::exists(marker));
+}
+
+TEST_CASE(RecycledPidMarkerDetected) {
+    // A dirty marker under this process's own pid is a crashed predecessor
+    // that recycled the pid: open must latch the debt (and re-mark) before
+    // recreating the directory, not silently sweep it.
+    TempDir tmp;
+    auto pid = std::to_string(llvm::sys::Process::getProcessId());
+    tmp.touch("root/cache/v1/tmp/" + pid + "/dirty", "1");
+
+    auto store = open_store(tmp);
+    register_lru(store);
+    ASSERT_TRUE(store.dead_writer_dirty());
+    ASSERT_TRUE(llvm::sys::fs::exists(tmp.path("root/cache/v1/tmp/" + pid + "/dirty")));
 }
 
 TEST_CASE(DeadWriterDirtyDetected) {

--- a/tests/unit/support/cache_store_tests.cpp
+++ b/tests/unit/support/cache_store_tests.cpp
@@ -298,44 +298,16 @@ TEST_CASE(FreshCommitNotEvicted) {
     ASSERT_TRUE(store.lookup("pch", "big").has_value());
 }
 
-TEST_CASE(PersistentNeverEvicted) {
+TEST_CASE(RewriteWins) {
     TempDir tmp;
     auto store = open_store(tmp);
-    store.register_namespace(
-        {.name = "index", .extension = ".idx", .policy = CachePolicy::Persistent, .max_bytes = 1});
+    register_lru(store);
 
-    put(store, "index", "a", "aaaaaaaaaa");
-    put(store, "index", "b", "bbbbbbbbbb");
-
-    ASSERT_TRUE(store.lookup("index", "a").has_value());
-    ASSERT_TRUE(store.lookup("index", "b").has_value());
-}
-
-TEST_CASE(PersistentRewriteWins) {
-    TempDir tmp;
-    auto store = open_store(tmp);
-    store.register_namespace(
-        {.name = "index", .extension = ".idx", .policy = CachePolicy::Persistent});
-
-    // Persistent keys are mutable: a rewrite of the same key must serve
-    // the new content, never the old blob.
-    put(store, "index", "project", "first snapshot");
-    auto path = put(store, "index", "project", "second");
+    // Keys are mutable (not fully content-addressed): a rewrite of the
+    // same key must serve the new content, never the old blob.
+    put(store, "pch", "k1", "first snapshot");
+    auto path = put(store, "pch", "k1", "second");
     ASSERT_EQ(fs::read(path).value_or(""), "second");
-}
-
-TEST_CASE(PersistentRenameRetry) {
-    TempDir tmp;
-    auto store = open_store(tmp);
-    store.register_namespace(
-        {.name = "index", .extension = ".idx", .policy = CachePolicy::Persistent});
-
-    // Squat the blob path with an empty directory: the first rename fails,
-    // and the store must remove the obstacle and publish the new blob.
-    tmp.mkdir("root/cache/v1/index/project.idx");
-    auto path = put(store, "index", "project", "fresh");
-    ASSERT_EQ(fs::read(path).value_or(""), "fresh");
-    ASSERT_TRUE(store.lookup("index", "project").has_value());
 }
 
 TEST_CASE(LruStaleBlobReplaced) {
@@ -353,19 +325,18 @@ TEST_CASE(LruStaleBlobReplaced) {
     ASSERT_TRUE(store.lookup("pch", "k1").has_value());
 }
 
-TEST_CASE(PersistentCommitFailureSurfaces) {
+TEST_CASE(CommitFailureSurfaces) {
     TempDir tmp;
     auto store = open_store(tmp);
-    store.register_namespace(
-        {.name = "index", .extension = ".idx", .policy = CachePolicy::Persistent});
+    register_lru(store);
 
     // A non-empty directory can neither be renamed over nor removed: the
     // commit must report the failure, not silently claim the data is stored.
-    tmp.touch("root/cache/v1/index/project.idx/squatter", "x");
-    auto pending = store.begin_store("index", "project");
+    tmp.touch("root/cache/v1/pch/k1.pch/squatter", "x");
+    auto pending = store.begin_store("pch", "k1");
     ASSERT_TRUE(fs::write(pending.tmp_path, "dropped").has_value());
     ASSERT_FALSE(store.commit(std::move(pending)).has_value());
-    ASSERT_FALSE(store.lookup("index", "project").has_value());
+    ASSERT_FALSE(store.lookup("pch", "k1").has_value());
 }
 
 TEST_CASE(InvalidateRemovesBlob) {
@@ -378,25 +349,6 @@ TEST_CASE(InvalidateRemovesBlob) {
 
     ASSERT_FALSE(store.lookup("pch", "k1").has_value());
     ASSERT_FALSE(llvm::sys::fs::exists(path));
-}
-
-TEST_CASE(ForEachKey) {
-    TempDir tmp;
-    auto store = open_store(tmp);
-    register_lru(store);
-
-    put(store, "pch", "a", "1");
-    put(store, "pch", "b", "2");
-
-    std::vector<std::string> keys;
-    store.for_each_key("pch", [&](llvm::StringRef key) { keys.push_back(key.str()); });
-    std::ranges::sort(keys);
-    ASSERT_EQ(keys, (std::vector<std::string>{"a", "b"}));
-
-    // Snapshot semantics: invalidating from the callback must be safe.
-    store.for_each_key("pch", [&](llvm::StringRef key) { store.invalidate("pch", key); });
-    ASSERT_FALSE(store.lookup("pch", "a").has_value());
-    ASSERT_FALSE(store.lookup("pch", "b").has_value());
 }
 
 TEST_CASE(MissingManifestRescans) {

--- a/tests/unit/support/cache_store_tests.cpp
+++ b/tests/unit/support/cache_store_tests.cpp
@@ -76,6 +76,82 @@ std::string
 
 TEST_SUITE(CacheStore) {
 
+TEST_CASE(BindingCatchesRepublish) {
+    // A record made for one blob generation must not vouch for a
+    // republished one: the commit-time binding pins the tmp file's inode,
+    // and every republish is a fresh tmp file — a free generation token
+    // even when size and mtime tick collide.
+    TempDir tmp;
+    auto store = open_store(tmp);
+    register_lru(store);
+
+    BlobBinding first;
+    {
+        auto pending = store.begin_store("pch", "k1");
+        require(fs::write(pending.tmp_path, "generation-A").has_value(), "tmp write");
+        auto committed = store.commit(std::move(pending), &first);
+        require(committed.has_value(), "commit failed");
+        ASSERT_TRUE(binding_stat_matches(*committed, first));
+        ASSERT_TRUE(binding_content_matches(*committed, first));
+    }
+
+    BlobBinding second;
+    {
+        // Same byte count as generation-A: size alone cannot tell them
+        // apart, the UniqueID does.
+        auto pending = store.begin_store("pch", "k1");
+        require(fs::write(pending.tmp_path, "generation-B").has_value(), "tmp write");
+        auto committed = store.commit(std::move(pending), &second);
+        require(committed.has_value(), "commit failed");
+        ASSERT_FALSE(binding_stat_matches(*committed, first));
+        ASSERT_TRUE(binding_stat_matches(*committed, second));
+        ASSERT_FALSE(binding_content_matches(*committed, first));
+    }
+}
+
+TEST_CASE(DirtyMarkerLifecycle) {
+    // A durable commit marks the writer dirty before publishing; the
+    // metadata barrier clears it — but only when nothing was published
+    // after the barrier's snapshot.
+    TempDir tmp;
+    auto store = open_store(tmp);
+    register_lru(store);
+    auto marker = tmp.path("root/cache/v1/tmp/" +
+                           std::to_string(llvm::sys::Process::getProcessId()) + "/dirty");
+
+    put(store, "pch", "k1", "blob");
+    ASSERT_TRUE(llvm::sys::fs::exists(marker));
+
+    auto marks = store.writer_mark_count();
+    put(store, "pch", "k2", "published after the snapshot");
+    store.clear_writer_dirty(marks);
+    ASSERT_TRUE(llvm::sys::fs::exists(marker));
+
+    store.clear_writer_dirty(store.writer_mark_count());
+    ASSERT_FALSE(llvm::sys::fs::exists(marker));
+}
+
+TEST_CASE(DeadWriterDirtyDetected) {
+    // A dead instance's dirty marker means it crashed between publishing
+    // blobs and persisting their metadata: the next open latches the
+    // verification debt (and re-marks itself so a crash before the first
+    // barrier cannot launder it).
+    TempDir tmp;
+    {
+        auto store = open_store(tmp);
+        register_lru(store);
+        put(store, "pch", "k1", "blob");
+        store.shutdown();
+    }
+    tmp.touch("root/cache/v1/tmp/" + std::string(dead_pid) + "/dirty", "1");
+
+    auto store = open_store(tmp);
+    ASSERT_TRUE(store.dead_writer_dirty());
+    auto own_marker = tmp.path("root/cache/v1/tmp/" +
+                               std::to_string(llvm::sys::Process::getProcessId()) + "/dirty");
+    ASSERT_TRUE(llvm::sys::fs::exists(own_marker));
+}
+
 TEST_CASE(StoreAndLookup) {
     TempDir tmp;
     auto store = open_store(tmp);

--- a/tests/unit/support/cache_store_tests.cpp
+++ b/tests/unit/support/cache_store_tests.cpp
@@ -40,11 +40,8 @@ CacheStore open_store(const TempDir& tmp, std::uint32_t ver = version) {
 }
 
 void register_lru(CacheStore& store, std::uint64_t max_bytes = 0) {
-    store.register_namespace({.name = "pch",
-                              .extension = ".pch",
-                              .policy = CachePolicy::LRU,
-                              .max_bytes = max_bytes,
-                              .deferred_metadata = true});
+    store.register_namespace(
+        {.name = "pch", .extension = ".pch", .policy = CachePolicy::LRU, .max_bytes = max_bytes});
 }
 
 void register_paired(CacheStore& store, std::uint64_t max_bytes = 0) {
@@ -52,8 +49,7 @@ void register_paired(CacheStore& store, std::uint64_t max_bytes = 0) {
                               .extension = ".pch",
                               .aux_extension = ".pch.idx",
                               .policy = CachePolicy::LRU,
-                              .max_bytes = max_bytes,
-                              .deferred_metadata = true});
+                              .max_bytes = max_bytes});
 }
 
 /// Run a full two-phase aux write with the given content.
@@ -79,115 +75,6 @@ std::string
 }
 
 TEST_SUITE(CacheStore) {
-
-TEST_CASE(BindingCatchesRepublish) {
-    // A record made for one blob generation must not vouch for a
-    // republished one: the commit-time binding pins the tmp file's inode,
-    // and every republish is a fresh tmp file — a free generation token
-    // even when size and mtime tick collide.
-    TempDir tmp;
-    auto store = open_store(tmp);
-    register_lru(store);
-
-    BlobBinding first;
-    {
-        auto pending = store.begin_store("pch", "k1");
-        require(fs::write(pending.tmp_path, "generation-A").has_value(), "tmp write");
-        auto committed = store.commit(std::move(pending), &first);
-        require(committed.has_value(), "commit failed");
-        ASSERT_TRUE(binding_stat_matches(*committed, first));
-        ASSERT_TRUE(binding_content_matches(*committed, first));
-    }
-
-    BlobBinding second;
-    {
-        // Same byte count as generation-A: size alone cannot tell them
-        // apart, the UniqueID does.
-        auto pending = store.begin_store("pch", "k1");
-        require(fs::write(pending.tmp_path, "generation-B").has_value(), "tmp write");
-        auto committed = store.commit(std::move(pending), &second);
-        require(committed.has_value(), "commit failed");
-        ASSERT_FALSE(binding_stat_matches(*committed, first));
-        ASSERT_TRUE(binding_stat_matches(*committed, second));
-        ASSERT_FALSE(binding_content_matches(*committed, first));
-    }
-}
-
-TEST_CASE(DirtyMarkerLifecycle) {
-    // A durable commit marks the writer dirty before publishing; the
-    // metadata barrier clears it — but only when nothing was published
-    // after the barrier's snapshot.
-    TempDir tmp;
-    auto store = open_store(tmp);
-    register_lru(store);
-    auto marker = tmp.path("root/cache/v1/tmp/" +
-                           std::to_string(llvm::sys::Process::getProcessId()) + "/dirty");
-
-    put(store, "pch", "k1", "blob");
-    ASSERT_TRUE(llvm::sys::fs::exists(marker));
-
-    auto marks = store.writer_mark_count();
-    put(store, "pch", "k2", "published after the snapshot");
-    store.clear_writer_dirty(marks);
-    ASSERT_TRUE(llvm::sys::fs::exists(marker));
-
-    store.clear_writer_dirty(store.writer_mark_count());
-    ASSERT_FALSE(llvm::sys::fs::exists(marker));
-}
-
-TEST_CASE(UndischargedDebtHandsOn) {
-    // A session that cannot persist the latched debt (read-only index
-    // database) leaves its marker at shutdown; the next open re-latches
-    // it through the recycled-pid path.
-    TempDir tmp;
-    tmp.touch("root/cache/v1/tmp/" + std::string(dead_pid) + "/dirty", "1");
-    {
-        auto store =
-            CacheStore::open(tmp.path("root"), version, false, /*adopt_writer_debt=*/false);
-        require(store.has_value(), "CacheStore::open failed");
-        register_lru(*store);
-        ASSERT_TRUE(store->dead_writer_dirty());
-        store->shutdown();
-    }
-
-    auto store = open_store(tmp);
-    ASSERT_TRUE(store.dead_writer_dirty());
-}
-
-TEST_CASE(RecycledPidMarkerDetected) {
-    // A dirty marker under this process's own pid is a crashed predecessor
-    // that recycled the pid: open must latch the debt (and re-mark) before
-    // recreating the directory, not silently sweep it.
-    TempDir tmp;
-    auto pid = std::to_string(llvm::sys::Process::getProcessId());
-    tmp.touch("root/cache/v1/tmp/" + pid + "/dirty", "1");
-
-    auto store = open_store(tmp);
-    register_lru(store);
-    ASSERT_TRUE(store.dead_writer_dirty());
-    ASSERT_TRUE(llvm::sys::fs::exists(tmp.path("root/cache/v1/tmp/" + pid + "/dirty")));
-}
-
-TEST_CASE(DeadWriterDirtyDetected) {
-    // A dead instance's dirty marker means it crashed between publishing
-    // blobs and persisting their metadata: the next open latches the
-    // verification debt (and re-marks itself so a crash before the first
-    // barrier cannot launder it).
-    TempDir tmp;
-    {
-        auto store = open_store(tmp);
-        register_lru(store);
-        put(store, "pch", "k1", "blob");
-        store.shutdown();
-    }
-    tmp.touch("root/cache/v1/tmp/" + std::string(dead_pid) + "/dirty", "1");
-
-    auto store = open_store(tmp);
-    ASSERT_TRUE(store.dead_writer_dirty());
-    auto own_marker = tmp.path("root/cache/v1/tmp/" +
-                               std::to_string(llvm::sys::Process::getProcessId()) + "/dirty");
-    ASSERT_TRUE(llvm::sys::fs::exists(own_marker));
-}
 
 TEST_CASE(StoreAndLookup) {
     TempDir tmp;

--- a/tests/unit/support/cache_store_tests.cpp
+++ b/tests/unit/support/cache_store_tests.cpp
@@ -135,6 +135,25 @@ TEST_CASE(DirtyMarkerLifecycle) {
     ASSERT_FALSE(llvm::sys::fs::exists(marker));
 }
 
+TEST_CASE(UndischargedDebtHandsOn) {
+    // A session that cannot persist the latched debt (read-only index
+    // database) leaves its marker at shutdown; the next open re-latches
+    // it through the recycled-pid path.
+    TempDir tmp;
+    tmp.touch("root/cache/v1/tmp/" + std::string(dead_pid) + "/dirty", "1");
+    {
+        auto store =
+            CacheStore::open(tmp.path("root"), version, false, /*adopt_writer_debt=*/false);
+        require(store.has_value(), "CacheStore::open failed");
+        register_lru(*store);
+        ASSERT_TRUE(store->dead_writer_dirty());
+        store->shutdown();
+    }
+
+    auto store = open_store(tmp);
+    ASSERT_TRUE(store.dead_writer_dirty());
+}
+
 TEST_CASE(RecycledPidMarkerDetected) {
     // A dirty marker under this process's own pid is a crashed predecessor
     // that recycled the pid: open must latch the debt (and re-mark) before

--- a/tests/unit/syntax/completion_tests.cpp
+++ b/tests/unit/syntax/completion_tests.cpp
@@ -146,11 +146,11 @@ TEST_CASE(ImportCursorMidLine) {
 TEST_SUITE(CompleteModuleImport) {
 
 TEST_CASE(PrefixMatch) {
-    llvm::DenseMap<std::uint32_t, std::string> modules;
-    modules[1] = "std";
-    modules[2] = "std.io";
-    modules[3] = "std.net";
-    modules[4] = "my_lib";
+    llvm::DenseMap<Fid, std::string> modules;
+    modules[Fid{1}] = "std";
+    modules[Fid{2}] = "std.io";
+    modules[Fid{3}] = "std.net";
+    modules[Fid{4}] = "my_lib";
 
     auto results = complete_module_import(modules, "std");
     EXPECT_EQ(results.size(), 3u);
@@ -160,35 +160,35 @@ TEST_CASE(PrefixMatch) {
 }
 
 TEST_CASE(EmptyPrefix) {
-    llvm::DenseMap<std::uint32_t, std::string> modules;
-    modules[1] = "std";
-    modules[2] = "my_lib";
+    llvm::DenseMap<Fid, std::string> modules;
+    modules[Fid{1}] = "std";
+    modules[Fid{2}] = "my_lib";
 
     auto results = complete_module_import(modules, "");
     EXPECT_EQ(results.size(), 2u);
 }
 
 TEST_CASE(NoMatch) {
-    llvm::DenseMap<std::uint32_t, std::string> modules;
-    modules[1] = "std";
-    modules[2] = "my_lib";
+    llvm::DenseMap<Fid, std::string> modules;
+    modules[Fid{1}] = "std";
+    modules[Fid{2}] = "my_lib";
 
     auto results = complete_module_import(modules, "xyz");
     EXPECT_TRUE(results.empty());
 }
 
 TEST_CASE(EmptyModules) {
-    llvm::DenseMap<std::uint32_t, std::string> modules;
+    llvm::DenseMap<Fid, std::string> modules;
     auto results = complete_module_import(modules, "std");
     EXPECT_TRUE(results.empty());
 }
 
 TEST_CASE(DottedPrefix) {
-    llvm::DenseMap<std::uint32_t, std::string> modules;
-    modules[1] = "std";
-    modules[2] = "std.io";
-    modules[3] = "std.core";
-    modules[4] = "boost.asio";
+    llvm::DenseMap<Fid, std::string> modules;
+    modules[Fid{1}] = "std";
+    modules[Fid{2}] = "std.io";
+    modules[Fid{3}] = "std.core";
+    modules[Fid{4}] = "boost.asio";
 
     auto results = complete_module_import(modules, "std.");
     EXPECT_EQ(results.size(), 2u);
@@ -198,11 +198,11 @@ TEST_CASE(DottedPrefix) {
 }
 
 TEST_CASE(PartitionPrefix) {
-    llvm::DenseMap<std::uint32_t, std::string> modules;
-    modules[1] = "foo";
-    modules[2] = "foo:core";
-    modules[3] = "foo:utils";
-    modules[4] = "bar:impl";
+    llvm::DenseMap<Fid, std::string> modules;
+    modules[Fid{1}] = "foo";
+    modules[Fid{2}] = "foo:core";
+    modules[Fid{3}] = "foo:utils";
+    modules[Fid{4}] = "bar:impl";
 
     auto results = complete_module_import(modules, "foo:");
     EXPECT_EQ(results.size(), 2u);
@@ -212,9 +212,9 @@ TEST_CASE(PartitionPrefix) {
 }
 
 TEST_CASE(PrefixIsFullName) {
-    llvm::DenseMap<std::uint32_t, std::string> modules;
-    modules[1] = "std";
-    modules[2] = "std.io";
+    llvm::DenseMap<Fid, std::string> modules;
+    modules[Fid{1}] = "std";
+    modules[Fid{2}] = "std.io";
 
     auto results = complete_module_import(modules, "std");
     EXPECT_EQ(results.size(), 2u);

--- a/tests/unit/syntax/dependency_graph_tests.cpp
+++ b/tests/unit/syntax/dependency_graph_tests.cpp
@@ -630,9 +630,10 @@ int main() {}
 )");
     // Out of the mtime guard window, or the cold scan's pairs stay
     // unreliable and cannot vouch for the warm run.
-    set_file_mtime(tmp.path("inc/util.h"), file_mtime_ns(tmp.path("inc/util.h")) - 10'000'000'000);
-    set_file_mtime(tmp.path("src/main.cpp"),
-                   file_mtime_ns(tmp.path("src/main.cpp")) - 10'000'000'000);
+    ASSERT_TRUE(set_file_mtime(tmp.path("inc/util.h"),
+                               file_mtime_ns(tmp.path("inc/util.h")) - 10'000'000'000));
+    ASSERT_TRUE(set_file_mtime(tmp.path("src/main.cpp"),
+                               file_mtime_ns(tmp.path("src/main.cpp")) - 10'000'000'000));
 
     FileTable file_table;
     CompilationDatabase cdb{file_table};

--- a/tests/unit/syntax/dependency_graph_tests.cpp
+++ b/tests/unit/syntax/dependency_graph_tests.cpp
@@ -2,7 +2,7 @@
 #include "test/temp_dir.h"
 #include "test/test.h"
 #include "command/command.h"
-#include "support/path_pool.h"
+#include "vfs/file_table.h"
 #include "syntax/dependency_graph.h"
 
 namespace clice::testing {
@@ -212,7 +212,8 @@ TEST_CASE(EmptyIncludes) {
 TEST_SUITE(ScanDependencyGraph) {
 
 TEST_CASE(EmptyCDB) {
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     DependencyGraph graph;
 
     scan_dependency_graph(cdb, graph);
@@ -232,7 +233,8 @@ export module m;
 #endif
 )");
 
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     DependencyGraph graph;
     auto json = build_cdb_json({
         {tmp.root, tmp.path("src/m.cppm"), {}}
@@ -261,7 +263,8 @@ export module m1;
 #endif
 )");
 
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     DependencyGraph graph;
     ScanCache cache;
     auto json = build_cdb_json({
@@ -287,7 +290,8 @@ TEST_CASE(SingleFileNoIncludes) {
     TempDir tmp;
     tmp.touch("src/main.cpp", R"(int main() { return 0; })");
 
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     DependencyGraph graph;
 
     auto json = build_cdb_json({
@@ -309,7 +313,8 @@ TEST_CASE(SingleFileWithInclude) {
 int main() { return x; }
 )");
 
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     DependencyGraph graph;
 
     auto json = build_cdb_json({
@@ -332,7 +337,8 @@ TEST_CASE(TransitiveIncludes) {
 int main() {}
 )");
 
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     DependencyGraph graph;
 
     auto json = build_cdb_json({
@@ -358,7 +364,8 @@ void a() {}
 void b() {}
 )");
 
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     DependencyGraph graph;
 
     std::vector<std::string> inc = {"-I", tmp.path("inc")};
@@ -384,7 +391,8 @@ TEST_CASE(ConditionalIncludes) {
 #endif
 )");
 
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     DependencyGraph graph;
 
     auto json = build_cdb_json({
@@ -399,7 +407,7 @@ TEST_CASE(ConditionalIncludes) {
     // Verify conditional flag.
     bool found_unconditional = false;
     bool found_conditional = false;
-    auto includes = graph.get_includes(cdb.paths().intern(tmp.path("src/main.cpp")), 0);
+    auto includes = graph.get_includes(cdb.files().intern(tmp.path("src/main.cpp")), 0);
     for(auto id: includes) {
         if(id & DependencyGraph::CONDITIONAL_FLAG) {
             found_conditional = true;
@@ -418,7 +426,8 @@ export module my.module;
 export int foo() { return 42; }
 )");
 
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     DependencyGraph graph;
 
     auto json = build_cdb_json({
@@ -430,7 +439,7 @@ export int foo() { return 42; }
     auto result = graph.lookup_module("my.module");
     ASSERT_EQ(result.size(), 1u);
 
-    auto path = cdb.paths().resolve(result[0]);
+    auto path = cdb.files().resolve(result[0]);
     EXPECT_TRUE(llvm::sys::fs::equivalent(path, tmp.path("src/mymod.cpp")));
 }
 
@@ -441,7 +450,8 @@ export module my.mod:part;
 void impl() {}
 )");
 
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     DependencyGraph graph;
 
     auto json = build_cdb_json({
@@ -470,7 +480,8 @@ int b = 1;
 int main() {}
 )");
 
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     DependencyGraph graph;
 
     auto json = build_cdb_json({
@@ -494,7 +505,8 @@ TEST_CASE(AngledVsQuoted) {
 int main() {}
 )");
 
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     DependencyGraph graph;
 
     auto json = build_cdb_json({
@@ -515,7 +527,8 @@ TEST_CASE(MissingInclude) {
 int main() {}
 )");
 
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     DependencyGraph graph;
 
     auto json = build_cdb_json({
@@ -543,7 +556,8 @@ module mod.a;
 void a_impl() {}
 )");
 
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     DependencyGraph graph;
 
     auto json = build_cdb_json({
@@ -571,7 +585,8 @@ TEST_CASE(DeepIncludeChain) {
 int main() {}
 )");
 
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     DependencyGraph graph;
 
     auto json = build_cdb_json({
@@ -595,7 +610,8 @@ export module my.lib;
 export int value() { return util; }
 )");
 
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     DependencyGraph graph;
 
     auto json = build_cdb_json({
@@ -616,7 +632,8 @@ TEST_CASE(ScanCacheWarmRun) {
 int main() {}
 )");
 
-    CompilationDatabase cdb;
+    FileTable file_table;
+    CompilationDatabase cdb{file_table};
     ScanCache cache;
 
     auto json = build_cdb_json({

--- a/tests/unit/syntax/dependency_graph_tests.cpp
+++ b/tests/unit/syntax/dependency_graph_tests.cpp
@@ -2,8 +2,8 @@
 #include "test/temp_dir.h"
 #include "test/test.h"
 #include "command/command.h"
-#include "vfs/file_table.h"
 #include "syntax/dependency_graph.h"
+#include "vfs/file_table.h"
 
 namespace clice::testing {
 namespace {

--- a/tests/unit/syntax/dependency_graph_tests.cpp
+++ b/tests/unit/syntax/dependency_graph_tests.cpp
@@ -21,60 +21,60 @@ TEST_CASE(LookupModuleEmpty) {
 
 TEST_CASE(AddAndLookupModule) {
     clice::DependencyGraph graph;
-    graph.add_module("foo.bar", 42);
+    graph.add_module("foo.bar", Fid{42});
 
     auto result = graph.lookup_module("foo.bar");
     ASSERT_EQ(result.size(), 1u);
-    EXPECT_EQ(result[0], 42u);
+    EXPECT_EQ(result[0].raw, 42u);
 }
 
 TEST_CASE(DuplicateModuleDedup) {
     clice::DependencyGraph graph;
     // Same module name, same path_id — should dedup.
-    graph.add_module("foo", 10);
-    graph.add_module("foo", 10);
+    graph.add_module("foo", Fid{10});
+    graph.add_module("foo", Fid{10});
     ASSERT_EQ(graph.lookup_module("foo").size(), 1u);
 
     // Same module name, different path_id — multiple candidates.
-    graph.add_module("foo", 20);
+    graph.add_module("foo", Fid{20});
     auto result = graph.lookup_module("foo");
     ASSERT_EQ(result.size(), 2u);
-    EXPECT_EQ(result[0], 10u);
-    EXPECT_EQ(result[1], 20u);
+    EXPECT_EQ(result[0].raw, 10u);
+    EXPECT_EQ(result[1].raw, 20u);
 }
 
 TEST_CASE(RedeclareKeepsProviderOrder) {
     clice::DependencyGraph graph;
-    graph.update_module_decl(1, "foo");
-    graph.update_module_decl(2, "foo");
+    graph.update_module_decl(Fid{1}, "foo");
+    graph.update_module_decl(Fid{2}, "foo");
 
     // Providers are selected by list order: re-declaring the unchanged
     // name must not rotate the duplicate-name list.
-    graph.update_module_decl(1, "foo");
+    graph.update_module_decl(Fid{1}, "foo");
     auto result = graph.lookup_module("foo");
     ASSERT_EQ(result.size(), 2u);
-    EXPECT_EQ(result[0], 1u);
-    EXPECT_EQ(result[1], 2u);
+    EXPECT_EQ(result[0].raw, 1u);
+    EXPECT_EQ(result[1].raw, 2u);
 
     // A real name change still moves the path.
-    graph.update_module_decl(1, "bar");
+    graph.update_module_decl(Fid{1}, "bar");
     ASSERT_EQ(graph.lookup_module("foo").size(), 1u);
-    EXPECT_EQ(graph.lookup_module("foo")[0], 2u);
+    EXPECT_EQ(graph.lookup_module("foo")[0].raw, 2u);
     ASSERT_EQ(graph.lookup_module("bar").size(), 1u);
 }
 
 TEST_CASE(MultipleModules) {
     clice::DependencyGraph graph;
-    graph.add_module("mod.a", 1);
-    graph.add_module("mod.b", 2);
-    graph.add_module("mod.c:part", 3);
+    graph.add_module("mod.a", Fid{1});
+    graph.add_module("mod.b", Fid{2});
+    graph.add_module("mod.c:part", Fid{3});
 
     ASSERT_EQ(graph.lookup_module("mod.a").size(), 1u);
-    EXPECT_EQ(graph.lookup_module("mod.a")[0], 1u);
+    EXPECT_EQ(graph.lookup_module("mod.a")[0].raw, 1u);
     ASSERT_EQ(graph.lookup_module("mod.b").size(), 1u);
-    EXPECT_EQ(graph.lookup_module("mod.b")[0], 2u);
+    EXPECT_EQ(graph.lookup_module("mod.b")[0].raw, 2u);
     ASSERT_EQ(graph.lookup_module("mod.c:part").size(), 1u);
-    EXPECT_EQ(graph.lookup_module("mod.c:part")[0], 3u);
+    EXPECT_EQ(graph.lookup_module("mod.c:part")[0].raw, 3u);
     EXPECT_TRUE(graph.lookup_module("mod.d").empty());
 }
 
@@ -82,14 +82,14 @@ TEST_CASE(ModuleCount) {
     clice::DependencyGraph graph;
     EXPECT_EQ(graph.module_count(), 0u);
 
-    graph.add_module("a", 1);
+    graph.add_module("a", Fid{1});
     EXPECT_EQ(graph.module_count(), 1u);
 
-    graph.add_module("b", 2);
+    graph.add_module("b", Fid{2});
     EXPECT_EQ(graph.module_count(), 2u);
 
     // Second candidate for "a" doesn't increase module name count.
-    graph.add_module("a", 3);
+    graph.add_module("a", Fid{3});
     EXPECT_EQ(graph.module_count(), 2u);
 }
 
@@ -99,86 +99,89 @@ TEST_CASE(ModuleCount) {
 
 TEST_CASE(EmptyGraphIncludes) {
     clice::DependencyGraph graph;
-    auto includes = graph.get_includes(0, 0);
+    auto includes = graph.get_includes(Fid{0}, 0);
     EXPECT_TRUE(includes.empty());
 }
 
 TEST_CASE(SetAndGetIncludes) {
     clice::DependencyGraph graph;
-    llvm::SmallVector<std::uint32_t> ids = {10, 20, 30};
-    graph.set_includes(1, 0, ids);
+    llvm::SmallVector<IncludeEdge> ids = {{Fid{10}}, {Fid{20}}, {Fid{30}}};
+    graph.set_includes(Fid{1}, 0, ids);
 
-    auto result = graph.get_includes(1, 0);
+    auto result = graph.get_includes(Fid{1}, 0);
     ASSERT_EQ(result.size(), 3u);
-    EXPECT_EQ(result[0], 10u);
-    EXPECT_EQ(result[1], 20u);
-    EXPECT_EQ(result[2], 30u);
+    EXPECT_EQ(result[0].fid.raw, 10u);
+    EXPECT_EQ(result[1].fid.raw, 20u);
+    EXPECT_EQ(result[2].fid.raw, 30u);
 }
 
 TEST_CASE(IncludesPerConfig) {
     clice::DependencyGraph graph;
 
     // Same file, different configs.
-    graph.set_includes(1, 0, {10, 20});
-    graph.set_includes(1, 1, {20, 30});
+    graph.set_includes(Fid{1}, 0, {{Fid{10}}, {Fid{20}}});
+    graph.set_includes(Fid{1}, 1, {{Fid{20}}, {Fid{30}}});
 
-    auto config0 = graph.get_includes(1, 0);
+    auto config0 = graph.get_includes(Fid{1}, 0);
     ASSERT_EQ(config0.size(), 2u);
-    EXPECT_EQ(config0[0], 10u);
-    EXPECT_EQ(config0[1], 20u);
+    EXPECT_EQ(config0[0].fid.raw, 10u);
+    EXPECT_EQ(config0[1].fid.raw, 20u);
 
-    auto config1 = graph.get_includes(1, 1);
+    auto config1 = graph.get_includes(Fid{1}, 1);
     ASSERT_EQ(config1.size(), 2u);
-    EXPECT_EQ(config1[0], 20u);
-    EXPECT_EQ(config1[1], 30u);
+    EXPECT_EQ(config1[0].fid.raw, 20u);
+    EXPECT_EQ(config1[1].fid.raw, 30u);
 }
 
 TEST_CASE(GetAllIncludesUnion) {
     clice::DependencyGraph graph;
 
-    graph.set_includes(1, 0, {10, 20});
-    graph.set_includes(1, 1, {20, 30});
+    graph.set_includes(Fid{1}, 0, {{Fid{10}}, {Fid{20}}});
+    graph.set_includes(Fid{1}, 1, {{Fid{20}}, {Fid{30}}});
 
-    auto all = graph.get_all_includes(1);
+    auto all = graph.get_all_includes(Fid{1});
     // Union of {10, 20} and {20, 30} = {10, 20, 30}.
     ASSERT_EQ(all.size(), 3u);
+    EXPECT_TRUE(llvm::is_contained(all, Fid{10}));
+    EXPECT_TRUE(llvm::is_contained(all, Fid{20}));
+    EXPECT_TRUE(llvm::is_contained(all, Fid{30}));
 }
 
 TEST_CASE(ConditionalFlag) {
     clice::DependencyGraph graph;
 
-    constexpr auto FLAG = clice::DependencyGraph::CONDITIONAL_FLAG;
-    constexpr auto MASK = clice::DependencyGraph::PATH_ID_MASK;
-
     // PathID 5 unconditional, PathID 7 conditional.
-    llvm::SmallVector<std::uint32_t> ids = {5, 7 | FLAG};
-    graph.set_includes(1, 0, ids);
+    llvm::SmallVector<IncludeEdge> ids = {
+        {Fid{5}},
+        {Fid{7}, /*conditional=*/true}
+    };
+    graph.set_includes(Fid{1}, 0, ids);
 
-    auto result = graph.get_includes(1, 0);
+    auto result = graph.get_includes(Fid{1}, 0);
     ASSERT_EQ(result.size(), 2u);
 
     // First: unconditional.
-    EXPECT_EQ(result[0] & MASK, 5u);
-    EXPECT_EQ(result[0] & FLAG, 0u);
+    EXPECT_EQ(result[0].fid.raw, 5u);
+    EXPECT_FALSE(result[0].conditional);
 
     // Second: conditional.
-    EXPECT_EQ(result[1] & MASK, 7u);
-    EXPECT_NE(result[1] & FLAG, 0u);
+    EXPECT_EQ(result[1].fid.raw, 7u);
+    EXPECT_TRUE(result[1].conditional);
 }
 
 TEST_CASE(FileCount) {
     clice::DependencyGraph graph;
     EXPECT_EQ(graph.file_count(), 0u);
 
-    graph.set_includes(1, 0, {10});
+    graph.set_includes(Fid{1}, 0, {{Fid{10}}});
     EXPECT_EQ(graph.file_count(), 1u);
 
     // Same file, different config.
-    graph.set_includes(1, 1, {20});
+    graph.set_includes(Fid{1}, 1, {{Fid{20}}});
     EXPECT_EQ(graph.file_count(), 1u);
 
     // Different file.
-    graph.set_includes(2, 0, {30});
+    graph.set_includes(Fid{2}, 0, {{Fid{30}}});
     EXPECT_EQ(graph.file_count(), 2u);
 }
 
@@ -186,18 +189,18 @@ TEST_CASE(EdgeCount) {
     clice::DependencyGraph graph;
     EXPECT_EQ(graph.edge_count(), 0u);
 
-    graph.set_includes(1, 0, {10, 20});
+    graph.set_includes(Fid{1}, 0, {{Fid{10}}, {Fid{20}}});
     EXPECT_EQ(graph.edge_count(), 2u);
 
-    graph.set_includes(2, 0, {30});
+    graph.set_includes(Fid{2}, 0, {{Fid{30}}});
     EXPECT_EQ(graph.edge_count(), 3u);
 }
 
 TEST_CASE(EmptyIncludes) {
     clice::DependencyGraph graph;
-    graph.set_includes(1, 0, {});
+    graph.set_includes(Fid{1}, 0, {});
 
-    auto result = graph.get_includes(1, 0);
+    auto result = graph.get_includes(Fid{1}, 0);
     EXPECT_TRUE(result.empty());
     EXPECT_EQ(graph.file_count(), 1u);
     EXPECT_EQ(graph.edge_count(), 0u);
@@ -405,8 +408,8 @@ TEST_CASE(ConditionalIncludes) {
     bool found_unconditional = false;
     bool found_conditional = false;
     auto includes = graph.get_includes(cdb.files().intern(tmp.path("src/main.cpp")), 0);
-    for(auto id: includes) {
-        if(id & DependencyGraph::CONDITIONAL_FLAG) {
+    for(auto edge: includes) {
+        if(edge.conditional) {
             found_conditional = true;
         } else {
             found_unconditional = true;
@@ -658,8 +661,9 @@ int main() {}
 
 // TODO: add tests for:
 // - Circular includes (A→B→A) to verify BFS terminates correctly
-// - get_all_includes flag merge: same header conditional in one config,
-//   unconditional in another — unconditional should win
+// - get_all_includes across configs: a header in one config but not
+//   another appears once in the deduped union (the union carries plain
+//   fids — conditionality is per-config, asserted via get_includes)
 // - set_includes overwrite: calling twice with same (path_id, config_id)
 
 };  // TEST_SUITE(ScanDependencyGraph)

--- a/tests/unit/syntax/dependency_graph_tests.cpp
+++ b/tests/unit/syntax/dependency_graph_tests.cpp
@@ -242,7 +242,6 @@ export module m;
     write_cdb(tmp, cdb, json);
     scan_dependency_graph(cdb,
                           graph,
-                          /*cache=*/nullptr,
                           [](llvm::StringRef,
                              std::vector<std::string>& append,
                              std::vector<std::string>&) { append.push_back("-DENABLE_M"); });
@@ -266,22 +265,20 @@ export module m1;
     FileTable file_table;
     CompilationDatabase cdb{file_table};
     DependencyGraph graph;
-    ScanCache cache;
     auto json = build_cdb_json({
         {tmp.root, tmp.path("src/m.cppm"), {}      },
         {tmp.root, tmp.path("src/m.cppm"), {"-DV2"}},
     });
     write_cdb(tmp, cdb, json);
-    scan_dependency_graph(cdb, graph, &cache);
+    scan_dependency_graph(cdb, graph);
 
     EXPECT_EQ(graph.lookup_module("m1").size(), 1u);
     EXPECT_EQ(graph.lookup_module("m2").size(), 1u);
 
-    // A warm run must reproduce both: the shared per-path cache cannot
-    // hold two names, so multi-group units re-derive under their own
-    // group command every run.
+    // A warm run must reproduce both: the module-decl memo keys by
+    // (content, rendered command), so each group resolves its own name.
     DependencyGraph graph2;
-    scan_dependency_graph(cdb, graph2, &cache);
+    scan_dependency_graph(cdb, graph2);
     EXPECT_EQ(graph2.lookup_module("m1").size(), 1u);
     EXPECT_EQ(graph2.lookup_module("m2").size(), 1u);
 }
@@ -631,10 +628,14 @@ TEST_CASE(ScanCacheWarmRun) {
 #include "util.h"
 int main() {}
 )");
+    // Out of the mtime guard window, or the cold scan's pairs stay
+    // unreliable and cannot vouch for the warm run.
+    set_file_mtime(tmp.path("inc/util.h"), file_mtime_ns(tmp.path("inc/util.h")) - 10'000'000'000);
+    set_file_mtime(tmp.path("src/main.cpp"),
+                   file_mtime_ns(tmp.path("src/main.cpp")) - 10'000'000'000);
 
     FileTable file_table;
     CompilationDatabase cdb{file_table};
-    ScanCache cache;
 
     auto json = build_cdb_json({
         {tmp.root, tmp.path("src/main.cpp"), {"-I", tmp.path("inc")}}
@@ -642,13 +643,13 @@ int main() {}
     write_cdb(tmp, cdb, json);
 
     DependencyGraph graph;
-    auto cold = scan_dependency_graph(cdb, graph, &cache);
+    auto cold = scan_dependency_graph(cdb, graph);
     EXPECT_GE(graph.edge_count(), 1u);
 
-    // Warm run with the same cache and pool reproduces the same graph
-    // and hits the scan result cache instead of re-reading files.
+    // A rescan against the same shared table skips the read and the lex
+    // for every unchanged file (stat-validated through the shared pairs).
     DependencyGraph graph2;
-    auto warm = scan_dependency_graph(cdb, graph2, &cache);
+    auto warm = scan_dependency_graph(cdb, graph2);
     EXPECT_GT(warm.scan_cache_hits, std::size_t(0));
     EXPECT_EQ(graph2.edge_count(), graph.edge_count());
     EXPECT_EQ(graph2.file_count(), graph.file_count());

--- a/tests/unit/test/temp_dir.h
+++ b/tests/unit/test/temp_dir.h
@@ -9,7 +9,6 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
-#include "llvm/Support/Process.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace clice::testing {
@@ -84,22 +83,11 @@ private:
     std::deque<std::string> pool;
 };
 
-/// Rewrite a file's mtime, for freshness tests that simulate backdated or
-/// preserved timestamps (rsync -t, git-restore-mtime). Returns false on
-/// failure so callers can assert.
-inline bool set_file_mtime(llvm::StringRef path, std::int64_t mtime_ns) {
-    int fd = -1;
-    if(llvm::sys::fs::openFileForWrite(path,
-                                       fd,
-                                       llvm::sys::fs::CD_OpenExisting,
-                                       llvm::sys::fs::OF_Append)) {
-        return false;
-    }
-    auto time = llvm::sys::TimePoint<>(std::chrono::nanoseconds(mtime_ns));
-    bool ok = !llvm::sys::fs::setLastAccessAndModificationTime(fd, time, time);
-    llvm::sys::Process::SafelyCloseFileDescriptor(fd);
-    return ok;
-}
+/// Rewrite a file's or directory's mtime, for freshness tests that simulate
+/// backdated or preserved timestamps (rsync -t, git-restore-mtime, a project
+/// tree older than the server). Returns false on failure so callers can
+/// assert.
+bool set_file_mtime(llvm::StringRef path, std::int64_t mtime_ns);
 
 /// A file's current mtime in nanoseconds, or -1 when it cannot be stat'ed.
 inline std::int64_t file_mtime_ns(llvm::StringRef path) {

--- a/tests/unit/test/tester.cpp
+++ b/tests/unit/test/tester.cpp
@@ -3,8 +3,23 @@
 #include <cassert>
 #include <format>
 
+#ifdef _WIN32
+// See cache_store.cpp: windows.h must not spill min/max macros.
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <sys/stat.h>
+#endif
+
+#include "test/temp_dir.h"
 #include "support/logging.h"
 #include "syntax/scan.h"
+
+#ifdef _WIN32
+#include "llvm/Support/ConvertUTF.h"
+#endif
 
 namespace clice::testing {
 
@@ -338,6 +353,42 @@ void Tester::prepare_driver(llvm::StringRef standard) {
 bool Tester::compile_driver(llvm::StringRef standard) {
     prepare_driver(standard);
     return try_compile();
+}
+
+bool set_file_mtime(llvm::StringRef path, std::int64_t mtime_ns) {
+#ifdef _WIN32
+    // Path-based instead of fd-based: opening a directory needs
+    // FILE_FLAG_BACKUP_SEMANTICS, which no LLVM open wrapper passes.
+    std::wstring wide;
+    if(!llvm::ConvertUTF8toWide(path, wide)) {
+        return false;
+    }
+    HANDLE handle = ::CreateFileW(wide.c_str(),
+                                  FILE_WRITE_ATTRIBUTES,
+                                  FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                  nullptr,
+                                  OPEN_EXISTING,
+                                  FILE_FLAG_BACKUP_SEMANTICS,
+                                  nullptr);
+    if(handle == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+    // FILETIME counts 100ns intervals since 1601-01-01.
+    std::uint64_t intervals = static_cast<std::uint64_t>(mtime_ns / 100) + 116444736000000000ull;
+    FILETIME time;
+    time.dwLowDateTime = static_cast<DWORD>(intervals);
+    time.dwHighDateTime = static_cast<DWORD>(intervals >> 32);
+    bool ok = ::SetFileTime(handle, nullptr, &time, &time);
+    ::CloseHandle(handle);
+    return ok;
+#else
+    timespec times[2];
+    times[0].tv_sec = mtime_ns / 1'000'000'000;
+    times[0].tv_nsec = mtime_ns % 1'000'000'000;
+    times[1] = times[0];
+    std::string buffer(path);
+    return ::utimensat(AT_FDCWD, buffer.c_str(), times, 0) == 0;
+#endif
 }
 
 void Tester::clear() {

--- a/tests/unit/test/tester.h
+++ b/tests/unit/test/tester.h
@@ -14,7 +14,8 @@ namespace clice::testing {
 
 struct Tester {
     CompilationParams params;
-    CompilationDatabase database;
+    FileTable file_table;
+    CompilationDatabase database{file_table};
     std::optional<CompilationUnit> unit;
     std::string src_path;
 

--- a/tests/unit/vfs/file_table_tests.cpp
+++ b/tests/unit/vfs/file_table_tests.cpp
@@ -71,6 +71,10 @@ TEST_CASE(HardlinkFirstBindReads) {
                     .has_value());
 }
 
+#ifndef _WIN32
+// The four tests below pin identity-based defenses (rename-over rebinds,
+// hardlink merging, live-identity stamp gates) that require file-stable
+// UniqueIDs — POSIX-only; see fs::stable_file_ids and FileTable::entity_key.
 TEST_CASE(RenameSaveRebinds) {
     // An editor-style save (write tmp, rename over) replaces the inode.
     // The forged stat makes the old pair match by (size, mtime): only the
@@ -180,6 +184,7 @@ TEST_CASE(FastPathChecksIdentity) {
     pool.begin_wave();
     ASSERT_TRUE(pool.check_version(vid) == FileTable::Verdict::Stale);
 }
+#endif
 
 TEST_CASE(FreshReadCannotStamp) {
     // A check that reads a just-written file gets the right verdict but
@@ -208,6 +213,7 @@ TEST_CASE(ListingSeesNewFile) {
     tmp.touch("inc/a.h", "");
     auto dir = tmp.path("inc");
     age(dir);
+    auto aged = file_mtime_ns(dir);
 
     FileTable pool;
     DirListingCache first_op;
@@ -218,7 +224,11 @@ TEST_CASE(ListingSeesNewFile) {
     ASSERT_FALSE(entries->contains("b.h"));
 
     tmp.touch("inc/b.h", "");
-    age(dir);
+    // A second age() rewinds relative to now and can land on the first
+    // listing's exact stamp within one coarse mtime tick, revalidating the
+    // cached listing; a fixed offset keeps the stamps distinct while
+    // staying outside the guard window.
+    ASSERT_TRUE(set_file_mtime(dir, aged + 1'000'000'000));
 
     DirListingCache second_op;
     second_op.shared = &pool;

--- a/tests/unit/vfs/file_table_tests.cpp
+++ b/tests/unit/vfs/file_table_tests.cpp
@@ -134,6 +134,53 @@ TEST_CASE(RevalidateClearsAliasStamps) {
     ASSERT_EQ(pool.version(vid).mtime_ns, 0);
 }
 
+TEST_CASE(StampNeedsLiveIdentity) {
+    // A stamp corroborates only through the identity the pair was earned
+    // under: a stat carrying a different UniqueID (same-stat replace)
+    // must decline even when size and mtime match the pair.
+    TempDir tmp;
+    tmp.touch("f.h", "int v1();\n");
+    auto f = tmp.path("f.h");
+    age(f);
+
+    FileTable pool;
+    auto fid = pool.intern(f);
+    auto read = pool.read(fid);
+    ASSERT_TRUE(read.has_value());
+    auto vid = pool.intern_version(fid, read->hash);
+
+    pool.try_stamp(vid, read->size, read->mtime_ns, read->uid_device + 1, read->uid_file + 1);
+    ASSERT_EQ(pool.version(vid).mtime_ns, 0);
+
+    pool.try_stamp(vid, read->size, read->mtime_ns, read->uid_device, read->uid_file);
+    ASSERT_TRUE(pool.version(vid).mtime_ns != 0);
+}
+
+TEST_CASE(FastPathChecksIdentity) {
+    // A stamped version's stat fast path must not survive a rename-over
+    // that forges the same size and mtime: the inode changed, and the
+    // session knows this fid's identity.
+    TempDir tmp;
+    tmp.touch("f.h", "int v1();\n");
+    auto f = tmp.path("f.h");
+    age(f);
+
+    FileTable pool;
+    auto fid = pool.intern(f);
+    auto read = pool.read(fid);
+    ASSERT_TRUE(read.has_value());
+    auto vid = pool.intern_version(fid, read->hash);
+    pool.try_stamp(vid, read->size, read->mtime_ns, read->uid_device, read->uid_file);
+    ASSERT_TRUE(pool.version(vid).mtime_ns != 0);
+
+    tmp.touch("f.h.tmp", "int v2();\n");
+    ASSERT_TRUE(bool(fs::rename(tmp.path("f.h.tmp"), f)));
+    EXPECT_TRUE(set_file_mtime(f, read->mtime_ns));
+
+    pool.begin_wave();
+    ASSERT_TRUE(pool.check_version(vid) == FileTable::Verdict::Stale);
+}
+
 TEST_CASE(FreshReadCannotStamp) {
     // A check that reads a just-written file gets the right verdict but
     // must not stamp the version: on a coarse-mtime filesystem a same-tick

--- a/tests/unit/vfs/file_table_tests.cpp
+++ b/tests/unit/vfs/file_table_tests.cpp
@@ -1,12 +1,160 @@
+#include "test/temp_dir.h"
 #include "test/test.h"
 #include "support/filesystem.h"
+#include "syntax/include_resolver.h"
 #include "vfs/file_table.h"
+
+#include "llvm/Support/FileSystem.h"
 
 namespace clice::testing {
 
 namespace {
 
+/// Rewind a file's (or directory's) mtime out of the guard window so its
+/// observations count as reliable, the way real project files predate a
+/// server start.
+void age(llvm::StringRef path) {
+    EXPECT_TRUE(set_file_mtime(path, file_mtime_ns(path) - 10'000'000'000));
+}
+
+llvm::sys::fs::file_status stat_of(llvm::StringRef path) {
+    llvm::sys::fs::file_status status;
+    EXPECT_FALSE(bool(llvm::sys::fs::status(path, status)));
+    return status;
+}
+
 TEST_SUITE(FileTable) {
+
+TEST_CASE(FirstBindToExistingEntityReads) {
+    // Two spellings hardlinked to one inode: the second spelling's first
+    // sight of the (already known) entity must not inherit the pair — a
+    // recycled inode can hand an unrelated new file an equal-looking stat.
+    // After one read through the second spelling, the twins share.
+    TempDir tmp;
+    tmp.touch("a.h", "int shared();\n");
+    auto a = tmp.path("a.h");
+    auto b = tmp.path("b.h");
+    ASSERT_FALSE(bool(llvm::sys::fs::create_hard_link(a, b)));
+    age(a);
+
+    FileTable pool;
+    auto a_id = pool.intern(a);
+    auto b_id = pool.intern(b);
+    auto read = pool.read(a_id);
+    ASSERT_TRUE(read.has_value());
+
+    auto status = stat_of(b);
+    auto uid = status.getUniqueID();
+    ASSERT_FALSE(pool.cached_hash(b_id,
+                                  status.getSize(),
+                                  fs::mtime_ns(status),
+                                  uid.getDevice(),
+                                  uid.getFile())
+                     .has_value());
+
+    ASSERT_TRUE(pool.read(b_id).has_value());
+    auto earned = pool.cached_hash(b_id,
+                                   status.getSize(),
+                                   fs::mtime_ns(status),
+                                   uid.getDevice(),
+                                   uid.getFile());
+    ASSERT_TRUE(earned.has_value());
+    ASSERT_EQ(*earned, read->hash);
+
+    // The earned binding also serves the first spelling still.
+    auto a_status = stat_of(a);
+    ASSERT_TRUE(pool.cached_hash(a_id,
+                                 a_status.getSize(),
+                                 fs::mtime_ns(a_status),
+                                 a_status.getUniqueID().getDevice(),
+                                 a_status.getUniqueID().getFile())
+                    .has_value());
+}
+
+TEST_CASE(RenameSaveRebinds) {
+    // An editor-style save (write tmp, rename over) replaces the inode:
+    // the spelling rebinds to the fresh entity and nothing serves the old
+    // pair for the new bytes.
+    TempDir tmp;
+    tmp.touch("f.h", "int v1();\n");
+    auto f = tmp.path("f.h");
+    age(f);
+
+    FileTable pool;
+    auto fid = pool.intern(f);
+    ASSERT_TRUE(pool.read(fid).has_value());
+
+    tmp.touch("f.h.tmp", "int v2();\n");
+    ASSERT_TRUE(bool(fs::rename(tmp.path("f.h.tmp"), f)));
+    age(f);
+
+    auto status = stat_of(f);
+    auto uid = status.getUniqueID();
+    ASSERT_FALSE(pool.cached_hash(fid,
+                                  status.getSize(),
+                                  fs::mtime_ns(status),
+                                  uid.getDevice(),
+                                  uid.getFile())
+                     .has_value());
+
+    auto reread = pool.read(fid);
+    ASSERT_TRUE(reread.has_value());
+    ASSERT_TRUE(
+        pool.cached_hash(fid, reread->size, reread->mtime_ns, reread->uid_device, reread->uid_file)
+            .has_value());
+}
+
+TEST_CASE(DirListingSeesNewFile) {
+    // An external generator dropping a header into a cached directory
+    // produces no event; the directory's own mtime is the anchor that
+    // makes the next operation re-list it.
+    TempDir tmp;
+    tmp.touch("inc/a.h", "");
+    auto dir = tmp.path("inc");
+    age(dir);
+
+    FileTable pool;
+    DirListingCache first_op;
+    first_op.shared = &pool;
+    auto* entries = resolve_dir(dir, first_op);
+    ASSERT_TRUE(entries != nullptr);
+    ASSERT_TRUE(entries->contains("a.h"));
+    ASSERT_FALSE(entries->contains("b.h"));
+
+    tmp.touch("inc/b.h", "");
+    age(dir);
+
+    DirListingCache second_op;
+    second_op.shared = &pool;
+    auto* refreshed = resolve_dir(dir, second_op);
+    ASSERT_TRUE(refreshed != nullptr);
+    ASSERT_TRUE(refreshed->contains("b.h"));
+}
+
+TEST_CASE(DirListingWarmWithoutChange) {
+    TempDir tmp;
+    tmp.touch("inc/a.h", "");
+    auto dir = tmp.path("inc");
+    age(dir);
+
+    FileTable pool;
+    {
+        DirListingCache op;
+        op.shared = &pool;
+        resolve_dir(dir, op);
+    }
+    ASSERT_TRUE(pool.dir_listings.contains(dir));
+    ASSERT_TRUE(pool.dir_listings.find(dir)->second.mtime_ns != 0);
+
+    // The next operation validates by one stat and reuses the listing.
+    StatCounters counters;
+    DirListingCache op;
+    op.shared = &pool;
+    auto* entries = resolve_dir(dir, op, &counters);
+    ASSERT_TRUE(entries->contains("a.h"));
+    ASSERT_EQ(counters.dir_listings, 0u);
+    ASSERT_EQ(counters.dir_hits, 1u);
+}
 
 TEST_CASE(CanonicalSpelling) {
     // The rewrite itself is platform-independent and testable anywhere;

--- a/tests/unit/vfs/file_table_tests.cpp
+++ b/tests/unit/vfs/file_table_tests.cpp
@@ -1,12 +1,12 @@
 #include "test/test.h"
 #include "support/filesystem.h"
-#include "support/path_pool.h"
+#include "vfs/file_table.h"
 
 namespace clice::testing {
 
 namespace {
 
-TEST_SUITE(PathPool) {
+TEST_SUITE(FileTable) {
 
 TEST_CASE(CanonicalSpelling) {
     // The rewrite itself is platform-independent and testable anywhere;
@@ -31,7 +31,7 @@ TEST_CASE(WindowsSpellingsCollapse) {
     // uppercase; on Windows every spelling of one file interns to one ID
     // and resolves to the client-facing form, or every CDB lookup misses
     // and compiles fall back to guessed commands.
-    PathPool pool;
+    FileTable pool;
     EXPECT_EQ(pool.intern("c:/a/b.h"), pool.intern(R"(C:\a\b.h)"));
     EXPECT_EQ(pool.resolve(pool.intern("C:/a/b.h")), "c:/a/b.h");
     EXPECT_EQ(pool.find(R"(c:\a\b.h)"), pool.find("C:/a/b.h"));
@@ -40,7 +40,7 @@ TEST_CASE(WindowsSpellingsCollapse) {
 TEST_CASE(PosixBytesPreserved) {
     // '\' and "C:" are ordinary filename characters on POSIX; identity is
     // the raw bytes and the Windows rewrite must not touch them.
-    PathPool pool;
+    FileTable pool;
     EXPECT_NE(pool.intern(R"(a\b)"), pool.intern("a/b"));
     EXPECT_NE(pool.intern("C:/x.h"), pool.intern("c:/x.h"));
     EXPECT_NE(pool.intern("/c/x.h"), pool.intern("/C/x.h"));
@@ -48,7 +48,7 @@ TEST_CASE(PosixBytesPreserved) {
 }
 #endif
 
-};  // TEST_SUITE(PathPool)
+};  // TEST_SUITE(FileTable)
 
 }  // namespace
 

--- a/tests/unit/vfs/file_table_tests.cpp
+++ b/tests/unit/vfs/file_table_tests.cpp
@@ -25,7 +25,7 @@ llvm::sys::fs::file_status stat_of(llvm::StringRef path) {
 
 TEST_SUITE(FileTable) {
 
-TEST_CASE(FirstBindToExistingEntityReads) {
+TEST_CASE(HardlinkFirstBindReads) {
     // Two spellings hardlinked to one inode: the second spelling's first
     // sight of the (already known) entity must not inherit the pair — a
     // recycled inode can hand an unrelated new file an equal-looking stat.
@@ -72,9 +72,10 @@ TEST_CASE(FirstBindToExistingEntityReads) {
 }
 
 TEST_CASE(RenameSaveRebinds) {
-    // An editor-style save (write tmp, rename over) replaces the inode:
-    // the spelling rebinds to the fresh entity and nothing serves the old
-    // pair for the new bytes.
+    // An editor-style save (write tmp, rename over) replaces the inode.
+    // The forged stat makes the old pair match by (size, mtime): only the
+    // rebind on the changed UniqueID keeps it from vouching for the new
+    // bytes.
     TempDir tmp;
     tmp.touch("f.h", "int v1();\n");
     auto f = tmp.path("f.h");
@@ -82,14 +83,17 @@ TEST_CASE(RenameSaveRebinds) {
 
     FileTable pool;
     auto fid = pool.intern(f);
-    ASSERT_TRUE(pool.read(fid).has_value());
+    auto first = pool.read(fid);
+    ASSERT_TRUE(first.has_value());
 
     tmp.touch("f.h.tmp", "int v2();\n");
     ASSERT_TRUE(bool(fs::rename(tmp.path("f.h.tmp"), f)));
-    age(f);
+    EXPECT_TRUE(set_file_mtime(f, first->mtime_ns));
 
     auto status = stat_of(f);
     auto uid = status.getUniqueID();
+    ASSERT_EQ(status.getSize(), first->size);
+    ASSERT_EQ(fs::mtime_ns(status), first->mtime_ns);
     ASSERT_FALSE(pool.cached_hash(fid,
                                   status.getSize(),
                                   fs::mtime_ns(status),
@@ -99,12 +103,57 @@ TEST_CASE(RenameSaveRebinds) {
 
     auto reread = pool.read(fid);
     ASSERT_TRUE(reread.has_value());
+    ASSERT_NE(reread->hash, first->hash);
     ASSERT_TRUE(
         pool.cached_hash(fid, reread->size, reread->mtime_ns, reread->uid_device, reread->uid_file)
             .has_value());
 }
 
-TEST_CASE(DirListingSeesNewFile) {
+TEST_CASE(RevalidateClearsAliasStamps) {
+    // force_revalidate through one spelling must clear the version stamps
+    // of a hardlinked twin: its stamp would otherwise vouch for a
+    // same-stat edit before the erased entity pair is ever consulted.
+    TempDir tmp;
+    tmp.touch("a.h", "int shared();\n");
+    auto a = tmp.path("a.h");
+    auto b = tmp.path("b.h");
+    ASSERT_FALSE(bool(llvm::sys::fs::create_hard_link(a, b)));
+    age(a);
+
+    FileTable pool;
+    auto a_id = pool.intern(a);
+    auto b_id = pool.intern(b);
+    ASSERT_TRUE(pool.read(a_id).has_value());
+    auto read = pool.read(b_id);
+    ASSERT_TRUE(read.has_value());
+    auto vid = pool.intern_version(b_id, read->hash);
+    pool.try_stamp(vid, read->size, read->mtime_ns, read->uid_device, read->uid_file);
+    ASSERT_TRUE(pool.version(vid).mtime_ns != 0);
+
+    pool.force_revalidate(a_id);
+    ASSERT_EQ(pool.version(vid).mtime_ns, 0);
+}
+
+TEST_CASE(FreshReadCannotStamp) {
+    // A check that reads a just-written file gets the right verdict but
+    // must not stamp the version: on a coarse-mtime filesystem a same-tick
+    // write could later forge the stamped stat.
+    TempDir tmp;
+    tmp.touch("f.h", "int fresh();\n");
+    auto f = tmp.path("f.h");
+
+    FileTable pool;
+    auto fid = pool.intern(f);
+    auto read = pool.read(fid);
+    ASSERT_TRUE(read.has_value());
+    auto vid = pool.intern_version(fid, read->hash);
+
+    pool.begin_wave();
+    ASSERT_TRUE(pool.check_version(vid) == FileTable::Verdict::Fresh);
+    ASSERT_EQ(pool.version(vid).mtime_ns, 0);
+}
+
+TEST_CASE(ListingSeesNewFile) {
     // An external generator dropping a header into a cached directory
     // produces no event; the directory's own mtime is the anchor that
     // makes the next operation re-list it.
@@ -131,7 +180,7 @@ TEST_CASE(DirListingSeesNewFile) {
     ASSERT_TRUE(refreshed->contains("b.h"));
 }
 
-TEST_CASE(DirListingWarmWithoutChange) {
+TEST_CASE(WarmListingReused) {
     TempDir tmp;
     tmp.touch("inc/a.h", "");
     auto dir = tmp.path("inc");

--- a/tests/unit/vfs/file_table_tests.cpp
+++ b/tests/unit/vfs/file_table_tests.cpp
@@ -181,7 +181,7 @@ TEST_CASE(FastPathChecksIdentity) {
     ASSERT_TRUE(bool(fs::rename(tmp.path("f.h.tmp"), f)));
     EXPECT_TRUE(set_file_mtime(f, read->mtime_ns));
 
-    pool.begin_wave();
+    auto wave = pool.wave();
     ASSERT_TRUE(pool.check_version(vid) == FileTable::Verdict::Stale);
 }
 #endif
@@ -200,7 +200,7 @@ TEST_CASE(FreshReadCannotStamp) {
     ASSERT_TRUE(read.has_value());
     auto vid = pool.intern_version(fid, read->hash);
 
-    pool.begin_wave();
+    auto wave = pool.wave();
     ASSERT_TRUE(pool.check_version(vid) == FileTable::Verdict::Fresh);
     ASSERT_EQ(pool.version(vid).mtime_ns, 0);
 }

--- a/tools/client/workspace.ts
+++ b/tools/client/workspace.ts
@@ -235,7 +235,6 @@ export interface ArtifactPchEntry {
     key: string;
     bound: number;
     deps: ArtifactDep[];
-    verify_content: boolean;
     [key: string]: unknown;
 }
 
@@ -244,7 +243,6 @@ export interface ArtifactPcmEntry {
     source_file: number;
     module_name: string;
     deps: ArtifactDep[];
-    verify_content: boolean;
     [key: string]: unknown;
 }
 

--- a/tools/client/workspace.ts
+++ b/tools/client/workspace.ts
@@ -120,9 +120,15 @@ export class Workspace {
         generateCDB(this.root);
     }
 
-    /// Write a clice.toml that pins cache_dir to <workspace>/.clice/.
-    pinCacheDir(): void {
-        this.write("clice.toml", '[project]\ncache_dir = "${workspace}/.clice"\n');
+    /// Write a clice.toml that pins cache_dir to <workspace>/.clice/. With
+    /// fsIndex, the index database uses the per-file backend so tests can
+    /// read (and rewrite) the persisted metadata blobs directly.
+    pinCacheDir(opts: { fsIndex?: boolean } = {}): void {
+        const lines = ["[project]", 'cache_dir = "${workspace}/.clice"'];
+        if (opts.fsIndex) {
+            lines.push('index_db = "files"');
+        }
+        this.write("clice.toml", lines.join("\n") + "\n");
     }
 
     /// The versioned cache store root.
@@ -180,41 +186,73 @@ export class Workspace {
             .sort();
     }
 
-    /// Read and parse cache.json, or return null if absent. Plain JSON.parse
-    /// mangles the 64-bit dep hashes; tests that rewrite the file use the
-    /// lossless helpers in persistent_cache.test.ts.
-    readCacheJson(): CacheJson | null {
-        const p = path.join(this.cacheRoot(), "cache.json");
+    /// The persisted artifact-metadata blob of the per-file index backend
+    /// (pin it with pinCacheDir({ fsIndex: true })).
+    artifactsBlobPath(): string {
+        return path.join(this.cacheRoot(), "index-artifacts", "artifacts.idx");
+    }
+
+    /// Read and parse the artifacts blob, or return null if absent. Dep
+    /// hashes are 64-bit integers that overflow JS doubles; oversized
+    /// values ride as BigInt (reviver source text in) and writeArtifactsBlob
+    /// emits them back verbatim (JSON.rawJSON out) — a mangled hash fails
+    /// revalidation and forces a spurious rebuild.
+    readArtifactsBlob(): ArtifactsBlob | null {
+        const p = this.artifactsBlobPath();
         if (!fs.existsSync(p)) {
             return null;
         }
-        return JSON.parse(fs.readFileSync(p, "utf8")) as CacheJson;
+        type Reviver = (key: string, value: unknown, ctx: { source?: string }) => unknown;
+        const parse = JSON.parse as unknown as (text: string, reviver: Reviver) => unknown;
+        return parse(fs.readFileSync(p, "utf8"), (_key, value, ctx) =>
+            typeof value === "number" && !Number.isSafeInteger(value) && ctx.source !== undefined
+                ? BigInt(ctx.source)
+                : value,
+        ) as ArtifactsBlob;
+    }
+
+    writeArtifactsBlob(blob: ArtifactsBlob): void {
+        const raw = (JSON as unknown as { rawJSON: (text: string) => unknown }).rawJSON;
+        fs.writeFileSync(
+            this.artifactsBlobPath(),
+            JSON.stringify(blob, (_key, value: unknown) =>
+                typeof value === "bigint" ? raw(value.toString()) : value,
+            ),
+        );
     }
 }
 
-export interface CacheDep {
+export interface ArtifactDep {
     path: number;
-    /// 64-bit content hash; bigint when read through a lossless parser
-    /// (the value overflows a JS double).
+    /// 64-bit content hash; bigint when the value overflows a JS double.
     hash: number | bigint;
-    mtime_ns?: number;
-    size?: number;
+    size: number | bigint;
+    mtime_ns: number | bigint;
+    missing: boolean;
+}
+
+export interface ArtifactPchEntry {
+    key: string;
+    bound: number;
+    deps: ArtifactDep[];
+    verify_content: boolean;
     [key: string]: unknown;
 }
 
-export interface CacheEntry {
-    key?: string;
-    deps: CacheDep[];
-    bound?: number;
-    build_at?: number;
-    source_file?: number;
-    module_name?: string;
+export interface ArtifactPcmEntry {
+    key: string;
+    source_file: number;
+    module_name: string;
+    deps: ArtifactDep[];
+    verify_content: boolean;
     [key: string]: unknown;
 }
 
-export interface CacheJson {
-    pch: CacheEntry[];
-    pcm?: CacheEntry[];
+export interface ArtifactsBlob {
     paths: string[];
+    pch_index_format: number;
+    pch: ArtifactPchEntry[];
+    pcm: ArtifactPcmEntry[];
+    header_modes: unknown[];
     [key: string]: unknown;
 }

--- a/tools/client/workspace.ts
+++ b/tools/client/workspace.ts
@@ -120,15 +120,9 @@ export class Workspace {
         generateCDB(this.root);
     }
 
-    /// Write a clice.toml that pins cache_dir to <workspace>/.clice/. With
-    /// fsIndex, the index database uses the per-file backend so tests can
-    /// read (and rewrite) the persisted metadata blobs directly.
-    pinCacheDir(opts: { fsIndex?: boolean } = {}): void {
-        const lines = ["[project]", 'cache_dir = "${workspace}/.clice"'];
-        if (opts.fsIndex) {
-            lines.push('index_db = "files"');
-        }
-        this.write("clice.toml", lines.join("\n") + "\n");
+    /// Write a clice.toml that pins cache_dir to <workspace>/.clice/.
+    pinCacheDir(): void {
+        this.write("clice.toml", '[project]\ncache_dir = "${workspace}/.clice"\n');
     }
 
     /// The versioned cache store root.
@@ -185,72 +179,4 @@ export class Workspace {
             })
             .sort();
     }
-
-    /// The persisted artifact-metadata blob of the per-file index backend
-    /// (pin it with pinCacheDir({ fsIndex: true })).
-    artifactsBlobPath(): string {
-        return path.join(this.cacheRoot(), "index-artifacts", "artifacts.idx");
-    }
-
-    /// Read and parse the artifacts blob, or return null if absent. Dep
-    /// hashes are 64-bit integers that overflow JS doubles; oversized
-    /// values ride as BigInt (reviver source text in) and writeArtifactsBlob
-    /// emits them back verbatim (JSON.rawJSON out) — a mangled hash fails
-    /// revalidation and forces a spurious rebuild.
-    readArtifactsBlob(): ArtifactsBlob | null {
-        const p = this.artifactsBlobPath();
-        if (!fs.existsSync(p)) {
-            return null;
-        }
-        type Reviver = (key: string, value: unknown, ctx: { source?: string }) => unknown;
-        const parse = JSON.parse as unknown as (text: string, reviver: Reviver) => unknown;
-        return parse(fs.readFileSync(p, "utf8"), (_key, value, ctx) =>
-            typeof value === "number" && !Number.isSafeInteger(value) && ctx.source !== undefined
-                ? BigInt(ctx.source)
-                : value,
-        ) as ArtifactsBlob;
-    }
-
-    writeArtifactsBlob(blob: ArtifactsBlob): void {
-        const raw = (JSON as unknown as { rawJSON: (text: string) => unknown }).rawJSON;
-        fs.writeFileSync(
-            this.artifactsBlobPath(),
-            JSON.stringify(blob, (_key, value: unknown) =>
-                typeof value === "bigint" ? raw(value.toString()) : value,
-            ),
-        );
-    }
-}
-
-export interface ArtifactDep {
-    path: number;
-    /// 64-bit content hash; bigint when the value overflows a JS double.
-    hash: number | bigint;
-    size: number | bigint;
-    mtime_ns: number | bigint;
-    missing: boolean;
-}
-
-export interface ArtifactPchEntry {
-    key: string;
-    bound: number;
-    deps: ArtifactDep[];
-    [key: string]: unknown;
-}
-
-export interface ArtifactPcmEntry {
-    key: string;
-    source_file: number;
-    module_name: string;
-    deps: ArtifactDep[];
-    [key: string]: unknown;
-}
-
-export interface ArtifactsBlob {
-    paths: string[];
-    pch_index_format: number;
-    pch: ArtifactPchEntry[];
-    pcm: ArtifactPcmEntry[];
-    header_modes: unknown[];
-    [key: string]: unknown;
 }

--- a/tools/client/workspace.ts
+++ b/tools/client/workspace.ts
@@ -9,7 +9,7 @@ import { URI } from "vscode-uri";
 import { buildCDBEntry, generateCDB } from "../compile_commands.ts";
 
 /// Versioned root of the unified cache store; bump together with
-/// cache_format_version in src/server/state/workspace.h.
+/// cache_format_version in src/sched/workspace.h.
 const CACHE_ROOT = path.join(".clice", "cache", "v8");
 
 /// The harness-wide canonical URI spelling: percent-decoded. vscode-uri


### PR DESCRIPTION
## What changed

Master-side file state was scattered: a `PathPool` for identity, five parallel `(size, mtime, hash)` staleness implementations, three copies of the two-layer freshness check, a dead `ScanCache`, and a `cache.json` sidecar. This PR unifies all of it into one `FileTable` in `src/vfs/`, with downstream code referencing files by a strongly-typed id.

The table is five compartments:

- **Identity** — spelling ↔ fid interning (the old `PathPool`), canonical Windows spellings. File ids and version ids are wrapper types (`Fid`, `VersionID`) rather than raw `u32`, so the two id spaces and other integers cannot mix silently; an invalid id is the default-constructed value, replacing the old `no_path_id` sentinel. Known limits recorded as FIXMEs: case-insensitive filesystems, non-UTF-8 paths, network-filesystem UniqueIDs, untracked `@rsp` files.
- **Disk state** — one shared `{stat, hash}` pair per on-disk file (entity), keyed by filesystem UniqueID the way clang's FileManager merges FileEntries. Every read follows a pairing discipline (fstat → read → fstat, with a 2s mtime-granularity guard) so a stat provably describes the bytes hashed. A fid's binding to an already-known entity starts untrusted and is earned by a read through that fid, so an inode recycled onto a new file cannot inherit the old file's hash.
- **Versions** — `(fid, content hash)` → monotonically-assigned `VersionID`s in a flat table, referenced by index manifests and artifact dep snapshots alike (dep snapshots previously re-interned `(fid, hash)` pairs on every check). Stat fast paths are only written corroborated: the shared pair, through the earned binding, at the live filesystem identity, must prove the disk bytes hash to the version's content — a same-stat rewrite cannot stamp itself fresh, and once a session has learned a file's identity, an equal stat carrying a different UniqueID falls through to a read. Check memoization is scoped by an RAII `Wave` guard — verdicts live exactly as long as the guard, a memo can never leak into the next operation, and checking outside a wave asserts. `force_revalidate` drops every trust anchor including hardlink aliases' stamps.
- **Content-derived** — scan results keyed by `(fid, content hash)`; module declarations hidden behind preprocessor conditionals keyed by `(content hash, semantic command hash)`. Warm rescans are zero-IO when the pair vouches for the stat, and a re-read that hashes differently re-runs the quick scan so no graph mixes two generations of one file.
- **Directories** — listings validated by the directory's own mtime under the same pre/post-stat + guard discipline (a failed or partial readdir earns no trust), shared across scan prefetch, rescans, header-context resolution and include completion.

The dependency graph's include lists drop their bit-31 conditional packing for an explicit `IncludeEdge { fid, conditional }`, deleting the mask constants and the caller-side masking; the union query returns plain deduped fids. The duplicate `pcm_paths` map (a second copy of every cached PCM's path) is deleted in favor of the PCM cache itself.

`cache.json` is retired: PCH/PCM validity metadata, header-mode verdicts and context choices persist as two JSON blobs in the index database, flushed debounced. Artifact deps persist as `(spelling, hash)` pairs so they self-heal against any index state. `switchContext` acknowledges only after its choice is durably committed (epoch tickets against the flush pipeline) and reports failure after repeated failed flushes instead of waiting forever; sessions without a writable database apply choices in memory and acknowledge immediately, as before. Read-only sessions open the database read-only, never write, and retire their opening snapshot on every load path. A legacy `cache.json` found in the store is removed. Index format version bumps 10 → 11.

The per-file index backend (`index_db = "files"`, one CacheStore-namespace file per blob) is removed along with its config option, and the CacheStore APIs it was the last consumer of go with it — the `Persistent` cache policy, key enumeration, and the scan-failure latch (whose only reader guarded a "the index namespace looks empty" case that no longer exists). LMDB is the only index store. The per-file backend existed as a remote-filesystem fallback, but it duplicated everything the database provides — atomic batches, read snapshots, corruption detection — while the remote scenarios it claimed to serve (NFS home directories, SMB shares, WSL drvfs checkouts) differ enough in locking and cache-coherence behavior that one untested fallback cannot honestly cover them. On a remote filesystem, index persistence is now disabled with a warning, and what those workspaces actually need is recorded as a FIXME at the single decision point (`open_database`). A config still naming `index_db` loads fine; the strict validation pass reports the unknown key as a warning.

While rewiring the staleness test onto batch `clice index` (below), its summary turned out to report the whole project as indexed on every warm rerun — it printed the manifest count, not this run's work. It now counts only TUs actually rebuilt, so the storm filter's skips no longer masquerade as indexing.

Out of scope, deliberately: whether several processes (a live server plus a batch lint) may share one blob store read-write — and how blob metadata stays truthful across crashes if they do — is an undecided design question. Artifact records are validated by their dependency snapshots only; the blobs themselves are not pinned, and a FIXME on `CacheStore` (with pointers at the PCH/PCM revalidation sites) records the exposure, the backstop (clang's own PCH/PCM validation), and where to find the backed-out prototype that pinned blob identity and tracked writer crashes, should the concurrency model be decided later.

Deviations from the reviewed design:

- The index round's freshness memo is kept (round-scoped) rather than replaced by the wave memo — it deliberately spans suspensions; recording new debt now voids it, so a mid-round save can no longer be skipped against a stale verdict.
- Angled-include resolution memos stay per-operation and unpersisted: with no persistence, the staleness surface the design worried about does not exist, and readdir — which is what the directory compartment persists — was the measured cost.
- The content-cache LRU is deferred; in-memory tables are append-only per session.
- Two acceptance probes (force_revalidate storm scheduling, commit-time xxh3 cost) have not been run; both are internal knobs measurable against real workloads later.

Accepted residuals from adversarial review: an edit that preserves byte size and forges the exact recorded mtime **on the same inode** defeats a version's stat fast path (the unavoidable mtime-cache residual — strictly narrower than the watermark comparison it replaces, and the identity check now catches the replaced-inode variant); commit is fail-open and parent directories are not fsynced, matching the store's existing durability posture.

Platform note: Windows file UniqueIDs turned out not to be file-stable on the CI runners (path-derived on ReFS dev drives — a rename-over changes the id, and handle- and path-stat can disagree), which broke the identity-based defenses in ways no portable id fixes. Identity semantics are therefore compiled in only where `fs::stable_file_ids` holds (POSIX). On Windows a single choke point, `FileTable::entity_key`, makes every spelling its own entity: no cross-spelling merging, identity gates pass trivially, and staleness falls back to pure stat-pair + guard semantics — the behavior main ships today. The four identity-defense unit tests are POSIX-gated accordingly.

Review: two codex rounds plus four parallel Claude reviewers (core semantics, coroutine interleavings, persistence/crash safety, migration completeness), then the PR's own review threads; every confirmed finding is fixed and pinned by a regression test where practical, and the declined ones are the residuals above.

## Tests

All four suites locally on the final tree: unit (1388 passed), integration (374 passed, 1 skipped), smoke (3/3), snap (630 passed); `npm run check` clean. The same tree also builds and passes the unit suite natively on Windows (1367 passed, 22 skipped — the POSIX-gated identity tests and toolchain probes).

- The artifacts-blob introspection tests move from TypeScript to the unit suite, where the database is directly accessible: stale-format drop, dep-less PCM drop, and header-mode persistence are pinned against IndexStore save/load. The integration suite keeps the behavioral pins — offline edit invalidation, PCH reuse across restarts, legacy cache.json removal — and the TS artifacts-blob reader/writer machinery is deleted with the backend that made it possible.
- The touch-storm test now runs batch `clice index` twice and asserts the second run reports zero indexed TUs — a stronger observable than the per-blob file mtimes it used to watch (a spurious re-dispatch whose merge hits writes no blob, so mtimes could not see it).
- New unit pins: hardlink first-bind must read, rename-over rebind under a forged stat, stamps require the live filesystem identity, the stat fast path distrusts a changed identity, guard-window reads cannot stamp, hardlink-alias revalidation, dir-listing warm reuse and invalidation, version-table hole semantics after adopting a garbage-collected persisted table, and the include-edge conditionality API.
