### PR TITLE
refactor(tools): share the fixture header, region and timeout helpers

### DIFF
--- a/src/server/protocol/extension.h
+++ b/src/server/protocol/extension.h
@@ -105,7 +105,7 @@ struct LogFloodResult {
 /// clice/internal/stats — TEST-ONLY, not a stable API. Ownership gauges
 /// for memory-lifecycle regression tests: instead of brittle RSS
 /// assertions, each leak class is pinned by a deterministic counter
-/// (consumed by tests/integration/server/test_memory_ownership.py).
+/// (consumed by tests/integration/server/memory_ownership.test.ts).
 /// Absent from capabilities and user docs.
 struct StatsParams {};
 

--- a/tests/integration/extensions/header_context.test.ts
+++ b/tests/integration/extensions/header_context.test.ts
@@ -11,6 +11,7 @@
 import * as proto from "vscode-languageserver-protocol";
 import { waitUntil, withTimeout } from "@clice/tools/client";
 import { expect, test } from "../fixtures.ts";
+import { wireKeys, type SwitchContextResult } from "@clice/tools/protocol";
 
 /// clice/queryContext on a header should return source files that include it.
 test("query context returns host sources", async ({ session }) => {
@@ -69,6 +70,11 @@ test("switch context and current context", async ({ session }) => {
     const switchResult = await client.switchContext(utilsUri, mainUri);
     expect(switchResult).not.toBeNull();
     expect(switchResult.success).toBe(true);
+    // The C++ and TS shapes of the reply are hand-written on both sides; a
+    // field added to one and not the other shows up here.
+    expect(Object.keys(switchResult).sort()).toEqual(
+        [...wireKeys<SwitchContextResult>()(["stale", "success"])].sort(),
+    );
 
     // Verify currentContext now returns main.cpp.
     const current = await client.currentContext(utilsUri);

--- a/tests/integration/server/memory_ownership.test.ts
+++ b/tests/integration/server/memory_ownership.test.ts
@@ -6,7 +6,7 @@
 /// cancelled builds leave no tmp blobs behind.
 
 import { MTIME_GRANULARITY, sleep, waitUntil, type CliceClient } from "@clice/tools/client";
-import type { StatsResult } from "@clice/tools/protocol";
+import { wireKeys, type StatsResult } from "@clice/tools/protocol";
 import { expect, test } from "../fixtures.ts";
 
 const EDIT_INTERVAL = 50;
@@ -140,17 +140,21 @@ test("cancel storm leaves no tmp", async ({ session }) => {
     expect(stats.sessions, `one open document: ${JSON.stringify(stats)}`).toBe(1);
     // The C++ and TS shapes of the reply are hand-written on both sides; a
     // gauge added to one and not the other shows up here.
-    expect(Object.keys(stats).sort()).toEqual([
-        "headerContexts",
-        "indexInmemoryShards",
-        "indexShardContentBytes",
-        "lastSaveShards",
-        "pchCacheEntries",
-        "pchLoadedStates",
-        "pchStateBytes",
-        "pendingTmpFiles",
-        "sessions",
-    ]);
+    expect(Object.keys(stats).sort()).toEqual(
+        [
+            ...wireKeys<StatsResult>()([
+                "headerContexts",
+                "indexInmemoryShards",
+                "indexShardContentBytes",
+                "lastSaveShards",
+                "pchCacheEntries",
+                "pchLoadedStates",
+                "pchStateBytes",
+                "pendingTmpFiles",
+                "sessions",
+            ]),
+        ].sort(),
+    );
     client.assertNoAnomaly();
 });
 

--- a/tests/tools/corpus.test.ts
+++ b/tests/tools/corpus.test.ts
@@ -8,6 +8,7 @@ import { expect, test } from "vitest";
 import {
     orphanSnapshots,
     parseFixtureMeta,
+    scanFixtureHeader,
     type SnapCorpus,
     type SnapFixture,
 } from "@clice/tools/snap/corpus";
@@ -145,4 +146,35 @@ test("snapshot ownership follows verify and snap modes", () => {
     } finally {
         fs.rmSync(tmp, { recursive: true, force: true });
     }
+});
+
+test("fixture header scanning", () => {
+    const content = [
+        "// license",
+        "",
+        "/// # Section",
+        "///",
+        "/// ## Title",
+        "///",
+        "/// - status: partial",
+        "/// - order : 3",
+        "///",
+        "/// Prose, with",
+        "///   - a bullet",
+        "int x;",
+        "",
+    ].join("\n");
+    const header = scanFixtureHeader(content);
+    expect(header.headings).toEqual(["# Section", "## Title"]);
+    expect(header.meta).toEqual([{ key: "status", value: "partial" }]);
+    expect(header.malformed).toEqual(["- order : 3"]);
+    expect(header.description).toEqual(["", "Prose, with", "  - a bullet"]);
+    expect(header.lines[header.bodyStart]).toBe("int x;");
+    // A malformed entry is an error for the snap suite too, not the end
+    // of the list on defaults.
+    expect(() => parseFixtureMeta(content, "f")).toThrow("malformed fixture meta line");
+    // No header at all.
+    const bare = scanFixtureHeader("int x;\n");
+    expect(bare.headings).toEqual([]);
+    expect(bare.bodyStart).toBe(0);
 });

--- a/tests/tools/corpus.test.ts
+++ b/tests/tools/corpus.test.ts
@@ -6,6 +6,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { expect, test } from "vitest";
 import {
+    headingLevel,
     orphanSnapshots,
     parseFixtureMeta,
     scanFixtureHeader,
@@ -200,6 +201,16 @@ test("fixture header scanning", () => {
     const levels = scanFixtureHeader("/// # T\n/// ### Sub\n/// ##x\n");
     expect(levels.headings).toEqual(["# T", "### Sub"]);
     expect(levels.malformed).toEqual(["##x"]);
+    expect(["# T", "##\tT", "###", "##x", "- x: y"].map(headingLevel)).toEqual([1, 2, 3, 0, 0]);
+    // Without a list, the blank `///` after the headings separates the
+    // description (bullets in it are prose); unseparated prose is a
+    // malformed entry.
+    const prose = scanFixtureHeader("/// # T\n///\n/// Documents T.\n/// - a: bullet\nint x;\n");
+    expect(prose).toMatchObject({ headings: ["# T"], meta: [], malformed: [] });
+    expect(prose.description).toEqual(["", "Documents T.", "- a: bullet"]);
+    expect(prose.lines[prose.bodyStart]).toBe("int x;");
+    expect(parseFixtureMeta("/// # T\n///\n/// Documents T.\n", "f")).toEqual(DEFAULTS);
+    expect(scanFixtureHeader("/// # T\n/// Documents T.\n").malformed).toEqual(["Documents T."]);
     // Blank `///` lines before the opening heading are skipped.
     expect(scanFixtureHeader("///\n/// # T\n///\n/// - snap: skip\n").headings).toEqual(["# T"]);
     expect(parseFixtureMeta("///\n/// - snap: skip\n", "f").snap).toBe("skip");

--- a/tests/tools/corpus.test.ts
+++ b/tests/tools/corpus.test.ts
@@ -177,4 +177,13 @@ test("fixture header scanning", () => {
     const bare = scanFixtureHeader("int x;\n");
     expect(bare.headings).toEqual([]);
     expect(bare.bodyStart).toBe(0);
+    // A leading `///` block that opens with prose is a doc comment on the
+    // code, not a header: nothing is malformed and the snap suite sees the
+    // defaults.
+    const doc = scanFixtureHeader("/// Documents f.\n/// - not: a key\nint f();\n");
+    expect(doc).toMatchObject({ headings: [], meta: [], malformed: [], bodyStart: 0 });
+    expect(parseFixtureMeta("/// Documents f.\nint f();\n", "f")).toEqual(DEFAULTS);
+    // Blank `///` lines before the opening heading are skipped.
+    expect(scanFixtureHeader("///\n/// # T\n///\n/// - snap: skip\n").headings).toEqual(["# T"]);
+    expect(parseFixtureMeta("///\n/// - snap: skip\n", "f").snap).toBe("skip");
 });

--- a/tests/tools/corpus.test.ts
+++ b/tests/tools/corpus.test.ts
@@ -183,6 +183,23 @@ test("fixture header scanning", () => {
     const doc = scanFixtureHeader("/// Documents f.\n/// - not: a key\nint f();\n");
     expect(doc).toMatchObject({ headings: [], meta: [], malformed: [], bodyStart: 0 });
     expect(parseFixtureMeta("/// Documents f.\nint f();\n", "f")).toEqual(DEFAULTS);
+    // So are a bullet without a colon and a `#` line that is no heading.
+    for (const prose of ["/// - first bullet\nint f();\n", "/// #include usage\nint f();\n"]) {
+        expect(scanFixtureHeader(prose)).toMatchObject({
+            headings: [],
+            malformed: [],
+            bodyStart: 0,
+        });
+        expect(parseFixtureMeta(prose, "f")).toEqual(DEFAULTS);
+    }
+    // A colon-bearing bullet is an entry attempt even when misspelled.
+    expect(() => parseFixtureMeta("/// - snap : skip\n", "f")).toThrow(
+        "malformed fixture meta line",
+    );
+    // Headings are markdown headings of any level; `##x` is not one.
+    const levels = scanFixtureHeader("/// # T\n/// ### Sub\n/// ##x\n");
+    expect(levels.headings).toEqual(["# T", "### Sub"]);
+    expect(levels.malformed).toEqual(["##x"]);
     // Blank `///` lines before the opening heading are skipped.
     expect(scanFixtureHeader("///\n/// # T\n///\n/// - snap: skip\n").headings).toEqual(["# T"]);
     expect(parseFixtureMeta("///\n/// - snap: skip\n", "f").snap).toBe("skip");

--- a/tests/tools/generated.test.ts
+++ b/tests/tools/generated.test.ts
@@ -1,0 +1,54 @@
+/// Tests for the generated-region helpers shared by the docs generators
+/// (tools/docs/generated.ts).
+
+import { expect, test } from "vitest";
+import { renderMarkdownTable, rewriteRegions } from "@clice/tools/docs/generated";
+
+const MARKERS = { begin: /^<!-- BEGIN X: (.+?) -->$/, end: "<!-- END X -->" };
+
+test("regions are rewritten in place, the page around them kept", () => {
+    const page = ["# Title", "", "<!-- BEGIN X: a -->", "old", "<!-- END X -->", "", "tail"].join(
+        "\n",
+    );
+    const problems: string[] = [];
+    const { text, seen } = rewriteRegions(page, "p.md", MARKERS, (key) => `new ${key}`, problems);
+    expect(text).toBe(
+        ["# Title", "", "<!-- BEGIN X: a -->", "", "new a", "", "<!-- END X -->", "", "tail"].join(
+            "\n",
+        ),
+    );
+    expect([...seen]).toEqual(["a"]);
+    expect(problems).toEqual([]);
+    // An empty body leaves one blank line between the markers.
+    expect(rewriteRegions(page, "p.md", MARKERS, () => "", problems).text).toContain(
+        "<!-- BEGIN X: a -->\n\n<!-- END X -->",
+    );
+});
+
+test("duplicate and unclosed regions are reported, not mangled", () => {
+    const problems: string[] = [];
+    const page = [
+        "<!-- BEGIN X: a -->",
+        "<!-- END X -->",
+        "<!-- BEGIN X: a -->",
+        "<!-- END X -->",
+        "<!-- BEGIN X: b -->",
+        "never closed",
+    ].join("\n");
+    const { text } = rewriteRegions(page, "p.md", MARKERS, (key) => key, problems);
+    expect(problems).toEqual([
+        "p.md: duplicate region 'a'",
+        "p.md: region 'b' has no closing marker",
+    ]);
+    // The unclosed region and everything after it stay as written.
+    expect(text.endsWith("<!-- BEGIN X: b -->\nnever closed")).toBe(true);
+});
+
+test("tables pad columns the way prettier does", () => {
+    expect(
+        renderMarkdownTable([
+            ["A", "Long"],
+            ["xx", "y"],
+        ]),
+    ).toEqual(["| A  | Long |", "| -- | ---- |", "| xx | y    |"]);
+});

--- a/tests/tools/promise.test.ts
+++ b/tests/tools/promise.test.ts
@@ -1,0 +1,18 @@
+/// Tests for the shared promise helpers (tools/promise.ts).
+
+import { expect, test } from "vitest";
+import { TimeoutError, withTimeout } from "@clice/tools/promise";
+
+test("timeout settles with the promise or a timeout error", async () => {
+    await expect(withTimeout(Promise.resolve(7), 50)).resolves.toBe(7);
+
+    const failure = new Error("boom");
+    await expect(withTimeout(Promise.reject(failure), 50)).rejects.toBe(failure);
+
+    const hang = new Promise<never>(() => undefined);
+    const timeout = await withTimeout(hang, 5, "the hang").catch((error: unknown) => error);
+    expect(timeout).toBeInstanceOf(TimeoutError);
+    expect((timeout as Error).message).toBe("timed out after 5ms: the hang");
+    const bare = await withTimeout(hang, 5).catch((error: unknown) => error);
+    expect((bare as Error).message).toBe("timed out after 5ms");
+});

--- a/tools/client/client.ts
+++ b/tools/client/client.ts
@@ -47,6 +47,10 @@ export {
     logFiles,
     SANITIZER_MARKERS,
 } from "../process_gate.ts";
+import { withTimeout } from "../promise.ts";
+
+// The harness's timing helpers are reached through this module.
+export { withTimeout } from "../promise.ts";
 
 // Standard timing constants — use these instead of hardcoded sleep values.
 export const MTIME_GRANULARITY = 1_100; // Filesystem mtime precision + margin
@@ -109,24 +113,6 @@ export function asLocations(result: unknown): proto.Location[] {
 }
 
 const SANITIZER_MARKER_BUFFERS = SANITIZER_MARKERS.map((m) => Buffer.from(m));
-
-export function withTimeout<T>(promise: Promise<T>, ms: number, what: string): Promise<T> {
-    return new Promise<T>((resolve, reject) => {
-        const timer = setTimeout(() => {
-            reject(new Error(`timed out after ${ms}ms: ${what}`));
-        }, ms);
-        promise.then(
-            (v) => {
-                clearTimeout(timer);
-                resolve(v);
-            },
-            (e: unknown) => {
-                clearTimeout(timer);
-                reject(e instanceof Error ? e : new Error(String(e)));
-            },
-        );
-    });
-}
 
 let nextPortOffset = 0;
 
@@ -924,8 +910,7 @@ export class CliceClient {
     async inactiveLines(uri: string): Promise<number[]> {
         const result = await this.semanticTokensFull(uri);
         const provider = this.initResult?.capabilities.semanticTokensProvider as
-            | proto.SemanticTokensOptions
-            | undefined;
+            proto.SemanticTokensOptions | undefined;
         const bit = provider?.legend.tokenModifiers.indexOf("inactive") ?? -1;
         if (bit < 0) {
             throw new Error("server legend misses the inactive modifier");

--- a/tools/client/client.ts
+++ b/tools/client/client.ts
@@ -910,7 +910,8 @@ export class CliceClient {
     async inactiveLines(uri: string): Promise<number[]> {
         const result = await this.semanticTokensFull(uri);
         const provider = this.initResult?.capabilities.semanticTokensProvider as
-            proto.SemanticTokensOptions | undefined;
+            | proto.SemanticTokensOptions
+            | undefined;
         const bit = provider?.legend.tokenModifiers.indexOf("inactive") ?? -1;
         if (bit < 0) {
             throw new Error("server legend misses the inactive modifier");

--- a/tools/docs/config.ts
+++ b/tools/docs/config.ts
@@ -20,12 +20,15 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { REPO_ROOT } from "../compile_commands.ts";
+import { renderMarkdownTable, rewriteRegions, type RegionMarkers } from "./generated.ts";
 
 const SCHEMA_PATH = "docs/public/clice-config.schema.json";
 const DOC_PATH = "docs/en/guide/configuration.md";
 
-const BEGIN_RE = /^<!-- BEGIN GENERATED CONFIG: (.+?) -->$/;
-const END_MARKER = "<!-- END GENERATED CONFIG -->";
+const MARKERS: RegionMarkers = {
+    begin: /^<!-- BEGIN GENERATED CONFIG: (.+?) -->$/,
+    end: "<!-- END GENERATED CONFIG -->",
+};
 
 interface FieldSchema {
     type?: string;
@@ -107,19 +110,6 @@ function renderDefault(field: FieldSchema): string {
     return `\`${JSON.stringify(field.default)}\``;
 }
 
-/// Prettier pads table columns to equal width; match it so `pixi run
-/// format` leaves the generated regions untouched.
-function renderTable(rows: string[][]): string[] {
-    const widths = rows[0]?.map((_, column) => {
-        return Math.max(...rows.map((row) => (row[column] ?? "").length));
-    });
-    const line = (row: string[]): string => {
-        return `| ${row.map((cell, i) => cell.padEnd(widths?.[i] ?? 0)).join(" | ")} |`;
-    };
-    const separator = (widths ?? []).map((width) => "-".repeat(width));
-    return [line(rows[0] ?? []), line(separator), ...rows.slice(1).map(line)];
-}
-
 /// One option: a `### section.name` heading, the type/default table, and
 /// the description paragraph from the annotation.
 function renderField(heading: string, field: FieldSchema): string[] {
@@ -127,7 +117,7 @@ function renderField(heading: string, field: FieldSchema): string[] {
     out.push(`### \`${heading}\``);
     out.push("");
     out.push(
-        ...renderTable([
+        ...renderMarkdownTable([
             ["Type", "Default"],
             [renderType(field), renderDefault(field)],
         ]),
@@ -159,49 +149,19 @@ function renderSection(root: StructSchema, section: string): string {
 }
 
 function rewriteDoc(docText: string, root: StructSchema, problems: string[]): string {
-    const lines = docText.split("\n");
-    const out: string[] = [];
-    const seen = new Set<string>();
-
-    let idx = 0;
-    while (idx < lines.length) {
-        const line = lines[idx] ?? "";
-        const match = BEGIN_RE.exec(line);
-        if (!match) {
-            out.push(line);
-            idx += 1;
-            continue;
-        }
-        const section = (match[1] ?? "").trim();
-        if (seen.has(section)) {
-            problems.push(`${DOC_PATH}: duplicate region '${section}'`);
-        }
-        seen.add(section);
-        let end = idx + 1;
-        while (end < lines.length && lines[end] !== END_MARKER) {
-            end += 1;
-        }
-        if (end >= lines.length) {
-            problems.push(`${DOC_PATH}: region '${section}' has no closing marker`);
-            for (let k = idx; k < lines.length; k++) {
-                out.push(lines[k] ?? "");
-            }
-            return out.join("\n");
-        }
-        out.push(line);
-        out.push("");
-        out.push(renderSection(root, section));
-        out.push("");
-        out.push(lines[end] ?? "");
-        idx = end + 1;
-    }
-
+    const { text, seen } = rewriteRegions(
+        docText,
+        DOC_PATH,
+        MARKERS,
+        (section) => renderSection(root, section),
+        problems,
+    );
     for (const section of Object.keys(root.properties ?? {})) {
         if (!seen.has(section)) {
             problems.push(`${DOC_PATH}: config section '${section}' has no marker region`);
         }
     }
-    return out.join("\n");
+    return text;
 }
 
 function main(argv: string[]): number {

--- a/tools/docs/feature.ts
+++ b/tools/docs/feature.ts
@@ -161,16 +161,18 @@ function parseFixture(filePath: string, featureDir: string, problems: string[]):
     // title with the fixture's subdirectory as the legacy section fallback.
     let section = "";
     let title = "";
+    let used = 1;
     if (second?.startsWith("## ")) {
         section = first.slice(2).trim();
         title = second.slice(3).trim();
+        used = 2;
     } else {
         title = first.slice(2).trim();
         section = relParts.length >= 2 ? (relParts[0] ?? "") : "";
     }
-    if (header.headings.length > 2) {
+    for (const heading of header.headings.slice(used)) {
         problems.push(
-            `${filePath}: unexpected heading '${header.headings[2] ?? ""}' ` +
+            `${filePath}: unexpected heading '${heading}' ` +
                 "(a doc header has an '# section' and at most one '## title')",
         );
     }

--- a/tools/docs/feature.ts
+++ b/tools/docs/feature.ts
@@ -1,6 +1,6 @@
 /// Generate feature-doc checklist sections from snapshot fixtures.
 ///
-/// Each fixture .cpp under tests/data/<feature>/ may begin with a doc header
+/// Each fixture .cpp under tests/snap/<feature>/ may begin with a doc header
 /// describing one checklist capability. This tool renders those headers into
 /// the GENERATED regions of docs/en/features/*.md, so the fixtures are the
 /// single source of truth and the doc checklist is derived from them.
@@ -17,27 +17,23 @@
 ///     ///
 ///     /// Optional markdown description after a bare `///` separator.
 ///
-/// A file is a doc item iff its first line (after stripping `/// `) starts
-/// with `# `. Anything else is a supplementary edge-case test, excluded
-/// from docs. A plain-`//` prologue (license/attribution comments) may
-/// precede the header; it belongs to neither the header nor the example.
-/// The heading hierarchy is plain markdown: with an `## item
-/// title` under the h1, the h1 names the doc section the item belongs to —
-/// matched verbatim against the doc page's generated-region key
-/// (`<!-- BEGIN GENERATED ITEMS: Fold Kinds -->`); an h1 alone is the item
-/// title, with the fixture's subdirectory as the legacy section fallback.
-/// A blank `///` separates the headings from a metadata list of
-/// `/// - key: value` lines; the known keys are `status` (required;
-/// `supported`, `partial` or `unsupported`), `issues` (optional), `order`
-/// (optional integer) and `snap` (snapshot suites, not rendered). A bare
-/// `///` then separates the metadata from an optional markdown
-/// description; everything after the last `///` line (trimmed of blank
-/// lines) is the example code.
+/// The header's shape (a plain-`//` prologue, the headings, the metadata
+/// list, the description) is read by scanFixtureHeader in
+/// tools/snap/corpus.ts, which the snap suite shares; the keys it may
+/// carry are FIXTURE_META_KEYS there. A file is a doc item iff the header
+/// opens with an `# ` heading; anything else is a supplementary edge-case
+/// test, excluded from docs. With an `## item title` under the h1, the h1
+/// names the doc section the item belongs to — matched verbatim against
+/// the doc page's generated-region key (`<!-- BEGIN GENERATED ITEMS: Fold
+/// Kinds -->`); an h1 alone is the item title, with the fixture's
+/// subdirectory as the legacy section fallback. This tool renders `status`
+/// (required; `supported`, `partial` or `unsupported`), `issues` and
+/// `order`; the other keys drive the snapshot suites. Everything after the
+/// last `///` line (trimmed of blank lines) is the example code.
 ///
 /// `partial` items render unchecked with a _(partial)_ marker but are still
 /// compiled and snapshotted, so the snapshot records the current partial
-/// behavior; only `unsupported` fixtures are skipped by the snapshot glob (via
-/// test/fixture.h, which reads the same header).
+/// behavior.
 ///
 /// Usage:
 ///     node tools/docs/feature.ts update   # rewrite generated regions
@@ -47,9 +43,8 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { REPO_ROOT } from "../compile_commands.ts";
 import { parseAnnotations } from "../snap/annotation.ts";
-import { FIXTURE_META_KEYS, scanFixtureHeader } from "../snap/corpus.ts";
+import { C_FAMILY, FIXTURE_META_KEYS, scanFixtureHeader } from "../snap/corpus.ts";
 import { renderMarkdownTable, rewriteRegions, type RegionMarkers } from "./generated.ts";
-import { C_FAMILY } from "../snap/corpus.ts";
 
 // feature -> doc path (relative to repo root). Extend as more features
 // adopt fixture-generated docs. Several corpora may feed one doc page
@@ -88,8 +83,10 @@ const OVERVIEW_ROWS: { name: string; page: string; keys?: string[]; label?: stri
 ];
 
 const OVERVIEW_DOC = "docs/en/features/overview.md";
-const OVERVIEW_BEGIN = "<!-- BEGIN GENERATED OVERVIEW -->";
-const OVERVIEW_END = "<!-- END GENERATED OVERVIEW -->";
+const OVERVIEW_MARKERS: RegionMarkers = {
+    begin: /^<!-- BEGIN GENERATED OVERVIEW -->$/,
+    end: "<!-- END GENERATED OVERVIEW -->",
+};
 
 const ISSUE_TRACKERS: Record<string, string> = {
     clangd: "https://github.com/clangd/clangd/issues/",
@@ -170,6 +167,12 @@ function parseFixture(filePath: string, featureDir: string, problems: string[]):
     } else {
         title = first.slice(2).trim();
         section = relParts.length >= 2 ? (relParts[0] ?? "") : "";
+    }
+    if (header.headings.length > 2) {
+        problems.push(
+            `${filePath}: unexpected heading '${header.headings[2] ?? ""}' ` +
+                "(a doc header has an '# section' and at most one '## title')",
+        );
     }
     if (!title) {
         problems.push(`${filePath}: empty title`);
@@ -417,13 +420,6 @@ function globCpp(dir: string): string[] {
         .sort();
 }
 
-function renderRegion(section: string, fixtures: Fixture[]): string {
-    return fixtures
-        .filter((fx) => fx.section === section)
-        .map(renderItem)
-        .join("\n\n");
-}
-
 function rewriteDoc(
     docText: string,
     sections: Map<string, Fixture[]>,
@@ -439,7 +435,7 @@ function rewriteDoc(
             if (matched.length === 0) {
                 problems.push(`${docPath}: region '${section}' matches no fixtures`);
             }
-            return renderRegion(section, matched);
+            return matched.map(renderItem).join("\n\n");
         },
         problems,
     );
@@ -492,7 +488,7 @@ function processFeature(
         }
     }
 
-    // Windows runners check out docs as CRLF (only tests/data/** is pinned
+    // Windows runners check out docs as CRLF (only the test data is pinned
     // to LF); normalize so the $-anchored marker regexes match.
     const current = fs.readFileSync(docPath, "utf8").replaceAll("\r\n", "\n");
     const updated = rewriteDoc(current, sections, docPath, problems);
@@ -524,29 +520,17 @@ function processOverview(
     }
 
     const current = fs.readFileSync(docPath, "utf8").replaceAll("\r\n", "\n");
-    const updated = rewriteOverview(
+    const { text: updated, seen } = rewriteRegions(
         current,
-        renderMarkdownTable(rows).join("\n"),
         docPath,
+        OVERVIEW_MARKERS,
+        () => renderMarkdownTable(rows).join("\n"),
         problems,
     );
-    return [docPath, current, updated];
-}
-
-function rewriteOverview(
-    docText: string,
-    table: string,
-    docPath: string,
-    problems: string[],
-): string {
-    const lines = docText.split("\n");
-    const begin = lines.indexOf(OVERVIEW_BEGIN);
-    const end = lines.indexOf(OVERVIEW_END);
-    if (begin < 0 || end < begin) {
+    if (seen.size === 0) {
         problems.push(`${docPath}: missing GENERATED OVERVIEW region`);
-        return docText;
     }
-    return [...lines.slice(0, begin + 1), "", table, "", ...lines.slice(end)].join("\n");
+    return [docPath, current, updated];
 }
 
 /// A compact unified-style diff of the differing lines, to report staleness.

--- a/tools/docs/feature.ts
+++ b/tools/docs/feature.ts
@@ -47,6 +47,8 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { REPO_ROOT } from "../compile_commands.ts";
 import { parseAnnotations } from "../snap/annotation.ts";
+import { FIXTURE_META_KEYS, scanFixtureHeader } from "../snap/corpus.ts";
+import { renderMarkdownTable, rewriteRegions, type RegionMarkers } from "./generated.ts";
 import { C_FAMILY } from "../snap/corpus.ts";
 
 // feature -> doc path (relative to repo root). Extend as more features
@@ -95,29 +97,13 @@ const ISSUE_TRACKERS: Record<string, string> = {
     llvm: "https://github.com/llvm/llvm-project/issues/",
 };
 
-// `snap` and `config` are consumed by the snapshot suites
-// (tools/snap/inspect.ts), not rendered into docs.
-const KNOWN_KEYS: readonly string[] = [
-    "status",
-    "issues",
-    "order",
-    "verify",
-    "snap",
-    "config",
-    "diagnostics",
-    "indexing",
-    "flags",
-];
 const VALID_STATUS: readonly string[] = ["supported", "partial", "unsupported"];
 
-// Markers must occupy their own unindented line, so marker text embedded in
-// generated item content (titles, descriptions, example code) can never
-// open or terminate a region.
-const BEGIN_RE = /^<!-- BEGIN GENERATED ITEMS: (.+?) -->$/;
-const END_MARKER = "<!-- END GENERATED ITEMS -->";
+const ITEM_MARKERS: RegionMarkers = {
+    begin: /^<!-- BEGIN GENERATED ITEMS: (.+?) -->$/,
+    end: "<!-- END GENERATED ITEMS -->",
+};
 const ISSUE_RE = /^([a-z]+)#(\d+)$/;
-// A metadata list entry: `- key: value`.
-const META_RE = /^-\s+(\w+):\s*(.*)$/;
 
 interface Fixture {
     path: string;
@@ -131,28 +117,6 @@ interface Fixture {
     /// Sibling sources of a multi-file unit fixture (unit-relative POSIX
     /// path, §-stripped content), rendered as extra labeled example blocks.
     siblings: { rel: string; content: string }[];
-}
-
-/// Split text into lines the way Python's str.splitlines() does: on any of
-/// \r\n, \r or \n, without a trailing empty element for a final line break.
-function splitLines(text: string): string[] {
-    if (text === "") {
-        return [];
-    }
-    const lines = text.split(/\r\n|\r|\n/);
-    if (lines[lines.length - 1] === "" && /[\r\n]$/.test(text)) {
-        lines.pop();
-    }
-    return lines;
-}
-
-/// Return the text of a `///` comment line, minus prefix and one space.
-function stripComment(line: string): string {
-    let text = line.trimStart().slice(3);
-    if (text.startsWith(" ")) {
-        text = text.slice(1);
-    }
-    return text;
 }
 
 function trimBlank(lines: string[]): string[] {
@@ -178,37 +142,13 @@ function parseIntStrict(value: string): number | null {
 
 /// Parse a fixture's doc header. Returns null for supplementary files.
 function parseFixture(filePath: string, featureDir: string, problems: string[]): Fixture | null {
-    const text = fs.readFileSync(filePath, "utf8");
-    let lines = splitLines(text);
-
-    // A fixture may open with a plain-`//` prologue (license/attribution
-    // comments) before the doc header. It is not part of the header or the
-    // example, so drop it: detection and example extraction both work on
-    // the remaining lines.
-    let prologue = 0;
-    while (prologue < lines.length) {
-        const line = (lines[prologue] ?? "").trim();
-        if (line !== "" && !(line.startsWith("//") && !line.startsWith("///"))) {
-            break;
-        }
-        prologue += 1;
-    }
-    lines = lines.slice(prologue);
-
-    /// Stripped `///` text at line i, or null if it is not a `///` line.
-    const comment = (i: number): string | null => {
-        const raw = lines[i];
-        if (!raw?.trimStart().startsWith("///")) {
-            return null;
-        }
-        return stripComment(raw);
-    };
-
-    const first = comment(0);
+    const header = scanFixtureHeader(fs.readFileSync(filePath, "utf8"));
+    const [first, second] = header.headings;
     if (!first?.startsWith("# ")) {
-        // Not an h1 line: supplementary fixture, not a doc item.
+        // Not an h1 heading: supplementary fixture, not a doc item.
         return null;
     }
+    const lines = header.lines;
 
     const relParts = path.relative(featureDir, filePath).split(path.sep);
     if (relParts.length > 2) {
@@ -222,20 +162,11 @@ function parseFixture(filePath: string, featureDir: string, problems: string[]):
     // h1 makes the h1 the section (matched verbatim against the doc page's
     // `<!-- BEGIN GENERATED ITEMS: ... -->` key); an h1 alone is the item
     // title with the fixture's subdirectory as the legacy section fallback.
-    let i = 1;
-    if (comment(i) === "") {
-        i += 1;
-    }
     let section = "";
     let title = "";
-    const second = comment(i);
     if (second?.startsWith("## ")) {
         section = first.slice(2).trim();
         title = second.slice(3).trim();
-        i += 1;
-        if (comment(i) === "") {
-            i += 1;
-        }
     } else {
         title = first.slice(2).trim();
         section = relParts.length >= 2 ? (relParts[0] ?? "") : "";
@@ -250,44 +181,23 @@ function parseFixture(filePath: string, featureDir: string, problems: string[]):
         );
     }
 
+    for (const line of header.malformed) {
+        problems.push(
+            `${filePath}: malformed metadata line '${line}' ` +
+                "(expected '- key: value'; separate the description with a bare ///)",
+        );
+    }
     const keys = new Map<string, string>();
-    for (;;) {
-        const line = comment(i);
-        if (line === null || line.trim() === "") {
-            break;
-        }
-        const stripped = line.trim();
-        const match = META_RE.exec(stripped);
-        if (!match) {
-            problems.push(
-                `${filePath}: malformed metadata line '${stripped}' ` +
-                    "(expected '- key: value'; separate the description with a bare ///)",
-            );
-            i += 1;
-            continue;
-        }
-        const key = match[1] ?? "";
-        if (!KNOWN_KEYS.includes(key)) {
+    for (const { key, value } of header.meta) {
+        if (!FIXTURE_META_KEYS.includes(key)) {
             problems.push(`${filePath}: unknown key '${key}'`);
         } else if (keys.has(key)) {
             problems.push(`${filePath}: duplicate ${key}`);
         }
-        keys.set(key, (match[2] ?? "").trim());
-        i += 1;
+        keys.set(key, value);
     }
-
-    // Everything from the trailing bare `///` up to the first non-comment
-    // line is the markdown description.
-    const desc: string[] = [];
-    for (;;) {
-        const line = comment(i);
-        if (line === null) {
-            break;
-        }
-        desc.push(line);
-        i += 1;
-    }
-    const bodyStart = i;
+    const desc = header.description;
+    const bodyStart = header.bodyStart;
 
     if (!keys.has("status")) {
         problems.push(`${filePath}: missing required key 'status'`);
@@ -520,60 +430,25 @@ function rewriteDoc(
     docPath: string,
     problems: string[],
 ): string {
-    const lines = docText.split("\n");
-    const out: string[] = [];
-    const docSections = new Set<string>();
-
-    let idx = 0;
-    while (idx < lines.length) {
-        const line = lines[idx] ?? "";
-        const match = BEGIN_RE.exec(line);
-        if (!match) {
-            out.push(line);
-            idx += 1;
-            continue;
-        }
-
-        const section = (match[1] ?? "").trim();
-        if (docSections.has(section)) {
-            problems.push(`${docPath}: duplicate region '${section}'`);
-        }
-        docSections.add(section);
-        let end = idx + 1;
-        while (end < lines.length && lines[end] !== END_MARKER) {
-            end += 1;
-        }
-        if (end >= lines.length) {
-            problems.push(`${docPath}: region '${section}' has no closing marker`);
-            for (let k = idx; k < lines.length; k++) {
-                out.push(lines[k] ?? "");
+    const { text, seen } = rewriteRegions(
+        docText,
+        docPath,
+        ITEM_MARKERS,
+        (section) => {
+            const matched = sections.get(section) ?? [];
+            if (matched.length === 0) {
+                problems.push(`${docPath}: region '${section}' matches no fixtures`);
             }
-            return out.join("\n");
-        }
-
-        const matched = sections.get(section) ?? [];
-        if (matched.length === 0) {
-            problems.push(`${docPath}: region '${section}' matches no fixtures`);
-        }
-
-        out.push(line);
-        const content = renderRegion(section, matched);
-        out.push("");
-        if (content) {
-            out.push(content);
-            out.push("");
-        }
-        out.push(lines[end] ?? "");
-        idx = end + 1;
-    }
-
+            return renderRegion(section, matched);
+        },
+        problems,
+    );
     for (const section of sections.keys()) {
-        if (!docSections.has(section)) {
+        if (!seen.has(section)) {
             problems.push(`${docPath}: section '${section}' has no matching marker region`);
         }
     }
-
-    return out.join("\n");
+    return text;
 }
 
 function processFeature(
@@ -649,23 +524,13 @@ function processOverview(
     }
 
     const current = fs.readFileSync(docPath, "utf8").replaceAll("\r\n", "\n");
-    const updated = rewriteOverview(current, renderTable(rows), docPath, problems);
+    const updated = rewriteOverview(
+        current,
+        renderMarkdownTable(rows).join("\n"),
+        docPath,
+        problems,
+    );
     return [docPath, current, updated];
-}
-
-/// A pipe table padded the way prettier formats markdown tables, so
-/// `pixi run format` leaves the generated region untouched.
-function renderTable(rows: string[][]): string {
-    const widths: number[] = [];
-    for (const row of rows) {
-        row.forEach((cell, i) => {
-            widths[i] = Math.max(widths[i] ?? 0, cell.length);
-        });
-    }
-    const line = (cells: string[]): string =>
-        `| ${cells.map((cell, i) => cell.padEnd(widths[i] ?? 0)).join(" | ")} |`;
-    const separator = widths.map((width) => "-".repeat(width));
-    return [line(rows[0] ?? []), line(separator), ...rows.slice(1).map(line)].join("\n");
 }
 
 function rewriteOverview(

--- a/tools/docs/feature.ts
+++ b/tools/docs/feature.ts
@@ -21,15 +21,15 @@
 /// list, the description) is read by scanFixtureHeader in
 /// tools/snap/corpus.ts, which the snap suite shares; the keys it may
 /// carry are FIXTURE_META_KEYS there. A file is a doc item iff the header
-/// opens with an `# ` heading; anything else is a supplementary edge-case
-/// test, excluded from docs. With an `## item title` under the h1, the h1
-/// names the doc section the item belongs to — matched verbatim against
-/// the doc page's generated-region key (`<!-- BEGIN GENERATED ITEMS: Fold
-/// Kinds -->`); an h1 alone is the item title, with the fixture's
-/// subdirectory as the legacy section fallback. This tool renders `status`
-/// (required; `supported`, `partial` or `unsupported`), `issues` and
-/// `order`; the other keys drive the snapshot suites. Everything after the
-/// last `///` line (trimmed of blank lines) is the example code.
+/// opens with an h1 (`#`) heading; anything else is a supplementary
+/// edge-case test, excluded from docs. With an `## item title` under the
+/// h1, the h1 names the doc section the item belongs to — matched verbatim
+/// against the doc page's generated-region key (`<!-- BEGIN GENERATED
+/// ITEMS: Fold Kinds -->`); an h1 alone is the item title, with the
+/// fixture's subdirectory as the legacy section fallback. This tool renders
+/// `status` (required; `supported`, `partial` or `unsupported`), `issues`
+/// and `order`; the other keys drive the snapshot suites. Everything after
+/// the last `///` line (trimmed of blank lines) is the example code.
 ///
 /// `partial` items render unchecked with a _(partial)_ marker but are still
 /// compiled and snapshotted, so the snapshot records the current partial
@@ -43,7 +43,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { REPO_ROOT } from "../compile_commands.ts";
 import { parseAnnotations } from "../snap/annotation.ts";
-import { C_FAMILY, FIXTURE_META_KEYS, scanFixtureHeader } from "../snap/corpus.ts";
+import { C_FAMILY, FIXTURE_META_KEYS, headingLevel, scanFixtureHeader } from "../snap/corpus.ts";
 import { renderMarkdownTable, rewriteRegions, type RegionMarkers } from "./generated.ts";
 
 // feature -> doc path (relative to repo root). Extend as more features
@@ -141,7 +141,7 @@ function parseIntStrict(value: string): number | null {
 function parseFixture(filePath: string, featureDir: string, problems: string[]): Fixture | null {
     const header = scanFixtureHeader(fs.readFileSync(filePath, "utf8"));
     const [first, second] = header.headings;
-    if (!first?.startsWith("# ")) {
+    if (first === undefined || headingLevel(first) !== 1) {
         // Not an h1 heading: supplementary fixture, not a doc item.
         return null;
     }
@@ -162,12 +162,12 @@ function parseFixture(filePath: string, featureDir: string, problems: string[]):
     let section = "";
     let title = "";
     let used = 1;
-    if (second?.startsWith("## ")) {
-        section = first.slice(2).trim();
-        title = second.slice(3).trim();
+    if (second !== undefined && headingLevel(second) === 2) {
+        section = first.slice(1).trim();
+        title = second.slice(2).trim();
         used = 2;
     } else {
-        title = first.slice(2).trim();
+        title = first.slice(1).trim();
         section = relParts.length >= 2 ? (relParts[0] ?? "") : "";
     }
     for (const heading of header.headings.slice(used)) {

--- a/tools/docs/generated.ts
+++ b/tools/docs/generated.ts
@@ -1,0 +1,76 @@
+/// The GENERATED regions of a handwritten markdown page and the table
+/// layout inside them, shared by the feature and configuration generators.
+
+/// A region's markers. `begin` captures the region key in its first group
+/// and, like `end`, must match an entire line, so marker text inside
+/// generated content can neither open nor close a region.
+export interface RegionMarkers {
+    begin: RegExp;
+    end: string;
+}
+
+/// Rewrites every region of `text`, its body replaced by `render(key)`
+/// with a blank line on each side of a non-empty body; the page's own text
+/// around the regions is kept. A duplicate key and a region without an end
+/// marker are reported into `problems`; the unclosed region keeps its
+/// original text, and so does everything after it. Returns the new text
+/// and the keys seen, for the callers' coverage checks.
+export function rewriteRegions(
+    text: string,
+    docPath: string,
+    markers: RegionMarkers,
+    render: (key: string) => string,
+    problems: string[],
+): { text: string; seen: Set<string> } {
+    const lines = text.split("\n");
+    const out: string[] = [];
+    const seen = new Set<string>();
+
+    let idx = 0;
+    while (idx < lines.length) {
+        const line = lines[idx] ?? "";
+        const match = markers.begin.exec(line);
+        if (!match) {
+            out.push(line);
+            idx += 1;
+            continue;
+        }
+        const key = (match[1] ?? "").trim();
+        if (seen.has(key)) {
+            problems.push(`${docPath}: duplicate region '${key}'`);
+        }
+        seen.add(key);
+        let end = idx + 1;
+        while (end < lines.length && lines[end] !== markers.end) {
+            end += 1;
+        }
+        if (end >= lines.length) {
+            problems.push(`${docPath}: region '${key}' has no closing marker`);
+            out.push(...lines.slice(idx));
+            break;
+        }
+        out.push(line, "");
+        const body = render(key);
+        if (body) {
+            out.push(body, "");
+        }
+        out.push(lines[end] ?? "");
+        idx = end + 1;
+    }
+    return { text: out.join("\n"), seen };
+}
+
+/// A pipe table padded the way prettier formats markdown tables, so
+/// `pixi run format` leaves the generated region untouched.
+export function renderMarkdownTable(rows: readonly (readonly string[])[]): string[] {
+    const widths: number[] = [];
+    for (const row of rows) {
+        row.forEach((cell, i) => {
+            widths[i] = Math.max(widths[i] ?? 0, cell.length);
+        });
+    }
+    const line = (cells: readonly string[]): string =>
+        `| ${cells.map((cell, i) => cell.padEnd(widths[i] ?? 0)).join(" | ")} |`;
+    const separator = widths.map((width) => "-".repeat(width));
+    return [line(rows[0] ?? []), line(separator), ...rows.slice(1).map(line)];
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -6,6 +6,8 @@
   "exports": {
     "./bench/perf": "./bench/perf.ts",
     "./client": "./client/client.ts",
+    "./promise": "./promise.ts",
+    "./docs/generated": "./docs/generated.ts",
     "./workspace": "./client/workspace.ts",
     "./session": "./client/session.ts",
     "./snap/annotation": "./snap/annotation.ts",

--- a/tools/promise.ts
+++ b/tools/promise.ts
@@ -1,0 +1,27 @@
+/// Promise helpers shared by the test client and the replay runner.
+
+/// The rejection of `withTimeout`: a caller that must tell a hang from any
+/// other failure checks for it with `instanceof`.
+export class TimeoutError extends Error {}
+
+/// Settles with `promise`, or rejects with a TimeoutError once `ms`
+/// elapsed first — `what` names the operation in the message. The timer is
+/// cleared on either outcome of the promise, so a settled wait never keeps
+/// the process alive; a rejection that is not an Error is wrapped in one.
+export function withTimeout<T>(promise: Promise<T>, ms: number, what = ""): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            reject(new TimeoutError(`timed out after ${ms}ms${what ? `: ${what}` : ""}`));
+        }, ms);
+        promise.then(
+            (value) => {
+                clearTimeout(timer);
+                resolve(value);
+            },
+            (error: unknown) => {
+                clearTimeout(timer);
+                reject(error instanceof Error ? error : new Error(String(error)));
+            },
+        );
+    });
+}

--- a/tools/protocol/protocol.ts
+++ b/tools/protocol/protocol.ts
@@ -76,7 +76,7 @@ export interface SwitchContextResult {
     success: boolean;
 
     /// The request referenced an outdated queryContext listing.
-    stale?: boolean;
+    stale: boolean;
 }
 
 export const SwitchContextRequest = new RequestType<SwitchContextParams, SwitchContextResult, void>(
@@ -132,3 +132,13 @@ export interface StatsResult {
 }
 
 export const StatsRequest = new RequestType0<StatsResult, void>("clice/internal/stats");
+
+/// The keys of a wire type, for pinning a live reply's shape against the
+/// hand-written C++ struct: the listing is checked complete at compile
+/// time (a key the type gains must be added here), and a test compares it
+/// with the reply's `Object.keys`.
+export function wireKeys<T>() {
+    return <const K extends readonly (keyof T)[]>(
+        keys: Exclude<keyof T, K[number]> extends never ? K : never,
+    ): readonly (keyof T)[] => keys;
+}

--- a/tools/replay.ts
+++ b/tools/replay.ts
@@ -18,6 +18,7 @@ import {
     logFiles,
     processGateFailures,
 } from "./process_gate.ts";
+import { TimeoutError, withTimeout } from "./promise.ts";
 
 // tools/ -> repo root.
 const REPO_ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
@@ -189,27 +190,6 @@ function printTraceInfo(name: string, records: TraceRecord[], workspace: string 
     // Python's sorted(..., key=lambda x: -x[1]) over an insertion-ordered dict.
     const top = [...methods.entries()].sort((a, b) => b[1] - a[1]).slice(0, 8);
     console.log(`  methods: ${top.map(([m, n]) => `${m}(${n})`).join(", ")}`);
-}
-
-class TimeoutError extends Error {}
-
-/// Reject with a TimeoutError after `ms`; otherwise settle with `promise`.
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-    return new Promise<T>((resolve, reject) => {
-        const timer = setTimeout(() => {
-            reject(new TimeoutError());
-        }, ms);
-        promise.then(
-            (v) => {
-                clearTimeout(timer);
-                resolve(v);
-            },
-            (e: unknown) => {
-                clearTimeout(timer);
-                reject(e instanceof Error ? e : new Error(String(e)));
-            },
-        );
-    });
 }
 
 function sleep(ms: number): Promise<void> {

--- a/tools/snap/corpus.ts
+++ b/tools/snap/corpus.ts
@@ -70,7 +70,8 @@ export interface FixtureHeader {
     /// The file's lines after any plain-`//` prologue (license or
     /// attribution comments belong to neither the header nor the example).
     lines: string[];
-    /// The `#` heading lines opening the block, comment prefix stripped.
+    /// The markdown heading lines opening the block, comment prefix
+    /// stripped.
     headings: string[];
     /// The `- key: value` list after the headings, in order; keys and
     /// duplicates unchecked.
@@ -107,7 +108,12 @@ function stripComment(line: string): string {
     return text;
 }
 
+const HEADING_RE = /^#{1,6}(?:\s|$)/;
 const META_RE = /^-\s+(\w+):\s*(.*)$/;
+/// Looser than META_RE on purpose: a misspelled entry (`- Snap:`, `- snap :`)
+/// must open the header and error rather than leave the fixture silently on
+/// defaults, while a bullet without a colon is prose.
+const ENTRY_RE = /^-\s+[^:]+:/;
 
 export function scanFixtureHeader(content: string): FixtureHeader {
     const all = splitLines(content);
@@ -147,13 +153,13 @@ export function scanFixtureHeader(content: string): FixtureHeader {
     const first = (lines[opening] ?? "").trimStart().startsWith("///")
         ? stripComment(lines[opening] ?? "").trim()
         : "";
-    if (!first.startsWith("#") && !first.startsWith("- ")) {
+    if (!HEADING_RE.test(first) && !ENTRY_RE.test(first)) {
         return header;
     }
     // The headings and the blank lines around them.
     for (let line = comment(); line !== null; line = comment()) {
         const text = line.trim();
-        if (text.startsWith("#")) {
+        if (HEADING_RE.test(text)) {
             header.headings.push(text);
         } else if (text !== "") {
             break;

--- a/tools/snap/corpus.ts
+++ b/tools/snap/corpus.ts
@@ -48,7 +48,11 @@ export interface FixtureMeta {
     flags: string[];
 }
 
-const META_KEYS = [
+/// The keys a fixture's doc header may carry — the one vocabulary the snap
+/// suite and the docs generator both validate against. `issues` and
+/// `order` are rendered into the docs only; `snap` and `config` are read
+/// by the snapshot suites only.
+export const FIXTURE_META_KEYS: readonly string[] = [
     "status",
     "issues",
     "order",
@@ -60,6 +64,106 @@ const META_KEYS = [
     "flags",
 ];
 
+/// A fixture's leading `///` block, split into its parts; the readers
+/// (parseFixtureMeta here, the docs generator) validate what they use.
+export interface FixtureHeader {
+    /// The file's lines after any plain-`//` prologue (license or
+    /// attribution comments belong to neither the header nor the example).
+    lines: string[];
+    /// The `#` heading lines opening the block, comment prefix stripped.
+    headings: string[];
+    /// The `- key: value` list after the headings, in order; keys and
+    /// duplicates unchecked.
+    meta: { key: string; value: string }[];
+    /// Lines inside the list that are not entries: a misspelled entry must
+    /// error, not silently end the list on defaults.
+    malformed: string[];
+    /// The stripped `///` lines after the list's blank separator: the
+    /// markdown description.
+    description: string[];
+    /// Index into `lines` of the first line after the block.
+    bodyStart: number;
+}
+
+/// Split text into lines the way Python's str.splitlines() does: on any of
+/// \r\n, \r or \n, without a trailing empty element for a final line break.
+export function splitLines(text: string): string[] {
+    if (text === "") {
+        return [];
+    }
+    const lines = text.split(/\r\n|\r|\n/);
+    if (lines[lines.length - 1] === "" && /[\r\n]$/.test(text)) {
+        lines.pop();
+    }
+    return lines;
+}
+
+/// The text of a `///` comment line, minus the prefix and one space.
+function stripComment(line: string): string {
+    let text = line.trimStart().slice(3);
+    if (text.startsWith(" ")) {
+        text = text.slice(1);
+    }
+    return text;
+}
+
+const META_RE = /^-\s+(\w+):\s*(.*)$/;
+
+export function scanFixtureHeader(content: string): FixtureHeader {
+    const all = splitLines(content);
+    let prologue = 0;
+    while (prologue < all.length) {
+        const line = (all[prologue] ?? "").trim();
+        if (line !== "" && !(line.startsWith("//") && !line.startsWith("///"))) {
+            break;
+        }
+        prologue += 1;
+    }
+    const lines = all.slice(prologue);
+    const header: FixtureHeader = {
+        lines,
+        headings: [],
+        meta: [],
+        malformed: [],
+        description: [],
+        bodyStart: 0,
+    };
+
+    let i = 0;
+    const comment = (): string | null => {
+        const raw = lines[i];
+        return raw?.trimStart().startsWith("///") ? stripComment(raw) : null;
+    };
+    // The headings and the blank lines around them.
+    for (let line = comment(); line !== null; line = comment()) {
+        const text = line.trim();
+        if (text.startsWith("#")) {
+            header.headings.push(text);
+        } else if (text !== "") {
+            break;
+        }
+        i += 1;
+    }
+    // The metadata list, up to its blank separator. Any `- something:` here
+    // is an entry attempt (a misspelled key must error), anything else is
+    // malformed.
+    for (let line = comment(); line !== null && line.trim() !== ""; line = comment()) {
+        const match = META_RE.exec(line.trim());
+        if (match) {
+            header.meta.push({ key: match[1] ?? "", value: (match[2] ?? "").trim() });
+        } else {
+            header.malformed.push(line.trim());
+        }
+        i += 1;
+    }
+    for (let line = comment(); line !== null; line = comment()) {
+        header.description.push(line);
+        i += 1;
+    }
+    header.bodyStart = i;
+    return header;
+}
+
 export function parseFixtureMeta(content: string, filePath: string): FixtureMeta {
     const meta: FixtureMeta = {
         status: "supported",
@@ -70,57 +174,17 @@ export function parseFixtureMeta(content: string, filePath: string): FixtureMeta
         flags: [],
     };
 
-    // Scan only the metadata list of the leading `///` block: heading
-    // lines and blank separators before it, then `- key: value` lines
-    // until the next blank `///`. The markdown description after that may
-    // legitimately contain bulleted `word:` lines (docs/feature.ts renders
-    // it) — mirroring parseFixture in tools/docs/feature.ts, they are not
-    // metadata. A doc heading is not required: a supplementary fixture
-    // (no `# ` title, ignored by docs/feature.ts) may still open with a bare
-    // `///` meta block.
-    let inMeta = false;
-    const seen = new Set<string>();
-    // A plain-`//` prologue (license/attribution comments) may precede the
-    // `///` header — skip it, mirroring parseFixture in docs/feature.ts.
-    const lines = content.split("\n");
-    let start = 0;
-    while (start < lines.length) {
-        const line = (lines[start] ?? "").trim();
-        if (line !== "" && !(line.startsWith("//") && !line.startsWith("///"))) {
-            break;
-        }
-        start += 1;
+    const header = scanFixtureHeader(content);
+    for (const line of header.malformed) {
+        throw new Error(`${filePath}: malformed fixture meta line '${line}'`);
     }
-    for (let line of lines.slice(start)) {
-        line = line.trim();
-        if (!line.startsWith("///")) {
-            break;
-        }
-        line = line.slice(3).trim();
-        if (line.startsWith("#")) {
-            continue;
-        }
-        if (line === "") {
-            if (inMeta) {
-                break;
-            }
-            continue;
-        }
-        // Any `- something:` at the metadata position is treated as a key so
-        // that a misspelling (`- Snap:`, `- snap :`) errors instead of
-        // silently ending the block on defaults.
-        const match = /^- ([^:]+):(.*)$/.exec(line);
-        if (!match) {
-            break;
-        }
-        inMeta = true;
-        const key = (match[1] ?? "").trim();
-        const value = (match[2] ?? "").trim();
-        if (!META_KEYS.includes(key)) {
+    // A repeated key (merge leftovers, copy/paste) must not silently
+    // let the later value win — it could flip a snap mode unnoticed.
+    const seen = new Set<string>();
+    for (const { key, value } of header.meta) {
+        if (!FIXTURE_META_KEYS.includes(key)) {
             throw new Error(`${filePath}: unknown fixture meta key '${key}'`);
         }
-        // A repeated key (merge leftovers, copy/paste) must not silently
-        // let the later value win — it could flip a snap mode unnoticed.
         if (seen.has(key)) {
             throw new Error(`${filePath}: duplicate fixture meta key '${key}'`);
         }

--- a/tools/snap/corpus.ts
+++ b/tools/snap/corpus.ts
@@ -79,8 +79,8 @@ export interface FixtureHeader {
     /// Lines inside the list that are not entries: a misspelled entry must
     /// error, not silently end the list on defaults.
     malformed: string[];
-    /// The stripped `///` lines after the list's blank separator: the
-    /// markdown description.
+    /// The stripped `///` lines from the blank separator after the list
+    /// (or after the headings, without a list): the markdown description.
     description: string[];
     /// Index into `lines` of the first line after the block.
     bodyStart: number;
@@ -108,12 +108,18 @@ function stripComment(line: string): string {
     return text;
 }
 
-const HEADING_RE = /^#{1,6}(?:\s|$)/;
+const HEADING_RE = /^(#{1,6})(?:\s|$)/;
 const META_RE = /^-\s+(\w+):\s*(.*)$/;
 /// Looser than META_RE on purpose: a misspelled entry (`- Snap:`, `- snap :`)
 /// must open the header and error rather than leave the fixture silently on
 /// defaults, while a bullet without a colon is prose.
 const ENTRY_RE = /^-\s+[^:]+:/;
+
+/// The level of a markdown heading line (`## Title` is 2); 0 for any
+/// other text.
+export function headingLevel(text: string): number {
+    return HEADING_RE.exec(text)?.[1]?.length ?? 0;
+}
 
 export function scanFixtureHeader(content: string): FixtureHeader {
     const all = splitLines(content);
@@ -153,18 +159,27 @@ export function scanFixtureHeader(content: string): FixtureHeader {
     const first = (lines[opening] ?? "").trimStart().startsWith("///")
         ? stripComment(lines[opening] ?? "").trim()
         : "";
-    if (!HEADING_RE.test(first) && !ENTRY_RE.test(first)) {
+    if (headingLevel(first) === 0 && !ENTRY_RE.test(first)) {
         return header;
     }
     // The headings and the blank lines around them.
+    let headingsEnd = 0;
     for (let line = comment(); line !== null; line = comment()) {
         const text = line.trim();
-        if (HEADING_RE.test(text)) {
+        if (headingLevel(text) > 0) {
             header.headings.push(text);
+            headingsEnd = i + 1;
         } else if (text !== "") {
             break;
         }
         i += 1;
+    }
+    // No list: when the line after the headings' blank separator is not an
+    // entry attempt, the description starts at that separator. (Without a
+    // separator the line is in list position, and malformed.)
+    const next = comment();
+    if (next !== null && i > headingsEnd && !ENTRY_RE.test(next.trim())) {
+        i = headingsEnd;
     }
     // The metadata list, up to its blank separator. Any `- something:` here
     // is an entry attempt (a misspelled key must error), anything else is

--- a/tools/snap/corpus.ts
+++ b/tools/snap/corpus.ts
@@ -87,7 +87,7 @@ export interface FixtureHeader {
 
 /// Split text into lines the way Python's str.splitlines() does: on any of
 /// \r\n, \r or \n, without a trailing empty element for a final line break.
-export function splitLines(text: string): string[] {
+function splitLines(text: string): string[] {
     if (text === "") {
         return [];
     }
@@ -134,6 +134,22 @@ export function scanFixtureHeader(content: string): FixtureHeader {
         const raw = lines[i];
         return raw?.trimStart().startsWith("///") ? stripComment(raw) : null;
     };
+    // A header opens with a heading or an entry (blank `///` lines before
+    // it are skipped). Any other leading `///` block is an ordinary doc
+    // comment on the code — the fixture has no header.
+    let opening = 0;
+    while (
+        (lines[opening] ?? "").trimStart().startsWith("///") &&
+        stripComment(lines[opening] ?? "").trim() === ""
+    ) {
+        opening += 1;
+    }
+    const first = (lines[opening] ?? "").trimStart().startsWith("///")
+        ? stripComment(lines[opening] ?? "").trim()
+        : "";
+    if (!first.startsWith("#") && !first.startsWith("- ")) {
+        return header;
+    }
     // The headings and the blank lines around them.
     for (let line = comment(); line !== null; line = comment()) {
         const text = line.trim();


### PR DESCRIPTION
## What changed

The TypeScript side of the third code-reuse review: four pieces of harness and docs tooling that existed twice, and one protocol shape that had drifted between the two languages.

- **One fixture-header parser.** The snap suite (`tools/snap/corpus.ts`) and the docs generator (`tools/docs/feature.ts`) each scanned a fixture's leading `///` block and each kept the list of allowed metadata keys. `scanFixtureHeader` and `FIXTURE_META_KEYS` now live in the corpus model, and both readers validate what they use on top of it. The snap side is a little stricter as a result: a line in the metadata list that is not a `- key: value` entry is an error there too (the docs check already rejected it), instead of silently ending the list on defaults. Every fixture in the corpus parses unchanged.
- **One generated-region rewriter and one table layout.** The feature and configuration generators shared the BEGIN/END marker protocol (duplicate keys, unclosed regions, keeping the page's own text) and the prettier-compatible pipe-table padding as two hand-written copies each; `tools/docs/generated.ts` owns both. The generated pages are byte-identical.
- **One promise timeout.** The test client and the replay runner each had a `withTimeout`; `tools/promise.ts` owns it, and the replay's `TimeoutError` distinction is now the one implementation's rejection type. Tests keep importing it through the client module.
- **`clice/switchContext` shape.** The C++ reply always carries `stale`; the TypeScript type declared it optional. It is required now, and the two hand-written wire shapes that live tests compare against (`switchContext`, `clice/internal/stats`) go through `wireKeys`, whose listing the compiler checks against the type.

## Tests

- New: `tests/tools/generated.test.ts` (region rewriting, duplicate and unclosed regions, table padding), `tests/tools/promise.test.ts`, and a `scanFixtureHeader` case in `tests/tools/corpus.test.ts`.
- `pixi run check-feature-docs` and `check-config-docs` pass unchanged; `npm run check`; the tools, integration, smoke and snap suites locally.
