### PR TITLE
refactor: one owner for module declarations, family ids, invocations

### DIFF
--- a/src/command/invocation.cpp
+++ b/src/command/invocation.cpp
@@ -1,0 +1,50 @@
+#include "command/invocation.h"
+
+#include "support/filesystem.h"
+
+#include "llvm/Support/VirtualFileSystem.h"
+#include "clang/Driver/CreateInvocationFromArgs.h"
+#include "clang/Frontend/CompilerInvocation.h"
+
+namespace clice {
+
+std::unique_ptr<clang::CompilerInvocation>
+    create_compiler_invocation(llvm::ArrayRef<const char*> arguments,
+                               llvm::StringRef directory,
+                               llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs,
+                               llvm::IntrusiveRefCntPtr<clang::DiagnosticsEngine> diagnostics) {
+    std::unique_ptr<clang::CompilerInvocation> invocation;
+    bool is_cc1 = arguments.size() >= 2 && llvm::StringRef(arguments[1]) == "-cc1";
+    if(is_cc1) {
+        invocation = std::make_unique<clang::CompilerInvocation>();
+        if(!clang::CompilerInvocation::CreateFromArgs(*invocation,
+                                                      arguments.drop_front(2),
+                                                      *diagnostics,
+                                                      arguments[0])) {
+            return nullptr;
+        }
+    } else {
+        clang::CreateInvocationOptions options = {
+            .Diags = std::move(diagnostics),
+            .VFS = std::move(vfs),
+            .ProbePrecompiled = false,
+        };
+        invocation = clang::createInvocation(arguments, options);
+        if(!invocation) {
+            return nullptr;
+        }
+    }
+
+    if(!directory.empty()) {
+        auto& working_dir = invocation->getFileSystemOpts().WorkingDir;
+        if(working_dir.empty()) {
+            working_dir = directory.str();
+        } else if(!path::is_absolute(working_dir)) {
+            working_dir = path::join(directory, working_dir);
+        }
+    }
+    invocation->getFrontendOpts().DisableFree = false;
+    return invocation;
+}
+
+}  // namespace clice

--- a/src/command/invocation.h
+++ b/src/command/invocation.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <memory>
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace clang {
+
+class CompilerInvocation;
+class DiagnosticsEngine;
+
+}  // namespace clang
+
+namespace llvm::vfs {
+
+class FileSystem;
+
+}  // namespace llvm::vfs
+
+namespace clice {
+
+/// The clang invocation of a compilation-database command — the one
+/// reading every consumer of an entry (the compile, the dependency scans)
+/// agrees on. A `-cc1` argument list is taken as already expanded; a
+/// driver command line goes through the driver without probing for
+/// precompiled headers (clang would otherwise turn `-include` into
+/// `-include-pch`, see clangd#856). The entry's directory governs
+/// relative paths the way an explicit -working-directory does: an
+/// explicit one wins, but its own relative value resolves from the
+/// entry's directory, like the real driver run from there. Null when
+/// clang rejects the arguments; `diagnostics` received what it said.
+std::unique_ptr<clang::CompilerInvocation>
+    create_compiler_invocation(llvm::ArrayRef<const char*> arguments,
+                               llvm::StringRef directory,
+                               llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs,
+                               llvm::IntrusiveRefCntPtr<clang::DiagnosticsEngine> diagnostics);
+
+}  // namespace clice

--- a/src/command/toolchain.cpp
+++ b/src/command/toolchain.cpp
@@ -1119,57 +1119,87 @@ Toolchain::ResolvedID Toolchain::synthesize(ConfigID id, llvm::ArrayRef<const ch
     return static_cast<ResolvedID>(resolved_configs.size() - 1);
 }
 
+struct Toolchain::ProbeAdmission {
+    enum class Kind : std::uint8_t { Hit, CoolingDown, Ready };
+
+    Kind kind;
+    std::string key;
+    /// Ready: the query to run.
+    QuerySpec spec;
+    /// CoolingDown: the cached failure.
+    std::string error;
+};
+
+Toolchain::ProbeAdmission Toolchain::admit_probe(ConfigID id, InputKind input) {
+    auto pk = probe_key(id, input);
+    ProbeAdmission admission{.kind = ProbeAdmission::Kind::Hit, .key = std::move(pk.key)};
+    if(probes.contains(admission.key)) {
+        return admission;
+    }
+    if(auto failed_it = failed.find(admission.key); failed_it != failed.end()) {
+        if(std::chrono::steady_clock::now() - failed_it->second.second < failed_retry) {
+            admission.kind = ProbeAdmission::Kind::CoolingDown;
+            admission.error = failed_it->second.first;
+            return admission;
+        }
+        // Cooldown over: the failure may have been transient — retry the
+        // real query (cf. CrashBudget's bounded-burn revival).
+        failed.erase(failed_it);
+    }
+
+    auto& config = db.config(id);
+    auto argv = probe_argv(config, pk.cwd_sensitive);
+    admission.kind = ProbeAdmission::Kind::Ready;
+    admission.spec.argv = std::move(argv.argv);
+    admission.spec.slot = argv.slot;
+    admission.spec.kind = input.value;
+    admission.spec.family = config.family;
+    admission.spec.cwd = probe_cwd(pk.cwd_sensitive ? config.directory : db.workspace_root);
+    return admission;
+}
+
+void Toolchain::land_probe(llvm::StringRef key,
+                           const std::expected<std::vector<std::string>, std::string>& result) {
+    if(!result) {
+        failed.try_emplace(key, std::pair{result.error(), std::chrono::steady_clock::now()});
+        return;
+    }
+    llvm::SmallVector<const char*, 64> saved;
+    saved.reserve(result->size());
+    for(auto& token: *result) {
+        saved.push_back(db.strings.save(token).data());
+    }
+    probes.try_emplace(key, std::move(saved));
+}
+
 std::expected<Toolchain::ResolvedID, std::string> Toolchain::resolve(ConfigID id, InputKind input) {
     auto synth_key = std::pair{static_cast<std::uint32_t>(id), input.value};
     if(auto it = synth_cache.find(synth_key); it != synth_cache.end()) {
         return it->second;
     }
 
-    auto pk = probe_key(id, input);
-    auto it = probes.find(pk.key);
-    if(it == probes.end()) {
-        if(auto failed_it = failed.find(pk.key); failed_it != failed.end()) {
-            if(std::chrono::steady_clock::now() - failed_it->second.second < failed_retry) {
-                return std::unexpected(failed_it->second.first);
-            }
-            // Cooldown over: the failure may have been transient — retry
-            // the real query (cf. CrashBudget's bounded-burn revival).
-            failed.erase(failed_it);
-        }
-
-        auto& config = db.config(id);
-        LOG_WARN("Toolchain probe miss: driver={} kind={}", config.driver, input.value);
-
-        QuerySpec spec;
-        auto argv = probe_argv(config, pk.cwd_sensitive);
-        spec.argv = std::move(argv.argv);
-        spec.slot = argv.slot;
-        spec.kind = input.value;
-        spec.family = config.family;
-        spec.cwd = probe_cwd(pk.cwd_sensitive ? config.directory : db.workspace_root);
+    auto admission = admit_probe(id, input);
+    if(admission.kind == ProbeAdmission::Kind::CoolingDown) {
+        return std::unexpected(std::move(admission.error));
+    }
+    if(admission.kind == ProbeAdmission::Kind::Ready) {
+        LOG_WARN("Toolchain probe miss: driver={} kind={}", db.config(id).driver, input.value);
 
         std::expected<std::vector<std::string>, std::string> result;
         kota::event_loop loop;
         auto task = [&]() -> kota::task<> {
-            result = co_await query_one(spec);
+            result = co_await query_one(admission.spec);
         };
         loop.schedule(task());
         loop.run();
 
+        land_probe(admission.key, result);
         if(!result) {
-            failed.try_emplace(pk.key, std::pair{result.error(), std::chrono::steady_clock::now()});
             return std::unexpected(std::move(result.error()));
         }
-
-        llvm::SmallVector<const char*, 64> saved;
-        saved.reserve(result->size());
-        for(auto& token: *result) {
-            saved.push_back(db.strings.save(token).data());
-        }
-        it = probes.try_emplace(pk.key, std::move(saved)).first;
     }
 
-    auto resolved_id = synthesize(id, it->second);
+    auto resolved_id = synthesize(id, probes.find(admission.key)->second);
     synth_cache.try_emplace(synth_key, resolved_id);
     return resolved_id;
 }
@@ -1184,31 +1214,12 @@ void Toolchain::warm(llvm::ArrayRef<std::pair<ConfigID, InputKind>> pairs) {
     std::vector<Pending> pending;
 
     for(auto& [id, input]: pairs) {
-        auto pk = probe_key(id, input);
-        if(probes.contains(pk.key)) {
+        auto admission = admit_probe(id, input);
+        if(admission.kind != ProbeAdmission::Kind::Ready ||
+           !seen.try_emplace(admission.key, true).second) {
             continue;
         }
-        if(auto failed_it = failed.find(pk.key); failed_it != failed.end()) {
-            // Same expiry as resolve(): a cooled-down failure retries
-            // through this warm instead of being skipped forever.
-            if(std::chrono::steady_clock::now() - failed_it->second.second < failed_retry) {
-                continue;
-            }
-            failed.erase(failed_it);
-        }
-        if(!seen.try_emplace(pk.key, true).second) {
-            continue;
-        }
-
-        auto& config = db.config(id);
-        auto argv = probe_argv(config, pk.cwd_sensitive);
-        QuerySpec spec;
-        spec.argv = std::move(argv.argv);
-        spec.slot = argv.slot;
-        spec.kind = input.value;
-        spec.family = config.family;
-        spec.cwd = probe_cwd(pk.cwd_sensitive ? config.directory : db.workspace_root);
-        pending.push_back({std::move(pk.key), std::move(spec)});
+        pending.push_back({std::move(admission.key), std::move(admission.spec)});
     }
 
     if(pending.empty()) {
@@ -1249,21 +1260,12 @@ void Toolchain::warm(llvm::ArrayRef<std::pair<ConfigID, InputKind>> pairs) {
 
     std::size_t succeeded = 0;
     for(auto& o: outcomes) {
-        if(!o.result) {
+        if(o.result) {
+            succeeded += 1;
+        } else {
             LOG_ERROR("Toolchain query failed: {}", o.result.error());
-            failed.try_emplace(
-                std::move(o.key),
-                std::pair{std::move(o.result.error()), std::chrono::steady_clock::now()});
-            continue;
         }
-
-        llvm::SmallVector<const char*, 64> saved;
-        saved.reserve(o.result->size());
-        for(auto& token: *o.result) {
-            saved.push_back(db.strings.save(token).data());
-        }
-        probes.try_emplace(std::move(o.key), std::move(saved));
-        succeeded += 1;
+        land_probe(o.key, o.result);
     }
 
     LOG_INFO("Toolchain cache warmed: {} succeeded, {} failed", succeeded, total - succeeded);

--- a/src/command/toolchain.h
+++ b/src/command/toolchain.h
@@ -130,6 +130,17 @@ private:
     /// the config's user-content args and replacing external resource dirs.
     ResolvedID synthesize(ConfigID id, llvm::ArrayRef<const char*> tokens);
 
+    /// What the probe caches say about a (config, input) key: a live
+    /// probe, a failure still cooling down, or the query to run. A
+    /// cooled-down failure is dropped on the way, so the query retries.
+    struct ProbeAdmission;
+    ProbeAdmission admit_probe(ConfigID id, InputKind input);
+
+    /// Lands a query's outcome: the tokens into the probe cache, a failure
+    /// into the negative cache with its time.
+    void land_probe(llvm::StringRef key,
+                    const std::expected<std::vector<std::string>, std::string>& result);
+
     CompilationDatabase& db;
 
     /// Probe layer: key → raw probe output tokens (interned).

--- a/src/compile/compilation.cpp
+++ b/src/compile/compilation.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 
 #include "command/command.h"
+#include "command/invocation.h"
 #include "compile/diagnostic.h"
 #include "compile/implement.h"
 #include "semantic/decls.h"
@@ -13,7 +14,6 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/xxhash.h"
 #include "clang/Basic/Stack.h"
-#include "clang/Driver/CreateInvocationFromArgs.h"
 #include "clang/Frontend/MultiplexConsumer.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/Lex/PreprocessorOptions.h"
@@ -49,54 +49,14 @@ std::unique_ptr<clang::CompilerInvocation>
         LOG_ERROR_RET(nullptr, "Fail to create diagnostics engine");
     }
 
-    std::unique_ptr<clang::CompilerInvocation> invocation;
-
-    /// If the second argument is "-cc1", the arguments are already expanded
-    /// (e.g. from compilation database + toolchain query). Skip driver and "-cc1"
-    /// and create invocation directly from the cc1 args.
-    bool is_cc1 = params.arguments.size() >= 2 && llvm::StringRef(params.arguments[1]) == "-cc1";
-    if(is_cc1) {
-        invocation = std::make_unique<clang::CompilerInvocation>();
-        if(!clang::CompilerInvocation::CreateFromArgs(
-               *invocation,
-               llvm::ArrayRef(params.arguments).drop_front(2),
-               *diagnostic_engine,
-               params.arguments[0])) {
-            LOG_ERROR_RET(nullptr,
-                          " Fail to create invocation, arguments list is: {}",
-                          print_argv(params.arguments));
-        }
-    } else {
-        /// Create clang invocation.
-        clang::CreateInvocationOptions options = {
-            .Diags = diagnostic_engine,
-            .VFS = params.vfs,
-
-            /// Avoid replacing -include with -include-pch, also
-            /// see https://github.com/clangd/clangd/issues/856.
-            .ProbePrecompiled = false,
-        };
-
-        invocation = clang::createInvocation(params.arguments, options);
-        if(!invocation) {
-            LOG_ERROR_RET(nullptr,
-                          " Fail to create invocation, arguments list is: {}",
-                          print_argv(params.arguments));
-        }
-    }
-
-    /// The entry's compilation directory governs relative paths in the
-    /// compile (inputs, -include, header search), the same way clang's
-    /// -working-directory does. An explicit -working-directory wins, but
-    /// its own relative value resolves from the compile's directory, like
-    /// the real driver run from there.
-    if(!params.directory.empty()) {
-        auto& working_dir = invocation->getFileSystemOpts().WorkingDir;
-        if(working_dir.empty()) {
-            working_dir = params.directory;
-        } else if(!path::is_absolute(working_dir)) {
-            working_dir = path::join(params.directory, working_dir);
-        }
+    auto invocation = create_compiler_invocation(params.arguments,
+                                                 params.directory,
+                                                 params.vfs,
+                                                 diagnostic_engine);
+    if(!invocation) {
+        LOG_ERROR_RET(nullptr,
+                      " Fail to create invocation, arguments list is: {}",
+                      print_argv(params.arguments));
     }
 
     auto& pp_opts = invocation->getPreprocessorOpts();
@@ -128,7 +88,6 @@ std::unique_ptr<clang::CompilerInvocation>
     }
 
     auto& front_opts = invocation->getFrontendOpts();
-    front_opts.DisableFree = false;
     front_opts.ShowHelp = false;
     front_opts.ShowStats = false;
     front_opts.ShowVersion = false;

--- a/src/sched/batch.cpp
+++ b/src/sched/batch.cpp
@@ -98,6 +98,35 @@ kota::task<> shutdown(BatchStack& stack) {
     co_await shutdown_indexing(stack.graph, stack.pump, stack.store, stack.pool, stack.workspace);
 }
 
+/// A batch run's signal handling and the order of its ending. Interruption
+/// is judged only after the scheduling stack shut down and the watchers
+/// settled: a signal arriving while the final save/teardown ran must still
+/// report an interruption, not a normal completion with exit code 0.
+struct BatchLifetime {
+    bool stop_requested = false;
+    kota::cancellation_source stop;
+    kota::task_group<> aux;
+
+    explicit BatchLifetime(BatchStack& stack) : aux(stack.loop) {
+        aux.spawn(watch_signal(SIGINT, stop, stop_requested));
+        aux.spawn(watch_signal(SIGTERM, stop, stop_requested));
+        aux.spawn(checkpoint_task(stack.workspace));
+    }
+
+    kota::cancellation_token token() {
+        return stop.token();
+    }
+
+    /// Shuts the stack down and settles the watchers; whether the run was
+    /// interrupted.
+    kota::task<bool> finish(BatchStack& stack) {
+        co_await shutdown(stack);
+        aux.cancel();
+        co_await aux.join();
+        co_return stop_requested;
+    }
+};
+
 /// Shared batch startup: the finalized config with the run's overrides,
 /// the session file logger, and the worker pool. `log_tag` names the log
 /// files after the subcommand.
@@ -181,22 +210,9 @@ kota::task<> run(BatchStack& stack, const BatchOptions& options, BatchResult& re
         co_return;
     }
 
-    bool stop_requested = false;
-    kota::cancellation_source stop_source;
-    kota::task_group<> aux(stack.loop);
-    aux.spawn(watch_signal(SIGINT, stop_source, stop_requested));
-    aux.spawn(watch_signal(SIGTERM, stop_source, stop_requested));
-    aux.spawn(checkpoint_task(workspace));
-
-    co_await kota::with_token(wait_until_indexed(stack.pump), stop_source.token());
-    co_await shutdown(stack);
-    aux.cancel();
-    co_await aux.join();
-
-    // Judged only after the watchers settle: a signal arriving while the
-    // final save/teardown ran must still report an interruption, not a
-    // normal completion with exit code 0.
-    if(stop_requested) {
+    BatchLifetime lifetime(stack);
+    co_await kota::with_token(wait_until_indexed(stack.pump), lifetime.token());
+    if(co_await lifetime.finish(stack)) {
         result.interrupted = true;
         result.exit_code = 130;
         co_return;
@@ -374,17 +390,11 @@ kota::task<> run_lint(BatchStack& stack,
         }
     }
 
-    bool stop_requested = false;
-    kota::cancellation_source stop_source;
-    kota::task_group<> aux(stack.loop);
-    aux.spawn(watch_signal(SIGINT, stop_source, stop_requested));
-    aux.spawn(watch_signal(SIGTERM, stop_source, stop_requested));
-    aux.spawn(checkpoint_task(workspace));
-
+    BatchLifetime lifetime(stack);
     LintSweep sweep;
     co_await kota::with_token(run_lint_sweep(stack, options, tus, sweep, on_findings),
-                              stop_source.token());
-    if(options.with_index && !stop_requested) {
+                              lifetime.token());
+    if(options.with_index && !lifetime.stop_requested) {
         // The sweep's merges can owe other TUs a reindex (a rebuilt shared
         // shard dropped their variants), and bootstrap may have claimed
         // prior-session debt — the sweep runs outside the pump, so nothing
@@ -393,13 +403,9 @@ kota::task<> run_lint(BatchStack& stack,
         // the run exits clean.
         workspace.config.project.enable_indexing.value = true;
         stack.pump.schedule(/*immediate=*/true);
-        co_await kota::with_token(wait_until_indexed(stack.pump), stop_source.token());
+        co_await kota::with_token(wait_until_indexed(stack.pump), lifetime.token());
     }
-    co_await shutdown(stack);
-    aux.cancel();
-    co_await aux.join();
-
-    if(stop_requested) {
+    if(co_await lifetime.finish(stack)) {
         result.interrupted = true;
         result.exit_code = 130;
         co_return;

--- a/src/sched/batch.cpp
+++ b/src/sched/batch.cpp
@@ -103,11 +103,12 @@ kota::task<> shutdown(BatchStack& stack) {
 /// settled: a signal arriving while the final save/teardown ran must still
 /// report an interruption, not a normal completion with exit code 0.
 struct BatchLifetime {
+    BatchStack& stack;
     bool stop_requested = false;
     kota::cancellation_source stop;
     kota::task_group<> aux;
 
-    explicit BatchLifetime(BatchStack& stack) : aux(stack.loop) {
+    explicit BatchLifetime(BatchStack& stack) : stack(stack), aux(stack.loop) {
         aux.spawn(watch_signal(SIGINT, stop, stop_requested));
         aux.spawn(watch_signal(SIGTERM, stop, stop_requested));
         aux.spawn(checkpoint_task(stack.workspace));
@@ -119,7 +120,7 @@ struct BatchLifetime {
 
     /// Shuts the stack down and settles the watchers; whether the run was
     /// interrupted.
-    kota::task<bool> finish(BatchStack& stack) {
+    kota::task<bool> finish() {
         co_await shutdown(stack);
         aux.cancel();
         co_await aux.join();
@@ -212,7 +213,7 @@ kota::task<> run(BatchStack& stack, const BatchOptions& options, BatchResult& re
 
     BatchLifetime lifetime(stack);
     co_await kota::with_token(wait_until_indexed(stack.pump), lifetime.token());
-    if(co_await lifetime.finish(stack)) {
+    if(co_await lifetime.finish()) {
         result.interrupted = true;
         result.exit_code = 130;
         co_return;
@@ -405,7 +406,7 @@ kota::task<> run_lint(BatchStack& stack,
         stack.pump.schedule(/*immediate=*/true);
         co_await kota::with_token(wait_until_indexed(stack.pump), lifetime.token());
     }
-    if(co_await lifetime.finish(stack)) {
+    if(co_await lifetime.finish()) {
         result.interrupted = true;
         result.exit_code = 130;
         co_return;

--- a/src/sched/bootstrap.cpp
+++ b/src/sched/bootstrap.cpp
@@ -121,7 +121,6 @@ BootstrapReport bootstrap_workspace(Workspace& workspace,
              scan.total_edges,
              scan.elapsed_ms);
 
-    workspace.build_module_map();
     pump.claim_report(store.load(read_only_index).report);
 
     if(cfg.enable_indexing.value) {

--- a/src/sched/families/pch.cpp
+++ b/src/sched/families/pch.cpp
@@ -16,7 +16,7 @@ PCHFamily::PCHFamily(TaskGraph& graph,
     graph(graph), workspace(workspace), contexts(contexts), pool(pool) {}
 
 void PCHFamily::register_runner() {
-    graph.register_family(pch_family,
+    graph.register_family(Family::PCH,
                           [this](RoundContext& ctx, NodeId id) { return run(ctx, id.key); });
 }
 

--- a/src/sched/families/pch.h
+++ b/src/sched/families/pch.h
@@ -15,7 +15,6 @@
 
 namespace clice {
 
-
 /// Preamble artifacts (a PCH and its pch.idx envelope, committed as one
 /// pair) as a task-graph family: one node per content-addressed pch_key,
 /// no edges, one round = one revalidation or build. The facade is the

--- a/src/sched/families/pch.h
+++ b/src/sched/families/pch.h
@@ -15,9 +15,6 @@
 
 namespace clice {
 
-/// The PCH family's id in the task graph. Node keys are family-interned
-/// content-addressed pch_keys (monotonic, never recycled).
-constexpr inline std::uint8_t pch_family = 2;
 
 /// Preamble artifacts (a PCH and its pch.idx envelope, committed as one
 /// pair) as a task-graph family: one node per content-addressed pch_key,
@@ -37,7 +34,7 @@ public:
 
     /// Register the production runner. Tests that drive the facade
     /// against a synthetic build register their own runner under
-    /// pch_family instead.
+    /// Family::PCH instead.
     void register_runner();
 
     /// One acquisition's request conditions: the artifact identity plus
@@ -123,7 +120,7 @@ private:
     std::uint64_t intern(llvm::StringRef pch_key);
 
     static NodeId node(std::uint64_t key_id) {
-        return {pch_family, key_id};
+        return {Family::PCH, key_id};
     }
 
     /// Per-key slot for the dispatch owner's stash; both fields are

--- a/src/sched/families/pcm.cpp
+++ b/src/sched/families/pcm.cpp
@@ -25,7 +25,7 @@ PCMFamily::PCMFamily(TaskGraph& graph,
     graph(graph), workspace(workspace), contexts(contexts), pool(pool) {}
 
 void PCMFamily::register_runner() {
-    graph.register_family(pcm_family, [this](RoundContext& ctx, NodeId id) {
+    graph.register_family(Family::PCM, [this](RoundContext& ctx, NodeId id) {
         return run(ctx, Fid{static_cast<std::uint32_t>(id.key)});
     });
 }
@@ -87,7 +87,7 @@ llvm::SmallVector<NodeId> PCMFamily::provider_appeared(llvm::StringRef name) {
         // Dirtied module units drop their cached PCM state, exactly as
         // invalidate() does for content changes — a PCM built against
         // the unresolved name embeds the failure.
-        if(id.family == pcm_family && !is_unresolved(id)) {
+        if(id.family == Family::PCM && !is_unresolved(id)) {
             erased |= workspace.pcm_cache.erase(Fid{static_cast<std::uint32_t>(id.key)});
         }
     }
@@ -127,14 +127,12 @@ kota::task<RoundOutcome> PCMFamily::run(RoundContext& ctx, Fid path_id) {
         }
     }
 
-    auto mod_it = workspace.path_to_module.find(path_id);
-    if(mod_it == workspace.path_to_module.end())
+    // Copied before any suspension below: while a PCM build is awaited, a
+    // concurrent didSave can re-declare the file and drop the graph's
+    // string.
+    std::string module_name(workspace.dep_graph.module_of(path_id));
+    if(module_name.empty())
         co_return RoundOutcome::Failed;
-
-    // Copy out of the map before any suspension below: while a PCM build
-    // is awaited, a concurrent didSave can insert into (or erase from)
-    // path_to_module, rehashing the DenseMap and invalidating mod_it.
-    auto module_name = mod_it->second;
 
     auto file_path = std::string(workspace.file_table.resolve(path_id));
 
@@ -296,7 +294,7 @@ kota::task<bool> PCMFamily::prepare_deps(Fid path_id,
                                          bool foreground) {
     // A project without module units pays nothing. A CDB reload that
     // introduces modules mid-session takes effect on the next call.
-    if(workspace.path_to_module.empty()) {
+    if(!workspace.dep_graph.has_modules()) {
         co_return true;
     }
 
@@ -312,7 +310,7 @@ kota::task<bool> PCMFamily::prepare_deps(Fid path_id,
     // (an unsaved removed import would disconnect the cached PCM from
     // the very dependency whose save should invalidate it). Plain TUs'
     // consumer nodes never run rounds; the declaration is theirs alone.
-    if(!workspace.path_to_module.contains(path_id)) {
+    if(workspace.dep_graph.module_of(path_id).empty()) {
         declare_deps(path_id, deps.declared);
     }
     if(deps.resolved.empty()) {

--- a/src/sched/families/pcm.h
+++ b/src/sched/families/pcm.h
@@ -14,7 +14,6 @@
 
 namespace clice {
 
-
 /// C++20 module artifacts (PCM) as a task-graph family: one node per
 /// module unit, edges to the modules it imports, one round = one PCM
 /// build (or cache revalidation). The facade is the only surface

--- a/src/sched/families/pcm.h
+++ b/src/sched/families/pcm.h
@@ -14,9 +14,6 @@
 
 namespace clice {
 
-/// The PCM family's id in the task graph. Node keys are module-unit
-/// path_ids widened into NodeId::key.
-constexpr inline std::uint8_t pcm_family = 1;
 
 /// C++20 module artifacts (PCM) as a task-graph family: one node per
 /// module unit, edges to the modules it imports, one round = one PCM
@@ -35,7 +32,7 @@ public:
 
     /// Register the production runner. Tests that drive the facade
     /// against a synthetic topology register their own runner under
-    /// pcm_family instead.
+    /// Family::PCM instead.
     void register_runner();
 
     /// Re-validate on-disk PCM blobs and build the module dependencies of
@@ -95,12 +92,12 @@ public:
     /// the edge — no side bookkeeping of who failed against the name.
     /// The high bit keeps the key space disjoint from path_ids.
     static NodeId unresolved_node(llvm::StringRef name) {
-        return {pcm_family, (1ull << 63) | (llvm::xxh3_64bits(name) >> 1)};
+        return {Family::PCM, (1ull << 63) | (llvm::xxh3_64bits(name) >> 1)};
     }
 
     /// Whether a node is an unresolved-import sentinel.
     static bool is_unresolved(NodeId id) {
-        return id.family == pcm_family && (id.key >> 63) != 0;
+        return id.family == Family::PCM && (id.key >> 63) != 0;
     }
 
     /// A module name gained a provider it lacked: void the sentinel's
@@ -137,7 +134,7 @@ private:
     kota::task<RoundOutcome> run(RoundContext& ctx, Fid path_id);
 
     static NodeId node(Fid path_id) {
-        return {pcm_family, path_id.raw};
+        return {Family::PCM, path_id.raw};
     }
 
     TaskGraph& graph;

--- a/src/sched/families/turun.cpp
+++ b/src/sched/families/turun.cpp
@@ -20,7 +20,7 @@ TURunFamily::TURunFamily(TaskGraph& graph,
     graph(graph), workspace(workspace), contexts(contexts), pcm(pcm), store(store), pool(pool) {}
 
 void TURunFamily::register_runner() {
-    graph.register_family(turun_family, [this](RoundContext& ctx, NodeId id) {
+    graph.register_family(Family::TURun, [this](RoundContext& ctx, NodeId id) {
         return round(ctx, Fid{static_cast<std::uint32_t>(id.key)});
     });
 }
@@ -106,8 +106,8 @@ kota::task<RoundOutcome> TURunFamily::round(RoundContext& ctx, Fid path_id) {
     // gates the cost. A failed PCM build is not terminal on either
     // shape — the parse consumes whatever artifacts landed and the
     // worker reports its own failure if they are not enough.
-    bool own_module = workspace.path_to_module.contains(path_id);
-    if(own_module || !workspace.path_to_module.empty() ||
+    bool own_module = !workspace.dep_graph.module_of(path_id).empty();
+    if(own_module || workspace.dep_graph.has_modules() ||
        !workspace.dep_graph.import_candidate_files().empty() ||
        llvm::any_of(params.arguments, [](const std::string& arg) {
            return llvm::StringRef(arg).starts_with("-include");
@@ -115,7 +115,7 @@ kota::task<RoundOutcome> TURunFamily::round(RoundContext& ctx, Fid path_id) {
         PCMFamily::ModuleDeps deps;
         if(own_module) {
             deps.resolved.push_back(path_id);
-            deps.declared.push_back({pcm_family, path_id.raw});
+            deps.declared.push_back({Family::PCM, path_id.raw});
         }
         // The scan must evaluate the same conditionals the worker's
         // parse will — the resolved command already carries the plan's
@@ -156,7 +156,7 @@ kota::task<RoundOutcome> TURunFamily::round(RoundContext& ctx, Fid path_id) {
                 break;
             }
             for(auto dep: deps.resolved) {
-                if(co_await ctx.depend({pcm_family, dep.raw}) == DependResult::Cancelled) {
+                if(co_await ctx.depend({Family::PCM, dep.raw}) == DependResult::Cancelled) {
                     landed[path_id] = {.verdict = Verdict::Preempted};
                     co_return RoundOutcome::Stale;
                 }

--- a/src/sched/families/turun.h
+++ b/src/sched/families/turun.h
@@ -19,9 +19,6 @@ namespace clice {
 
 class PCMFamily;
 
-/// The TURun family's id in the task graph. Node keys are TU path_ids
-/// widened into NodeId::key.
-constexpr inline std::uint8_t turun_family = 4;
 
 /// One-shot whole-TU runs as a task-graph family: one round = one parse on
 /// a stateless worker serving the products of the frozen plan — the full
@@ -47,7 +44,7 @@ public:
                 WorkerPool& pool);
 
     /// Register the production runner. Tests that drive the pump against a
-    /// synthetic runner register their own under turun_family instead.
+    /// synthetic runner register their own under Family::TURun instead.
     void register_runner();
 
     /// The frozen product plan of one run.
@@ -126,7 +123,7 @@ private:
     kota::task<RoundOutcome> round(RoundContext& ctx, Fid path_id);
 
     static NodeId node(Fid path_id) {
-        return {turun_family, path_id.raw};
+        return {Family::TURun, path_id.raw};
     }
 
     TaskGraph& graph;

--- a/src/sched/families/turun.h
+++ b/src/sched/families/turun.h
@@ -19,7 +19,6 @@ namespace clice {
 
 class PCMFamily;
 
-
 /// One-shot whole-TU runs as a task-graph family: one round = one parse on
 /// a stateless worker serving the products of the frozen plan — the full
 /// index merged into the IndexStore, a clang-tidy pass, or both from the

--- a/src/sched/graph.cpp
+++ b/src/sched/graph.cpp
@@ -1,8 +1,8 @@
 #include "sched/graph.h"
 
 #include <algorithm>
-#include <utility>
 #include <cassert>
+#include <utility>
 
 #include "llvm/ADT/DenseSet.h"
 

--- a/src/sched/graph.cpp
+++ b/src/sched/graph.cpp
@@ -1,6 +1,7 @@
 #include "sched/graph.h"
 
 #include <algorithm>
+#include <utility>
 #include <cassert>
 
 #include "llvm/ADT/DenseSet.h"
@@ -47,9 +48,9 @@ bool RoundContext::foreground() const {
 
 TaskGraph::TaskGraph(kota::event_loop& loop) : tasks(loop) {}
 
-void TaskGraph::register_family(std::uint8_t family, RoundRunner run) {
-    assert(!families.contains(family) && "family registered twice");
-    families[family] = std::move(run);
+void TaskGraph::register_family(Family family, RoundRunner run) {
+    assert(!families.contains(std::to_underlying(family)) && "family registered twice");
+    families[std::to_underlying(family)] = std::move(run);
 }
 
 void TaskGraph::acquire(NodeId id) {
@@ -138,7 +139,8 @@ bool TaskGraph::spawn_round(NodeId id) {
 
     auto& node = nodes.find(id)->second;
     assert(!node.compiling && "spawn requested while a round is in flight");
-    assert(families.contains(id.family) && "request for an unregistered family");
+    assert(families.contains(std::to_underlying(id.family)) &&
+           "request for an unregistered family");
     node.compiling = true;
     node.round = std::make_shared<Round>();
     node.round->generation = node.generation;
@@ -157,7 +159,7 @@ kota::task<> TaskGraph::round_task(NodeId id,
                                    std::shared_ptr<Round> round,
                                    kota::cancellation_token token) {
     RoundContext ctx(*this, id, std::move(token));
-    auto reported = co_await families.find(id.family)->second(ctx, id);
+    auto reported = co_await families.find(std::to_underlying(id.family))->second(ctx, id);
     finish_round(id, *round, reported);
 }
 

--- a/src/sched/graph.h
+++ b/src/sched/graph.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <utility>
 
 #include "kota/async/async.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -13,12 +14,23 @@
 
 namespace clice {
 
+/// The families partitioning the graph's node space, each with its own
+/// key convention: PCM nodes are module-unit path ids (unresolved-import
+/// sentinels take the high half of the key space), PCH nodes are
+/// family-interned preamble keys, AST nodes are open documents' path ids,
+/// TURun nodes are TU path ids. 0xFF is reserved for map sentinels.
+enum class Family : std::uint8_t {
+    PCM = 1,
+    PCH = 2,
+    AST = 3,
+    TURun = 4,
+};
+
 /// Identity of a task-graph node. Each family interns its own keys —
 /// monotonically, never recycling: the graph may retain an id in edges or
-/// rounds long after the family dropped the underlying artifact. Family
-/// 0xFF is reserved for map sentinels.
+/// rounds long after the family dropped the underlying artifact.
 struct NodeId {
-    std::uint8_t family = 0;
+    Family family = Family{0};
     std::uint64_t key = 0;
 
     friend bool operator==(const NodeId&, const NodeId&) = default;
@@ -29,16 +41,16 @@ struct NodeId {
 template <>
 struct llvm::DenseMapInfo<clice::NodeId> {
     static clice::NodeId getEmptyKey() {
-        return {0xFF, 0};
+        return {clice::Family{0xFF}, 0};
     }
 
     static clice::NodeId getTombstoneKey() {
-        return {0xFF, 1};
+        return {clice::Family{0xFF}, 1};
     }
 
     static unsigned getHashValue(const clice::NodeId& id) {
         return llvm::detail::combineHashValue(
-            id.family,
+            std::to_underlying(id.family),
             llvm::DenseMapInfo<std::uint64_t>::getHashValue(id.key));
     }
 
@@ -191,7 +203,7 @@ public:
     explicit TaskGraph(kota::event_loop& loop);
 
     /// Families register once, before any request for their nodes.
-    void register_family(std::uint8_t family, RoundRunner run);
+    void register_family(Family family, RoundRunner run);
 
     /// Join a node's compilation from outside the graph (root interest).
     kota::task<JoinOutcome> request(NodeId id, JoinOptions options = {});

--- a/src/sched/index/pump.cpp
+++ b/src/sched/index/pump.cpp
@@ -430,7 +430,7 @@ kota::task<> IndexPump::run_background_indexing() {
     store.begin_round();
 
     std::stable_partition(index_queue.begin() + index_queue_pos, index_queue.end(), [this](Fid id) {
-        return workspace.path_to_module.contains(id);
+        return !workspace.dep_graph.module_of(id).empty();
     });
 
     // This round consumes [index_queue_pos, round_end) only. Anything

--- a/src/sched/index/store.cpp
+++ b/src/sched/index/store.cpp
@@ -245,8 +245,7 @@ std::string IndexStore::serialize_artifacts() {
         CachePCMEntry entry;
         entry.key = st.key;
         entry.source_file = intern(path_id);
-        auto mod_it = workspace.path_to_module.find(path_id);
-        entry.module_name = mod_it != workspace.path_to_module.end() ? mod_it->second : "";
+        entry.module_name = workspace.dep_graph.module_of(path_id).str();
         dump_deps(st.deps, entry.deps);
         data.pcm.push_back(std::move(entry));
     }

--- a/src/sched/workspace.cpp
+++ b/src/sched/workspace.cpp
@@ -449,7 +449,6 @@ void Workspace::enforce_loaded_budget() {
     }
 }
 
-
 void Workspace::fill_pcm_deps(std::unordered_map<std::string, std::string>& pcms,
                               Fid exclude_path_id) const {
     for(auto& [pid, st]: pcm_cache) {

--- a/src/sched/workspace.cpp
+++ b/src/sched/workspace.cpp
@@ -158,8 +158,7 @@ void Workspace::rescan_after_save(Fid path_id) {
         dep_graph.build_reverse_map();
         context_epoch += 1;
 
-        // Update both module maps: path_to_module gates the module code
-        // paths, and the dep_graph side is what import resolution reads —
+        // The graph's module declaration is what import resolution reads —
         // left stale, an interface saved mid-session could never satisfy
         // its importers.
         auto module_name = scan.module_name;
@@ -196,8 +195,8 @@ void Workspace::rescan_after_save(Fid path_id) {
                 is_interface_unit = cached->second.is_interface_unit;
             }
         }
-        // Both maps hold interface units only, mirroring the startup scan:
-        // an implementation unit (`module foo;`) must never satisfy
+        // Interface units only, mirroring the startup scan: an
+        // implementation unit (`module foo;`) must never satisfy
         // lookup_module — importers would edge to it and try to build it
         // as an interface — nor claim a PCM node of its own.
         if(!is_interface_unit) {
@@ -205,11 +204,6 @@ void Workspace::rescan_after_save(Fid path_id) {
         }
         dep_graph.update_module_decl(path_id, module_name);
         dep_graph.set_import_candidate(path_id, scan.has_import);
-        if(!module_name.empty()) {
-            path_to_module[path_id] = std::move(module_name);
-        } else {
-            path_to_module.erase(path_id);
-        }
         return;
     }
 
@@ -455,22 +449,15 @@ void Workspace::enforce_loaded_budget() {
     }
 }
 
-void Workspace::build_module_map() {
-    for(auto& [module_name, path_ids]: dep_graph.modules()) {
-        for(auto path_id: path_ids) {
-            path_to_module[path_id] = module_name.str();
-        }
-    }
-}
 
 void Workspace::fill_pcm_deps(std::unordered_map<std::string, std::string>& pcms,
                               Fid exclude_path_id) const {
     for(auto& [pid, st]: pcm_cache) {
         if(pid == exclude_path_id)
             continue;
-        auto mod_it = path_to_module.find(pid);
-        if(mod_it != path_to_module.end()) {
-            pcms[mod_it->second] = st.path;
+        auto module_name = dep_graph.module_of(pid);
+        if(!module_name.empty()) {
+            pcms[module_name.str()] = st.path;
         }
     }
 }

--- a/src/sched/workspace.h
+++ b/src/sched/workspace.h
@@ -226,7 +226,6 @@ struct Workspace {
     /// Built once at startup from CDB scan; updated incrementally on didSave.
     DependencyGraph dep_graph;
 
-
     /// PCH cache, keyed by content key (preamble text + canonical flags),
     /// so files with identical preambles share one PCH.  Hot-path mirror
     /// of CacheStore state; blob paths come from the store.
@@ -354,7 +353,6 @@ struct Workspace {
             request_flush();
         }
     }
-
 
     /// Fill PCM paths for all built modules, excluding exclude_path_id.
     void fill_pcm_deps(std::unordered_map<std::string, std::string>& pcms,

--- a/src/sched/workspace.h
+++ b/src/sched/workspace.h
@@ -226,10 +226,6 @@ struct Workspace {
     /// Built once at startup from CDB scan; updated incrementally on didSave.
     DependencyGraph dep_graph;
 
-    /// Reverse mapping: file path_id → module name (e.g. "std", "foo.bar").
-    /// Built from dep_graph at startup; updated on didSave when module
-    /// declarations change.
-    llvm::DenseMap<Fid, std::string> path_to_module;
 
     /// PCH cache, keyed by content key (preamble text + canonical flags),
     /// so files with identical preambles share one PCH.  Hot-path mirror
@@ -359,8 +355,7 @@ struct Workspace {
         }
     }
 
-    /// Build path_to_module reverse mapping from dep_graph.
-    void build_module_map();
+
     /// Fill PCM paths for all built modules, excluding exclude_path_id.
     void fill_pcm_deps(std::unordered_map<std::string, std::string>& pcms,
                        Fid exclude_path_id = {}) const;

--- a/src/semantic/decls.cpp
+++ b/src/semantic/decls.cpp
@@ -118,34 +118,18 @@ const clang::NamedDecl* undeclared_pattern(const Spec* spec) {
                                        deduced);
     };
 
-    Partial* best = nullptr;
     llvm::SmallVector<Partial*, 4> matched;
     for(auto* partial: partials) {
         if(matches(partial)) {
             matched.push_back(partial);
-            if(!best || types::more_specialized(context, partial, best)) {
-                best = partial;
-            }
         }
     }
 
-    if(!best) {
+    auto choice = types::select_partial(context, matched);
+    if(choice.verdict != types::PartialVerdict::Selected) {
         return primary->getTemplatedDecl();
     }
-
-    /// Real instantiation diagnoses ambiguity; degrade to the primary
-    /// rather than picking arbitrarily.
-    for(auto* partial: matched) {
-        if(partial != best && !types::more_specialized(context, best, partial)) {
-            return primary->getTemplatedDecl();
-        }
-    }
-
-    if(best->getTemplateParameters()->hasAssociatedConstraints()) {
-        return primary->getTemplatedDecl();
-    }
-
-    return best;
+    return choice.winner;
 }
 
 const clang::CXXRecordDecl* getDeclContextForTemplateInstationPattern(const clang::Decl* D) {

--- a/src/semantic/resolver.cpp
+++ b/src/semantic/resolver.cpp
@@ -674,7 +674,6 @@ public:
         /// most specialized one, as real instantiation would — but only among
         /// partials whose dependent pattern constraints survive the
         /// pseudo-SFINAE probe (see member_absent).
-        clang::ClassTemplatePartialSpecializationDecl* best = nullptr;
         llvm::SmallVector<clang::ClassTemplatePartialSpecializationDecl*, 4> matched;
         for(auto partial: partials) {
             if(deduce_template_arguments(partial, arguments)) {
@@ -689,32 +688,22 @@ public:
                     continue;
                 }
                 matched.push_back(partial);
-                if(!best || more_specialized(context, partial, best)) {
-                    best = partial;
-                }
             }
         }
 
-        /// Real instantiation diagnoses ambiguity: if the winner does not
-        /// dominate every other match, neither a partial nor the primary may
-        /// be chosen — degrade to unresolved rather than picking arbitrarily.
-        if(best && matched.size() > 1) {
-            for(auto partial: matched) {
-                if(partial != best && !more_specialized(context, best, partial)) {
-                    LOG_DEBUG(
-                        "{}"
-                        "ambiguous partials; degrading",
-                        pad());
-                    indent -= 1;
-                    return lookup_result();
-                }
-            }
+        /// An ambiguous or constrained winner degrades to unresolved:
+        /// neither a partial nor the primary may be chosen (see
+        /// select_partial).
+        auto choice = select_partial(context, matched);
+        if(choice.verdict == PartialVerdict::Ambiguous) {
+            LOG_DEBUG(
+                "{}"
+                "ambiguous partials; degrading",
+                pad());
+            indent -= 1;
+            return lookup_result();
         }
-
-        /// Constraint satisfaction is not evaluated (`requires false` would
-        /// need subsumption machinery); a structurally matching constrained
-        /// partial is therefore unverifiable — degrade rather than trust it.
-        if(best && best->getTemplateParameters()->hasAssociatedConstraints()) {
+        if(choice.verdict == PartialVerdict::Constrained) {
             LOG_DEBUG(
                 "{}"
                 "constrained partial; degrading",
@@ -722,6 +711,7 @@ public:
             indent -= 1;
             return lookup_result();
         }
+        auto* best = choice.winner;
 
         if(best && deduce_template_arguments(best, arguments)) {
             LOG_DEBUG(

--- a/src/semantic/unifier.cpp
+++ b/src/semantic/unifier.cpp
@@ -794,6 +794,29 @@ bool more_specialized_impl(clang::ASTContext& context, Partial* left, Partial* r
     return matches(right, left) && !matches(left, right);
 }
 
+template <typename Partial>
+PartialChoice<Partial> select_partial_impl(clang::ASTContext& context,
+                                           llvm::ArrayRef<Partial*> viable) {
+    Partial* best = nullptr;
+    for(auto* partial: viable) {
+        if(!best || more_specialized_impl(context, partial, best)) {
+            best = partial;
+        }
+    }
+    if(!best) {
+        return {};
+    }
+    for(auto* partial: viable) {
+        if(partial != best && !more_specialized_impl(context, best, partial)) {
+            return {.verdict = PartialVerdict::Ambiguous};
+        }
+    }
+    if(best->getTemplateParameters()->hasAssociatedConstraints()) {
+        return {.verdict = PartialVerdict::Constrained};
+    }
+    return {.verdict = PartialVerdict::Selected, .winner = best};
+}
+
 }  // namespace
 
 bool more_specialized(clang::ASTContext& context,
@@ -806,6 +829,18 @@ bool more_specialized(clang::ASTContext& context,
                       clang::VarTemplatePartialSpecializationDecl* left,
                       clang::VarTemplatePartialSpecializationDecl* right) {
     return more_specialized_impl(context, left, right);
+}
+
+PartialChoice<clang::ClassTemplatePartialSpecializationDecl>
+    select_partial(clang::ASTContext& context,
+                   llvm::ArrayRef<clang::ClassTemplatePartialSpecializationDecl*> viable) {
+    return select_partial_impl(context, viable);
+}
+
+PartialChoice<clang::VarTemplatePartialSpecializationDecl>
+    select_partial(clang::ASTContext& context,
+                   llvm::ArrayRef<clang::VarTemplatePartialSpecializationDecl*> viable) {
+    return select_partial_impl(context, viable);
 }
 
 }  // namespace clice::types

--- a/src/semantic/unifier.cpp
+++ b/src/semantic/unifier.cpp
@@ -782,8 +782,10 @@ bool deduce_arguments(clang::ASTContext& context,
 
 namespace {
 
+/// Partial ordering via symmetric deduction: `left` is more specialized than
+/// `right` iff right's pattern matches left's and not vice versa.
 template <typename Partial>
-bool more_specialized_impl(clang::ASTContext& context, Partial* left, Partial* right) {
+bool more_specialized(clang::ASTContext& context, Partial* left, Partial* right) {
     auto matches = [&](Partial* pattern, Partial* argument) {
         auto params = pattern->getTemplateParameters();
         Unifier unifier(context, params->getDepth(), params->size());
@@ -799,7 +801,7 @@ PartialChoice<Partial> select_partial_impl(clang::ASTContext& context,
                                            llvm::ArrayRef<Partial*> viable) {
     Partial* best = nullptr;
     for(auto* partial: viable) {
-        if(!best || more_specialized_impl(context, partial, best)) {
+        if(!best || more_specialized(context, partial, best)) {
             best = partial;
         }
     }
@@ -807,7 +809,7 @@ PartialChoice<Partial> select_partial_impl(clang::ASTContext& context,
         return {};
     }
     for(auto* partial: viable) {
-        if(partial != best && !more_specialized_impl(context, best, partial)) {
+        if(partial != best && !more_specialized(context, best, partial)) {
             return {.verdict = PartialVerdict::Ambiguous};
         }
     }
@@ -818,18 +820,6 @@ PartialChoice<Partial> select_partial_impl(clang::ASTContext& context,
 }
 
 }  // namespace
-
-bool more_specialized(clang::ASTContext& context,
-                      clang::ClassTemplatePartialSpecializationDecl* left,
-                      clang::ClassTemplatePartialSpecializationDecl* right) {
-    return more_specialized_impl(context, left, right);
-}
-
-bool more_specialized(clang::ASTContext& context,
-                      clang::VarTemplatePartialSpecializationDecl* left,
-                      clang::VarTemplatePartialSpecializationDecl* right) {
-    return more_specialized_impl(context, left, right);
-}
 
 PartialChoice<clang::ClassTemplatePartialSpecializationDecl>
     select_partial(clang::ASTContext& context,

--- a/src/semantic/unifier.h
+++ b/src/semantic/unifier.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/DeclTemplate.h"
 
@@ -96,6 +98,36 @@ bool more_specialized(clang::ASTContext& context,
 bool more_specialized(clang::ASTContext& context,
                       clang::VarTemplatePartialSpecializationDecl* left,
                       clang::VarTemplatePartialSpecializationDecl* right);
+
+/// The verdict of select_partial: a winner, or why there is none. Real
+/// instantiation diagnoses an ambiguity (no partial dominates every other
+/// match); constraint satisfaction is not evaluated here (`requires false`
+/// would need subsumption machinery), so a structurally matching
+/// constrained winner is unverifiable. Callers degrade on both rather than
+/// pick arbitrarily or trust the unverified.
+enum class PartialVerdict : std::uint8_t {
+    None,
+    Selected,
+    Ambiguous,
+    Constrained,
+};
+
+template <typename Partial>
+struct PartialChoice {
+    PartialVerdict verdict = PartialVerdict::None;
+    /// Set for Selected only.
+    Partial* winner = nullptr;
+};
+
+/// The partial specialization real instantiation would pick among
+/// `viable` — the ones whose pattern deduced against the arguments.
+PartialChoice<clang::ClassTemplatePartialSpecializationDecl>
+    select_partial(clang::ASTContext& context,
+                   llvm::ArrayRef<clang::ClassTemplatePartialSpecializationDecl*> viable);
+
+PartialChoice<clang::VarTemplatePartialSpecializationDecl>
+    select_partial(clang::ASTContext& context,
+                   llvm::ArrayRef<clang::VarTemplatePartialSpecializationDecl*> viable);
 
 /// If `expr` is a (possibly parenthesized/casted) reference to a non-type
 /// template parameter, return its declaration.

--- a/src/semantic/unifier.h
+++ b/src/semantic/unifier.h
@@ -89,16 +89,6 @@ bool deduce_arguments(clang::ASTContext& context,
                       llvm::ArrayRef<clang::TemplateArgument> arguments,
                       llvm::SmallVectorImpl<clang::TemplateArgument>& deduced);
 
-/// Partial ordering via symmetric deduction: `left` is more specialized than
-/// `right` iff right's pattern matches left's and not vice versa.
-bool more_specialized(clang::ASTContext& context,
-                      clang::ClassTemplatePartialSpecializationDecl* left,
-                      clang::ClassTemplatePartialSpecializationDecl* right);
-
-bool more_specialized(clang::ASTContext& context,
-                      clang::VarTemplatePartialSpecializationDecl* left,
-                      clang::VarTemplatePartialSpecializationDecl* right);
-
 /// The verdict of select_partial: a winner, or why there is none. Real
 /// instantiation diagnoses an ambiguity (no partial dominates every other
 /// match); constraint satisfaction is not evaluated here (`requires false`

--- a/src/server/protocol/lsp_projection.cpp
+++ b/src/server/protocol/lsp_projection.cpp
@@ -4,6 +4,8 @@
 #include <string>
 #include <variant>
 
+#include "feature/feature.h"
+
 #include "llvm/ADT/StringRef.h"
 
 namespace clice::to_lsp {
@@ -40,7 +42,7 @@ protocol::SymbolKind symbol_kind(SymbolKind kind) {
     }
 }
 
-std::optional<protocol::SymbolInformation> symbol_information(const SymbolRef& symbol,
+std::optional<protocol::SymbolInformation> symbol_information(const index::SymbolRef& symbol,
                                                               const Site& site) {
     auto mapped = location(site);
     if(!mapped) {
@@ -54,7 +56,7 @@ std::optional<protocol::SymbolInformation> symbol_information(const SymbolRef& s
 }
 
 template <typename Item>
-static std::optional<Item> hierarchy_item(const SymbolRef& symbol, const Site& site) {
+static std::optional<Item> hierarchy_item(const index::SymbolRef& symbol, const Site& site) {
     auto mapped = location(site);
     if(!mapped) {
         return std::nullopt;
@@ -69,12 +71,12 @@ static std::optional<Item> hierarchy_item(const SymbolRef& symbol, const Site& s
     return item;
 }
 
-std::optional<protocol::CallHierarchyItem> call_hierarchy_item(const SymbolRef& symbol,
+std::optional<protocol::CallHierarchyItem> call_hierarchy_item(const index::SymbolRef& symbol,
                                                                const Site& site) {
     return hierarchy_item<protocol::CallHierarchyItem>(symbol, site);
 }
 
-std::optional<protocol::TypeHierarchyItem> type_hierarchy_item(const SymbolRef& symbol,
+std::optional<protocol::TypeHierarchyItem> type_hierarchy_item(const index::SymbolRef& symbol,
                                                                const Site& site) {
     return hierarchy_item<protocol::TypeHierarchyItem>(symbol, site);
 }

--- a/src/server/protocol/lsp_projection.h
+++ b/src/server/protocol/lsp_projection.h
@@ -3,7 +3,9 @@
 #include <optional>
 #include <vector>
 
-#include "server/service/query.h"
+#include "index/types.h"
+#include "semantic/symbol.h"
+#include "server/protocol/position.h"
 
 #include "kota/codec/json/json.h"
 #include "kota/ipc/lsp/protocol.h"
@@ -30,15 +32,15 @@ std::vector<protocol::Location> locations(llvm::ArrayRef<Site> sites);
 /// table, with the kinds these surfaces display differently overridden.
 protocol::SymbolKind symbol_kind(SymbolKind kind);
 
-std::optional<protocol::SymbolInformation> symbol_information(const SymbolRef& symbol,
+std::optional<protocol::SymbolInformation> symbol_information(const index::SymbolRef& symbol,
                                                               const Site& site);
 
 /// Hierarchy items carry their symbol handle in `data` as a decimal
 /// string: a raw 64-bit integer would be parsed into a double by a
 /// JavaScript client and come back rounded.
-std::optional<protocol::CallHierarchyItem> call_hierarchy_item(const SymbolRef& symbol,
+std::optional<protocol::CallHierarchyItem> call_hierarchy_item(const index::SymbolRef& symbol,
                                                                const Site& site);
-std::optional<protocol::TypeHierarchyItem> type_hierarchy_item(const SymbolRef& symbol,
+std::optional<protocol::TypeHierarchyItem> type_hierarchy_item(const index::SymbolRef& symbol,
                                                                const Site& site);
 
 /// The symbol handle a prepared hierarchy item came back with, if intact.

--- a/src/server/protocol/position.h
+++ b/src/server/protocol/position.h
@@ -1,11 +1,15 @@
 #pragma once
 
-/// Shared LSP position clamping for master-side buffer access.
+/// Positions, coordinate systems and sites shared by the master's buffer
+/// access and its index projections.
 
 #include <algorithm>
 #include <optional>
 #include <span>
 #include <string_view>
+
+#include "syntax/token.h"
+#include "vfs/file_table.h"
 
 #include "kota/ipc/lsp/position.h"
 #include "llvm/ADT/StringRef.h"
@@ -119,6 +123,18 @@ private:
     llvm::StringRef content;
     std::uint32_t content_size = 0;
     std::span<const std::uint32_t> starts;
+};
+
+/// One row's site: the file it lies in, its byte range in that file's
+/// serving source, and the coordinates that turn the bytes into positions.
+/// `file` is invalid when the path is unknown to the file table (an overlay
+/// header no scan interned); `path` always names it, in the table's
+/// canonical spelling whenever the file is known.
+struct Site {
+    Fid file;
+    llvm::StringRef path;
+    LocalSourceRange range;
+    Coordinates coords;
 };
 
 }  // namespace clice

--- a/src/server/service/ast_family.cpp
+++ b/src/server/service/ast_family.cpp
@@ -127,7 +127,7 @@ ASTFamily::ASTFamily(Workspace& workspace,
     sessions(sessions), kicks(loop) {}
 
 void ASTFamily::register_runner() {
-    graph.register_family(ast_family, [this](RoundContext& ctx, NodeId id) {
+    graph.register_family(Family::AST, [this](RoundContext& ctx, NodeId id) {
         return run(ctx, Fid{static_cast<std::uint32_t>(id.key)});
     });
 }
@@ -352,7 +352,7 @@ kota::task<DependResult> ASTFamily::depend_modules(RoundContext& ctx,
     // buffer's own unsaved import, a header context's suffix, a forced
     // include. The scan's sentinel edges are what let the name's first
     // provider re-dirty this document.
-    bool scan_worth = !workspace.path_to_module.empty() ||
+    bool scan_worth = workspace.dep_graph.has_modules() ||
                       !workspace.dep_graph.import_candidate_files().empty() ||
                       contexts.header_context(path_id) != nullptr ||
                       llvm::any_of(arguments, [](const std::string& arg) {
@@ -415,7 +415,7 @@ kota::task<DependResult> ASTFamily::depend_modules(RoundContext& ctx,
         }
 
         for(auto dep: deps.resolved) {
-            switch(co_await ctx.depend({pcm_family, dep.raw})) {
+            switch(co_await ctx.depend({Family::PCM, dep.raw})) {
                 case DependResult::Ready: break;
                 case DependResult::Failed: co_return DependResult::Failed;
                 case DependResult::Cancelled: co_return DependResult::Cancelled;

--- a/src/server/service/ast_family.h
+++ b/src/server/service/ast_family.h
@@ -31,7 +31,6 @@ struct ASTFamilyFixture;
 
 class ContextResolver;
 
-
 /// Open documents' ASTs as a task-graph family: one node per document,
 /// candidate/durable edges to the PCM and PCH nodes its rounds wait on,
 /// one round = one compile (up to two worker sends for the

--- a/src/server/service/ast_family.h
+++ b/src/server/service/ast_family.h
@@ -31,9 +31,6 @@ struct ASTFamilyFixture;
 
 class ContextResolver;
 
-/// The AST family's id in the task graph. Node keys are document path_ids
-/// widened into NodeId::key.
-constexpr inline std::uint8_t ast_family = 3;
 
 /// Open documents' ASTs as a task-graph family: one node per document,
 /// candidate/durable edges to the PCM and PCH nodes its rounds wait on,
@@ -66,7 +63,7 @@ public:
               kota::event_loop& loop);
 
     /// Register the production runner. Tests that drive the facade
-    /// against a synthetic runner register their own under ast_family.
+    /// against a synthetic runner register their own under Family::AST.
     void register_runner();
 
     /// Per-document projections and freshness state; the read surface for
@@ -186,7 +183,7 @@ public:
 
 private:
     static NodeId node(Fid path_id) {
-        return {ast_family, path_id.raw};
+        return {Family::AST, path_id.raw};
     }
 
     /// One compile round; see the class comment for its obligations.

--- a/src/server/service/features.cpp
+++ b/src/server/service/features.cpp
@@ -772,7 +772,7 @@ Features::RawResult Features::completion(std::shared_ptr<Session> session,
             co_return serde_raw{json ? std::move(*json) : "[]"};
         }
         if(pctx.kind == CompletionContext::Import) {
-            auto module_names = complete_module_import(workspace.path_to_module, pctx.prefix);
+            auto module_names = complete_module_import(workspace.dep_graph, pctx.prefix);
 
             std::vector<protocol::CompletionItem> items;
             items.reserve(module_names.size());

--- a/src/server/service/features.cpp
+++ b/src/server/service/features.cpp
@@ -42,43 +42,53 @@ bool Features::ast_answerable(const Session& session) const {
 }
 
 kota::task<Features::Route> Features::pick_route(const Ticket& ticket,
-                                                 bool full_lex,
+                                                 RouteOptions options,
                                                  ServingSource* source) {
-    // This handler is resumed eagerly: drain the transport pipe before
-    // reading any buffer state, so a queued didChange or cancel lands
-    // first (the same discipline as completion's yield).
-    co_await kota::yield();
-    if(!ticket.fresh()) {
-        co_return Route::Superseded;
-    }
-    auto& session = *ticket.session;
-    if(ast_answerable(session)) {
-        co_return Route::Ast;
-    }
-    // An oversized buffer is not worth a synchronous main-thread lex; the
-    // full-lex projections follow the investment policy instead of the
-    // index slice. Row-backed answers serve at any size.
-    constexpr std::size_t full_lex_cap = 8 * 1024 * 1024;
-    bool capped = full_lex && session.text.size() > full_lex_cap;
-    if(!capped) {
-        // The session's own rows when current (the quarantine fallback —
-        // the worker cannot be asked, the rows are still true), else the
-        // disk shard admitted by freshness clause 4.
-        if(auto serving = query.serving_source(session.path_id)) {
-            // An index answer must not strand an escalated session's pending
-            // build: this request still pulls the compile it would otherwise
-            // have waited on, just without blocking.
-            if(session.serving == ServingMode::Escalated &&
-               !ast.projections.current(session.path_id)) {
-                ast.request_compile(ticket.session);
-            }
-            if(source) {
-                *source = serving;
-            }
-            co_return Route::Index;
+    for(bool waited = false;;) {
+        // This handler is resumed eagerly: drain the transport pipe before
+        // reading any buffer state, so a queued didChange or cancel lands
+        // first (the same discipline as completion's yield).
+        co_await kota::yield();
+        if(!ticket.fresh()) {
+            co_return Route::Superseded;
         }
+        auto& session = *ticket.session;
+        if(ast_answerable(session)) {
+            co_return Route::Ast;
+        }
+        // An oversized buffer is not worth a synchronous main-thread lex;
+        // the full-lex projections follow the investment policy instead of
+        // the index slice. Row-backed answers serve at any size.
+        constexpr std::size_t full_lex_cap = 8 * 1024 * 1024;
+        bool capped = options.full_lex && session.text.size() > full_lex_cap;
+        if(!capped) {
+            // The session's own rows when current (the quarantine fallback
+            // — the worker cannot be asked, the rows are still true), else
+            // the disk shard admitted by freshness clause 4.
+            if(auto serving = query.serving_source(session.path_id)) {
+                // An index answer must not strand an escalated session's
+                // pending build: this request still pulls the compile it
+                // would otherwise have waited on, just without blocking.
+                if(session.serving == ServingMode::Escalated &&
+                   !ast.projections.current(session.path_id)) {
+                    ast.request_compile(ticket.session);
+                }
+                if(source) {
+                    *source = serving;
+                }
+                co_return Route::Index;
+            }
+        }
+        if(session.serving == ServingMode::Escalated) {
+            co_return Route::Ast;
+        }
+        if(options.await_cold_attempt && !waited) {
+            waited = true;
+            co_await pump.await_attempt(session.path_id);
+            continue;
+        }
+        co_return Route::Empty;
     }
-    co_return session.serving == ServingMode::Escalated ? Route::Ast : Route::Empty;
 }
 
 Features::RawResult Features::stop_reply(Stop stop) {
@@ -89,7 +99,7 @@ Features::RawResult Features::stop_reply(Stop stop) {
 }
 
 kota::task<std::optional<Features::Stop>> Features::nav_gate(const Ticket& ticket) {
-    switch(co_await pick_route(ticket, /*full_lex=*/false)) {
+    switch(co_await pick_route(ticket, {})) {
         case Route::Superseded: co_return Stop{content_modified()};
         // The index sources resolve the cursor under clauses 1/4 — or
         // reject it, which the query layer answers as empty. Either way
@@ -313,46 +323,29 @@ kota::task<std::vector<protocol::DocumentLink>, kota::ipc::Error>
         }
     };
 
-    for(bool waited = false;;) {
-        switch(co_await pick_route(ticket, /*full_lex=*/false)) {
-            case Route::Superseded: co_return kota::outcome_error(content_modified());
-            case Route::Index: {
-                // Manifest edges cover the whole document (the background
-                // index has no preamble split); guard-skipped lines and
-                // __has_include/#embed have no edge and produce no link.
-                // Unlike the rows the other projections serve, the edges are
-                // disk truth: the quarantine fallback (own index current,
-                // buffer edited) must not project them onto a buffer the
-                // manifest never described — an edited directive would get
-                // the old target, confidently wrong.
-                std::vector<protocol::DocumentLink> links;
-                if(query.matching_shard(*session)) {
-                    auto raw = feature::index_document_links(session->text,
-                                                             index_lang_options(*session),
-                                                             query.include_edges(*session));
-                    convert(raw, links);
-                }
-                session->index_served = true;
-                co_return links;
+    switch(co_await pick_route(ticket, {.await_cold_attempt = true})) {
+        case Route::Superseded: co_return kota::outcome_error(content_modified());
+        case Route::Index: {
+            // Manifest edges cover the whole document (the background
+            // index has no preamble split); guard-skipped lines and
+            // __has_include/#embed have no edge and produce no link.
+            // Unlike the rows the other projections serve, the edges are
+            // disk truth: the quarantine fallback (own index current,
+            // buffer edited) must not project them onto a buffer the
+            // manifest never described — an edited directive would get
+            // the old target, confidently wrong.
+            std::vector<protocol::DocumentLink> links;
+            if(query.matching_shard(*session)) {
+                auto raw = feature::index_document_links(session->text,
+                                                         index_lang_options(*session),
+                                                         query.include_edges(*session));
+                convert(raw, links);
             }
-            case Route::Empty: {
-                // Like the outline, links have no refresh request; a cold
-                // document's empty reply would outlive the boost that is
-                // about to make them real. Await it once, then answer
-                // from the settled state.
-                if(!waited) {
-                    waited = true;
-                    co_await pump.await_attempt(session->path_id);
-                    if(ticket.fresh()) {
-                        continue;
-                    }
-                    co_return kota::outcome_error(content_modified());
-                }
-                co_return std::vector<protocol::DocumentLink>{};
-            }
-            case Route::Ast: break;
+            session->index_served = true;
+            co_return links;
         }
-        break;
+        case Route::Empty: co_return std::vector<protocol::DocumentLink>{};
+        case Route::Ast: break;
     }
 
     auto result = co_await dispatcher.document_links(ticket, std::move(token));
@@ -484,7 +477,7 @@ Features::RawResult Features::hover(std::shared_ptr<Session> session,
         return std::nullopt;
     };
 
-    switch(co_await pick_route(ticket, /*full_lex=*/false)) {
+    switch(co_await pick_route(ticket, {})) {
         case Route::Superseded: co_return kota::outcome_error(content_modified());
         case Route::Index: {
             if(auto card = index_card()) {
@@ -531,7 +524,7 @@ Features::RawResult Features::semantic_tokens(std::shared_ptr<Session> session,
                                               std::optional<kota::cancellation_token> token) {
     auto ticket = Ticket::take(session);
     ServingSource source;
-    switch(co_await pick_route(ticket, /*full_lex=*/true, &source)) {
+    switch(co_await pick_route(ticket, {.full_lex = true}, &source)) {
         case Route::Superseded: co_return kota::outcome_error(content_modified());
         case Route::Index: {
             auto rows = feature::extract_index_rows(*source.rows);
@@ -588,7 +581,7 @@ Features::RawResult Features::folding_range(std::shared_ptr<Session> session,
                                             std::optional<kota::cancellation_token> token) {
     auto ticket = Ticket::take(session);
     ServingSource source;
-    switch(co_await pick_route(ticket, /*full_lex=*/true, &source)) {
+    switch(co_await pick_route(ticket, {.full_lex = true}, &source)) {
         case Route::Superseded: co_return kota::outcome_error(content_modified());
         case Route::Index: {
             auto rows = feature::extract_index_rows(*source.rows);
@@ -623,44 +616,23 @@ Features::RawResult Features::folding_range(std::shared_ptr<Session> session,
 Features::RawResult Features::document_symbol(std::shared_ptr<Session> session,
                                               std::optional<kota::cancellation_token> token) {
     auto ticket = Ticket::take(session);
-    for(bool waited = false;;) {
-        ServingSource source;
-        switch(co_await pick_route(ticket, /*full_lex=*/false, &source)) {
-            case Route::Superseded: co_return kota::outcome_error(content_modified());
-            case Route::Index: {
-                auto rows = feature::extract_index_rows(*source.rows);
-                auto symbols =
-                    feature::index_document_symbols(rows.decls, [&](index::SymbolHash hash) {
-                        return query.symbol_info(hash);
-                    });
-                session->index_served = true;
-                co_return to_raw(
-                    feature::document_symbols_to_protocol(symbols,
-                                                          session->text,
-                                                          session->line_starts,
-                                                          feature::PositionEncoding::UTF16));
-            }
-            case Route::Empty: {
-                // The outline has no workspace refresh request: an
-                // empty reply to a cold document would be cached by
-                // the client for good — no signal ever makes it
-                // re-pull. Await the didOpen boost instead (bounded
-                // by one index attempt) and answer from whatever
-                // source that settles: the shard, the escalated
-                // compile, or honestly empty under readonly "on".
-                if(!waited) {
-                    waited = true;
-                    co_await pump.await_attempt(session->path_id);
-                    if(ticket.fresh()) {
-                        continue;
-                    }
-                    co_return kota::outcome_error(content_modified());
-                }
-                co_return serde_raw{"[]"};
-            }
-            case Route::Ast: break;
+    ServingSource source;
+    switch(co_await pick_route(ticket, {.await_cold_attempt = true}, &source)) {
+        case Route::Superseded: co_return kota::outcome_error(content_modified());
+        case Route::Index: {
+            auto rows = feature::extract_index_rows(*source.rows);
+            auto symbols = feature::index_document_symbols(rows.decls, [&](index::SymbolHash hash) {
+                return query.symbol_info(hash);
+            });
+            session->index_served = true;
+            co_return to_raw(
+                feature::document_symbols_to_protocol(symbols,
+                                                      session->text,
+                                                      session->line_starts,
+                                                      feature::PositionEncoding::UTF16));
         }
-        break;
+        case Route::Empty: co_return serde_raw{"[]"};
+        case Route::Ast: break;
     }
     co_return co_await dispatcher.query(worker::QueryKind::DocumentSymbol,
                                         ticket,

--- a/src/server/service/features.h
+++ b/src/server/service/features.h
@@ -183,17 +183,28 @@ private:
         Empty,
     };
 
+    struct RouteOptions {
+        /// The projection raw-lexes the whole buffer (semantic tokens,
+        /// folds): it follows the investment policy once the buffer is
+        /// oversized, while row- and cursor-backed answers serve at any
+        /// size.
+        bool full_lex = false;
+        /// The feature has no refresh request, so an empty reply to a cold
+        /// document would be cached by the client for good — no signal
+        /// ever makes it re-pull. Await the didOpen boost once (bounded by
+        /// one index attempt) before answering Empty, and decide again
+        /// from whatever source that settles: the shard, the escalated
+        /// compile, or honestly empty under readonly "on".
+        bool await_cold_attempt = false;
+    };
+
     /// See Route. Sets up escalated sessions' compile kick so an index
-    /// answer never strands the AST investment the policy asked for.
-    /// `full_lex` marks projections that raw-lex the whole buffer
-    /// (semantic tokens, folds): those follow the investment policy once
-    /// the buffer is oversized, while row- and cursor-backed answers
-    /// serve at any size. A Route::Index decision stores the admitted
-    /// source into `source` (when given) — callers must serve from it
-    /// rather than re-derive, or the state could shift between the
-    /// decision and the read.
+    /// answer never strands the AST investment the policy asked for. A
+    /// Route::Index decision stores the admitted source into `source`
+    /// (when given) — callers must serve from it rather than re-derive,
+    /// or the state could shift between the decision and the read.
     kota::task<Route> pick_route(const Ticket& ticket,
-                                 bool full_lex,
+                                 RouteOptions options,
                                  ServingSource* source = nullptr);
 
     /// What a gate decided instead of the feature's own answer: null (no

--- a/src/server/service/query.cpp
+++ b/src/server/service/query.cpp
@@ -806,10 +806,9 @@ std::vector<IndexQuery::Located> IndexQuery::search(llvm::StringRef query,
     return results;
 }
 
-std::vector<IndexQuery::Located>
-    IndexQuery::locate(const agentic::ReadSymbolParams& locator) const {
-    if(locator.symbol_id.has_value() && *locator.symbol_id != 0) {
-        auto hash = static_cast<index::SymbolHash>(*locator.symbol_id);
+std::vector<IndexQuery::Located> IndexQuery::locate(const SymbolLocator& locator) const {
+    if(locator.symbol) {
+        auto hash = *locator.symbol;
         auto info = symbol_info(hash);
         if(!info) {
             return {};
@@ -823,8 +822,8 @@ std::vector<IndexQuery::Located>
         };
     }
 
-    if(locator.name.has_value() && !locator.name->empty()) {
-        std::string query_lower = llvm::StringRef(*locator.name).lower();
+    if(!locator.name.empty()) {
+        std::string query_lower = locator.name.lower();
         std::vector<Located> candidates;
         std::vector<Located> exact_matches;
 
@@ -837,8 +836,8 @@ std::vector<IndexQuery::Located>
             if(!site) {
                 continue;
             }
-            if(locator.path.has_value() && !locator.path->empty()) {
-                llvm::StringRef wanted(*locator.path);
+            if(!locator.path.empty()) {
+                llvm::StringRef wanted = locator.path;
                 bool basename_only = wanted.find_last_of("/\\") == llvm::StringRef::npos;
                 if(basename_only) {
                     if(llvm::sys::path::filename(site->path) != wanted)
@@ -849,7 +848,7 @@ std::vector<IndexQuery::Located>
             }
 
             bool is_exact = llvm::StringRef(symbol.name).lower() == query_lower ||
-                            llvm::StringRef(symbol.name).ends_with("::" + *locator.name);
+                            llvm::StringRef(symbol.name).ends_with(("::" + locator.name).str());
             Located located{
                 .symbol = {.hash = hash, .name = symbol.name, .kind = symbol.kind},
                 .site = *site,
@@ -865,8 +864,8 @@ std::vector<IndexQuery::Located>
         return candidates;
     }
 
-    if(locator.path.has_value() && locator.line.has_value()) {
-        auto path_id = workspace.file_table.find(*locator.path);
+    if(!locator.path.empty() && locator.line.has_value()) {
+        auto path_id = workspace.file_table.find(locator.path);
         if(!path_id) {
             return {};
         }

--- a/src/server/service/query.h
+++ b/src/server/service/query.h
@@ -9,7 +9,6 @@
 #include "feature/feature.h"
 #include "sched/workspace.h"
 #include "semantic/symbol.h"
-#include "server/protocol/agentic.h"
 #include "server/protocol/position.h"
 
 #include "llvm/ADT/SmallVector.h"
@@ -25,18 +24,6 @@ struct Session;
 struct SessionStore;
 
 using index::SymbolRef;
-
-/// One row's site: the file it lies in, its byte range in that file's
-/// serving source, and the coordinates that turn the bytes into positions.
-/// `file` is invalid when the path is unknown to the file table (an overlay
-/// header no scan interned); `path` always names it, in the table's
-/// canonical spelling whenever the file is known.
-struct Site {
-    Fid file;
-    llvm::StringRef path;
-    LocalSourceRange range;
-    Coordinates coords;
-};
 
 /// Which of a file's index sources serves it right now — the freshness
 /// contract's arbitration, decided in one place (IndexQuery::serving_source).
@@ -68,6 +55,17 @@ struct QuerySources {
     const SessionStore* sessions = nullptr;
     const ASTProjectionTable* projections = nullptr;
     const IndexPump* pump = nullptr;
+};
+
+/// How an agent names a symbol, tried in this order: by handle; by name,
+/// case-insensitively, optionally narrowed to a path — a bare file name
+/// matches the site's file name, anything longer the tail of its path;
+/// by path and 1-based line.
+struct SymbolLocator {
+    std::optional<index::SymbolHash> symbol;
+    llvm::StringRef name;
+    llvm::StringRef path;
+    std::optional<int> line;
 };
 
 /// Read-only queries over every index source: disk shards, open sessions'
@@ -234,9 +232,8 @@ public:
     /// site are listed.
     std::vector<Located> search(llvm::StringRef query, std::size_t limit) const;
 
-    /// Resolve an agentic locator: by symbol id, by name (optionally
-    /// narrowed to a path), or by path and 1-based line.
-    std::vector<Located> locate(const agentic::ReadSymbolParams& locator) const;
+    /// The symbols a locator names; several when a name is ambiguous.
+    std::vector<Located> locate(const SymbolLocator& locator) const;
 
     /// Every project symbol with a definition site in the file's serving
     /// source, anchored at the definition's name token.

--- a/src/server/state/invalidator.cpp
+++ b/src/server/state/invalidator.cpp
@@ -3,8 +3,6 @@
 #include <utility>
 
 #include "sched/families/pcm.h"
-#include "sched/families/turun.h"
-#include "server/service/ast_family.h"
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringMap.h"
@@ -63,9 +61,9 @@ void Invalidator::provider_appeared(llvm::StringRef module_name, DirtySet& dirty
             continue;
         }
         auto path_id = Fid{static_cast<std::uint32_t>(id.key)};
-        if(id.family == turun_family) {
+        if(id.family == Family::TURun) {
             dirty.add_reindex_content_changed(path_id);
-        } else if(id.family == ast_family) {
+        } else if(id.family == Family::AST) {
             if(auto session = store.find(path_id)) {
                 dirty.mark_ast_dirty.push_back(path_id);
                 if(session->serving == ServingMode::IndexOnly) {
@@ -81,11 +79,9 @@ void Invalidator::provider_appeared(llvm::StringRef module_name, DirtySet& dirty
 }
 
 void Invalidator::rescan_disk_state(Fid path_id, DirtySet& dirty) {
-    auto old_module = workspace.path_to_module.lookup(path_id);
+    std::string old_module(workspace.dep_graph.module_of(path_id));
     workspace.rescan_after_save(path_id);
-    auto it = workspace.path_to_module.find(path_id);
-    llvm::StringRef new_module =
-        it != workspace.path_to_module.end() ? it->second : llvm::StringRef();
+    auto new_module = workspace.dep_graph.module_of(path_id);
     if(new_module == old_module) {
         return;
     }
@@ -350,7 +346,6 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                 // module itself among its dirtied units: the removal is this
                 // event's final word for the file itself.
                 dirty.add_clear_reindex(path_id);
-                workspace.path_to_module.erase(path_id);
                 // The provider leaves the module map too, or a later
                 // replacement provider would sit behind the deleted one in
                 // the candidate list and never be selected.
@@ -416,8 +411,6 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                                           workspace.config.match_rules(path, append, remove);
                                       });
                 workspace.dep_graph.build_reverse_map();
-                workspace.path_to_module.clear();
-                workspace.build_module_map();
                 workspace.context_epoch += 1;
 
                 // A module name that just gained its first provider: its

--- a/src/server/transport/agent_client.cpp
+++ b/src/server/transport/agent_client.cpp
@@ -104,8 +104,8 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                 continue;
 
             std::string kind_str;
-            auto mod_it = ws.path_to_module.find(path_id);
-            if(mod_it != ws.path_to_module.end()) {
+            auto module_name = ws.dep_graph.module_of(path_id);
+            if(!module_name.empty()) {
                 kind_str = "module";
             } else {
                 auto ext = llvm::sys::path::extension(file_path);
@@ -121,8 +121,8 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
             FileInfo fi;
             fi.path = file_path.str();
             fi.kind = std::move(kind_str);
-            if(mod_it != ws.path_to_module.end())
-                fi.module_name = mod_it->second;
+            if(!module_name.empty())
+                fi.module_name = module_name.str();
             result.files.push_back(std::move(fi));
         }
 
@@ -259,13 +259,13 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
             }
 
             for(auto host_id: hosts) {
-                auto it = ws.path_to_module.find(host_id);
-                if(it != ws.path_to_module.end())
-                    result.affected_modules.push_back(it->second);
+                auto module_name = ws.dep_graph.module_of(host_id);
+                if(!module_name.empty())
+                    result.affected_modules.push_back(module_name.str());
             }
-            auto mod_it = ws.path_to_module.find(path_id);
-            if(mod_it != ws.path_to_module.end())
-                result.affected_modules.push_back(mod_it->second);
+            auto module_name = ws.dep_graph.module_of(path_id);
+            if(!module_name.empty())
+                result.affected_modules.push_back(module_name.str());
 
             co_return result;
         });

--- a/src/server/transport/agent_client.cpp
+++ b/src/server/transport/agent_client.cpp
@@ -197,7 +197,12 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                 co_return FileDepsResult{.file = params.path};
             auto path_id = *pool_id;
             auto direction = params.direction.value_or("both");
+            // A negative depth is a client error and reads like the
+            // default, never as "unbounded" (that is 0).
             auto max_depth = params.depth.value_or(1);
+            if(max_depth < 0) {
+                max_depth = 1;
+            }
 
             FileDepsResult result;
             result.file = params.path;

--- a/src/server/transport/agent_client.cpp
+++ b/src/server/transport/agent_client.cpp
@@ -35,7 +35,18 @@ static std::string_view symbol_kind_name(SymbolKind kind) {
 /// found", several candidates ask the client to disambiguate via symbolId.
 static std::expected<IndexQuery::Located, kota::ipc::Error>
     resolve_unique(const agentic::ReadSymbolParams& loc, const IndexQuery& query) {
-    auto candidates = query.locate(loc);
+    SymbolLocator locator;
+    if(loc.symbol_id.value_or(0) != 0) {
+        locator.symbol = static_cast<index::SymbolHash>(*loc.symbol_id);
+    }
+    if(loc.name) {
+        locator.name = *loc.name;
+    }
+    if(loc.path) {
+        locator.path = *loc.path;
+    }
+    locator.line = loc.line;
+    auto candidates = query.locate(locator);
     if(candidates.empty())
         return std::unexpected(kota::ipc::Error{"symbol not found"});
     if(candidates.size() > 1) {
@@ -44,6 +55,35 @@ static std::expected<IndexQuery::Located, kota::ipc::Error>
                                          candidates.size())});
     }
     return std::move(candidates[0]);
+}
+
+/// The files reachable from `root` along `adjacent`, breadth first and
+/// each once: direct neighbours at depth 1, `max_depth` levels at most,
+/// 0 meaning unbounded.
+static std::vector<agentic::DepEntry>
+    collect_deps(Workspace& ws,
+                 Fid root,
+                 int max_depth,
+                 llvm::function_ref<llvm::SmallVector<Fid>(Fid)> adjacent) {
+    std::vector<agentic::DepEntry> entries;
+    llvm::SmallVector<std::pair<Fid, int>> queue{
+        {root, 0}
+    };
+    llvm::DenseSet<Fid> visited{root};
+    for(std::size_t i = 0; i < queue.size(); i += 1) {
+        auto [id, depth] = queue[i];
+        if(max_depth > 0 && depth >= max_depth) {
+            continue;
+        }
+        for(auto next: adjacent(id)) {
+            if(!visited.insert(next).second) {
+                continue;
+            }
+            queue.push_back({next, depth + 1});
+            entries.push_back({.path = ws.file_table.resolve(next).str(), .depth = depth + 1});
+        }
+    }
+    return entries;
 }
 
 /// The 1-based lines a site spans, as agents read files; nullopt when its
@@ -163,69 +203,14 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
             result.file = params.path;
 
             if(direction == "includes" || direction == "both") {
-                auto includes = ws.dep_graph.get_all_includes(path_id);
-                for(auto inc_id: includes) {
-                    auto inc_path = ws.file_table.resolve(inc_id);
-                    result.includes.push_back(DepEntry{.path = inc_path.str(), .depth = 1});
-                }
-
-                if(max_depth == 0 || max_depth > 1) {
-                    llvm::DenseSet<Fid> visited;
-                    visited.insert(path_id);
-                    for(auto& dep: result.includes)
-                        visited.insert(ws.file_table.intern(dep.path));
-
-                    for(std::size_t i = 0; i < result.includes.size(); ++i) {
-                        if(max_depth > 0 && result.includes[i].depth >= max_depth)
-                            continue;
-                        auto dep_id = ws.file_table.intern(result.includes[i].path);
-                        auto sub = ws.dep_graph.get_all_includes(dep_id);
-                        for(auto sub_id: sub) {
-                            if(!visited.insert(sub_id).second)
-                                continue;
-                            auto sub_path = ws.file_table.resolve(sub_id);
-                            result.includes.push_back(DepEntry{
-                                .path = sub_path.str(),
-                                .depth = result.includes[i].depth + 1,
-                            });
-                        }
-                    }
-                }
+                result.includes = collect_deps(ws, path_id, max_depth, [&](Fid id) {
+                    return ws.dep_graph.get_all_includes(id);
+                });
             }
-
             if(direction == "includers" || direction == "both") {
-                auto includers = ws.dep_graph.get_includers(path_id);
-                for(auto inc_id: includers) {
-                    auto inc_path = ws.file_table.resolve(inc_id);
-                    result.includers.push_back(DepEntry{.path = inc_path.str(), .depth = 1});
-                }
-
-                if(max_depth == 0 || max_depth > 1) {
-                    llvm::DenseSet<Fid> visited;
-                    visited.insert(path_id);
-                    for(auto& dep: result.includers) {
-                        if(auto id = ws.file_table.find(dep.path))
-                            visited.insert(*id);
-                    }
-
-                    for(std::size_t i = 0; i < result.includers.size(); ++i) {
-                        if(max_depth > 0 && result.includers[i].depth >= max_depth)
-                            continue;
-                        auto dep_id = ws.file_table.find(result.includers[i].path);
-                        if(!dep_id)
-                            continue;
-                        auto sub = ws.dep_graph.get_includers(*dep_id);
-                        for(auto sub_id: sub) {
-                            if(!visited.insert(sub_id).second)
-                                continue;
-                            auto sub_path = ws.file_table.resolve(sub_id);
-                            result.includers.push_back(DepEntry{
-                                .path = sub_path.str(),
-                                .depth = result.includers[i].depth + 1,
-                            });
-                        }
-                    }
-                }
+                result.includers = collect_deps(ws, path_id, max_depth, [&](Fid id) {
+                    return llvm::SmallVector<Fid>(ws.dep_graph.get_includers(id));
+                });
             }
 
             co_return result;

--- a/src/support/cache_store.cpp
+++ b/src/support/cache_store.cpp
@@ -583,16 +583,17 @@ CacheStore::PendingEntry CacheStore::begin_store_aux(llvm::StringRef ns, llvm::S
 CacheStore::PendingEntry CacheStore::begin_store_locked(llvm::StringRef ns,
                                                         llvm::StringRef key,
                                                         bool aux) {
+    llvm::StringRef entry = aux ? "begin_store_aux" : "begin_store";
     assert(!state->read_only && "write on a read-only store");
     if(state->read_only) {
-        LOG_ERROR("CacheStore: begin_store on a read-only store");
+        LOG_ERROR("CacheStore: {} on a read-only store", entry);
         return {};
     }
 
     auto* ns_state = state->find_namespace(ns);
     assert(ns_state && "begin_store on unregistered namespace");
     if(!ns_state) {
-        LOG_ERROR("CacheStore: begin_store on unregistered namespace {}", ns);
+        LOG_ERROR("CacheStore: {} on unregistered namespace {}", entry, ns);
         return {};
     }
     auto& extension = aux ? ns_state->config.aux_extension : ns_state->config.extension;

--- a/src/support/cache_store.cpp
+++ b/src/support/cache_store.cpp
@@ -572,6 +572,17 @@ std::optional<std::string> CacheStore::lookup_aux(llvm::StringRef ns, llvm::Stri
 
 CacheStore::PendingEntry CacheStore::begin_store(llvm::StringRef ns, llvm::StringRef key) {
     std::lock_guard guard(state->mutex);
+    return begin_store_locked(ns, key, /*aux=*/false);
+}
+
+CacheStore::PendingEntry CacheStore::begin_store_aux(llvm::StringRef ns, llvm::StringRef key) {
+    std::lock_guard guard(state->mutex);
+    return begin_store_locked(ns, key, /*aux=*/true);
+}
+
+CacheStore::PendingEntry CacheStore::begin_store_locked(llvm::StringRef ns,
+                                                        llvm::StringRef key,
+                                                        bool aux) {
     assert(!state->read_only && "write on a read-only store");
     if(state->read_only) {
         LOG_ERROR("CacheStore: begin_store on a read-only store");
@@ -584,6 +595,11 @@ CacheStore::PendingEntry CacheStore::begin_store(llvm::StringRef ns, llvm::Strin
         LOG_ERROR("CacheStore: begin_store on unregistered namespace {}", ns);
         return {};
     }
+    auto& extension = aux ? ns_state->config.aux_extension : ns_state->config.extension;
+    if(aux && extension.empty()) {
+        LOG_ERROR("CacheStore: begin_store_aux on namespace {} without aux extension", ns);
+        return {};
+    }
 
     // The cache directory can be wiped externally while the server runs
     // (a user resetting state with `rm -rf`); re-create the tmp dir so
@@ -592,35 +608,10 @@ CacheStore::PendingEntry CacheStore::begin_store(llvm::StringRef ns, llvm::Strin
         LOG_WARN("CacheStore: cannot re-create tmp dir {}: {}", state->tmp_dir, ec.message());
     }
 
-    auto tmp_name = std::format("{}{}", state->next_tmp_id++, ns_state->config.extension);
-    return PendingEntry{ns.str(), key.str(), path::join(state->tmp_dir, tmp_name)};
-}
-
-CacheStore::PendingEntry CacheStore::begin_store_aux(llvm::StringRef ns, llvm::StringRef key) {
-    std::lock_guard guard(state->mutex);
-    assert(!state->read_only && "write on a read-only store");
-    if(state->read_only) {
-        LOG_ERROR("CacheStore: begin_store_aux on a read-only store");
-        return {};
-    }
-
-    auto* ns_state = state->find_namespace(ns);
-    assert(ns_state && "begin_store_aux on unregistered namespace");
-    if(!ns_state) {
-        LOG_ERROR("CacheStore: begin_store_aux on unregistered namespace {}", ns);
-        return {};
-    }
-    if(ns_state->config.aux_extension.empty()) {
-        LOG_ERROR("CacheStore: begin_store_aux on namespace {} without aux extension", ns);
-        return {};
-    }
-
-    if(auto ec = llvm::sys::fs::create_directories(state->tmp_dir)) {
-        LOG_WARN("CacheStore: cannot re-create tmp dir {}: {}", state->tmp_dir, ec.message());
-    }
-
-    auto tmp_name = std::format("{}{}", state->next_tmp_id++, ns_state->config.aux_extension);
-    return PendingEntry{ns.str(), key.str(), path::join(state->tmp_dir, tmp_name), /*aux=*/true};
+    auto tmp_id = state->next_tmp_id;
+    state->next_tmp_id += 1;
+    auto tmp_name = std::format("{}{}", tmp_id, extension);
+    return PendingEntry{ns.str(), key.str(), path::join(state->tmp_dir, tmp_name), aux};
 }
 
 std::expected<std::string, std::error_code> CacheStore::commit(PendingEntry pending) {

--- a/src/support/cache_store.h
+++ b/src/support/cache_store.h
@@ -263,6 +263,10 @@ private:
     /// Checkpoint if enough changes accumulated since the last one.
     void maybe_checkpoint();
 
+    /// The admission both begin_store entry points share; the caller holds
+    /// the state lock.
+    PendingEntry begin_store_locked(llvm::StringRef ns, llvm::StringRef key, bool aux);
+
     std::unique_ptr<State> state;
 };
 

--- a/src/syntax/completion.cpp
+++ b/src/syntax/completion.cpp
@@ -1,5 +1,6 @@
 #include "syntax/completion.h"
 
+#include "syntax/dependency_graph.h"
 #include "syntax/include_resolver.h"
 #include "syntax/lexer.h"
 
@@ -65,16 +66,17 @@ PreambleCompletionContext detect_completion_context(llvm::StringRef text, std::u
     return {CompletionContext::Import, prefix.str()};
 }
 
-std::vector<std::string> complete_module_import(const llvm::DenseMap<Fid, std::string>& modules,
+std::vector<std::string> complete_module_import(const DependencyGraph& graph,
                                                 llvm::StringRef prefix) {
     std::vector<std::string> results;
     // FIXME: exclude the current file's own module name from results
     // (self-import is never valid). Needs the requesting path_id passed in.
-    // TODO: `modules` is only refreshed on file save; unsaved new module
-    // files won't appear in completions until written to disk.
-    for(auto& [path_id, module_name]: modules) {
-        if(llvm::StringRef(module_name).starts_with(prefix)) {
-            results.push_back(module_name);
+    // TODO: the graph's declarations are only refreshed on file save;
+    // unsaved new module files won't appear in completions until written
+    // to disk.
+    for(auto& entry: graph.modules()) {
+        if(!entry.getValue().empty() && entry.getKey().starts_with(prefix)) {
+            results.push_back(entry.getKey().str());
         }
     }
     return results;

--- a/src/syntax/completion.h
+++ b/src/syntax/completion.h
@@ -34,9 +34,8 @@ struct PreambleCompletionContext {
 /// Pure text parsing — no compiler state needed.
 PreambleCompletionContext detect_completion_context(llvm::StringRef text, std::uint32_t offset);
 
-/// Return module names matching a prefix, suitable for `import` completion.
-/// @param modules  Module name map (path_id → module name).
-/// @param prefix   Partially-typed module name to match against.
+/// The names of the graph's provided modules that start with `prefix`,
+/// suitable for `import` completion.
 std::vector<std::string> complete_module_import(const DependencyGraph& graph,
                                                 llvm::StringRef prefix);
 

--- a/src/syntax/completion.h
+++ b/src/syntax/completion.h
@@ -11,6 +11,8 @@
 
 namespace clice {
 
+class DependencyGraph;
+
 struct ResolvedSearchConfig;
 struct DirListingCache;
 
@@ -35,7 +37,7 @@ PreambleCompletionContext detect_completion_context(llvm::StringRef text, std::u
 /// Return module names matching a prefix, suitable for `import` completion.
 /// @param modules  Module name map (path_id → module name).
 /// @param prefix   Partially-typed module name to match against.
-std::vector<std::string> complete_module_import(const llvm::DenseMap<Fid, std::string>& modules,
+std::vector<std::string> complete_module_import(const DependencyGraph& graph,
                                                 llvm::StringRef prefix);
 
 /// Entry in the include path completion result.

--- a/src/syntax/dependency_graph.cpp
+++ b/src/syntax/dependency_graph.cpp
@@ -35,6 +35,10 @@ void DependencyGraph::update_module_decl(Fid path_id, llvm::StringRef module_nam
     // by list order, so an erase-and-append would silently reselect
     // among a duplicated name's providers without any cascade.
     if(!module_name.empty() && llvm::is_contained(lookup_module(module_name), path_id)) {
+        // The file may still be listed under a name another configuration
+        // scanned it as; the declaration the save met is the one it
+        // provides now.
+        module_by_path[path_id] = module_name.str();
         return;
     }
     // An emptied name stays behind as an empty provider list — lookup

--- a/src/syntax/dependency_graph.cpp
+++ b/src/syntax/dependency_graph.cpp
@@ -27,6 +27,7 @@ void DependencyGraph::add_module(llvm::StringRef module_name, Fid path_id) {
     if(llvm::find(ids, path_id) == ids.end()) {
         ids.push_back(path_id);
     }
+    module_by_path[path_id] = module_name.str();
 }
 
 void DependencyGraph::update_module_decl(Fid path_id, llvm::StringRef module_name) {
@@ -41,9 +42,15 @@ void DependencyGraph::update_module_decl(Fid path_id, llvm::StringRef module_nam
     for(auto& entry: module_to_path) {
         llvm::erase(entry.getValue(), path_id);
     }
+    module_by_path.erase(path_id);
     if(!module_name.empty()) {
         add_module(module_name, path_id);
     }
+}
+
+llvm::StringRef DependencyGraph::module_of(Fid path_id) const {
+    auto it = module_by_path.find(path_id);
+    return it == module_by_path.end() ? llvm::StringRef() : llvm::StringRef(it->second);
 }
 
 llvm::ArrayRef<Fid> DependencyGraph::lookup_module(llvm::StringRef module_name) const {

--- a/src/syntax/dependency_graph.h
+++ b/src/syntax/dependency_graph.h
@@ -67,6 +67,17 @@ public:
     /// Look up all fids that provide a given module (may have multiple candidates).
     llvm::ArrayRef<Fid> lookup_module(llvm::StringRef module_name) const;
 
+    /// The module a file provides as an interface unit; empty for every
+    /// other file. Borrowed from the graph: copy it before a suspension
+    /// that could re-declare the file.
+    llvm::StringRef module_of(Fid path_id) const;
+
+    /// Whether any file provides a module: the gate the module code
+    /// paths (import scans, PCM planning) pay only once modules exist.
+    bool has_modules() const {
+        return !module_by_path.empty();
+    }
+
     /// Set the direct include list for a (file, config) pair.
     void set_includes(Fid path_id,
                       std::uint32_t config_id,
@@ -138,6 +149,9 @@ public:
 private:
     /// Module name -> fids (multiple candidates possible, e.g. different targets).
     llvm::StringMap<llvm::SmallVector<Fid, 2>> module_to_path;
+
+    /// The inverse of module_to_path, maintained by the same two writers.
+    llvm::DenseMap<Fid, std::string> module_by_path;
 
     /// See set_import_candidate().
     llvm::DenseSet<Fid> import_candidates;

--- a/src/syntax/scan.cpp
+++ b/src/syntax/scan.cpp
@@ -2,6 +2,7 @@
 
 #include <deque>
 
+#include "command/invocation.h"
 #include "syntax/lexer.h"
 
 #include "llvm/ADT/StringSet.h"
@@ -10,7 +11,6 @@
 #include "clang/Basic/FileEntry.h"
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/SourceManager.h"
-#include "clang/Driver/CreateInvocationFromArgs.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendActions.h"
 #include "clang/Lex/PPCallbacks.h"
@@ -291,31 +291,10 @@ std::unique_ptr<clang::CompilerInstance>
                                                                   new clang::IgnoringDiagConsumer(),
                                                                   true);
 
-    std::unique_ptr<clang::CompilerInvocation> invocation;
-
-    bool is_cc1 = arguments.size() >= 2 && llvm::StringRef(arguments[1]) == "-cc1";
-    if(is_cc1) {
-        invocation = std::make_unique<clang::CompilerInvocation>();
-        if(!clang::CompilerInvocation::CreateFromArgs(*invocation,
-                                                      llvm::ArrayRef(arguments).drop_front(2),
-                                                      *diag_engine,
-                                                      arguments[0])) {
-            return nullptr;
-        }
-    } else {
-        clang::CreateInvocationOptions options = {
-            .Diags = diag_engine,
-            .VFS = vfs,
-            .ProbePrecompiled = false,
-        };
-        invocation = clang::createInvocation(arguments, options);
-        if(!invocation) {
-            return nullptr;
-        }
+    auto invocation = create_compiler_invocation(arguments, directory, vfs, diag_engine);
+    if(!invocation) {
+        return nullptr;
     }
-
-    invocation->getFrontendOpts().DisableFree = false;
-    invocation->getFileSystemOpts().WorkingDir = directory.str();
 
     if(content.has_value()) {
         auto& inputs = invocation->getFrontendOpts().Inputs;
@@ -342,6 +321,54 @@ std::unique_ptr<clang::CompilerInstance>
     return instance;
 }
 
+/// The setup every preprocessor-driven scan shares: the instance from the
+/// command, the directives getter — a remapped main file bypasses the
+/// path-keyed cache, or it would read a prior on-disk scan of the same
+/// path and poison it for later ones — the target, and the main file
+/// entered through a preprocess-only action. `body` runs on the entered
+/// preprocessor; the module declaration it reached is read into `result`
+/// before the source file is ended.
+void scan_with_preprocessor(
+    llvm::ArrayRef<const char*> arguments,
+    llvm::StringRef directory,
+    std::optional<llvm::StringRef> content,
+    SharedScanCache* cache,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs,
+    ScanResult& result,
+    llvm::function_ref<void(clang::CompilerInstance&, clang::FrontendAction&)> body) {
+    if(!vfs) {
+        vfs = llvm::vfs::createPhysicalFileSystem();
+    }
+
+    auto instance = create_scan_instance(arguments, directory, content, vfs);
+    if(!instance) {
+        return;
+    }
+
+    auto getter = std::make_unique<ScanDirectivesGetter>(content ? nullptr : cache,
+                                                         instance->getFileManager());
+    instance->setDependencyDirectivesGetter(std::move(getter));
+
+    if(!instance->createTarget()) {
+        return;
+    }
+
+    auto action = std::make_unique<clang::PreprocessOnlyAction>();
+    if(!action->BeginSourceFile(*instance, instance->getFrontendOpts().Inputs[0])) {
+        return;
+    }
+
+    body(*instance, *action);
+
+    auto& pp = instance->getPreprocessor();
+    if(pp.isInNamedModule()) {
+        result.module_name = pp.getNamedModuleName();
+        result.is_interface_unit = pp.isInNamedInterfaceUnit();
+    }
+
+    action->EndSourceFile();
+}
+
 }  // namespace
 
 ScanResult scan_precise(llvm::ArrayRef<const char*> arguments,
@@ -350,47 +377,19 @@ ScanResult scan_precise(llvm::ArrayRef<const char*> arguments,
                         SharedScanCache* cache,
                         llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs) {
     ScanResult result;
-
-    if(!vfs) {
-        vfs = llvm::vfs::createPhysicalFileSystem();
-    }
-
-    auto instance = create_scan_instance(arguments, directory, content, vfs);
-    if(!instance) {
-        return result;
-    }
-
-    // The cache is keyed by path alone; a remapped main file must not read
-    // a prior on-disk scan of the same path nor poison it for later ones.
-    auto getter = std::make_unique<ScanDirectivesGetter>(content ? nullptr : cache,
-                                                         instance->getFileManager());
-    instance->setDependencyDirectivesGetter(std::move(getter));
-
-    if(!instance->createTarget()) {
-        return result;
-    }
-
-    auto action = std::make_unique<clang::PreprocessOnlyAction>();
-
-    if(!action->BeginSourceFile(*instance, instance->getFrontendOpts().Inputs[0])) {
-        return result;
-    }
-
-    instance->getPreprocessor().addPPCallbacks(std::make_unique<PreciseScanPPCallbacks>(result));
-
-    if(auto error = action->Execute()) {
-        llvm::consumeError(std::move(error));
-    }
-
-    action->EndSourceFile();
-
-    // Get module name from preprocessor.
-    auto& pp = instance->getPreprocessor();
-    if(pp.isInNamedModule()) {
-        result.module_name = pp.getNamedModuleName();
-        result.is_interface_unit = pp.isInNamedInterfaceUnit();
-    }
-
+    scan_with_preprocessor(arguments,
+                           directory,
+                           content,
+                           cache,
+                           std::move(vfs),
+                           result,
+                           [&](clang::CompilerInstance& instance, clang::FrontendAction& action) {
+                               instance.getPreprocessor().addPPCallbacks(
+                                   std::make_unique<PreciseScanPPCallbacks>(result));
+                               if(auto error = action.Execute()) {
+                                   llvm::consumeError(std::move(error));
+                               }
+                           });
     return result;
 }
 
@@ -400,48 +399,23 @@ ScanResult scan_module_decl(llvm::ArrayRef<const char*> arguments,
                             SharedScanCache* cache,
                             llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs) {
     ScanResult result;
-
-    if(!vfs) {
-        vfs = llvm::vfs::createPhysicalFileSystem();
-    }
-
-    auto instance = create_scan_instance(arguments, directory, content, vfs);
-    if(!instance) {
-        return result;
-    }
-
-    // See scan_precise: a remapped main file bypasses the path-keyed cache.
-    auto getter = std::make_unique<ScanDirectivesGetter>(content ? nullptr : cache,
-                                                         instance->getFileManager());
-    instance->setDependencyDirectivesGetter(std::move(getter));
-
-    if(!instance->createTarget()) {
-        return result;
-    }
-
-    auto action = std::make_unique<clang::PreprocessOnlyAction>();
-
-    if(!action->BeginSourceFile(*instance, instance->getFrontendOpts().Inputs[0])) {
-        return result;
-    }
-
-    // Instead of action->Execute() which processes the entire file,
-    // manually lex tokens and stop as soon as the module declaration is found.
-    auto& pp = instance->getPreprocessor();
-    pp.EnterMainSourceFile();
-
-    clang::Token tok;
-    do {
-        pp.Lex(tok);
-        if(pp.isInNamedModule()) {
-            result.module_name = pp.getNamedModuleName();
-            result.is_interface_unit = pp.isInNamedInterfaceUnit();
-            break;
-        }
-    } while(tok.isNot(clang::tok::eof));
-
-    action->EndSourceFile();
-
+    scan_with_preprocessor(arguments,
+                           directory,
+                           content,
+                           cache,
+                           std::move(vfs),
+                           result,
+                           [](clang::CompilerInstance& instance, clang::FrontendAction&) {
+                               // Instead of Execute(), which processes the
+                               // entire file, lex and stop as soon as the
+                               // module declaration is found.
+                               auto& pp = instance.getPreprocessor();
+                               pp.EnterMainSourceFile();
+                               clang::Token tok;
+                               do {
+                                   pp.Lex(tok);
+                               } while(!pp.isInNamedModule() && tok.isNot(clang::tok::eof));
+                           });
     return result;
 }
 

--- a/src/syntax/scan.cpp
+++ b/src/syntax/scan.cpp
@@ -278,51 +278,8 @@ private:
     int conditional_depth = 0;
 };
 
-/// Create and configure a CompilerInstance for scanning.
-/// An engaged content remaps the main file to it, even when empty.
-std::unique_ptr<clang::CompilerInstance>
-    create_scan_instance(llvm::ArrayRef<const char*> arguments,
-                         llvm::StringRef directory,
-                         std::optional<llvm::StringRef> content,
-                         llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs) {
-    clang::DiagnosticOptions diag_opts;
-    auto diag_engine = clang::CompilerInstance::createDiagnostics(*vfs,
-                                                                  diag_opts,
-                                                                  new clang::IgnoringDiagConsumer(),
-                                                                  true);
-
-    auto invocation = create_compiler_invocation(arguments, directory, vfs, diag_engine);
-    if(!invocation) {
-        return nullptr;
-    }
-
-    if(content.has_value()) {
-        auto& inputs = invocation->getFrontendOpts().Inputs;
-        if(!inputs.empty()) {
-            auto main_file = inputs[0].getFile();
-            // Use an overlay VFS to inject the remapped content. This ensures
-            // both the preprocessor and the DependencyDirectivesGetter see it.
-            auto overlay = llvm::makeIntrusiveRefCnt<llvm::vfs::OverlayFileSystem>(vfs);
-            auto mem_fs = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
-            mem_fs->addFile(main_file,
-                            0,
-                            llvm::MemoryBuffer::getMemBufferCopy(*content, main_file));
-            overlay->pushOverlay(std::move(mem_fs));
-            vfs = std::move(overlay);
-        }
-    }
-
-    auto instance = std::make_unique<clang::CompilerInstance>(std::move(invocation));
-    instance->setVirtualFileSystem(std::move(vfs));
-    instance->createDiagnostics(new clang::IgnoringDiagConsumer(), true);
-    instance->getDiagnostics().setSuppressAllDiagnostics(true);
-    instance->createFileManager();
-
-    return instance;
-}
-
 /// The setup every preprocessor-driven scan shares: the instance from the
-/// command, the directives getter — a remapped main file bypasses the
+/// command (diagnostics ignored), the directives getter — a remapped main file bypasses the
 /// path-keyed cache, or it would read a prior on-disk scan of the same
 /// path and poison it for later ones — the target, and the main file
 /// entered through a preprocess-only action. `body` runs on the entered
@@ -340,10 +297,37 @@ void scan_with_preprocessor(
         vfs = llvm::vfs::createPhysicalFileSystem();
     }
 
-    auto instance = create_scan_instance(arguments, directory, content, vfs);
-    if(!instance) {
+    clang::DiagnosticOptions diag_opts;
+    auto diag_engine = clang::CompilerInstance::createDiagnostics(*vfs,
+                                                                  diag_opts,
+                                                                  new clang::IgnoringDiagConsumer(),
+                                                                  true);
+    auto invocation = create_compiler_invocation(arguments, directory, vfs, diag_engine);
+    if(!invocation) {
         return;
     }
+
+    // An engaged content remaps the main file to it, even when empty: an
+    // overlay VFS, so both the preprocessor and the directives getter see it.
+    if(content.has_value()) {
+        auto& inputs = invocation->getFrontendOpts().Inputs;
+        if(!inputs.empty()) {
+            auto main_file = inputs[0].getFile();
+            auto overlay = llvm::makeIntrusiveRefCnt<llvm::vfs::OverlayFileSystem>(vfs);
+            auto mem_fs = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+            mem_fs->addFile(main_file,
+                            0,
+                            llvm::MemoryBuffer::getMemBufferCopy(*content, main_file));
+            overlay->pushOverlay(std::move(mem_fs));
+            vfs = std::move(overlay);
+        }
+    }
+
+    auto instance = std::make_unique<clang::CompilerInstance>(std::move(invocation));
+    instance->setVirtualFileSystem(std::move(vfs));
+    instance->createDiagnostics(new clang::IgnoringDiagConsumer(), true);
+    instance->getDiagnostics().setSuppressAllDiagnostics(true);
+    instance->createFileManager();
 
     auto getter = std::make_unique<ScanDirectivesGetter>(content ? nullptr : cache,
                                                          instance->getFileManager());

--- a/src/worker/stateless.cpp
+++ b/src/worker/stateless.cpp
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <cstdlib>
+#include <expected>
 #include <format>
 #include <optional>
 
@@ -88,6 +89,52 @@ static std::optional<std::string> write_preamble_envelope(llvm::StringRef blob,
     return std::nullopt;
 }
 
+/// Where an artifact build writes: the master's tmp path when it provided
+/// one (already allocated by its CacheStore — the master commits with
+/// fsync + atomic rename after we report success), else a temporary file
+/// of our own.
+static std::expected<std::string, std::string> artifact_output(llvm::StringRef label,
+                                                               llvm::StringRef output_path,
+                                                               llvm::StringRef prefix,
+                                                               llvm::StringRef extension) {
+    if(!output_path.empty()) {
+        return output_path.str();
+    }
+    auto tmp = fs::createTemporaryFile(prefix, extension);
+    if(!tmp) {
+        LOG_ERROR("Build{}: failed to create temp file", label);
+        return std::unexpected(std::format("Failed to create temporary {} file", label));
+    }
+    return *tmp;
+}
+
+/// The reply of a finished artifact build. Success hands the master the
+/// path to commit and the build's inputs; failure removes the half-written
+/// file and classifies the errors — `internal_error` marks a failure of
+/// the worker's own I/O, never the user's code, and must not be downgraded
+/// to an expected build failure.
+static worker::ArtifactBuildResult land_artifact(llvm::StringRef label,
+                                                 bool success,
+                                                 const std::string& tmp_path,
+                                                 std::int64_t build_at,
+                                                 const auto& deps,
+                                                 std::string errors,
+                                                 bool internal_error) {
+    worker::ArtifactBuildResult result;
+    if(success) {
+        result.success = true;
+        result.output_path = tmp_path;
+        result.build_at = build_at;
+        result.deps = deps;
+        return result;
+    }
+    fs::remove(tmp_path);
+    result.success = false;
+    result.has_user_errors = !internal_error && !errors.empty();
+    result.error = errors.empty() ? std::format("{} compilation failed", label) : std::move(errors);
+    return result;
+}
+
 static worker::ArtifactBuildResult handle_build_pch(const worker::BuildPCHParams& params,
                                                     const std::shared_ptr<std::atomic_bool>& stop) {
     ScopedTimer timer;
@@ -98,21 +145,11 @@ static worker::ArtifactBuildResult handle_build_pch(const worker::BuildPCHParams
     cp.add_remapped_file(params.file, params.content, params.preamble_bound);
     cp.stop = stop;
 
-    // When the master provides an output path it is already a tmp path
-    // allocated by its CacheStore: write directly, the master commits
-    // (fsync + atomic rename) after we report success.
-    std::string tmp_path;
-    if(!params.output_path.empty()) {
-        tmp_path = params.output_path;
-    } else {
-        auto tmp = fs::createTemporaryFile("clice-pch", "pch");
-        if(!tmp) {
-            LOG_ERROR("BuildPCH: failed to create temp file");
-            return {false, "Failed to create temporary PCH file"};
-        }
-        tmp_path = *tmp;
+    auto output = artifact_output("PCH", params.output_path, "clice-pch", "pch");
+    if(!output) {
+        return {false, output.error()};
     }
-    cp.output_file = tmp_path;
+    cp.output_file = *output;
 
     PCHInfo pch_info;
     ScopedTimer compile_timer;
@@ -144,9 +181,7 @@ static worker::ArtifactBuildResult handle_build_pch(const worker::BuildPCHParams
     // restart adoption validates a pair by "aux not older than primary"
     // (renames preserve mtimes), so the on-disk order must match the
     // logical one. The PCH is only served together with its blob, so a
-    // blob write failure fails the whole build. It is an internal I/O
-    // failure, never a user-code problem — must not be downgraded to an
-    // expected build failure.
+    // blob write failure fails the whole build.
     bool internal_error = false;
     ScopedTimer state_write_timer;
     if(success) {
@@ -163,27 +198,22 @@ static worker::ArtifactBuildResult handle_build_pch(const worker::BuildPCHParams
                  "kind=pch file={} output={} compile_ms={} preamble_index_ms={} flush_ms={} "
                  "state_write_ms={} total_ms={}",
                  params.file,
-                 tmp_path,
+                 *output,
                  compile_ms,
                  index_ms,
                  flush_ms,
                  state_write_ms,
                  timer.ms());
-        worker::ArtifactBuildResult result;
-        result.success = true;
-        result.output_path = tmp_path;
-        result.build_at = build_at;
-        result.deps = pch_info.deps;
-        return result;
     } else {
         LOG_WARN("BuildPCH failed: file={}, {}ms, errors=[{}]", params.file, timer.ms(), errors);
-        fs::remove(tmp_path);
-        worker::ArtifactBuildResult result;
-        result.success = false;
-        result.error = errors.empty() ? "PCH compilation failed" : errors;
-        result.has_user_errors = !internal_error && !errors.empty();
-        return result;
     }
+    return land_artifact("PCH",
+                         success,
+                         *output,
+                         build_at,
+                         pch_info.deps,
+                         std::move(errors),
+                         internal_error);
 }
 
 static worker::ArtifactBuildResult handle_build_pcm(const worker::BuildPCMParams& params,
@@ -198,19 +228,11 @@ static worker::ArtifactBuildResult handle_build_pcm(const worker::BuildPCMParams
     }
     cp.stop = stop;
 
-    // See handle_build_pch: a provided output path is the master's tmp path.
-    std::string tmp_path;
-    if(!params.output_path.empty()) {
-        tmp_path = params.output_path;
-    } else {
-        auto tmp = fs::createTemporaryFile("clice-pcm", "pcm");
-        if(!tmp) {
-            LOG_ERROR("BuildPCM: failed to create temp file");
-            return {false, "Failed to create temporary PCM file"};
-        }
-        tmp_path = *tmp;
+    auto output = artifact_output("PCM", params.output_path, "clice-pcm", "pcm");
+    if(!output) {
+        return {false, output.error()};
     }
-    cp.output_file = tmp_path;
+    cp.output_file = *output;
 
     PCMInfo pcm_info;
     ScopedTimer compile_timer;
@@ -238,24 +260,19 @@ static worker::ArtifactBuildResult handle_build_pcm(const worker::BuildPCMParams
                  compile_ms,
                  flush_ms,
                  timer.ms());
-        worker::ArtifactBuildResult result;
-        result.success = true;
-        result.output_path = tmp_path;
-        result.build_at = build_at;
-        result.deps = pcm_info.deps;
-        return result;
     } else {
         LOG_WARN("BuildPCM failed: module={}, {}ms, errors=[{}]",
                  params.module_name,
                  timer.ms(),
                  errors);
-        fs::remove(tmp_path);
-        worker::ArtifactBuildResult result;
-        result.success = false;
-        result.error = errors.empty() ? "PCM compilation failed" : errors;
-        result.has_user_errors = !errors.empty();
-        return result;
     }
+    return land_artifact("PCM",
+                         success,
+                         *output,
+                         build_at,
+                         pcm_info.deps,
+                         std::move(errors),
+                         /*internal_error=*/false);
 }
 
 /// Collect the tidy pass's findings with real per-file locations: unlike

--- a/tests/integration/compilation/persistent_cache.test.ts
+++ b/tests/integration/compilation/persistent_cache.test.ts
@@ -606,18 +606,27 @@ test("cache wiped while running", async ({ session }) => {
 /// removed at startup, so its files cannot be navigated into through the
 /// metadata that still names them; the store's own namespace is untouched.
 test("legacy header_context directory removed", async ({ session }) => {
-    const { client, workspace } = session.tmp();
+    const workspace = session.tmpdir();
     workspace.pinCacheDir();
+    workspace.write("main.cpp", "int main() { return 0; }\n");
+    workspace.writeCDB(["main.cpp"]);
+    // A first session opens the store: only then is its namespace
+    // directory known, the version being the server's to choose.
+    const c1 = session.spawn(workspace);
+    await c1.initialize(workspace);
+    await c1.openAndWait("main.cpp");
+    await c1.shutdown();
+
     const legacy = workspace.path(path.join(".clice", "header_context"));
     fs.mkdirSync(legacy, { recursive: true });
     fs.writeFileSync(path.join(legacy, "0123456789abcdef.h"), "// stale prefix\n");
     const kept = path.join(workspace.headerContextDir(), "fedcba9876543210.h");
     fs.mkdirSync(workspace.headerContextDir(), { recursive: true });
     fs.writeFileSync(kept, "// store prefix\n");
-    workspace.write("main.cpp", "int main() { return 0; }\n");
-    workspace.writeCDB(["main.cpp"]);
-    await client.initialize(workspace);
-    await client.openAndWait("main.cpp");
+
+    const c2 = session.spawn(workspace);
+    await c2.initialize(workspace);
+    await c2.openAndWait("main.cpp");
 
     expect(fs.existsSync(legacy)).toBe(false);
     expect(workspace.headerContextFiles()).toEqual([kept]);

--- a/tests/tools/client.test.ts
+++ b/tests/tools/client.test.ts
@@ -1,0 +1,35 @@
+/// Tests for the test client's initialization overlay (tools/client/client.ts).
+
+import * as path from "node:path";
+import { expect, test } from "vitest";
+import { initializationOptionsFor } from "@clice/tools/client";
+import { Workspace } from "@clice/tools/workspace";
+
+const ws = new Workspace(path.join(path.sep, "ws"));
+
+test("defaults overlay the caller's options", () => {
+    const options = initializationOptionsFor(ws, {
+        initializationOptions: { project: { stateful_worker_count: 3 }, tracker: {} },
+    });
+    expect(options).toEqual({
+        project: {
+            cache_dir: ws.path(".clice"),
+            stateful_worker_count: 3,
+            stateless_worker_count: 1,
+        },
+        tracker: { cdb_poll_seconds: 0, workspace_poll_seconds: 0 },
+    });
+});
+
+test("without test defaults only the cache is pinned", () => {
+    // A benchmark runs the server's real defaults: nothing but the cache
+    // location is added, so the defaults stay spelled in the C++ config.
+    const options = initializationOptionsFor(ws, {
+        initializationOptions: { project: { compile_commands_paths: ["/cdb"] } },
+        testDefaults: false,
+    });
+    expect(options).toEqual({
+        project: { cache_dir: ws.path(".clice"), compile_commands_paths: ["/cdb"] },
+        tracker: {},
+    });
+});

--- a/tests/tools/workspace.test.ts
+++ b/tests/tools/workspace.test.ts
@@ -1,7 +1,10 @@
 /// Tests for workspace helpers (tools/client/workspace.ts).
 
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { expect, test } from "vitest";
-import { canonicalUri } from "@clice/tools/workspace";
+import { Workspace, canonicalUri } from "@clice/tools/workspace";
 
 test("canonical uri edges", () => {
     // The identity canonicalizer must be a faithful percent-decode:
@@ -16,4 +19,27 @@ test("canonical uri edges", () => {
     // The two drive-colon spellings — client-encoded and server-literal —
     // collapse to one identity.
     expect(canonicalUri("file:///c%3A/x.h")).toBe(canonicalUri("file:///c:/x.h"));
+});
+
+test("cache root follows the store's version directory", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "clice-ws-"));
+    try {
+        const ws = new Workspace(root);
+        // No store yet: the blob helpers see empty namespaces, while a
+        // caller that needs the root itself is told there is none.
+        expect(ws.pchFiles()).toEqual([]);
+        expect(ws.tmpFiles()).toEqual([]);
+        expect(() => ws.cacheRoot()).toThrow(/found \[\]/);
+
+        fs.mkdirSync(path.join(root, ".clice", "cache", "v9", "pch"), { recursive: true });
+        fs.writeFileSync(path.join(root, ".clice", "cache", "v9", "pch", "k.pch"), "");
+        expect(ws.cacheRoot()).toBe(path.join(root, ".clice", "cache", "v9"));
+        expect(ws.pchFiles()).toEqual([path.join(root, ".clice", "cache", "v9", "pch", "k.pch")]);
+
+        // Two versions side by side would let a test read the wrong one.
+        fs.mkdirSync(path.join(root, ".clice", "cache", "v10"));
+        expect(() => ws.cacheRoot()).toThrow(/found \[v10, v9\]|found \[v9, v10\]/);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
 });

--- a/tests/tools/workspace.test.ts
+++ b/tests/tools/workspace.test.ts
@@ -36,6 +36,11 @@ test("cache root follows the store's version directory", () => {
         expect(ws.cacheRoot()).toBe(path.join(root, ".clice", "cache", "v9"));
         expect(ws.pchFiles()).toEqual([path.join(root, ".clice", "cache", "v9", "pch", "k.pch")]);
 
+        // Only directories are stores: a stray file spelled like a version
+        // neither becomes the root nor counts as a second one.
+        fs.writeFileSync(path.join(root, ".clice", "cache", "v8"), "");
+        expect(ws.cacheRoot()).toBe(path.join(root, ".clice", "cache", "v9"));
+
         // Two versions side by side would let a test read the wrong one.
         fs.mkdirSync(path.join(root, ".clice", "cache", "v10"));
         expect(() => ws.cacheRoot()).toThrow(/found \[v10, v9\]|found \[v9, v10\]/);

--- a/tests/unit/sched/graph_tests.cpp
+++ b/tests/unit/sched/graph_tests.cpp
@@ -11,8 +11,8 @@ namespace {
 namespace ranges = std::ranges;
 
 /// Two arbitrary families exercising the multi-family surface.
-constexpr std::uint8_t FamA = 1;
-constexpr std::uint8_t FamB = 2;
+constexpr Family FamA = Family{1};
+constexpr Family FamB = Family{2};
 
 NodeId a(std::uint64_t key) {
     return {FamA, key};

--- a/tests/unit/sched/pcm_graph_integration_tests.cpp
+++ b/tests/unit/sched/pcm_graph_integration_tests.cpp
@@ -15,7 +15,7 @@ namespace {
 using DispatchFn = std::function<kota::task<RoundOutcome>(std::uint32_t path_id, bool foreground)>;
 using ResolveFn = std::function<llvm::SmallVector<std::uint32_t>(std::uint32_t path_id)>;
 
-constexpr std::uint8_t test_family = 1;
+constexpr Family test_family = Family{1};
 
 NodeId nid(std::uint32_t path_id) {
     return {test_family, path_id};

--- a/tests/unit/server/ast_family_tests.cpp
+++ b/tests/unit/server/ast_family_tests.cpp
@@ -61,7 +61,7 @@ struct Stack {
     }
 
     bool is_compiling(Fid path_id) const {
-        return graph.is_compiling({ast_family, path_id.raw});
+        return graph.is_compiling({Family::AST, path_id.raw});
     }
 
     void register_pch_store(TempDir& tmp) {
@@ -428,7 +428,6 @@ TEST_CASE(BufferImportBuildsPCM) {
     }));
     scan_dependency_graph(stack.workspace.cdb, stack.workspace.dep_graph);
     stack.workspace.dep_graph.build_reverse_map();
-    stack.workspace.build_module_map();
 
     auto store = CacheStore::open(tmp.path("root"), 1);
     ASSERT_TRUE(store.has_value());
@@ -508,7 +507,7 @@ TEST_CASE(BufferImportRecorded) {
     // The sentinel edge survives the landing: a first provider's update
     // must reach this document's node.
     auto dirtied = stack.graph.update(PCMFamily::unresolved_node("m"));
-    EXPECT_TRUE(std::ranges::find(dirtied, NodeId{ast_family, session->path_id.raw}) !=
+    EXPECT_TRUE(std::ranges::find(dirtied, NodeId{Family::AST, session->path_id.raw}) !=
                 dirtied.end());
 
     logging::reset_anomaly_for_testing();
@@ -554,7 +553,7 @@ TEST_CASE(IncludeImportRecorded) {
     EXPECT_TRUE(done);
 
     auto dirtied = stack.graph.update(PCMFamily::unresolved_node("m"));
-    EXPECT_TRUE(std::ranges::find(dirtied, NodeId{ast_family, session->path_id.raw}) !=
+    EXPECT_TRUE(std::ranges::find(dirtied, NodeId{Family::AST, session->path_id.raw}) !=
                 dirtied.end());
 
     logging::reset_anomaly_for_testing();

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -3227,7 +3227,6 @@ TEST_CASE(ModuleLintScanParity) {
     }));
     scan_dependency_graph(f.workspace.cdb, f.workspace.dep_graph);
     f.workspace.dep_graph.build_reverse_map();
-    f.workspace.build_module_map();
 
     auto store = CacheStore::open(tmp.path("root"), 1);
     ASSERT_TRUE(store.has_value());

--- a/tests/unit/server/invalidator_tests.cpp
+++ b/tests/unit/server/invalidator_tests.cpp
@@ -86,8 +86,8 @@ TEST_CASE(NewProviderDirtiesImporters) {
 
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
-    ph.graph.declare({turun_family, closed.raw}, {PCMFamily::unresolved_node("m")});
-    ph.graph.declare({ast_family, open.raw}, {PCMFamily::unresolved_node("m")});
+    ph.graph.declare({Family::TURun, closed.raw}, {PCMFamily::unresolved_node("m")});
+    ph.graph.declare({Family::AST, open.raw}, {PCMFamily::unresolved_node("m")});
     Invalidator invalidator(workspace, store, resolver, ph.pcm);
 
     FileEvent events[] = {FileEvent::disk_changed(iface)};
@@ -124,7 +124,7 @@ TEST_CASE(ReloadProviderCascades) {
 
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
-    ph.graph.declare({turun_family, retired.raw}, {PCMFamily::unresolved_node("m")});
+    ph.graph.declare({Family::TURun, retired.raw}, {PCMFamily::unresolved_node("m")});
     Invalidator invalidator(workspace, store, resolver, ph.pcm);
 
     FileEvent::CDBDelta delta;
@@ -145,7 +145,7 @@ TEST_CASE(DiskRemovedDropsProvider) {
     SessionStore store;
     auto iface = workspace.file_table.intern("/proj/m.cppm");
     workspace.dep_graph.add_module("m", iface);
-    workspace.path_to_module[iface] = "m";
+
 
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
@@ -211,7 +211,7 @@ TEST_CASE(CascadeSplitsOpenClosed) {
     PCMHarness ph(workspace, resolver);
     // The consumer edges build_deps declares in production — no rounds.
     auto node = [](Fid pid) {
-        return NodeId{pcm_family, pid.raw};
+        return NodeId{Family::PCM, pid.raw};
     };
     ph.graph.declare(node(open_user), {node(mod)});
     ph.graph.declare(node(closed_user), {node(mod)});
@@ -415,10 +415,10 @@ TEST_CASE(CloseStaleModuleCascades) {
     PCMHarness ph(workspace, resolver);
     ph.graph.declare(
         {
-            turun_family,
+            Family::TURun,
             user.raw
     },
-        {{pcm_family, mod.raw}});
+        {{Family::PCM, mod.raw}});
     Invalidator invalidator(workspace, store, resolver, ph.pcm);
     auto dirty = invalidator.apply(FileEvent::buffer_closed(mod));
 
@@ -506,7 +506,7 @@ TEST_CASE(CloseFirstProviderCascades) {
 
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
-    ph.graph.declare({turun_family, importer.raw}, {PCMFamily::unresolved_node("m")});
+    ph.graph.declare({Family::TURun, importer.raw}, {PCMFamily::unresolved_node("m")});
     Invalidator invalidator(workspace, store, resolver, ph.pcm);
 
     auto dirty = invalidator.apply(FileEvent::buffer_closed(iface));
@@ -526,7 +526,6 @@ TEST_CASE(CloseProviderRenameCascades) {
     SessionStore store;
     auto iface = workspace.file_table.intern(tmp.path("m.cppm"));
     auto importer = workspace.file_table.intern("/proj/use.cpp");
-    workspace.path_to_module[iface] = "a";
     workspace.dep_graph.update_module_decl(iface, "a");
 
     auto disk = llvm::MemoryBuffer::getFile(tmp.path("m.cppm"));
@@ -536,10 +535,10 @@ TEST_CASE(CloseProviderRenameCascades) {
     PCMHarness ph(workspace, resolver);
     ph.graph.declare(
         {
-            turun_family,
+            Family::TURun,
             importer.raw
     },
-        {{pcm_family, iface.raw}});
+        {{Family::PCM, iface.raw}});
     Invalidator invalidator(workspace, store, resolver, ph.pcm);
 
     auto dirty = invalidator.apply(FileEvent::buffer_closed(iface));
@@ -557,7 +556,6 @@ TEST_CASE(CloseKeepsGuardedProvider) {
     Workspace workspace;
     SessionStore store;
     auto iface = workspace.file_table.intern(tmp.path("m.cpp"));
-    workspace.path_to_module[iface] = "m";
     workspace.dep_graph.update_module_decl(iface, "m");
 
     auto disk = llvm::MemoryBuffer::getFile(tmp.path("m.cpp"));
@@ -569,7 +567,7 @@ TEST_CASE(CloseKeepsGuardedProvider) {
 
     invalidator.apply(FileEvent::buffer_closed(iface));
 
-    EXPECT_EQ(workspace.path_to_module.lookup(iface), "m");
+    EXPECT_EQ(workspace.dep_graph.module_of(iface), "m");
     EXPECT_TRUE(llvm::is_contained(workspace.dep_graph.lookup_module("m"), iface));
 }
 
@@ -597,10 +595,10 @@ TEST_CASE(CloseStalePCMCascades) {
     PCMHarness ph(workspace, resolver);
     ph.graph.declare(
         {
-            turun_family,
+            Family::TURun,
             user.raw
     },
-        {{pcm_family, mod.raw}});
+        {{Family::PCM, mod.raw}});
     Invalidator invalidator(workspace, store, resolver, ph.pcm);
     auto dirty = invalidator.apply(FileEvent::buffer_closed(mod));
 
@@ -1012,7 +1010,7 @@ TEST_CASE(CDBChangedCascadesModule) {
     PCMHarness ph(workspace, resolver);
     // The consumer edges build_deps declares in production — no rounds.
     auto node = [](Fid pid) {
-        return NodeId{pcm_family, pid.raw};
+        return NodeId{Family::PCM, pid.raw};
     };
     ph.graph.declare(node(open_user), {node(mod)});
     ph.graph.declare(node(closed_user), {node(mod)});

--- a/tests/unit/server/invalidator_tests.cpp
+++ b/tests/unit/server/invalidator_tests.cpp
@@ -146,7 +146,6 @@ TEST_CASE(DiskRemovedDropsProvider) {
     auto iface = workspace.file_table.intern("/proj/m.cppm");
     workspace.dep_graph.add_module("m", iface);
 
-
     ContextResolver resolver(workspace);
     PCMHarness ph(workspace, resolver);
     Invalidator invalidator(workspace, store, resolver, ph.pcm);

--- a/tests/unit/server/query_freshness_tests.cpp
+++ b/tests/unit/server/query_freshness_tests.cpp
@@ -136,8 +136,8 @@ TEST_CASE(PendingGateSplitsRows) {
     ASSERT_TRUE(std::ranges::contains(reference_files(hash), "main.cpp"));
 
     // Line-based resolution in the file works while its rows are current.
-    agentic::ReadSymbolParams by_line;
-    by_line.path = std::string(workspace.file_table.resolve(main_id));
+    SymbolLocator by_line;
+    by_line.path = workspace.file_table.resolve(main_id);
     by_line.line = 3;
     ASSERT_FALSE(agent_query.locate(by_line).empty());
 

--- a/tests/unit/syntax/completion_tests.cpp
+++ b/tests/unit/syntax/completion_tests.cpp
@@ -1,5 +1,6 @@
 #include "test/test.h"
 #include "syntax/completion.h"
+#include "syntax/dependency_graph.h"
 
 #include "llvm/ADT/DenseMap.h"
 
@@ -146,11 +147,11 @@ TEST_CASE(ImportCursorMidLine) {
 TEST_SUITE(CompleteModuleImport) {
 
 TEST_CASE(PrefixMatch) {
-    llvm::DenseMap<Fid, std::string> modules;
-    modules[Fid{1}] = "std";
-    modules[Fid{2}] = "std.io";
-    modules[Fid{3}] = "std.net";
-    modules[Fid{4}] = "my_lib";
+    clice::DependencyGraph modules;
+    modules.add_module("std", Fid{1});
+    modules.add_module("std.io", Fid{2});
+    modules.add_module("std.net", Fid{3});
+    modules.add_module("my_lib", Fid{4});
 
     auto results = complete_module_import(modules, "std");
     EXPECT_EQ(results.size(), 3u);
@@ -160,35 +161,35 @@ TEST_CASE(PrefixMatch) {
 }
 
 TEST_CASE(EmptyPrefix) {
-    llvm::DenseMap<Fid, std::string> modules;
-    modules[Fid{1}] = "std";
-    modules[Fid{2}] = "my_lib";
+    clice::DependencyGraph modules;
+    modules.add_module("std", Fid{1});
+    modules.add_module("my_lib", Fid{2});
 
     auto results = complete_module_import(modules, "");
     EXPECT_EQ(results.size(), 2u);
 }
 
 TEST_CASE(NoMatch) {
-    llvm::DenseMap<Fid, std::string> modules;
-    modules[Fid{1}] = "std";
-    modules[Fid{2}] = "my_lib";
+    clice::DependencyGraph modules;
+    modules.add_module("std", Fid{1});
+    modules.add_module("my_lib", Fid{2});
 
     auto results = complete_module_import(modules, "xyz");
     EXPECT_TRUE(results.empty());
 }
 
 TEST_CASE(EmptyModules) {
-    llvm::DenseMap<Fid, std::string> modules;
+    clice::DependencyGraph modules;
     auto results = complete_module_import(modules, "std");
     EXPECT_TRUE(results.empty());
 }
 
 TEST_CASE(DottedPrefix) {
-    llvm::DenseMap<Fid, std::string> modules;
-    modules[Fid{1}] = "std";
-    modules[Fid{2}] = "std.io";
-    modules[Fid{3}] = "std.core";
-    modules[Fid{4}] = "boost.asio";
+    clice::DependencyGraph modules;
+    modules.add_module("std", Fid{1});
+    modules.add_module("std.io", Fid{2});
+    modules.add_module("std.core", Fid{3});
+    modules.add_module("boost.asio", Fid{4});
 
     auto results = complete_module_import(modules, "std.");
     EXPECT_EQ(results.size(), 2u);
@@ -198,11 +199,11 @@ TEST_CASE(DottedPrefix) {
 }
 
 TEST_CASE(PartitionPrefix) {
-    llvm::DenseMap<Fid, std::string> modules;
-    modules[Fid{1}] = "foo";
-    modules[Fid{2}] = "foo:core";
-    modules[Fid{3}] = "foo:utils";
-    modules[Fid{4}] = "bar:impl";
+    clice::DependencyGraph modules;
+    modules.add_module("foo", Fid{1});
+    modules.add_module("foo:core", Fid{2});
+    modules.add_module("foo:utils", Fid{3});
+    modules.add_module("bar:impl", Fid{4});
 
     auto results = complete_module_import(modules, "foo:");
     EXPECT_EQ(results.size(), 2u);
@@ -212,9 +213,9 @@ TEST_CASE(PartitionPrefix) {
 }
 
 TEST_CASE(PrefixIsFullName) {
-    llvm::DenseMap<Fid, std::string> modules;
-    modules[Fid{1}] = "std";
-    modules[Fid{2}] = "std.io";
+    clice::DependencyGraph modules;
+    modules.add_module("std", Fid{1});
+    modules.add_module("std.io", Fid{2});
 
     auto results = complete_module_import(modules, "std");
     EXPECT_EQ(results.size(), 2u);

--- a/tests/unit/syntax/dependency_graph_tests.cpp
+++ b/tests/unit/syntax/dependency_graph_tests.cpp
@@ -5,6 +5,8 @@
 #include "syntax/dependency_graph.h"
 #include "vfs/file_table.h"
 
+#include "llvm/ADT/STLExtras.h"
+
 namespace clice::testing {
 namespace {
 
@@ -84,6 +86,22 @@ TEST_CASE(ModuleOfFollowsDeclarations) {
     EXPECT_TRUE(graph.module_of(Fid{1}).empty());
     EXPECT_FALSE(graph.has_modules());
     EXPECT_TRUE(graph.lookup_module("bar").empty());
+}
+
+TEST_CASE(ModuleOfFollowsRedeclaredName) {
+    // A file scanned under two configurations can be listed under two
+    // names (a macro picks the declaration). Re-declaring one of them
+    // keeps both provider lists untouched — no reselection — but the
+    // file's own declaration is the one the save met.
+    clice::DependencyGraph graph;
+    graph.add_module("a", Fid{1});
+    graph.add_module("b", Fid{1});
+    EXPECT_EQ(graph.module_of(Fid{1}), "b");
+
+    graph.update_module_decl(Fid{1}, "a");
+    EXPECT_EQ(graph.module_of(Fid{1}), "a");
+    EXPECT_TRUE(llvm::is_contained(graph.lookup_module("a"), Fid{1}));
+    EXPECT_TRUE(llvm::is_contained(graph.lookup_module("b"), Fid{1}));
 }
 
 TEST_CASE(MultipleModules) {

--- a/tests/unit/syntax/dependency_graph_tests.cpp
+++ b/tests/unit/syntax/dependency_graph_tests.cpp
@@ -63,6 +63,29 @@ TEST_CASE(RedeclareKeepsProviderOrder) {
     ASSERT_EQ(graph.lookup_module("bar").size(), 1u);
 }
 
+TEST_CASE(ModuleOfFollowsDeclarations) {
+    clice::DependencyGraph graph;
+    EXPECT_FALSE(graph.has_modules());
+    EXPECT_TRUE(graph.module_of(Fid{1}).empty());
+
+    graph.add_module("foo", Fid{1});
+    EXPECT_TRUE(graph.has_modules());
+    EXPECT_EQ(graph.module_of(Fid{1}), "foo");
+
+    // A re-declaration moves the file: the old name loses it, the
+    // reverse view follows in the same write.
+    graph.update_module_decl(Fid{1}, "bar");
+    EXPECT_EQ(graph.module_of(Fid{1}), "bar");
+    EXPECT_TRUE(graph.lookup_module("foo").empty());
+
+    // Dropping the declaration leaves the name behind as an empty
+    // provider list, yet the file declares nothing and no module remains.
+    graph.update_module_decl(Fid{1}, {});
+    EXPECT_TRUE(graph.module_of(Fid{1}).empty());
+    EXPECT_FALSE(graph.has_modules());
+    EXPECT_TRUE(graph.lookup_module("bar").empty());
+}
+
 TEST_CASE(MultipleModules) {
     clice::DependencyGraph graph;
     graph.add_module("mod.a", Fid{1});

--- a/tests/unit/syntax/scan_tests.cpp
+++ b/tests/unit/syntax/scan_tests.cpp
@@ -227,6 +227,32 @@ TEST_CASE(PreciseWithContent) {
     EXPECT_FALSE(result.includes[0].not_found);
 }
 
+TEST_CASE(PreciseHonorsWorkingDirectory) {
+    // The scan interprets the command like the compile does: an explicit
+    // -working-directory wins over the entry's directory, and a relative
+    // one resolves from it — else a header the compile finds through a
+    // relative search path scans as missing and never enters the graph.
+    auto vfs = llvm::makeIntrusiveRefCnt<TestVFS>();
+    auto main_path = TestVFS::path("main.cpp");
+    vfs->add("main.cpp", R"(#include "x.h")");
+    vfs->add("other/rel/x.h");
+
+    auto absolute = "-working-directory=" + TestVFS::path("other");
+    auto args = std::vector<const char*>{"clang++",
+                                         "-std=c++20",
+                                         absolute.c_str(),
+                                         "-Irel",
+                                         main_path.c_str()};
+    auto result = scan_precise(args, TestVFS::root(), {}, nullptr, vfs);
+    ASSERT_EQ(result.includes.size(), 1u);
+    EXPECT_FALSE(result.includes[0].not_found);
+
+    args[2] = "-working-directory=other";
+    result = scan_precise(args, TestVFS::root(), {}, nullptr, vfs);
+    ASSERT_EQ(result.includes.size(), 1u);
+    EXPECT_FALSE(result.includes[0].not_found);
+}
+
 TEST_CASE(RemapBypassesSharedCache) {
     auto vfs = llvm::makeIntrusiveRefCnt<TestVFS>();
     auto main_path = TestVFS::path("main.cpp");

--- a/tools/bench/bench.ts
+++ b/tools/bench/bench.ts
@@ -347,11 +347,9 @@ function serverArgs(opts: Options): string[] {
         : ["--background-index", `--compile-commands-dir=${opts.cdbDir}`];
 }
 
-/// CliceClient.initialize defaults worker counts to 1 and zeroes the
-/// tracker polling loops for cheap deterministic tests; a benchmark must
-/// run the server's real defaults (stateful 2, stateless cores/2, tracker
-/// 3s/30s, from src/server/state/config.h) including the background
-/// activity those loops generate.
+/// Only what the comparison must pin; everything else runs at the
+/// server's real defaults (see startServer), including the background
+/// activity the tracker's polling loops generate.
 function initializationOptions(opts: Options): Record<string, unknown> {
     return {
         project: {
@@ -364,14 +362,6 @@ function initializationOptions(opts: Options): Record<string, unknown> {
             // <workspace>/.clice/logs); a clice.toml logging_dir would
             // otherwise send the worker perf lines elsewhere.
             logging_dir: path.join(opts.workspace, ".clice", "logs"),
-            stateful_worker_count: 2,
-            // availableParallelism respects cpusets and container CPU
-            // quotas; os.cpus() is the host's full list.
-            stateless_worker_count: Math.max(Math.floor(os.availableParallelism() / 2), 2),
-        },
-        tracker: {
-            cdb_poll_seconds: 3,
-            workspace_poll_seconds: 30,
         },
     };
 }
@@ -380,6 +370,7 @@ async function startServer(opts: Options): Promise<CliceClient> {
     const client = CliceClient.start(opts.binary, { args: serverArgs(opts) });
     await client.initialize(new Workspace(opts.workspace), {
         initializationOptions: initializationOptions(opts),
+        testDefaults: false,
     });
     return client;
 }

--- a/tools/client/client.ts
+++ b/tools/client/client.ts
@@ -174,6 +174,11 @@ export interface StartOptions {
 
 export interface InitializeOptions {
     initializationOptions?: Record<string, unknown> | undefined;
+    /// Whether to overlay the test defaults — one worker of each kind and
+    /// the tracker's polling loops off — onto the initialization options.
+    /// A benchmark switches them off to run the server's real defaults,
+    /// which stay spelled in one place: the C++ config initializers.
+    testDefaults?: boolean | undefined;
     /// Client capabilities to advertise; empty by default so servers see
     /// the most conservative client unless a test opts in.
     capabilities?: proto.ClientCapabilities | undefined;
@@ -408,19 +413,21 @@ export class CliceClient {
         // Force cache_dir into the workspace so .clice/ cleanup prevents
         // stale PCH.
         project["cache_dir"] = ws.path(".clice");
-        // One worker of each kind is enough for tests and halves the
-        // per-test process-spawn cost. Tests needing more pass their own
-        // counts via initializationOptions.
-        project["stateless_worker_count"] ??= 1;
-        project["stateful_worker_count"] ??= 1;
-        initializationOptions["project"] = project;
-        // Disable the stat-polling loops: tests drive ticks deterministically
-        // through the clice/internal/poll hook instead.
         const tracker = {
             ...((initializationOptions["tracker"] ?? {}) as Record<string, unknown>),
         };
-        tracker["cdb_poll_seconds"] ??= 0;
-        tracker["workspace_poll_seconds"] ??= 0;
+        if (options.testDefaults ?? true) {
+            // One worker of each kind is enough for tests and halves the
+            // per-test process-spawn cost. Tests needing more pass their own
+            // counts via initializationOptions.
+            project["stateless_worker_count"] ??= 1;
+            project["stateful_worker_count"] ??= 1;
+            // Disable the stat-polling loops: tests drive ticks deterministically
+            // through the clice/internal/poll hook instead.
+            tracker["cdb_poll_seconds"] ??= 0;
+            tracker["workspace_poll_seconds"] ??= 0;
+        }
+        initializationOptions["project"] = project;
         initializationOptions["tracker"] = tracker;
 
         // Wire URIs stay percent-encoded (a '#' in the path must travel as

--- a/tools/client/client.ts
+++ b/tools/client/client.ts
@@ -189,6 +189,35 @@ interface Transport {
     writer: Writable;
 }
 
+/// The initialization options a client sends for `ws`: the caller's, with
+/// the cache pinned into the workspace (so `.clice/` cleanup prevents a
+/// stale PCH) and, unless switched off, the test defaults — one worker of
+/// each kind (halves the per-test spawn cost; tests needing more pass their
+/// own counts) and the stat-polling loops disabled (tests drive ticks
+/// deterministically through the clice/internal/poll hook).
+export function initializationOptionsFor(
+    ws: Workspace,
+    options: InitializeOptions,
+): Record<string, unknown> {
+    const initializationOptions = { ...(options.initializationOptions ?? {}) };
+    const project = {
+        ...((initializationOptions["project"] ?? {}) as Record<string, unknown>),
+    };
+    project["cache_dir"] = ws.path(".clice");
+    const tracker = {
+        ...((initializationOptions["tracker"] ?? {}) as Record<string, unknown>),
+    };
+    if (options.testDefaults ?? true) {
+        project["stateless_worker_count"] ??= 1;
+        project["stateful_worker_count"] ??= 1;
+        tracker["cdb_poll_seconds"] ??= 0;
+        tracker["workspace_poll_seconds"] ??= 0;
+    }
+    initializationOptions["project"] = project;
+    initializationOptions["tracker"] = tracker;
+    return initializationOptions;
+}
+
 export class CliceClient {
     child: ChildProcessWithoutNullStreams;
     protected connection: proto.ProtocolConnection;
@@ -406,29 +435,7 @@ export class CliceClient {
         options: InitializeOptions = {},
     ): Promise<this> {
         const ws = workspace instanceof Workspace ? workspace : new Workspace(workspace);
-        const initializationOptions = { ...(options.initializationOptions ?? {}) };
-        const project = {
-            ...((initializationOptions["project"] ?? {}) as Record<string, unknown>),
-        };
-        // Force cache_dir into the workspace so .clice/ cleanup prevents
-        // stale PCH.
-        project["cache_dir"] = ws.path(".clice");
-        const tracker = {
-            ...((initializationOptions["tracker"] ?? {}) as Record<string, unknown>),
-        };
-        if (options.testDefaults ?? true) {
-            // One worker of each kind is enough for tests and halves the
-            // per-test process-spawn cost. Tests needing more pass their own
-            // counts via initializationOptions.
-            project["stateless_worker_count"] ??= 1;
-            project["stateful_worker_count"] ??= 1;
-            // Disable the stat-polling loops: tests drive ticks deterministically
-            // through the clice/internal/poll hook instead.
-            tracker["cdb_poll_seconds"] ??= 0;
-            tracker["workspace_poll_seconds"] ??= 0;
-        }
-        initializationOptions["project"] = project;
-        initializationOptions["tracker"] = tracker;
+        const initializationOptions = initializationOptionsFor(ws, options);
 
         // Wire URIs stay percent-encoded (a '#' in the path must travel as
         // %23, not become a fragment); the decoded ws.uri() form is for

--- a/tools/client/workspace.ts
+++ b/tools/client/workspace.ts
@@ -144,7 +144,10 @@ export class Workspace {
         if (!fs.existsSync(this.cacheBase())) {
             return [];
         }
-        return fs.readdirSync(this.cacheBase()).filter((name) => /^v\d+$/.test(name));
+        return fs
+            .readdirSync(this.cacheBase(), { withFileTypes: true })
+            .filter((entry) => entry.isDirectory() && /^v\d+$/.test(entry.name))
+            .map((entry) => entry.name);
     }
 
     private globCache(sub: string, suffix: string): string[] {

--- a/tools/client/workspace.ts
+++ b/tools/client/workspace.ts
@@ -8,10 +8,6 @@ import * as path from "node:path";
 import { URI } from "vscode-uri";
 import { buildCDBEntry, generateCDB } from "../compile_commands.ts";
 
-/// Versioned root of the unified cache store; bump together with
-/// cache_format_version in src/sched/workspace.h.
-const CACHE_ROOT = path.join(".clice", "cache", "v8");
-
 /// The harness-wide canonical URI spelling: percent-decoded. vscode-uri
 /// encodes the drive colon (file:///c%3A/...) while the server emits it
 /// literally (file:///c:/...); both decode to one form. Every URI used
@@ -125,12 +121,38 @@ export class Workspace {
         this.write("clice.toml", '[project]\ncache_dir = "${workspace}/.clice"\n');
     }
 
-    /// The versioned cache store root.
+    /// The versioned cache store root the server opened: the one
+    /// `v<N>` directory under `.clice/cache`, so a version bump on the
+    /// C++ side never leaves the helpers reading a stale tree. Throws
+    /// when there is none yet or more than one.
     cacheRoot(): string {
-        return this.path(CACHE_ROOT);
+        const versions = this.cacheVersions();
+        const [only] = versions;
+        if (versions.length !== 1 || only === undefined) {
+            throw new Error(
+                `expected one cache version directory under ${this.cacheBase()}, found [${versions.join(", ")}]`,
+            );
+        }
+        return path.join(this.cacheBase(), only);
+    }
+
+    private cacheBase(): string {
+        return this.path(path.join(".clice", "cache"));
+    }
+
+    private cacheVersions(): string[] {
+        if (!fs.existsSync(this.cacheBase())) {
+            return [];
+        }
+        return fs.readdirSync(this.cacheBase()).filter((name) => /^v\d+$/.test(name));
     }
 
     private globCache(sub: string, suffix: string): string[] {
+        // No store yet (a read-only session opens none) is an empty
+        // namespace, not an error.
+        if (this.cacheVersions().length === 0) {
+            return [];
+        }
         const dir = path.join(this.cacheRoot(), sub);
         if (!fs.existsSync(dir)) {
             return [];
@@ -170,6 +192,9 @@ export class Workspace {
     /// atomically, so anything under tmp/ is either an in-flight write of a
     /// live server or crash residue awaiting cleanup.
     tmpFiles(): string[] {
+        if (this.cacheVersions().length === 0) {
+            return [];
+        }
         const tmpDir = path.join(this.cacheRoot(), "tmp");
         if (!fs.existsSync(tmpDir)) {
             return [];


### PR DESCRIPTION
## What changed

The third code-reuse and module-boundary review found a handful of facts that still had two hand-written owners, one of which had already diverged. This PR gives each of them a single owner, in the same spirit as #654; the file-tracking items the review raised (open-file disk changes, response-file freshness) are deliberately not part of it.

Facts with one owner now:

- **Module declarations.** `DependencyGraph` owns both directions of the module-declaration relation (`module_of`, `has_modules`); the `Workspace::path_to_module` mirror and `build_module_map` are gone, so the save, delete and CDB-reload paths write the relation once instead of twice. Module-name completion reads the graph's names, which also stops listing a name once per provider.
- **Task-graph families.** The four family ids are one `Family` enum next to `NodeId` instead of four literals spread over four headers; `Invalidator` no longer includes `server/service/ast_family.h` just to compare a tag.
- **The clang invocation of a compile command.** `create_compiler_invocation` (`src/command/invocation.h`) is used by both the compile and the dependency scans. The scan used to overwrite the working directory with the entry's directory unconditionally, while the compile honored an explicit `-working-directory` (absolute wins, relative resolves from the entry's directory) — a header the compile found through a relative search path scanned as missing and never entered the dependency graph. The two preprocessor-driven scans also share their instance setup now.
- **Protocol versus service.** `IndexQuery::locate` takes a domain `SymbolLocator` instead of the agentic wire struct, and `Site` lives with `Coordinates` in `server/protocol/position.h`, so `server/protocol` and `server/service` no longer include each other.
- **Smaller merges of the same shape:** the route picker owns the "await one cold-index attempt before answering empty" policy (`RouteOptions`) that document links and the outline each carried; both batch commands share a `BatchLifetime` for signal handling and the shutdown order; `Toolchain` admits and lands probes through one path for `resolve` and `warm`; partial-specialization selection (`types::select_partial`) is one function for declaration normalization and the resolver; the PCH and PCM builders share output allocation and result landing; the agent `fileDeps` walk is one bounded BFS; `CacheStore`'s two `begin_store` entry points share their admission.
- **Test tooling.** The test client's worker-count and tracker overrides are an option (`testDefaults`) the benchmark switches off instead of copying the server's defaults by hand, and the cache helpers discover the store's version directory instead of hard-coding `v8`.

## Tests

- Unit: full suite; new cases pin the graph's reverse module view and the scan honoring absolute and relative `-working-directory`.
- Tools: `tests/tools/workspace.test.ts` pins the version-directory discovery (no store, one version, two versions).
- `npm run check`, format, and the integration, smoke and snap suites locally.
