### PR TITLE
docs: gate table alignment, nested comments and frontmatter shape

### DIFF
--- a/.claude/skills/docs/SKILL.md
+++ b/.claude/skills/docs/SKILL.md
@@ -16,8 +16,9 @@ description: The clice documentation system — generated feature/config pages, 
 - `docs/zh/` — Chinese pages, equally real and equally hand-edited (by a
   person or a model). Each zh page must stay **segment-isomorphic** to its
   en counterpart: same sequence of markdown blocks, translated text in the
-  translatable blocks, code blocks and HTML comments byte-identical. The
-  tool never writes these files.
+  translatable blocks, code blocks and HTML comments byte-identical.
+  `check`, `report` and `record` never write these files; only an
+  explicit `translate <page>` overwrites the named zh page.
 - `docs/meta/translations/` — one JSON per page pair: an ordered list of
   `{kind, en-hash, zh-hash}` pairs, each attesting "these two segments were
   last reviewed as translations of each other". Maintained exclusively by
@@ -44,9 +45,10 @@ Pages split into segments: headings, paragraphs, blockquotes, list items,
 table rows, and index.md's YAML frontmatter are translatable; everything
 else (code blocks, HTML comments including GENERATED markers) is verbatim
 and must be byte-identical across the two trees, as must any fenced code
-nested inside a translatable segment (a snap example under its checklist
-item). Segment shapes must match too: heading depth, ordered vs. bulleted
-list, table column count. No text is stored twice — the mapping holds
+or HTML comment nested inside a translatable segment (a snap example
+under its checklist item). Segment shapes must match too: heading depth,
+ordered vs. bulleted list, task-list state, table column count and
+alignment, and the mapping/sequence skeleton of index.md's frontmatter. No text is stored twice — the mapping holds
 hashes only. Old wording of a drifted segment comes from git history of
 the markdown page.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10161,6 +10161,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yargs": {
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
@@ -10304,7 +10319,8 @@
         "remark-parse": "^11.0.0",
         "unified": "^11.0.5",
         "vscode-languageserver-protocol": "^3.17.5",
-        "vscode-uri": "^3.1.0"
+        "vscode-uri": "^3.1.0",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@types/node": "~25.0.3",

--- a/tools/docs/segment.ts
+++ b/tools/docs/segment.ts
@@ -6,12 +6,13 @@
 /// translate mode feeds the translatable ones to a model.
 
 import { createHash } from "node:crypto";
-import type { Nodes, RootContent } from "mdast";
+import type { Nodes, RootContent, Table } from "mdast";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import { unified } from "unified";
 import type { Point } from "unist";
+import { parse as parseYaml } from "yaml";
 
 export interface Range {
     start: number;
@@ -62,17 +63,39 @@ function rangeOf(node: Nodes, page: string): Range {
     };
 }
 
+/// Column alignment of a table as one letter per column: `l`, `r`, `c`,
+/// or `-` for none. Only the delimiter line carries it, and that line has
+/// no row node, so rows get it from their table.
+export function tableAlign(table: Table): string {
+    return (table.align ?? []).map((align) => align?.[0] ?? "-").join("");
+}
+
+/// Mapping and sequence nesting of a YAML block, with key names and
+/// scalar types; a translation may only change scalar string values.
+function yamlSkeleton(value: unknown): string {
+    if (Array.isArray(value)) {
+        return `[${value.map(yamlSkeleton).join(",")}]`;
+    }
+    if (value !== null && typeof value === "object") {
+        const entries = Object.entries(value as Record<string, unknown>);
+        return `{${entries.map(([key, item]) => `${key}:${yamlSkeleton(item)}`).join(",")}}`;
+    }
+    return value === null ? "null" : typeof value;
+}
+
 /// Block structure, recursively through flow containers (blockquotes,
 /// lists, tables); everything below a paragraph, heading or table cell is
 /// phrasing, which a translation may reflow freely.
-function shapeOf(node: Nodes, ordered: boolean): string {
+function shapeOf(node: Nodes, ordered: boolean, align = ""): string {
     switch (node.type) {
         case "heading":
             return `heading:${node.depth}`;
         case "tableRow":
-            return `tableRow:${node.children.length}`;
-        case "table":
-            return `table(${node.children.map((row) => shapeOf(row, false)).join(",")})`;
+            return `tableRow:${node.children.length}:${align}`;
+        case "table": {
+            const inner = node.children.map((row) => shapeOf(row, false, tableAlign(node)));
+            return `table(${inner.join(",")})`;
+        }
         case "list": {
             const inner = node.children.map((child) => shapeOf(child, node.ordered === true));
             return `${node.ordered === true ? "list:ordered" : "list"}(${inner.join(",")})`;
@@ -85,23 +108,32 @@ function shapeOf(node: Nodes, ordered: boolean): string {
         }
         case "blockquote":
             return `blockquote(${node.children.map((child) => shapeOf(child, false)).join(",")})`;
+        case "yaml": {
+            try {
+                return `yaml${yamlSkeleton(parseYaml(node.value))}`;
+            } catch {
+                return "yaml:invalid";
+            }
+        }
         default:
             return node.type;
     }
 }
 
-/// Fenced or indented code blocks anywhere below `node` (inline code is
-/// prose and may be reflowed by a translation). The range starts at the
-/// beginning of the opening fence's line, so the list or blockquote
-/// prefix in front of the fence is compared too — it decides how much
-/// indentation is stripped from the block's lines.
-function nestedCode(node: Nodes, source: string, from: number, page: string): Range[] {
+/// Code blocks and HTML comments anywhere below `node` (inline code and
+/// other inline HTML are prose and may be reflowed by a translation). A
+/// code range starts at the beginning of the opening fence's line, so the
+/// list or blockquote prefix in front of the fence is compared too — it
+/// decides how much indentation is stripped from the block's lines.
+function nestedVerbatim(node: Nodes, source: string, from: number, page: string): Range[] {
     const out: Range[] = [];
     const visit = (current: Nodes) => {
         if (current.type === "code") {
             const range = rangeOf(current, page);
             const lineStart = source.lastIndexOf("\n", range.start - 1) + 1;
             out.push({ start: Math.max(lineStart, from), end: range.end });
+        } else if (current.type === "html" && current.value.startsWith("<!--")) {
+            out.push(rangeOf(current, page));
         } else if ("children" in current) {
             for (const child of current.children) {
                 visit(child);
@@ -119,7 +151,7 @@ function nestedCode(node: Nodes, source: string, from: number, page: string): Ra
 export function splitSegments(source: string, page: string): Segment[] {
     const tree = parser.parse(source);
     const segments: Segment[] = [];
-    const push = (node: RootContent, ordered: boolean, translatable: boolean) => {
+    const push = (node: RootContent, ordered: boolean, translatable: boolean, align = "") => {
         const range = rangeOf(node, page);
         // Take the indentation in front of a block along with it: for a
         // list item it decides how much is stripped from the lines below.
@@ -130,9 +162,9 @@ export function splitSegments(source: string, page: string): Segment[] {
         segments.push({
             ...range,
             kind: node.type,
-            shape: shapeOf(node, ordered),
+            shape: shapeOf(node, ordered, align),
             translatable,
-            verbatim: translatable ? nestedCode(node, source, range.start, page) : [range],
+            verbatim: translatable ? nestedVerbatim(node, source, range.start, page) : [range],
         });
     };
     for (const node of tree.children) {
@@ -145,9 +177,10 @@ export function splitSegments(source: string, page: string): Segment[] {
             case "table":
                 // The delimiter line between header and body has no row
                 // node; it lands in the gap between rows and is not
-                // compared, so the two sides may align columns differently.
+                // compared. Its alignment travels with each row's shape,
+                // so only dash count and padding may differ.
                 for (const row of node.children) {
-                    push(row, false, true);
+                    push(row, false, true, tableAlign(node));
                 }
                 break;
             case "heading":

--- a/tools/docs/translate.ts
+++ b/tools/docs/translate.ts
@@ -202,13 +202,13 @@ function segmentLabel(left: SegmentInfo, right: SegmentInfo): string {
 
 function verbatimLabel(left: SegmentInfo, right: SegmentInfo): string {
     return left.translatable
-        ? `code block inside ${segmentLabel(left, right)}`
+        ? `verbatim block inside ${segmentLabel(left, right)}`
         : `verbatim ${segmentLabel(left, right)}`;
 }
 
 function verbatimReason(left: SegmentInfo): string {
     return left.translatable
-        ? "nested code block must be byte-identical"
+        ? "nested code or comment must be byte-identical"
         : "verbatim segment must be byte-identical";
 }
 
@@ -678,8 +678,17 @@ function validateSegment(
     // A lone row does not parse as a table: give it the delimiter line
     // the page will, so a row that would stop the page being a table
     // fails here instead of at the page level.
-    const width = /^tableRow:(\d+)$/.exec(en.shape)?.[1];
-    const probe = width === undefined ? zhText : `${zhText}\n|${" --- |".repeat(Number(width))}`;
+    const align = /^tableRow:\d+:([lrc-]*)$/.exec(en.shape)?.[1];
+    const delimiter = (column: string) =>
+        column === "l"
+            ? " :--- |"
+            : column === "r"
+              ? " ---: |"
+              : column === "c"
+                ? " :---: |"
+                : " --- |";
+    const probe =
+        align === undefined ? zhText : `${zhText}\n|${Array.from(align, delimiter).join("")}`;
     const parsed = splitSegments(probe, "reply");
     const reply = parsed.at(0);
     if (parsed.length !== 1 || reply?.shape !== en.shape) {
@@ -687,14 +696,7 @@ function validateSegment(
     }
     const code = reply.verbatim.map((range) => probe.slice(range.start, range.end));
     if (code.length !== blocks.length || code.some((text, i) => text !== blocks.at(i))) {
-        return "nested code block altered";
-    }
-    if (en.kind === "yaml") {
-        const keys = (text: string) =>
-            [...text.matchAll(/^\s*([\w-]+):/gm)].map((match) => match[1]).join(",");
-        if (keys(zhText) !== keys(enText)) {
-            return "yaml keys changed";
-        }
+        return "nested verbatim block altered";
     }
     return null;
 }

--- a/tools/package.json
+++ b/tools/package.json
@@ -32,7 +32,8 @@
     "remark-parse": "^11.0.0",
     "unified": "^11.0.5",
     "vscode-languageserver-protocol": "^3.17.5",
-    "vscode-uri": "^3.1.0"
+    "vscode-uri": "^3.1.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@types/node": "~25.0.3",


### PR DESCRIPTION
## What changed

Follow-up to #651, closing the review threads deferred there. The translation contract now also gates:

- **Table column alignment.** The delimiter line's `:---` / `---:` / `:---:` markers travel with every row's shape, so a zh table cannot silently change column alignment while dash counts and padding may still differ. The machine-translation row probe reproduces the en alignment.
- **HTML comments nested in translatable segments.** A comment inside a list item or blockquote is now a verbatim range like nested fenced code: byte-identical across trees, masked out of the model round trip. Other inline HTML (e.g. `<summary>`) stays translatable.
- **Frontmatter structure.** The yaml segment's shape is the parsed mapping/sequence skeleton with key names and scalar types, so `check`, `record` and `translate` all reject a draft that turns a sequence into a mapping; the previous regex key-sequence check is gone.

The docs skill's claim that the tool never writes zh pages is scoped correctly: only an explicit `translate <page>` overwrites the named page. `yaml` is added to the tools workspace dependencies.

## Tests

- Temp-tree self-test: faithful zh page with different delimiter dash counts records and checks green; flipped alignment, an altered nested comment, and a sequence-to-mapping frontmatter each fail `check` and are refused by `record`.
- Real tree unchanged: `check-doc-translations` green (32 pages, 1883 pairs), `check-feature-docs`, `check-config-docs` green.
- `npm run check` green; all four suites green locally on RelWithDebInfo (unit 1389, integration 374, smoke 3/3, snap 630).
