### PR TITLE
refactor: merge the duplicates the code-reuse audits left behind

### DIFF
--- a/docs/en/features/folding-ranges.md
+++ b/docs/en/features/folding-ranges.md
@@ -196,6 +196,14 @@
   #else                    // │
   void run_inline();       // │
   #endif                   // ┘
+
+  #ifdef USE_EPOLL         // ┐
+  void poll_epoll();       // │ no fold yet: the branch before #elifdef
+  #elifdef USE_KQUEUE      // │ ┐
+  void poll_kqueue();      // │ │ folds: the #elifdef branch, delimited by #else
+  #else                    // │ ┘
+  void poll_select();      // │
+  #endif                   // ┘
   ```
 
   </details>

--- a/docs/meta/translations/features/folding-ranges.json
+++ b/docs/meta/translations/features/folding-ranges.json
@@ -7,7 +7,7 @@
     { "kind": "listItem", "en": "f4cb4c8471f9b453", "zh": "75e2e92d9da9c98e" },
     { "kind": "listItem", "en": "d936bba28f7bbf20", "zh": "d97213cbee1a4753" },
     { "kind": "listItem", "en": "3c0bd5179b516f1f", "zh": "2a79d7dda297fff9" },
-    { "kind": "listItem", "en": "7a2919351c6fbd79", "zh": "e57f1212d02abb37" },
+    { "kind": "listItem", "en": "1b3c6bfb25c6c765", "zh": "c88c0d4d5255a171" },
     { "kind": "listItem", "en": "6aca42801f09cb0c", "zh": "7aab26f88a23f0c5" },
     { "kind": "listItem", "en": "89f82821054b414d", "zh": "264538578ab6f505" },
     { "kind": "listItem", "en": "e9eede22d5f40138", "zh": "a1bc2d35c5cec50d" },

--- a/docs/zh/features/folding-ranges.md
+++ b/docs/zh/features/folding-ranges.md
@@ -195,6 +195,14 @@
   #else                    // │
   void run_inline();       // │
   #endif                   // ┘
+
+  #ifdef USE_EPOLL         // ┐
+  void poll_epoll();       // │ no fold yet: the branch before #elifdef
+  #elifdef USE_KQUEUE      // │ ┐
+  void poll_kqueue();      // │ │ folds: the #elifdef branch, delimited by #else
+  #else                    // │ ┘
+  void poll_select();      // │
+  #endif                   // ┘
   ```
 
   </details>

--- a/editors/vscode/src/feature/context.ts
+++ b/editors/vscode/src/feature/context.ts
@@ -359,15 +359,13 @@ export function registerCompilationContext(client: ClientHandle, ext: vscode.Ext
         }
     }
 
-    // X-macro style fragments (.def/.inc/.inl/...) open as plain text and
-    // never reach the language server. If clice knows the file is included
-    // by some C++ TU (it has compilation contexts), flip its language so
-    // the whole toolchain attaches.
+    // X-macro style fragments (.def/.inc/...) open as plain text and never
+    // reach the language server. If clice knows the file is included by
+    // some C++ TU (it has compilation contexts), flip its language so the
+    // whole toolchain attaches. Which files count is the server's call —
+    // the query is the whole check, one cheap lookup per plain-text open.
     async function detectCxxFragment(document: vscode.TextDocument) {
         if (document.languageId !== "plaintext" || resyncing.has(document.uri.toString())) {
-            return;
-        }
-        if (!/\.(def|inc|inl|tpp|ipp)$/.test(document.uri.fsPath)) {
             return;
         }
         try {

--- a/editors/vscode/src/feature/context.ts
+++ b/editors/vscode/src/feature/context.ts
@@ -365,14 +365,20 @@ export function registerCompilationContext(client: ClientHandle, ext: vscode.Ext
     // whole toolchain attaches. Which files count is the server's call —
     // the query is the whole check, one cheap lookup per plain-text open.
     async function detectCxxFragment(document: vscode.TextDocument) {
-        if (document.languageId !== "plaintext" || resyncing.has(document.uri.toString())) {
+        const uri = document.uri.toString();
+        const awaitingDetection = () =>
+            !document.isClosed && document.languageId === "plaintext" && !resyncing.has(uri);
+        if (!awaitingDetection()) {
             return;
         }
         try {
             const query = await client.sendRequest<QueryContextResult>("clice/queryContext", {
-                uri: document.uri.toString(),
+                uri,
             });
-            if (query.total > 0) {
+            // The document may have moved on while the query was in flight:
+            // closed, re-languaged by the user, or entered a resync whose
+            // plaintext hop must not be pinned to cpp.
+            if (query.total > 0 && awaitingDetection()) {
                 await vscode.languages.setTextDocumentLanguage(document, "cpp");
             }
         } catch {

--- a/src/driver/driver.h
+++ b/src/driver/driver.h
@@ -6,9 +6,13 @@
 #include <sstream>
 #include <string>
 
+#include "support/filesystem.h"
 #include "support/logging.h"
 
 #include "kota/deco/deco.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/FileSystem.h"
 
 namespace clice::driver {
 
@@ -44,6 +48,21 @@ inline bool apply_log_level(const std::string& level_str) {
     }
     logging::options.level = level;
     return true;
+}
+
+/// The workspace root of a batch subcommand: the --workspace argument
+/// made absolute, or the current directory when it is empty,
+/// canonicalized either way.
+inline std::string workspace_root(llvm::StringRef argument) {
+    llvm::SmallString<256> workspace(argument);
+    if(workspace.empty()) {
+        llvm::sys::fs::current_path(workspace);
+    } else {
+        llvm::sys::fs::make_absolute(workspace);
+    }
+    std::string root(workspace.str());
+    path::canonicalize(root);
+    return root;
 }
 
 template <typename Command>

--- a/src/driver/index.cc
+++ b/src/driver/index.cc
@@ -12,11 +12,9 @@
 #include "sched/index/store.h"
 #include "sched/workspace.h"
 #include "support/cache_store.h"
-#include "support/filesystem.h"
 #include "support/timer.h"
 
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/Support/FileSystem.h"
 
 namespace clice::driver {
 
@@ -340,15 +338,7 @@ void add_index(kota::deco::cli::SubCommander& root, int& exit_code, const char* 
                return;
            logging::stderr_logger("index", logging::options);
 
-           llvm::SmallString<256> workspace(opts.workspace.value_or(""));
-           if(workspace.empty()) {
-               llvm::sys::fs::current_path(workspace);
-           } else {
-               llvm::sys::fs::make_absolute(workspace);
-           }
-           std::string ws(workspace.str());
-           path::canonicalize(ws);
-
+           auto ws = workspace_root(opts.workspace.value_or(""));
            if(opts.stats) {
                exit_code = run_stats(ws, opts.top.value_or(20));
                return;

--- a/src/driver/lint.cc
+++ b/src/driver/lint.cc
@@ -2,10 +2,7 @@
 
 #include "driver/driver.h"
 #include "sched/batch.h"
-#include "support/filesystem.h"
 #include "support/logging.h"
-
-#include "llvm/Support/FileSystem.h"
 
 namespace clice::driver {
 
@@ -101,16 +98,7 @@ void add_lint(kota::deco::cli::SubCommander& root, int& exit_code, const char* s
                return;
            logging::stderr_logger("lint", logging::options);
 
-           llvm::SmallString<256> workspace(opts.workspace.value_or(""));
-           if(workspace.empty()) {
-               llvm::sys::fs::current_path(workspace);
-           } else {
-               llvm::sys::fs::make_absolute(workspace);
-           }
-           std::string ws(workspace.str());
-           path::canonicalize(ws);
-
-           exit_code = run_lint(std::move(ws),
+           exit_code = run_lint(workspace_root(opts.workspace.value_or("")),
                                 opts.workers.value_or(0),
                                 static_cast<bool>(opts.index),
                                 self_path);

--- a/src/feature/document_links.cpp
+++ b/src/feature/document_links.cpp
@@ -38,8 +38,7 @@ auto find_directive_argument(llvm::StringRef content,
             // A directive keyword only counts before the first match; a
             // later one is a macro standing in for the filename (legal
             // pre-C++20 even for one literally named `import`).
-            if(!after_keyword && (text == "include" || text == "include_next" || text == "import" ||
-                                  text == "embed")) {
+            if(!after_keyword && takes_header_name(text)) {
                 after_keyword = true;
                 continue;
             }

--- a/src/feature/feature.h
+++ b/src/feature/feature.h
@@ -21,6 +21,12 @@
 #include "kota/meta/annotation.h"
 #include "llvm/ADT/ArrayRef.h"
 
+namespace clice::index {
+
+class Shard;
+
+}
+
 namespace clice::feature {
 
 namespace lsp = kota::ipc::lsp;
@@ -472,6 +478,16 @@ struct IndexDeclRow {
     index::SymbolHash symbol = 0;
     bool definition = false;
 };
+
+/// The rows of one document the projections consume, extracted from its
+/// serving shard: every occurrence, and the Decl/Def relations as decl
+/// rows.
+struct IndexRows {
+    std::vector<index::Occurrence> occurrences;
+    std::vector<IndexDeclRow> decls;
+};
+
+auto extract_index_rows(const index::Shard& shard) -> IndexRows;
 
 /// An include edge of the document, from the TU manifest: the 1-based
 /// directive line and the resolved target's absolute path.

--- a/src/feature/folding_ranges.cpp
+++ b/src/feature/folding_ranges.cpp
@@ -280,6 +280,7 @@ private:
                 case Condition::BranchKind::Ifdef:
                 case Condition::BranchKind::Ifndef:
                 case Condition::BranchKind::Elif:
+                case Condition::BranchKind::Elifdef:
                 case Condition::BranchKind::Elifndef: stack.push_back(&condition); break;
 
                 case Condition::BranchKind::Else: {
@@ -299,8 +300,6 @@ private:
                         (void)stack.pop_back_val();
                     }
                     break;
-
-                default: break;
             }
         }
     }

--- a/src/feature/hover.cpp
+++ b/src/feature/hover.cpp
@@ -4,6 +4,7 @@
 
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "compile/compilation_unit.h"
@@ -1011,6 +1012,9 @@ auto format_offset(std::uint64_t offset_in_bits) -> std::string {
     return offset;
 }
 
+/// The noun a hover card heads its title with; empty for the lexical
+/// kinds no card is about. Exhaustive so a new kind fails to compile
+/// rather than silently lose its noun.
 auto symbol_kind_string(SymbolKind kind) -> llvm::StringRef {
     switch(kind) {
         case SymbolKind::Module: return "module";
@@ -1029,8 +1033,26 @@ auto symbol_kind_string(SymbolKind kind) -> llvm::StringRef {
         case SymbolKind::Parameter: return "parameter";
         case SymbolKind::Label: return "label";
         case SymbolKind::Macro: return "macro";
-        default: return "";
+        case SymbolKind::MacroParameter:
+        case SymbolKind::Comment:
+        case SymbolKind::Number:
+        case SymbolKind::Character:
+        case SymbolKind::String:
+        case SymbolKind::Keyword:
+        case SymbolKind::Directive:
+        case SymbolKind::Header:
+        case SymbolKind::Attribute:
+        case SymbolKind::Operator:
+        case SymbolKind::Paren:
+        case SymbolKind::Bracket:
+        case SymbolKind::Brace:
+        case SymbolKind::Angle:
+        case SymbolKind::Conflict:
+        case SymbolKind::Primitive:
+        case SymbolKind::Invalid:
+        case SymbolKind::Identifier: return "";
     }
+    std::unreachable();
 }
 
 /// If the backtick at the offset starts a probable quoted range, return the

--- a/src/feature/index_projection.cpp
+++ b/src/feature/index_projection.cpp
@@ -8,6 +8,7 @@
 
 #include "feature/feature.h"
 #include "feature/lexical_classify.h"
+#include "index/shard.h"
 #include "syntax/lexer.h"
 
 #include "llvm/ADT/ArrayRef.h"
@@ -18,6 +19,26 @@
 #include "clang/Basic/LangStandard.h"
 
 namespace clice::feature {
+
+IndexRows extract_index_rows(const index::Shard& shard) {
+    IndexRows rows;
+    shard.for_each_occurrence([&](const index::Occurrence& occurrence) {
+        rows.occurrences.push_back(occurrence);
+        return true;
+    });
+    shard.for_each_relation([&](index::SymbolHash hash, const index::Relation& relation) {
+        RelationKind kind(relation.kind);
+        if(kind.isDeclOrDef()) {
+            auto copy = relation;
+            rows.decls.push_back({.range = relation.range,
+                                  .extent = copy.definition_range(),
+                                  .symbol = hash,
+                                  .definition = kind.is_one_of(RelationKind::Definition)});
+        }
+        return true;
+    });
+    return rows;
+}
 
 namespace {
 
@@ -156,16 +177,6 @@ auto index_semantic_tokens(llvm::StringRef content,
     }
 
     std::vector<SemanticToken> tokens;
-    auto emit = [&](LocalSourceRange range, SymbolKind kind, std::uint32_t modifiers) {
-        if(!tokens.empty()) {
-            auto& last = tokens.back();
-            if(last.range.end == range.begin && last.kind == kind && last.modifiers == modifiers) {
-                last.range.end = range.end;
-                return;
-            }
-        }
-        tokens.push_back({.range = range, .kind = kind, .modifiers = modifiers});
-    };
 
     enum class Directive : std::uint8_t {
         None,
@@ -186,7 +197,7 @@ auto index_semantic_tokens(llvm::StringRef content,
             continue;
         }
         if(token.kind == clang::tok::comment) {
-            emit(token.range, SymbolKind::Comment, 0);
+            append_token(tokens, token.range, SymbolKind::Comment, 0);
             continue;
         }
 
@@ -252,18 +263,10 @@ auto index_semantic_tokens(llvm::StringRef content,
             }
         }
 
-        // Semantic classification beats the lexical directive kinds; any
-        // other disagreement is a Conflict, matching the AST path's rule.
-        Classified result = semantic;
-        if(result.kind == SymbolKind::Invalid) {
-            result = lexical;
-        } else if(lexical.kind != SymbolKind::Invalid && lexical.kind != SymbolKind::Directive &&
-                  lexical.kind != SymbolKind::Header && lexical.kind != result.kind) {
-            result.kind = SymbolKind::Conflict;
-        }
+        Classified result = settle(semantic, lexical);
 
         if(result.kind != SymbolKind::Invalid) {
-            emit(token.range, result.kind, result.modifiers);
+            append_token(tokens, token.range, result.kind, result.modifiers);
         }
     }
 

--- a/src/feature/lexical_classify.h
+++ b/src/feature/lexical_classify.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <vector>
+
+#include "feature/feature.h"
 #include "semantic/symbol.h"
 
 #include "llvm/ADT/StringRef.h"
@@ -29,6 +33,38 @@ inline void combine(Classified& result, Classified candidate) {
     if(result.kind != candidate.kind) {
         result.kind = SymbolKind::Conflict;
     }
+}
+
+/// A token's classification once the semantic layer has spoken: the
+/// semantic kind when there is one, the lexical kind otherwise. A
+/// semantic kind beats the lexical directive kinds (a macro named in an
+/// `#ifdef` is a macro); any other disagreement is a Conflict.
+inline Classified settle(Classified semantic, Classified lexical) {
+    if(semantic.kind == SymbolKind::Invalid) {
+        return lexical;
+    }
+    if(lexical.kind != SymbolKind::Invalid && lexical.kind != SymbolKind::Directive &&
+       lexical.kind != SymbolKind::Header && lexical.kind != semantic.kind) {
+        semantic.kind = SymbolKind::Conflict;
+    }
+    return semantic;
+}
+
+/// Append a token to a document's stream, extending the previous token
+/// instead when the two abut with the same kind and modifiers: one token
+/// per colored span, however the lexer split it.
+inline void append_token(std::vector<SemanticToken>& tokens,
+                         LocalSourceRange range,
+                         SymbolKind kind,
+                         std::uint32_t modifiers) {
+    if(!tokens.empty()) {
+        auto& last = tokens.back();
+        if(last.range.end == range.begin && last.kind == kind && last.modifiers == modifiers) {
+            last.range.end = range.end;
+            return;
+        }
+    }
+    tokens.push_back({.range = range, .kind = kind, .modifiers = modifiers});
 }
 
 /// Lexical classification of one token, shared by the AST semantic-token

--- a/src/feature/semantic_tokens.cpp
+++ b/src/feature/semantic_tokens.cpp
@@ -10,6 +10,7 @@
 #include "semantic/decls.h"
 #include "semantic/semantics.h"
 #include "semantic/symbol.h"
+#include "syntax/lexer.h"
 #include "syntax/token.h"
 
 #include "llvm/ADT/DenseMap.h"
@@ -281,15 +282,7 @@ private:
             semantic = it->second;
         }
 
-        /// Semantic classification beats the lexical directive kinds; any
-        /// other disagreement is a Conflict, matching the historical rule.
-        Classified result = semantic;
-        if(result.kind == SymbolKind::Invalid) {
-            result = lexical;
-        } else if(lexical.kind != SymbolKind::Invalid && lexical.kind != SymbolKind::Directive &&
-                  lexical.kind != SymbolKind::Header && lexical.kind != result.kind) {
-            result.kind = SymbolKind::Conflict;
-        }
+        Classified result = settle(semantic, lexical);
 
         /// Unclassified tokens in an inactive region (bare identifiers,
         /// punctuation) still need a token to carry the Inactive modifier
@@ -329,8 +322,7 @@ private:
                 }
 
                 auto spelling = content.substr(offset, token.length());
-                if(spelling == "include" || spelling == "include_next" || spelling == "import" ||
-                   spelling == "embed") {
+                if(takes_header_name(spelling)) {
                     directive_context = DirectiveContext::InIncludeName;
                 } else if(spelling == "define") {
                     directive_context = DirectiveContext::AfterDefine;
@@ -626,15 +618,7 @@ private:
         if(inactive(range)) {
             modifiers |= SymbolModifiers::to_mask(SymbolModifiers::Inactive);
         }
-        if(!tokens.empty()) {
-            auto& last = tokens.back();
-            if(last.range.end == range.begin && last.kind == kind && last.modifiers == modifiers) {
-                last.range.end = range.end;
-                return;
-            }
-        }
-
-        tokens.push_back({.range = range, .kind = kind, .modifiers = modifiers});
+        append_token(tokens, range, kind, modifiers);
     }
 
     enum class DirectiveContext : std::uint8_t {

--- a/src/sched/batch.cpp
+++ b/src/sched/batch.cpp
@@ -92,21 +92,10 @@ kota::task<> checkpoint_task(Workspace& workspace) {
     }
 }
 
-/// Quiesce and persist in contract-11 order: pump and graph first, then
-/// the final save (with the one metadata retry late debt may owe), the
-/// artifact cache, and last the pool and the store.
+/// Quiesce the pump, then the shared contract-11 tail.
 kota::task<> shutdown(BatchStack& stack) {
     co_await stack.pump.stop();
-    co_await stack.graph.shutdown();
-    auto report = co_await stack.store.save(stack.pump.save_debt());
-    stack.pump.claim_report(report);
-    if(report.snapshot_stale) {
-        stack.pump.claim_report(co_await stack.store.save(stack.pump.save_debt()));
-    }
-    co_await stack.pool.stop();
-    if(stack.workspace.store) {
-        stack.workspace.store->shutdown();
-    }
+    co_await shutdown_indexing(stack.graph, stack.pump, stack.store, stack.pool, stack.workspace);
 }
 
 /// Shared batch startup: the finalized config with the run's overrides,

--- a/src/sched/bootstrap.cpp
+++ b/src/sched/bootstrap.cpp
@@ -48,6 +48,12 @@ BootstrapReport bootstrap_workspace(Workspace& workspace,
                                        .extension = ".h",
                                        .policy = CachePolicy::LRU,
                                        .max_bytes = 1 * GiB});
+            // Synthesized header-context files once lived directly under
+            // the cache root, outside the store. A directory an earlier
+            // version left there is regenerable, and its files would
+            // otherwise stay navigable through the metadata that names
+            // them.
+            fs::remove_all(path::join(cfg.cache_dir, header_context_ns));
             workspace.store.emplace(std::move(*cache));
             // A read-only bootstrap opens the index database read-only:
             // no writer lock (a concurrent server or index run keeps

--- a/src/sched/bootstrap.cpp
+++ b/src/sched/bootstrap.cpp
@@ -44,8 +44,10 @@ BootstrapReport bootstrap_workspace(Workspace& workspace,
                                        .extension = ".pcm",
                                        .policy = CachePolicy::LRU,
                                        .max_bytes = 8 * GiB});
-            cache->register_namespace(
-                {.name = "header_context", .extension = ".h", .policy = CachePolicy::Scratch});
+            cache->register_namespace({.name = std::string(header_context_ns),
+                                       .extension = ".h",
+                                       .policy = CachePolicy::LRU,
+                                       .max_bytes = 1 * GiB});
             workspace.store.emplace(std::move(*cache));
             // A read-only bootstrap opens the index database read-only:
             // no writer lock (a concurrent server or index run keeps

--- a/src/sched/context.cpp
+++ b/src/sched/context.cpp
@@ -203,16 +203,38 @@ void ContextResolver::load_choice_slices(
     for(auto& entry: artifacts) {
         auto file = resolve(entry.file);
         auto host = resolve(entry.host);
-        // A file the store evicted since (or a wiped cache) has nothing
-        // left to open under the host's command.
-        if(file.empty() || host.empty() || !llvm::sys::fs::exists(file))
+        if(file.empty() || host.empty())
             continue;
+        // A file the store evicted since (or a wiped cache) has nothing
+        // left to open under the host's command; the record leaves the
+        // blob with the next save.
+        if(!llvm::sys::fs::exists(file)) {
+            workspace.mark_contexts_dirty();
+            continue;
+        }
         synthesized_hosts[file] = workspace.file_table.intern(host);
     }
 }
 
+/// Whether the store still serves a synthesized file: a blob the budget
+/// evicted, or a directory wiped from outside, must not reach a compile
+/// command. The lookup also refreshes the blob's last use, so a context
+/// in service never ages out under the budget.
+static bool artifact_alive(Workspace& workspace, llvm::StringRef path) {
+    if(path.empty()) {
+        return true;
+    }
+    auto served = workspace.store->lookup(header_context_ns, llvm::sys::path::stem(path));
+    return served && llvm::sys::fs::exists(*served);
+}
+
+static bool artifacts_alive(Workspace& workspace, const HeaderContext& context) {
+    return artifact_alive(workspace, context.preamble_path) &&
+           artifact_alive(workspace, context.suffix_path) &&
+           artifact_alive(workspace, context.snapshot_path);
+}
+
 void ContextResolver::drop_evicted_artifacts() {
-    header_contexts.clear();
     llvm::SmallVector<std::string> gone;
     for(auto& entry: synthesized_hosts) {
         if(!llvm::sys::fs::exists(entry.getKey())) {
@@ -307,7 +329,7 @@ bool ContextResolver::fill_header_context_args(llvm::StringRef path,
                                     cached->host_base_hash != choice->base_hash);
             bool mode_mismatch = cached->preamble_path.empty() == synthesize;
             auto wave = workspace.file_table.wave();
-            if(override_mismatch || mode_mismatch ||
+            if(override_mismatch || mode_mismatch || !artifacts_alive(workspace, *cached) ||
                deps_changed(workspace.file_table, cached->deps)) {
                 drop_header_context(path_id);
             }
@@ -577,6 +599,7 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(Fid header_
                              "",
                              0,
                              "",
+                             "",
                              occurrence.value_or(0),
                              std::move(host_command_hash),
                              std::move(host_base_hash),
@@ -670,7 +693,11 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(Fid header_
     // header finds its preamble — and the PCH keyed on that path — intact,
     // and the store's budget bounds what a long-lived cache accumulates.
     auto store_blob = [&](std::string key, llvm::StringRef content) -> std::optional<std::string> {
-        if(auto hit = workspace.store->lookup(header_context_ns, key)) {
+        // A hit is the manifest's word; the file may have been wiped from
+        // outside (the store survives that), so a missing one is
+        // republished under its key.
+        if(auto hit = workspace.store->lookup(header_context_ns, key);
+           hit && llvm::sys::fs::exists(*hit)) {
             return hit;
         }
         auto pending = workspace.store->begin_store(header_context_ns, key);
@@ -762,6 +789,7 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(Fid header_
                          preamble_path,
                          preamble_hash,
                          std::move(suffix_path),
+                         std::move(self_snapshot_path),
                          occurrence.value_or(0),
                          std::move(host_command_hash),
                          std::move(host_base_hash),

--- a/src/sched/context.cpp
+++ b/src/sched/context.cpp
@@ -80,38 +80,37 @@ static ConfigID pick_host_config(Workspace& workspace,
 }
 
 HeaderMode ContextResolver::header_mode(llvm::StringRef path, Fid path_id) const {
-    // Keep in sync with the client's C++ fragment detection
-    // (editors/vscode/src/feature/context.ts).
     if(path.ends_with(".def") || path.ends_with(".inc") || path.ends_with(".inl") ||
        path.ends_with(".tpp") || path.ends_with(".ipp")) {
         return HeaderMode::NeedsContext;
     }
-    if(auto it = header_modes.find(path_id); it != header_modes.end()) {
-        return it->second;
+    if(auto it = header_verdicts.find(path_id); it != header_verdicts.end()) {
+        return it->second.mode;
     }
     return HeaderMode::Unknown;
 }
 
 void ContextResolver::forget_self_contained(Fid path_id) {
-    if(auto it = header_modes.find(path_id);
-       it != header_modes.end() && it->second == HeaderMode::SelfContained) {
-        header_modes.erase(it);
+    if(auto it = header_verdicts.find(path_id);
+       it != header_verdicts.end() && it->second.mode == HeaderMode::SelfContained) {
+        header_verdicts.erase(it);
     }
 }
 
 std::uint64_t ContextResolver::persisted_mode_hash(Fid path_id) const {
-    if(header_modes.lookup(path_id) != HeaderMode::NeedsContext) {
+    auto it = header_verdicts.find(path_id);
+    if(it == header_verdicts.end() || it->second.mode != HeaderMode::NeedsContext) {
         return 0;
     }
-    return header_mode_hashes.lookup(path_id);
+    return it->second.content_hash;
 }
 
 void ContextResolver::record_header_mode(Fid path_id, HeaderMode mode, std::uint64_t content_hash) {
     auto persisted = persisted_mode_hash(path_id);
-    header_modes[path_id] = mode;
-    if(mode == HeaderMode::NeedsContext) {
-        header_mode_hashes[path_id] = content_hash;
-    }
+    header_verdicts[path_id] = {
+        .mode = mode,
+        .content_hash = mode == HeaderMode::NeedsContext ? content_hash : 0,
+    };
     if(persisted_mode_hash(path_id) != persisted) {
         workspace.mark_artifacts_dirty();
     }
@@ -121,23 +120,20 @@ void ContextResolver::reset_header_mode(Fid path_id) {
     if(persisted_mode_hash(path_id) != 0) {
         workspace.mark_artifacts_dirty();
     }
-    header_modes.erase(path_id);
-    header_mode_hashes.erase(path_id);
+    header_verdicts.erase(path_id);
 }
 
 void ContextResolver::dump_mode_slices(std::vector<CacheModeEntry>& modes,
                                        llvm::function_ref<std::uint32_t(Fid)> intern_id) const {
-    for(auto& [path_id, mode]: header_modes) {
-        if(mode != HeaderMode::NeedsContext)
-            continue;
+    for(auto& [path_id, verdict]: header_verdicts) {
         // A verdict scored with no disk observation (hash 0) cannot be
         // validated on load, so it stays in memory: persisted, it would
         // skip the self-containment trial for whatever bytes the next
         // session finds on disk.
-        auto hash = header_mode_hashes.lookup(path_id);
-        if(hash == 0)
+        if(verdict.mode != HeaderMode::NeedsContext || verdict.content_hash == 0)
             continue;
-        modes.push_back({intern_id(path_id), static_cast<std::uint32_t>(mode), hash});
+        modes.push_back(
+            {intern_id(path_id), static_cast<std::uint32_t>(verdict.mode), verdict.content_hash});
     }
 }
 
@@ -176,8 +172,8 @@ void ContextResolver::load_mode_slices(llvm::ArrayRef<CacheModeEntry> modes,
         auto disk = workspace.file_table.current(id);
         if(!disk || disk->hash != entry.content_hash)
             continue;
-        header_modes[id] = HeaderMode::NeedsContext;
-        header_mode_hashes[id] = entry.content_hash;
+        header_verdicts[id] = {.mode = HeaderMode::NeedsContext,
+                               .content_hash = entry.content_hash};
     }
 }
 
@@ -207,9 +203,27 @@ void ContextResolver::load_choice_slices(
     for(auto& entry: artifacts) {
         auto file = resolve(entry.file);
         auto host = resolve(entry.host);
-        if(file.empty() || host.empty())
+        // A file the store evicted since (or a wiped cache) has nothing
+        // left to open under the host's command.
+        if(file.empty() || host.empty() || !llvm::sys::fs::exists(file))
             continue;
         synthesized_hosts[file] = workspace.file_table.intern(host);
+    }
+}
+
+void ContextResolver::drop_evicted_artifacts() {
+    header_contexts.clear();
+    llvm::SmallVector<std::string> gone;
+    for(auto& entry: synthesized_hosts) {
+        if(!llvm::sys::fs::exists(entry.getKey())) {
+            gone.push_back(entry.getKey().str());
+        }
+    }
+    for(auto& path: gone) {
+        synthesized_hosts.erase(path);
+    }
+    if(!gone.empty()) {
+        workspace.mark_contexts_dirty();
     }
 }
 
@@ -646,36 +660,53 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(Fid header_
                                        observed->obs.uid_file);
     }
 
+    if(!workspace.store) {
+        LOG_WARN("resolve_header_context: no cache store to hold the preamble of {}",
+                 workspace.file_table.resolve(chain.back()));
+        return std::nullopt;
+    }
+    // Every synthesized file is a content-addressed blob of the store: the
+    // same bytes land on the same path across sessions, so a reopened
+    // header finds its preamble — and the PCH keyed on that path — intact,
+    // and the store's budget bounds what a long-lived cache accumulates.
+    auto store_blob = [&](std::string key, llvm::StringRef content) -> std::optional<std::string> {
+        if(auto hit = workspace.store->lookup(header_context_ns, key)) {
+            return hit;
+        }
+        auto pending = workspace.store->begin_store(header_context_ns, key);
+        if(auto result = fs::write(pending.tmp_path, content); !result) {
+            LOG_WARN("resolve_header_context: cannot write {}: {}",
+                     pending.tmp_path,
+                     result.error().message());
+            return std::nullopt;
+        }
+        auto published = workspace.store->commit(std::move(pending));
+        if(!published) {
+            LOG_WARN("resolve_header_context: cannot publish {}: {}",
+                     key,
+                     published.error().message());
+            return std::nullopt;
+        }
+        LOG_INFO("resolve_header_context: stored {} for header path_id={}",
+                 *published,
+                 header_path_id);
+        return *published;
+    };
+
     // Snapshot the header itself for other occurrences along the chain:
     // its real path is remapped to the open buffer at compile time, so
     // includes of it inside the prefix/suffix must point at a copy.
     auto target_path = workspace.file_table.resolve(chain.back());
     std::string self_snapshot_path;
     std::optional<ObservedFile> target_observed;
-    auto preamble_dir = path::join(workspace.config.project.cache_dir, "header_context");
     if((target_observed = read_file_observed(target_path.data()))) {
         auto content = target_observed->content->getBuffer();
         workspace.file_table.observe(chain.back(), target_observed->obs);
-        self_snapshot_path =
-            path::join(preamble_dir, std::format("{:016x}.self.h", target_observed->obs.hash));
-        if(!llvm::sys::fs::exists(self_snapshot_path)) {
-            auto ec = llvm::sys::fs::create_directories(preamble_dir);
-            if(ec) {
-                LOG_WARN("resolve_header_context: cannot create dir {}: {}",
-                         preamble_dir,
-                         ec.message());
-                return std::nullopt;
-            }
-            if(auto result = fs::write(self_snapshot_path, content); !result) {
-                LOG_WARN("resolve_header_context: cannot write snapshot {}: {}",
-                         self_snapshot_path,
-                         result.error().message());
-                return std::nullopt;
-            }
+        auto stored = store_blob(std::format("{:016x}.self", target_observed->obs.hash), content);
+        if(!stored) {
+            return std::nullopt;
         }
-    }
-
-    if(!self_snapshot_path.empty()) {
+        self_snapshot_path = std::move(*stored);
         record_synthesized_host(self_snapshot_path, host_path_id);
     }
 
@@ -689,29 +720,12 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(Fid header_
     }
     auto& preamble = synthesized->prefix;
 
-    // Hash the preamble and write to cache directory.
     auto preamble_hash = llvm::xxh3_64bits(llvm::StringRef(preamble));
-    auto preamble_filename = std::format("{:016x}.h", preamble_hash);
-    auto preamble_path = path::join(preamble_dir, preamble_filename);
-
-    if(!llvm::sys::fs::exists(preamble_path)) {
-        auto ec = llvm::sys::fs::create_directories(preamble_dir);
-        if(ec) {
-            LOG_WARN("resolve_header_context: cannot create dir {}: {}",
-                     preamble_dir,
-                     ec.message());
-            return std::nullopt;
-        }
-        if(auto result = fs::write(preamble_path, preamble); !result) {
-            LOG_WARN("resolve_header_context: cannot write preamble {}: {}",
-                     preamble_path,
-                     result.error().message());
-            return std::nullopt;
-        }
-        LOG_INFO("resolve_header_context: wrote preamble {} for header path_id={}",
-                 preamble_path,
-                 header_path_id);
+    auto stored_preamble = store_blob(std::format("{:016x}", preamble_hash), preamble);
+    if(!stored_preamble) {
+        return std::nullopt;
     }
+    auto preamble_path = std::move(*stored_preamble);
     record_synthesized_host(preamble_path, host_path_id);
 
     // The suffix restores everything after the include position (closing
@@ -720,15 +734,11 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(Fid header_
     std::string suffix_path;
     if(!synthesized->suffix.empty()) {
         auto suffix_hash = llvm::xxh3_64bits(llvm::StringRef(synthesized->suffix));
-        suffix_path = path::join(preamble_dir, std::format("{:016x}.suffix.h", suffix_hash));
-        if(!llvm::sys::fs::exists(suffix_path)) {
-            if(auto result = fs::write(suffix_path, synthesized->suffix); !result) {
-                LOG_WARN("resolve_header_context: cannot write suffix {}: {}",
-                         suffix_path,
-                         result.error().message());
-                return std::nullopt;
-            }
+        auto stored = store_blob(std::format("{:016x}.suffix", suffix_hash), synthesized->suffix);
+        if(!stored) {
+            return std::nullopt;
         }
+        suffix_path = std::move(*stored);
         record_synthesized_host(suffix_path, host_path_id);
     }
 

--- a/src/sched/context.h
+++ b/src/sched/context.h
@@ -61,13 +61,18 @@ class ContextResolver {
 public:
     explicit ContextResolver(Workspace& workspace) : workspace(workspace) {}
 
+    /// A header's self-containment verdict. NeedsContext carries the
+    /// content hash it was scored on — persisted so a stale verdict is
+    /// dropped on cache load; 0 means scored with no disk observation,
+    /// which keeps the verdict session-local.
+    struct HeaderVerdict {
+        HeaderMode mode = HeaderMode::Unknown;
+        std::uint64_t content_hash = 0;
+    };
+
     /// Self-containment verdicts for headers, persisted in the artifacts
     /// blob. Reset when the header itself is saved.
-    llvm::DenseMap<Fid, HeaderMode> header_modes;
-
-    /// Content hash of the header at the time its NeedsContext verdict was
-    /// scored — persisted so a stale verdict is dropped on cache load.
-    llvm::DenseMap<Fid, std::uint64_t> header_mode_hashes;
+    llvm::DenseMap<Fid, HeaderVerdict> header_verdicts;
 
     /// User context choices (clice/switchContext), persisted in the contexts blob
     /// and validated against the CDB and include graph on didOpen. The
@@ -108,6 +113,12 @@ public:
     void drop_header_context(Fid path_id) {
         header_contexts.erase(path_id);
     }
+
+    /// The store evicted synthesized files. Any resolved context may
+    /// embed one (its preamble includes the self snapshot), so every
+    /// context re-resolves on its next compile, and the host records of
+    /// the files gone from disk are dropped.
+    void drop_evicted_artifacts();
 
     /// Drop the header context's dependency fast paths so the next use
     /// re-validates every chain file by a real read. The context itself is

--- a/src/sched/context.h
+++ b/src/sched/context.h
@@ -114,10 +114,9 @@ public:
         header_contexts.erase(path_id);
     }
 
-    /// The store evicted synthesized files. Any resolved context may
-    /// embed one (its preamble includes the self snapshot), so every
-    /// context re-resolves on its next compile, and the host records of
-    /// the files gone from disk are dropped.
+    /// The store evicted synthesized files: drop the host records of the
+    /// files gone from disk. A resolved context checks its own files on
+    /// every reuse, so none needs dropping here.
     void drop_evicted_artifacts();
 
     /// Drop the header context's dependency fast paths so the next use

--- a/src/sched/graph.cpp
+++ b/src/sched/graph.cpp
@@ -230,19 +230,25 @@ void TaskGraph::declare(NodeId id, llvm::ArrayRef<NodeId> deps) {
     set_durable_edges(id, unique);
 }
 
+void TaskGraph::record_candidate(NodeId self, NodeId dep) {
+    auto round = nodes.find(self)->second.round;
+    if(ranges::contains(round->candidates, dep)) {
+        return;
+    }
+    round->candidates.push_back(dep);
+    acquire(dep);
+    nodes.find(dep)->second.candidate_dependents.push_back(self);
+    // Re-find: acquire may rehash the map.
+    if(nodes.find(self)->second.foreground) {
+        mark_foreground(dep);
+    }
+}
+
 void TaskGraph::reference_from(NodeId self, NodeId dep) {
     if(dep == self) {
         return;
     }
-    auto round = nodes.find(self)->second.round;
-    if(!ranges::contains(round->candidates, dep)) {
-        round->candidates.push_back(dep);
-        acquire(dep);
-        nodes.find(dep)->second.candidate_dependents.push_back(self);
-        if(nodes.find(self)->second.foreground) {
-            mark_foreground(dep);
-        }
-    }
+    record_candidate(self, dep);
 }
 
 kota::task<DependResult> TaskGraph::depend_from(NodeId self,
@@ -256,16 +262,7 @@ kota::task<DependResult> TaskGraph::depend_from(NodeId self,
     // Synchronous phase: the edge takes effect for cascade, interest and
     // foreground the moment it is declared — no window between "the round
     // uses dep" and "update(dep) reaches the round".
-    auto round = nodes.find(self)->second.round;
-    if(!ranges::contains(round->candidates, dep)) {
-        round->candidates.push_back(dep);
-        acquire(dep);
-        nodes.find(dep)->second.candidate_dependents.push_back(self);
-        // Re-find: acquire may rehash the map.
-        if(nodes.find(self)->second.foreground) {
-            mark_foreground(dep);
-        }
-    }
+    record_candidate(self, dep);
 
     // Race the dependency wait against this round's own advisory token: a
     // voided round must stop blocking on slow dependencies and wind down,

--- a/src/sched/graph.h
+++ b/src/sched/graph.h
@@ -351,6 +351,11 @@ private:
     /// already exist.
     void set_durable_edges(NodeId id, llvm::ArrayRef<NodeId> deps);
 
+    /// Register `dep` in the current round's candidate set of `self`: one
+    /// interest reference, the back-edge, and foreground propagation, all
+    /// at once. Idempotent per round.
+    void record_candidate(NodeId self, NodeId dep);
+
     /// RoundContext::depend() body.
     kota::task<DependResult> depend_from(NodeId self, kota::cancellation_token token, NodeId dep);
 

--- a/src/sched/index/pump.cpp
+++ b/src/sched/index/pump.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "sched/families/turun.h"
+#include "sched/graph.h"
 #include "support/logging.h"
 #include "support/timer.h"
 #include "worker/pool.h"
@@ -497,6 +498,26 @@ kota::task<> IndexPump::run_background_indexing() {
     // stay skipped for that whole wait.
     if(index_queue_pos < index_queue.size()) {
         schedule(/*immediate=*/true);
+    }
+}
+
+kota::task<> shutdown_indexing(TaskGraph& graph,
+                               IndexPump& pump,
+                               IndexStore& store,
+                               WorkerPool& pool,
+                               Workspace& workspace) {
+    co_await graph.shutdown();
+    auto report = co_await store.save(pump.save_debt());
+    pump.claim_report(report);
+    if(report.snapshot_stale) {
+        // Debt surfaced after the snapshot serialized (write-time
+        // corruption recovery): one metadata retry, or a dropped
+        // standalone header's repair debt dies with this process.
+        pump.claim_report(co_await store.save(pump.save_debt()));
+    }
+    co_await pool.stop();
+    if(workspace.store) {
+        workspace.store->shutdown();
     }
 }
 

--- a/src/sched/index/pump.h
+++ b/src/sched/index/pump.h
@@ -19,6 +19,7 @@
 
 namespace clice {
 
+class TaskGraph;
 class TURunFamily;
 class WorkerPool;
 
@@ -307,5 +308,15 @@ private:
                                 std::size_t total,
                                 RoundState& round);
 };
+
+/// The shutdown tail every indexing stack shares once its compile and
+/// index work is quiesced (contract 11): wind down the graph's rounds,
+/// the final save with the one metadata retry late debt may owe, then
+/// the pool and the store.
+kota::task<> shutdown_indexing(TaskGraph& graph,
+                               IndexPump& pump,
+                               IndexStore& store,
+                               WorkerPool& pool,
+                               Workspace& workspace);
 
 }  // namespace clice

--- a/src/sched/workspace.cpp
+++ b/src/sched/workspace.cpp
@@ -23,11 +23,10 @@
 namespace clice {
 
 bool Workspace::is_synthesized_artifact(llvm::StringRef path) const {
-    if(config.project.cache_dir.empty()) {
+    if(!store) {
         return false;
     }
-    auto artifact_dir = path::join(config.project.cache_dir, "header_context");
-    return path.starts_with(artifact_dir);
+    return path.starts_with(path::join(store->base_dir(), header_context_ns));
 }
 
 std::uint32_t Workspace::count_occurrences(Fid host_id, Fid target_id) const {

--- a/src/sched/workspace.h
+++ b/src/sched/workspace.h
@@ -82,6 +82,11 @@ struct HeaderContext {
     /// trailing #include line. Empty when the suffix is empty.
     std::string suffix_path;
 
+    /// Path to the disk snapshot of the header itself, which the prefix
+    /// includes in place of the header's other occurrences along the
+    /// chain. Empty when the header could not be read.
+    std::string snapshot_path;
+
     /// Which include of this header in its direct includer produced the
     /// preamble (0-based, in directive order).
     std::uint32_t occurrence = 0;

--- a/src/sched/workspace.h
+++ b/src/sched/workspace.h
@@ -66,6 +66,12 @@ using DepsSnapshot = llvm::SmallVector<DepState>;
 void force_revalidate_deps(FileTable& files, const DepsSnapshot& snap);
 
 /// Context for compiling a header file that lacks its own CDB entry.
+/// The cache-store namespace of synthesized header-context files
+/// (preamble, suffix and self snapshot): content-addressed blobs, so a
+/// header reopened in a later session finds its preamble — and the PCH
+/// keyed on the preamble's path — intact.
+constexpr inline llvm::StringLiteral header_context_ns = "header_context";
+
 struct HeaderContext {
     Fid host_path_id;             ///< Source file acting as host.
     std::string preamble_path;    ///< Path to generated preamble file on disk.

--- a/src/server/service/ast_family.cpp
+++ b/src/server/service/ast_family.cpp
@@ -51,22 +51,10 @@ static kota::codec::RawValue quarantine_diagnostics(unsigned crashes) {
     return kota::codec::RawValue{json ? std::move(*json) : "[]"};
 }
 
-/// The PCH acquisition plan of a buffer state: whether a PCH is owed at
-/// all, and the request that identifies/builds it when so. Shared by the
-/// AST round (depend path) and the stateless build path (acquire path).
-struct PCHPlan {
-    /// False when the preamble is empty and no prefix is injected — a
-    /// PCH would be empty, and a previously adopted key must be cleared.
-    bool wanted = false;
-    PCHFamily::Request request;
-};
-
-static PCHPlan plan_pch(Workspace& workspace,
-                        ContextResolver& contexts,
-                        Fid path_id,
-                        llvm::StringRef text,
-                        const std::string& directory,
-                        const std::vector<std::string>& arguments) {
+ASTFamily::PCHPlan ASTFamily::plan_pch(Fid path_id,
+                                       llvm::StringRef text,
+                                       const std::string& directory,
+                                       const std::vector<std::string>& arguments) {
     auto path = workspace.file_table.resolve(path_id);
     auto bound = compute_preamble_bound(text);
     auto* header_context = contexts.header_context(path_id);
@@ -99,16 +87,31 @@ static PCHPlan plan_pch(Workspace& workspace,
                               path::parent_path(path),
                               preamble_text,
                               canonicalize(arguments, ArgsProfile::Frontend)});
+    if(!pch.fresh(pch_key) && !is_preamble_complete(text, bound)) {
+        // Preamble incomplete (user still typing) and nothing fresh to
+        // adopt under the new key: defer the rebuild, keep using the
+        // previously adopted PCH while its artifact is still available.
+        LOG_DEBUG("Preamble incomplete for {}, deferring PCH rebuild", path);
+        PCHPlan plan{.verdict = PCHPlan::Verdict::Defer};
+        if(auto previous = projections.projection(path_id); previous && previous->pch_key) {
+            auto it = workspace.pch_cache.find(*previous->pch_key);
+            if(it != workspace.pch_cache.end() && !it->second.path.empty()) {
+                plan.previous = previous->pch_key;
+            }
+        }
+        return plan;
+    }
     return {
-        .wanted = true,
-        .request = {
-                    .pch_key = std::move(pch_key),
-                    .file = std::string(path),
-                    .directory = directory,
-                    .arguments = arguments,
-                    .content = std::string(text),
-                    .preamble_bound = bound,
-                    }
+        .verdict = PCHPlan::Verdict::Acquire,
+        .request =
+            {
+                      .pch_key = std::move(pch_key),
+                      .file = std::string(path),
+                      .directory = directory,
+                      .arguments = arguments,
+                      .content = std::string(text),
+                      .preamble_bound = bound,
+                      },
     };
 }
 
@@ -518,26 +521,12 @@ kota::task<RoundOutcome> ASTFamily::run(RoundContext& ctx, Fid path_id) {
         // degradation: the compile proceeds preamble-less.
         std::optional<std::string> adopted_pch;
         if(readonly != ReadonlyMode::On) {
-            auto plan = plan_pch(workspace,
-                                 contexts,
-                                 path_id,
-                                 params.text,
-                                 params.directory,
-                                 params.arguments);
-            if(plan.wanted) {
-                auto pch_key = plan.request.pch_key;
-                if(!pch.fresh(pch_key) &&
-                   !is_preamble_complete(params.text, plan.request.preamble_bound)) {
-                    // Preamble incomplete (user still typing) and nothing
-                    // fresh to adopt under the new key — defer the
-                    // rebuild, keep using the previous PCH if it is still
-                    // available.
-                    LOG_DEBUG("Preamble incomplete for {}, deferring PCH rebuild", file_path);
-                    if(auto previous = projections.projection(path_id);
-                       previous && previous->pch_key.has_value()) {
-                        adopted_pch = previous->pch_key;
-                    }
-                } else {
+            auto plan = plan_pch(path_id, params.text, params.directory, params.arguments);
+            switch(plan.verdict) {
+                case PCHPlan::Verdict::None: break;
+                case PCHPlan::Verdict::Defer: adopted_pch = plan.previous; break;
+                case PCHPlan::Verdict::Acquire: {
+                    auto pch_key = plan.request.pch_key;
                     // This round is the dispatch owner when its depend
                     // spawns the PCH round: the probe pins every worker
                     // death of the build on this document (the preamble is
@@ -568,6 +557,7 @@ kota::task<RoundOutcome> ASTFamily::run(RoundContext& ctx, Fid path_id) {
                         case DependResult::Failed: break;
                         case DependResult::Cancelled: co_return RoundOutcome::Stale;
                     }
+                    break;
                 }
             }
         }
@@ -886,26 +876,13 @@ kota::task<bool> ASTFamily::ensure_pch(const std::shared_ptr<Session>& session,
         co_return false;
     }
 
-    auto plan = plan_pch(workspace, contexts, path_id, session->text, directory, arguments);
-    if(!plan.wanted) {
-        projections.set_pch_key(path_id, std::nullopt);
-        co_return true;
+    auto plan = plan_pch(path_id, session->text, directory, arguments);
+    switch(plan.verdict) {
+        case PCHPlan::Verdict::None: projections.set_pch_key(path_id, std::nullopt); co_return true;
+        case PCHPlan::Verdict::Defer: co_return plan.previous.has_value();
+        case PCHPlan::Verdict::Acquire: break;
     }
     auto pch_key = plan.request.pch_key;
-
-    // Preamble incomplete (user still typing) and nothing fresh to adopt
-    // under the new key — defer the rebuild, keep using the previously
-    // adopted PCH if it is still available.
-    if(!pch.fresh(pch_key) && !is_preamble_complete(session->text, plan.request.preamble_bound)) {
-        LOG_DEBUG("Preamble incomplete for {}, deferring PCH rebuild",
-                  workspace.file_table.resolve(path_id));
-        auto projection = projections.projection(path_id);
-        if(projection && projection->pch_key.has_value()) {
-            auto it = workspace.pch_cache.find(*projection->pch_key);
-            co_return it != workspace.pch_cache.end() && !it->second.path.empty();
-        }
-        co_return false;
-    }
 
     // Joiners of an already-running round install nothing and replay
     // nothing; only the dispatch owner's probe pins the build's deaths.

--- a/src/server/service/ast_family.h
+++ b/src/server/service/ast_family.h
@@ -208,6 +208,25 @@ private:
     /// stat fast paths in place (see deps_changed).
     bool is_stale(const Session& session);
 
+    /// What a buffer state owes the PCH family: nothing (an empty
+    /// preamble with no injected prefix — a previously adopted key must
+    /// be cleared), a deferral (the preamble is mid-edit and nothing
+    /// fresh exists under its key: keep `previous`, the last adopted key,
+    /// while its artifact is still built), or the acquisition of
+    /// `request`.
+    struct PCHPlan {
+        enum class Verdict : std::uint8_t { None, Defer, Acquire };
+
+        Verdict verdict = Verdict::None;
+        PCHFamily::Request request;
+        std::optional<std::string> previous;
+    };
+
+    PCHPlan plan_pch(Fid path_id,
+                     llvm::StringRef text,
+                     const std::string& directory,
+                     const std::vector<std::string>& arguments);
+
     /// Revalidate or build the session's preamble PCH through the family
     /// and adopt its key under the request's license (see
     /// prepare_stateless_inputs). This request is the dispatch owner when

--- a/src/server/service/features.cpp
+++ b/src/server/service/features.cpp
@@ -126,26 +126,6 @@ std::optional<IndexQuery::Cursor> Features::cursor_at(Fid path_id,
     return query.symbol_at(path_id, *offset);
 }
 
-Features::IndexRows Features::extract_rows(const index::Shard& shard) {
-    IndexRows rows;
-    shard.for_each_occurrence([&](const index::Occurrence& occurrence) {
-        rows.occurrences.push_back(occurrence);
-        return true;
-    });
-    shard.for_each_relation([&](index::SymbolHash hash, const index::Relation& relation) {
-        RelationKind kind(relation.kind);
-        if(kind.isDeclOrDef()) {
-            auto copy = relation;
-            rows.decls.push_back({.range = relation.range,
-                                  .extent = copy.definition_range(),
-                                  .symbol = hash,
-                                  .definition = kind.is_one_of(RelationKind::Definition)});
-        }
-        return true;
-    });
-    return rows;
-}
-
 /// The language selectors of a file's CDB entry: what the last -x forces,
 /// if any (the driver override beats every suffix heuristic), and the
 /// last -std value. Rules applied, like the resolve path's effective
@@ -554,7 +534,7 @@ Features::RawResult Features::semantic_tokens(std::shared_ptr<Session> session,
     switch(co_await pick_route(ticket, /*full_lex=*/true, &source)) {
         case Route::Superseded: co_return kota::outcome_error(content_modified());
         case Route::Index: {
-            auto rows = extract_rows(*source.rows);
+            auto rows = feature::extract_index_rows(*source.rows);
             auto tokens = feature::index_semantic_tokens(
                 session->text,
                 index_lang_options(*session),
@@ -611,7 +591,7 @@ Features::RawResult Features::folding_range(std::shared_ptr<Session> session,
     switch(co_await pick_route(ticket, /*full_lex=*/true, &source)) {
         case Route::Superseded: co_return kota::outcome_error(content_modified());
         case Route::Index: {
-            auto rows = extract_rows(*source.rows);
+            auto rows = feature::extract_index_rows(*source.rows);
             auto folds = feature::index_folding_ranges(
                 session->text,
                 index_lang_options(*session),
@@ -648,7 +628,7 @@ Features::RawResult Features::document_symbol(std::shared_ptr<Session> session,
         switch(co_await pick_route(ticket, /*full_lex=*/false, &source)) {
             case Route::Superseded: co_return kota::outcome_error(content_modified());
             case Route::Index: {
-                auto rows = extract_rows(*source.rows);
+                auto rows = feature::extract_index_rows(*source.rows);
                 auto symbols =
                     feature::index_document_symbols(rows.decls, [&](index::SymbolHash hash) {
                         return query.symbol_info(hash);

--- a/src/server/service/features.h
+++ b/src/server/service/features.h
@@ -216,15 +216,6 @@ private:
     std::optional<IndexQuery::Cursor> cursor_at(Fid path_id,
                                                 const protocol::Position& position) const;
 
-    /// The document's rows extracted for the projections, plus the
-    /// resolver the projections share.
-    struct IndexRows {
-        std::vector<index::Occurrence> occurrences;
-        std::vector<feature::IndexDeclRow> decls;
-    };
-
-    static IndexRows extract_rows(const index::Shard& shard);
-
     /// The lexing dialect of a session's index projections. An explicit -x
     /// in the file's own CDB entry decides outright; a header follows its
     /// active context's host when one exists; otherwise C when the file is

--- a/src/server/service/query.cpp
+++ b/src/server/service/query.cpp
@@ -62,20 +62,6 @@ LocalSourceRange to_local(const index::Occurrence& occurrence) {
     return {occurrence.range.begin, occurrence.range.end};
 }
 
-/// A definition's extent within one source's rows, or nullopt when the
-/// rows carry no in-bounds Definition payload for the symbol.
-std::optional<LocalSourceRange> definition_extent(const RowSource& source, index::SymbolHash hash) {
-    std::optional<LocalSourceRange> extent;
-    source.rows->lookup(hash, RelationKind::Definition, [&](const index::Relation& r) {
-        auto def_range = std::bit_cast<LocalSourceRange>(r.target_symbol);
-        if(def_range.begin >= def_range.end || def_range.end > source.coords.size())
-            return true;
-        extent = def_range;
-        return false;
-    });
-    return extent;
-}
-
 std::string extract_line(llvm::StringRef content, std::uint32_t offset) {
     if(content.empty() || offset >= content.size())
         return {};
@@ -677,70 +663,34 @@ std::optional<llvm::StringRef>
 }
 
 std::optional<IndexQuery::Definition> IndexQuery::definition_text(index::SymbolHash hash) const {
+    // Live sources first: buffer-true rows also know symbols the project
+    // table has never seen (an unsaved definition), the preamble region
+    // holds the buffer's own macros, and an overlay is the only source for
+    // a header seen under the live context. The first in-bounds Definition
+    // payload whose text is available wins.
     std::optional<Definition> found;
-    auto slice = [&](const RowSource& source) {
-        auto extent = definition_extent(source, hash);
-        if(!extent) {
-            return false;
-        }
-        std::unique_ptr<llvm::MemoryBuffer> storage;
-        auto text = source_text(source, storage);
-        if(!text) {
-            return false;
-        }
-        found = Definition{
-            .extent = source.site(*extent),
-            .text = std::string(text->substr(extent->begin, extent->length())),
-            .comment = feature::preceding_comment(*text, extent->begin),
-        };
-        return true;
-    };
-
-    // Live sources first, in the first-hit order: buffer-true rows also
-    // know symbols the project table has never seen (an unsaved
-    // definition), the preamble region holds the buffer's own macros, and
-    // an overlay is the only source for a header seen under the live
-    // context.
-    visit_sessions([&](Fid path_id, const Session& session) -> bool {
-        return !slice(session_source(path_id, session));
-    });
-    if(found) {
-        return found;
-    }
-    visit_preambles([&](Fid path_id, const Session& session, const index::TUIndex& state) -> bool {
-        return !slice(preamble_source(path_id, session, state));
-    });
-    if(found) {
-        return found;
-    }
-    visit_overlays([&](const index::TUIndex& state) -> bool {
-        visit_overlay_files(state, [&](const RowSource& source) { return !slice(source); });
-        return !found;
-    });
-    if(found) {
-        return found;
-    }
-
-    auto it = workspace.project_index.symbols.find(hash);
-    if(it == workspace.project_index.symbols.end()) {
-        return std::nullopt;
-    }
-    for(auto file_id: it->second.reference_files) {
-        Fid file{file_id};
-        auto serving = serving_source(file);
-        if(serving.by != ServingSource::By::ShardAsClosed) {
-            continue;
-        }
-        RowSource source{.kind = RowSource::Kind::Shard,
-                         .file = file,
-                         .path = workspace.file_table.resolve(file),
-                         .rows = serving.rows,
-                         .coords = serving.coords};
-        if(slice(source)) {
-            return found;
-        }
-    }
-    return std::nullopt;
+    for_each_relation(hash,
+                      RelationKind::Definition,
+                      Order::LiveFirst,
+                      {},
+                      [&](const RowSource& source, const index::Relation& relation) {
+                          auto extent = std::bit_cast<LocalSourceRange>(relation.target_symbol);
+                          if(extent.begin >= extent.end || extent.end > source.coords.size()) {
+                              return true;
+                          }
+                          std::unique_ptr<llvm::MemoryBuffer> storage;
+                          auto text = source_text(source, storage);
+                          if(!text) {
+                              return true;
+                          }
+                          found = Definition{
+                              .extent = source.site(extent),
+                              .text = std::string(text->substr(extent.begin, extent.length())),
+                              .comment = feature::preceding_comment(*text, extent.begin),
+                          };
+                          return false;
+                      });
+    return found;
 }
 
 std::string IndexQuery::context_line(const Site& site) const {

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -565,22 +565,10 @@ kota::task<> MasterServer::shutdown_and_cleanup() {
     // Quiesce in-flight compilation and indexing first so the persisted
     // snapshot below covers everything that actually completed.
     co_await kota::when_all(pump.stop(), ast.stop());
-    // Requests have unwound and released their interest; wind down the
-    // graph's rounds before the persistence pass and the pool stop
-    // (contract 11: quiesce -> final save -> pool/store).
-    co_await graph.shutdown();
-    auto report = co_await index_store.save(pump.save_debt());
-    pump.claim_report(report);
-    if(report.snapshot_stale) {
-        // Debt surfaced after the snapshot serialized (write-time
-        // corruption recovery): one metadata retry, or a dropped
-        // standalone header's repair debt dies with this process.
-        pump.claim_report(co_await index_store.save(pump.save_debt()));
-    }
-    co_await pool.stop();
-    if(workspace.store) {
-        workspace.store->shutdown();
-    }
+    // Requests have unwound and released their interest; the shared tail
+    // winds down the graph's rounds before the persistence pass and the
+    // pool stop.
+    co_await shutdown_indexing(graph, pump, index_store, pool, workspace);
     lifecycle = ServerLifecycle::Exited;
 }
 
@@ -627,7 +615,12 @@ void MasterServer::drain_store_evictions() {
     // lifetime even for keys never requested again. An entry mid-rebuild
     // keeps its slot — its commit republishes fresh blobs over the
     // eviction.
+    bool artifacts_evicted = false;
     for(auto& evicted: workspace.store->take_evictions()) {
+        if(evicted.ns == header_context_ns) {
+            artifacts_evicted = true;
+            continue;
+        }
         if(evicted.ns != "pch") {
             continue;
         }
@@ -642,6 +635,9 @@ void MasterServer::drain_store_evictions() {
            it != workspace.pch_cache.end() && !pch.building(evicted.key)) {
             workspace.pch_cache.erase(it);
         }
+    }
+    if(artifacts_evicted) {
+        contexts.drop_evicted_artifacts();
     }
 }
 

--- a/src/support/logging.h
+++ b/src/support/logging.h
@@ -69,8 +69,9 @@
 /// time until a worker was ready, total_ms = end-to-end), "query"
 /// (worker-side share of a request: acquire_ms = AST wait + strand lock,
 /// compute_ms = the feature call itself), "build" (stateless-worker build
-/// tasks: kind=pch|pcm|index with per-stage splits — compile_ms, and per
-/// kind preamble_index_ms/flush_ms or index_ms/serialize_ms),
+/// tasks: kind=pch|pcm|turun with per-stage splits — compile_ms, then
+/// preamble_index_ms/flush_ms/state_write_ms for a pch, flush_ms for a
+/// pcm, index_ms/teardown_ms for a turun),
 /// "index_query" (master-side index lookups: kind=relations|search),
 /// "index_detail" (inside one index pass: op=build splits the semantics
 /// table from projection and finishing, op=serialize splits the path-id

--- a/src/syntax/lexer.cpp
+++ b/src/syntax/lexer.cpp
@@ -82,8 +82,7 @@ void Lexer::lex(Token& token) {
         auto kw = token.text(content);
         // `import` here is the directive form (`#import`), which takes a
         // filename; a module import never sets parse_pp_keyword.
-        parse_header_name =
-            kw == "include" || kw == "include_next" || kw == "embed" || kw == "import";
+        parse_header_name = takes_header_name(kw);
     }
 
     // The __has_include family takes a parenthesized filename argument the

--- a/src/syntax/lexer.h
+++ b/src/syntax/lexer.h
@@ -24,6 +24,15 @@ struct LexerOptions {
     const clang::LangOptions* lang_opts = nullptr;
 };
 
+/// Whether a directive keyword takes a header-name argument: `#include`,
+/// `#include_next`, `#import` and `#embed`. The lexer switches to
+/// header-name mode after one, and every consumer hunting the filename
+/// token keys on the same set.
+inline bool takes_header_name(llvm::StringRef keyword) {
+    return keyword == "include" || keyword == "include_next" || keyword == "import" ||
+           keyword == "embed";
+}
+
 /// A pull-style wrapper over clang's raw lexer with just enough
 /// preprocessor awareness for scanning: directive lines are terminated by
 /// eod tokens, directive keywords are flagged via Token::is_pp_keyword, and

--- a/src/syntax/scan.cpp
+++ b/src/syntax/scan.cpp
@@ -506,14 +506,14 @@ bool is_preamble_complete(llvm::StringRef content, std::uint32_t bound) {
     llvm::SmallVector<Token, 8> line;
 
     auto line_complete = [&] {
-        // A #include/#import directive is complete once it has a terminated
-        // filename argument (or a macro identifier standing in for one).
+        // A header-name directive (#include, #embed, ...) is complete once
+        // it has a terminated filename argument (or a macro identifier
+        // standing in for one).
         if(line.front().is_directive_hash()) {
             if(line.size() < 2 || !line[1].is_identifier()) {
                 return true;
             }
-            auto keyword = line[1].text(content);
-            if(keyword != "include" && keyword != "include_next" && keyword != "import") {
+            if(!takes_header_name(line[1].text(content))) {
                 return true;
             }
             if(line.size() < 3) {

--- a/src/worker/stateless.cpp
+++ b/src/worker/stateless.cpp
@@ -457,6 +457,37 @@ static kota::codec::RawValue handle_format(const worker::FormatParams& params) {
     return to_raw(edits);
 }
 
+/// Register the handler of one request type. Each request arms a fresh
+/// stop flag as the most recent build's — published before the
+/// pool-thread hop so a CancelBuild aimed at it still lands — and runs
+/// the handler on the pool thread. A cancellation (peer close, wire-level
+/// $/cancelRequest) dequeues work that has not started, which answers
+/// `cancelled`; work already on the pool thread learns through the hook:
+/// the flag doubles as CompilationParams::stop, which clang polls after
+/// every top-level declaration, so even the parse itself stops instead of
+/// running to completion for a result nobody will read.
+template <typename Params, typename Result, typename Handler>
+static void serve(kota::ipc::BincodePeer& peer,
+                  std::shared_ptr<std::atomic_bool>& build_stop,
+                  Result cancelled,
+                  Handler handler) {
+    peer.on_request([&build_stop,
+                     cancelled,
+                     handler](RequestContext&, const Params& params) -> RequestResult<Params> {
+        auto stop = std::make_shared<std::atomic_bool>(false);
+        build_stop = stop;
+        auto result = co_await kota::queue(
+            [&]() -> Result {
+                if(stop->load(std::memory_order_relaxed)) {
+                    return cancelled;
+                }
+                return handler(params, stop);
+            },
+            [stop] { stop->store(true, std::memory_order_relaxed); });
+        co_return result.value();
+    });
+}
+
 int run_stateless_worker_mode(const std::string& worker_name, const std::string& log_dir) {
     // Limit libuv thread pool to 1 thread so each stateless worker executes
     // only one compilation at a time. Must be set before any kota::queue call.
@@ -507,105 +538,27 @@ int run_stateless_worker_mode(const std::string& worker_name, const std::string&
         }
     });
 
-    // A cancellation (peer close, wire-level $/cancelRequest) dequeues
-    // work that has not started; work already on the pool thread learns
-    // through the hook: the shared flag doubles as CompilationParams::
-    // stop, which clang polls after every top-level declaration, so even
-    // the parse itself stops instead of running to completion for a
-    // result nobody will read.
-    auto arm_stop = [&build_stop] {
-        auto stop = std::make_shared<std::atomic_bool>(false);
-        build_stop = stop;
-        return stop;
-    };
-
-    peer.on_request(
-        [&](RequestContext& ctx,
-            const worker::BuildPCHParams& params) -> RequestResult<worker::BuildPCHParams> {
-            auto stop = arm_stop();
-            auto result = co_await kota::queue(
-                [&]() -> worker::ArtifactBuildResult {
-                    if(stop->load(std::memory_order_relaxed)) {
-                        return {false, "Build cancelled"};
-                    }
-                    return handle_build_pch(params, stop);
-                },
-                [stop] { stop->store(true, std::memory_order_relaxed); });
-            co_return result.value();
+    const worker::ArtifactBuildResult cancelled_build{.success = false, .error = "Build cancelled"};
+    serve<worker::BuildPCHParams>(peer, build_stop, cancelled_build, &handle_build_pch);
+    serve<worker::BuildPCMParams>(peer, build_stop, cancelled_build, &handle_build_pcm);
+    serve<worker::TURunParams>(
+        peer,
+        build_stop,
+        worker::TURunResult{.success = false, .error = "Build cancelled"},
+        [](const worker::TURunParams& params, const std::shared_ptr<std::atomic_bool>& stop) {
+            ScopedNice guard;
+            return handle_turun(params, stop);
         });
-
-    peer.on_request(
-        [&](RequestContext& ctx,
-            const worker::BuildPCMParams& params) -> RequestResult<worker::BuildPCMParams> {
-            auto stop = arm_stop();
-            auto result = co_await kota::queue(
-                [&]() -> worker::ArtifactBuildResult {
-                    if(stop->load(std::memory_order_relaxed)) {
-                        return {false, "Build cancelled"};
-                    }
-                    return handle_build_pcm(params, stop);
-                },
-                [stop] { stop->store(true, std::memory_order_relaxed); });
-            co_return result.value();
+    const kota::codec::RawValue cancelled_query{"null"};
+    serve<worker::CompletionParams>(peer, build_stop, cancelled_query, &handle_completion);
+    serve<worker::SignatureHelpParams>(peer, build_stop, cancelled_query, &handle_signature_help);
+    serve<worker::FormatParams>(
+        peer,
+        build_stop,
+        cancelled_query,
+        [](const worker::FormatParams& params, const std::shared_ptr<std::atomic_bool>&) {
+            return handle_format(params);
         });
-
-    peer.on_request([&](RequestContext& ctx,
-                        const worker::TURunParams& params) -> RequestResult<worker::TURunParams> {
-        auto stop = arm_stop();
-        auto result = co_await kota::queue(
-            [&]() -> worker::TURunResult {
-                if(stop->load(std::memory_order_relaxed)) {
-                    return {false, "Build cancelled"};
-                }
-                ScopedNice guard;
-                return handle_turun(params, stop);
-            },
-            [stop] { stop->store(true, std::memory_order_relaxed); });
-        co_return result.value();
-    });
-
-    peer.on_request(
-        [&](RequestContext& ctx,
-            const worker::CompletionParams& params) -> RequestResult<worker::CompletionParams> {
-            auto stop = arm_stop();
-            auto result = co_await kota::queue(
-                [&]() -> kota::codec::RawValue {
-                    if(stop->load(std::memory_order_relaxed)) {
-                        return kota::codec::RawValue{"null"};
-                    }
-                    return handle_completion(params, stop);
-                },
-                [stop] { stop->store(true, std::memory_order_relaxed); });
-            co_return result.value();
-        });
-
-    peer.on_request([&](RequestContext& ctx, const worker::SignatureHelpParams& params)
-                        -> RequestResult<worker::SignatureHelpParams> {
-        auto stop = arm_stop();
-        auto result = co_await kota::queue(
-            [&]() -> kota::codec::RawValue {
-                if(stop->load(std::memory_order_relaxed)) {
-                    return kota::codec::RawValue{"null"};
-                }
-                return handle_signature_help(params, stop);
-            },
-            [stop] { stop->store(true, std::memory_order_relaxed); });
-        co_return result.value();
-    });
-
-    peer.on_request([&](RequestContext& ctx,
-                        const worker::FormatParams& params) -> RequestResult<worker::FormatParams> {
-        auto stop = arm_stop();
-        auto result = co_await kota::queue(
-            [&]() -> kota::codec::RawValue {
-                if(stop->load(std::memory_order_relaxed)) {
-                    return kota::codec::RawValue{"null"};
-                }
-                return handle_format(params);
-            },
-            [stop] { stop->store(true, std::memory_order_relaxed); });
-        co_return result.value();
-    });
 
     LOG_INFO("Stateless worker ready, waiting for requests");
     loop.schedule(peer.run());

--- a/tests/integration/compilation/persistent_cache.test.ts
+++ b/tests/integration/compilation/persistent_cache.test.ts
@@ -600,3 +600,22 @@ test("cache wiped while running", async ({ session }) => {
     client.assertCleanCompile(uri);
     expect(workspace.pchFiles().length, "PCH build must recover after a cache wipe").toBe(1);
 });
+
+/// Synthesized header-context files once lived directly under the cache
+/// root, outside the store. A directory an earlier version left there is
+/// removed at startup, so its files cannot be navigated into through the
+/// metadata that still names them; the store's own namespace is untouched.
+test("legacy header_context directory removed", async ({ session }) => {
+    const { client, workspace } = session.tmp();
+    workspace.pinCacheDir();
+    const legacy = workspace.path(path.join(".clice", "header_context"));
+    fs.mkdirSync(legacy, { recursive: true });
+    fs.writeFileSync(path.join(legacy, "0123456789abcdef.h"), "// stale prefix\n");
+    workspace.write("main.cpp", "int main() { return 0; }\n");
+    workspace.writeCDB(["main.cpp"]);
+    await client.initialize(workspace);
+    await client.openAndWait("main.cpp");
+
+    expect(fs.existsSync(legacy)).toBe(false);
+    expect(fs.existsSync(workspace.headerContextDir())).toBe(true);
+});

--- a/tests/integration/compilation/persistent_cache.test.ts
+++ b/tests/integration/compilation/persistent_cache.test.ts
@@ -611,11 +611,14 @@ test("legacy header_context directory removed", async ({ session }) => {
     const legacy = workspace.path(path.join(".clice", "header_context"));
     fs.mkdirSync(legacy, { recursive: true });
     fs.writeFileSync(path.join(legacy, "0123456789abcdef.h"), "// stale prefix\n");
+    const kept = path.join(workspace.headerContextDir(), "fedcba9876543210.h");
+    fs.mkdirSync(workspace.headerContextDir(), { recursive: true });
+    fs.writeFileSync(kept, "// store prefix\n");
     workspace.write("main.cpp", "int main() { return 0; }\n");
     workspace.writeCDB(["main.cpp"]);
     await client.initialize(workspace);
     await client.openAndWait("main.cpp");
 
     expect(fs.existsSync(legacy)).toBe(false);
-    expect(fs.existsSync(workspace.headerContextDir())).toBe(true);
+    expect(workspace.headerContextFiles()).toEqual([kept]);
 });

--- a/tests/integration/compilation/self_containment.test.ts
+++ b/tests/integration/compilation/self_containment.test.ts
@@ -6,25 +6,14 @@
 /// only the final diagnostics are published. Verdicts and user context
 /// choices persist across server sessions via the index database.
 
-import * as fs from "node:fs";
-import * as path from "node:path";
 import { MTIME_GRANULARITY, sleep } from "@clice/tools/client";
 import type { Workspace } from "@clice/tools/workspace";
 import { expect, test } from "../fixtures.ts";
 
 function prefixFiles(workspace: Workspace): string[] {
-    const prefixDir = workspace.path(path.join(".clice", "header_context"));
-    if (!fs.existsSync(prefixDir)) {
-        return [];
-    }
-    return fs
-        .readdirSync(prefixDir)
-        .filter(
-            (name) =>
-                name.endsWith(".h") && !name.endsWith(".suffix.h") && !name.endsWith(".self.h"),
-        )
-        .sort()
-        .map((name) => path.join(prefixDir, name));
+    return workspace
+        .headerContextFiles()
+        .filter((file) => !file.endsWith(".suffix.h") && !file.endsWith(".self.h"));
 }
 
 test("self contained skips synthesis", async ({ session }) => {

--- a/tests/integration/extensions/context_switching.test.ts
+++ b/tests/integration/extensions/context_switching.test.ts
@@ -333,7 +333,7 @@ test("reopen reuses preamble", async ({ session }) => {
     expect(switched.success).toBe(true);
     await client.waitForRecompile(defUri);
 
-    const artifactDir = workspace.path(path.join(".clice", "header_context"));
+    const artifactDir = workspace.headerContextDir();
     const snapshot = snapshotMtimes(artifactDir);
     expect(Object.keys(snapshot).length, "expected synthesized preamble artifacts").toBeGreaterThan(
         0,
@@ -375,7 +375,7 @@ test("chain change resynthesizes", async ({ session }) => {
     expect(switched.success).toBe(true);
     await client.waitForRecompile(defUri);
 
-    const artifactDir = workspace.path(path.join(".clice", "header_context"));
+    const artifactDir = workspace.headerContextDir();
     const snapshot = snapshotMtimes(artifactDir);
     expect(Object.keys(snapshot).length, "expected synthesized preamble artifacts").toBeGreaterThan(
         0,

--- a/tests/integration/extensions/context_switching.test.ts
+++ b/tests/integration/extensions/context_switching.test.ts
@@ -350,6 +350,50 @@ test("reopen reuses preamble", async ({ session }) => {
     expect(after, "reopen must reuse the preamble, not re-synthesize").toEqual(snapshot);
 });
 
+/// A synthesized preamble wiped from the cache while the server runs (a
+/// user resetting state, or the store's own budget) is re-synthesized on
+/// the header's next compile instead of reaching clang as a missing
+/// -include.
+test("wiped artifacts resynthesize", async ({ session }) => {
+    const { client, workspace } = session.tmp();
+    workspace.write("list.def", "X(alpha)\nX(beta)\n");
+    workspace.write(
+        "main.cpp",
+        "#define X(name) int name = 1;\n" +
+            '#include "list.def"\n' +
+            "#undef X\n" +
+            "#define X(name) void get_##name();\n" +
+            '#include "list.def"\n' +
+            "#undef X\n" +
+            "int main() { return alpha; }\n",
+    );
+    workspace.writeCDB(["main.cpp"]);
+    await client.initialize(workspace);
+
+    const [mainUri] = await client.openAndWait("main.cpp");
+    const [defUri] = await client.openAndWait("list.def");
+    const switched = await client.switchContext(defUri, mainUri, { occurrence: 1 });
+    expect(switched.success).toBe(true);
+    await client.waitForRecompile(defUri);
+    client.assertCleanCompile(defUri);
+
+    const artifactDir = workspace.headerContextDir();
+    const before = Object.keys(snapshotMtimes(artifactDir)).sort();
+    expect(before.length, "expected synthesized preamble artifacts").toBeGreaterThan(0);
+    for (const name of before) {
+        fs.rmSync(path.join(artifactDir, name));
+    }
+
+    client.change(defUri, 2, "X(alpha)\nX(beta)\nX(gamma)\n");
+    await client.waitForRecompile(defUri);
+    client.assertCleanCompile(defUri);
+    // Content-addressed: the header's current context synthesizes the same
+    // file names again; the other occurrence's files stay gone until used.
+    const after = Object.keys(snapshotMtimes(artifactDir));
+    expect(after.length, "expected re-synthesized artifacts").toBeGreaterThan(0);
+    expect(before).toEqual(expect.arrayContaining(after));
+});
+
 /// Reopening a header after its chain file changed on disk must NOT
 /// reuse the stale preamble — the chain content is embedded in it.
 test("chain change resynthesizes", async ({ session }) => {

--- a/tests/integration/server/memory_ownership.test.ts
+++ b/tests/integration/server/memory_ownership.test.ts
@@ -134,10 +134,23 @@ test("cancel storm leaves no tmp", async ({ session }) => {
     // session must both register.
     const stats = await client.stats();
     expect(
-        stats["pchCacheEntries"],
+        stats.pchCacheEntries,
         `a PCH was built: ${JSON.stringify(stats)}`,
     ).toBeGreaterThanOrEqual(1);
-    expect(stats["sessions"], `one open document: ${JSON.stringify(stats)}`).toBe(1);
+    expect(stats.sessions, `one open document: ${JSON.stringify(stats)}`).toBe(1);
+    // The C++ and TS shapes of the reply are hand-written on both sides; a
+    // gauge added to one and not the other shows up here.
+    expect(Object.keys(stats).sort()).toEqual([
+        "headerContexts",
+        "indexInmemoryShards",
+        "indexShardContentBytes",
+        "lastSaveShards",
+        "pchCacheEntries",
+        "pchLoadedStates",
+        "pchStateBytes",
+        "pendingTmpFiles",
+        "sessions",
+    ]);
     client.assertNoAnomaly();
 });
 
@@ -208,6 +221,6 @@ test("same preamble shared", async ({ session }) => {
     // blob: opening more consumers must not multiply loaded states.
     const stats = await client.stats();
     expect(stats.pchLoadedStates, `one shared key: ${JSON.stringify(stats)}`).toBe(1);
-    expect(stats["pchCacheEntries"], `one shared entry: ${JSON.stringify(stats)}`).toBe(1);
+    expect(stats.pchCacheEntries, `one shared entry: ${JSON.stringify(stats)}`).toBe(1);
     client.assertNoAnomaly();
 });

--- a/tests/snap/folding_range/preprocessor_conditional.cpp
+++ b/tests/snap/folding_range/preprocessor_conditional.cpp
@@ -5,6 +5,7 @@
 /// - status: partial
 /// - issues: clangd#1661, clangd#2059
 /// - order: 5
+/// - flags: ["-std=c++23"]
 ///
 /// Branch regions delimited by `#else` fold today; a bare `#if ... #endif`
 /// block without an `#else` does not fold yet. clangd#2059 is a duplicate
@@ -18,4 +19,12 @@ void log_message();      // │ no fold yet: bare conditional without #else
 void spawn_workers();    // │ folds: branches delimited by #else
 #else                    // │
 void run_inline();       // │
+#endif                   // ┘
+
+#ifdef USE_EPOLL         // ┐
+void poll_epoll();       // │ no fold yet: the branch before #elifdef
+#elifdef USE_KQUEUE      // │ ┐
+void poll_kqueue();      // │ │ folds: the #elifdef branch, delimited by #else
+#else                    // │ ┘
+void poll_select();      // │
 #endif                   // ┘

--- a/tests/snap/folding_range/preprocessor_conditional.snap.yml
+++ b/tests/snap/folding_range/preprocessor_conditional.snap.yml
@@ -2,4 +2,5 @@
 created_at: 2026-07-27
 input_file: preprocessor_conditional.cpp
 ---
-- { range: "16:7-18:5", kind: conditionDirective }
+- { range: "17:7-19:5", kind: conditionDirective }
+- { range: "25:9-27:5", kind: conditionDirective }

--- a/tests/unit/compile/directive_tests.cpp
+++ b/tests/unit/compile/directive_tests.cpp
@@ -173,6 +173,36 @@ TEST_CASE(Condition) {
     EXPECT_CON(7, Condition::BranchKind::EndIf, "7");
 };
 
+TEST_CASE(ElifndefBranches) {
+    run(R"cpp(
+#[main.cpp]
+#define other
+#§(0)ifdef name
+#§(1)elifndef name
+#§(2)else
+#§(3)endif
+
+#§(4)ifdef name
+#§(5)elifndef other
+#§(6)else
+#§(7)endif
+)cpp");
+
+    ASSERT_EQ(conditions.size(), 8U);
+    EXPECT_CON(0, Condition::BranchKind::Ifdef, "0");
+    EXPECT_CON(1, Condition::BranchKind::Elifndef, "1");
+    EXPECT_CON(2, Condition::BranchKind::Else, "2");
+    EXPECT_CON(3, Condition::BranchKind::EndIf, "3");
+    EXPECT_CON(4, Condition::BranchKind::Ifdef, "4");
+    EXPECT_CON(5, Condition::BranchKind::Elifndef, "5");
+    EXPECT_CON(6, Condition::BranchKind::Else, "6");
+    EXPECT_CON(7, Condition::BranchKind::EndIf, "7");
+    // The recorded value is the branch truth: an #elifndef of an undefined
+    // macro is taken, of a defined one is not.
+    EXPECT_EQ(int(conditions[1].value), int(Condition::True));
+    EXPECT_EQ(int(conditions[5].value), int(Condition::False));
+};
+
 TEST_CASE(Macro) {
     run(R"cpp(
 #[main.cpp]

--- a/tests/unit/feature/index_projection_tests.cpp
+++ b/tests/unit/feature/index_projection_tests.cpp
@@ -25,26 +25,9 @@ void extract_rows() {
     tu = index::TUIndex::from_bytes(envelope);
 
     auto main_id = tu.path_count() - 1;
-    auto& shard = tu.shard_of(main_id);
-
-    occurrences.clear();
-    shard.for_each_occurrence([&](const index::Occurrence& occurrence) {
-        occurrences.push_back(occurrence);
-        return true;
-    });
-
-    decls.clear();
-    shard.for_each_relation([&](index::SymbolHash hash, const index::Relation& relation) {
-        RelationKind kind(relation.kind);
-        if(kind.isDeclOrDef()) {
-            auto copy = relation;
-            decls.push_back({.range = relation.range,
-                             .extent = copy.definition_range(),
-                             .symbol = hash,
-                             .definition = kind.is_one_of(RelationKind::Definition)});
-        }
-        return true;
-    });
+    auto rows = feature::extract_index_rows(tu.shard_of(main_id));
+    occurrences = std::move(rows.occurrences);
+    decls = std::move(rows.decls);
 }
 
 std::optional<index::SymbolRef> resolve(index::SymbolHash hash) {

--- a/tests/unit/server/query_overlay_tests.cpp
+++ b/tests/unit/server/query_overlay_tests.cpp
@@ -1,3 +1,4 @@
+#include <format>
 #include <string>
 #include <vector>
 
@@ -16,6 +17,8 @@
 #include "server/service/query.h"
 #include "server/state/ast_projection.h"
 #include "server/state/session_store.h"
+#include "support/cache_store.h"
+#include "support/filesystem.h"
 #include "worker/pool.h"
 
 #include "kota/ipc/lsp/text.h"
@@ -552,18 +555,25 @@ int main() { §(ref)⟦foo⟧(); return 0; }
 }
 
 TEST_CASE(SynthesizedArtifactSkipped) {
-    workspace.config.project.cache_dir = TestVFS::root();
-    add_file("header_context/gen.h", R"(
-inline void §(def)⟦gen⟧() {}
+    auto store = CacheStore::open(dir.path("cache"), cache_format_version);
+    ASSERT_TRUE(store.has_value());
+    store->register_namespace({.name = std::string(header_context_ns), .extension = ".h"});
+    workspace.store.emplace(std::move(*store));
+
+    // The header lives inside the store's synthesized-artifact namespace:
+    // its overlay rows must never send the user into the cache.
+    auto header = path::join(workspace.store->base_dir(), header_context_ns, "gen.h");
+    add_file(header, R"(
+inline void gen() {}
 )");
-    add_main("main.cpp", R"(
-#include "header_context/gen.h"
-int main() { §(ref)⟦gen⟧(); return 0; }
-)");
+    add_main("main.cpp",
+             std::format(R"(
+#include "{}"
+int main() {{ gen(); return 0; }}
+)",
+                         header));
     open_with_overlay();
 
-    // The header lives inside the synthesized-artifact directory: its
-    // overlay rows must never send the user into the cache.
     EXPECT_FALSE(index_query.first_site(hash_of("gen"), RelationKind::Definition).has_value());
 }
 

--- a/tests/unit/syntax/scan_tests.cpp
+++ b/tests/unit/syntax/scan_tests.cpp
@@ -374,6 +374,18 @@ TEST_CASE(IncludeWithNoPath) {
     EXPECT_FALSE(is_preamble_complete(content, bound));
 }
 
+TEST_CASE(IncompleteEmbed) {
+    llvm::StringRef content = "#embed <data\nint x;";
+    auto bound = compute_preamble_bound(content);
+    EXPECT_FALSE(is_preamble_complete(content, bound));
+}
+
+TEST_CASE(CompleteEmbed) {
+    llvm::StringRef content = "#embed \"data.bin\" limit(4)\nint x;";
+    auto bound = compute_preamble_bound(content);
+    EXPECT_TRUE(is_preamble_complete(content, bound));
+}
+
 TEST_CASE(IncludeMacroUsage) {
     llvm::StringRef content = "#include FOO\nint x;";
     auto bound = compute_preamble_bound(content);

--- a/tests/unit/test/platform.h
+++ b/tests/unit/test/platform.h
@@ -39,14 +39,20 @@ public:
 #endif
     }
 
-    /// root() + relative → absolute path.
+    /// root() + relative → absolute path; an absolute path stays as is
+    /// (a file that must live outside the root, e.g. inside a cache
+    /// store's directory).
     static std::string path(llvm::StringRef relative) {
+        if(llvm::sys::path::is_absolute(relative)) {
+            return relative.str();
+        }
         llvm::SmallString<128> result;
         llvm::sys::path::append(result, root(), relative);
         return std::string(result);
     }
 
-    /// Add a file with an optional content (relative path, auto-prefixed with root()).
+    /// Add a file with an optional content (relative path, auto-prefixed
+    /// with root(), or absolute).
     void add(llvm::StringRef relative, llvm::StringRef content = {}) {
         auto p = path(relative);
         addFile(p, 0, llvm::MemoryBuffer::getMemBufferCopy(content, p));

--- a/tools/client/workspace.ts
+++ b/tools/client/workspace.ts
@@ -156,6 +156,16 @@ export class Workspace {
         return this.globCache("pcm", ".pcm");
     }
 
+    /// The cache store's namespace of synthesized header-context files
+    /// (preamble `<hash>.h`, `<hash>.suffix.h`, `<hash>.self.h`).
+    headerContextDir(): string {
+        return path.join(this.cacheRoot(), "header_context");
+    }
+
+    headerContextFiles(): string[] {
+        return this.globCache("header_context", ".h");
+    }
+
     /// In-flight tmp files of all store instances. Committed blobs appear
     /// atomically, so anything under tmp/ is either an in-flight write of a
     /// live server or crash residue awaiting cleanup.

--- a/tools/protocol/protocol.ts
+++ b/tools/protocol/protocol.ts
@@ -126,7 +126,9 @@ export interface StatsResult {
     indexShardContentBytes: number;
     lastSaveShards: number;
     pendingTmpFiles: number;
-    [key: string]: number;
+    pchCacheEntries: number;
+    headerContexts: number;
+    sessions: number;
 }
 
 export const StatsRequest = new RequestType0<StatsResult, void>("clice/internal/stats");


### PR DESCRIPTION
## What changed

The small duplicates the two code-reuse audits left behind after the service-layer recut, plus the three half-finished items from that recut, in one cleanup pass. Every change is either a mechanical merge of identical code or a one-line behavior fix; nothing changes an interface.

**Shared code where two copies drifted or could drift**

- `TaskGraph`: candidate-edge registration (dedup, interest, back-edge, foreground propagation) is one `record_candidate` used by both `reference_from` and `depend_from`.
- Stateless worker: the six request registrations share one `serve` template — arm the stop flag, hop to the pool thread, answer the cancel sentinel. Format still ignores the flag; the wrapper makes that explicit.
- Shutdown: the contract-11 tail (graph wind-down, final save with the one metadata retry, pool and store stop) is `shutdown_indexing`, called by both the server and the batch stack.
- Semantic tokens: the "semantic beats lexical directive kinds, anything else conflicts" rule and the adjacent-token merge are `settle` and `append_token`, shared by the AST and index paths.
- Header-name directives: `takes_header_name` is the one list (`include`, `include_next`, `import`, `embed`) behind the lexer, document links, semantic tokens and the preamble-completeness check.
- `ContextResolver`: header mode and its content hash are one `HeaderVerdict` map instead of two maps keyed alike; a SelfContained verdict can no longer leave an orphan hash behind.
- `ASTFamily::plan_pch` now returns a verdict (none / defer / acquire) so the compile round and the stateless path make the preamble-incomplete deferral decision in one place.
- `IndexQuery::definition_text` is a fold over `for_each_relation` like every other relation query, instead of a fifth hand-written source walk.
- The projections' row model (`IndexRows`, `extract_index_rows`) lives with the projections in the feature layer; the unit tests use the same extractor.
- `clice index` and `clice lint` share `workspace_root` for the `--workspace` handling.

**Behavior fixes found by the audits**

- Folding ranges: `#elifdef` opens a branch like `#elifndef` does; the switch is now exhaustive. Pinned by the preprocessor-conditional fixture.
- Preamble completeness: an unterminated `#embed <...` argument no longer counts as complete, so typing one mid-way does not trigger a PCH rebuild.
- Hover: the kind-noun table is exhaustive over `SymbolKind`, so a new kind fails to compile instead of silently losing its noun.
- Header-context files: the synthesized preamble, suffix and self-snapshot were written straight into `cache_dir/header_context/` while the cache store had a `header_context` namespace registered as per-process scratch that nothing used, so the real files accumulated forever. They are now content-addressed blobs of that namespace under an LRU budget; paths stay stable across sessions (the PCH keyed on the preamble path stays valid). A resolved context re-checks its three files on every reuse, a manifest hit whose file was wiped from outside is republished, and persisted host records of files gone from disk are pruned on load. A cache store is now required to synthesize a context; without one the header degrades to no context, as it already did when synthesis failed.
- `clice/internal/stats`: the TypeScript `StatsResult` lists every gauge the server sends and drops its catch-all index signature; the memory-ownership test pins the key set so the two hand-written shapes cannot drift again.
- VS Code: the client no longer keeps its own copy of the C++-fragment extension list. Any plain-text document is checked with `clice/queryContext`; the server's list is the only one.
- `LOG_PERF` documentation names the build kinds actually emitted (`pch|pcm|turun`) and their per-kind splits.

## Tests

- New unit cases: `#embed` complete/incomplete preamble, `#ifndef/#elifndef/#else` directive collection.
- Folding-range fixture extended with an `#elifdef` chain (C++23 flags); snapshot reviewed.
- Memory-ownership integration test pins the stats key set.
- New integration test: synthesized files wiped from the cache while the server runs are re-synthesized on the header's next compile.
- All four suites run locally on Debug (ASan + assertions).
