### PR TITLE
ci(nightly): pick the promoted commit from the artifact list

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,24 +39,38 @@ jobs:
         run: |
           # The tag must point at the exact commit the promoted binaries
           # were built from, so pick the newest main commit whose green run
-          # still has live package artifacts: path-filtered runs (e.g.
-          # docs-only commits) build nothing, and packages expire after
-          # 30 days. The artifacts API occasionally answers with an empty
-          # list for a while, so an empty or failed query is retried before
-          # giving up.
-          PACKAGE=package-clice.x86_64-unknown-linux-gnu.tar.gz
+          # still has a live package artifact for every platform (the same
+          # set publish-clice.yml refuses to promote without): path-filtered
+          # runs (e.g. docs-only commits) build nothing, and packages expire
+          # after 30 days. The artifacts API occasionally answers with an
+          # empty list for a while, so an empty or failed query is retried
+          # before giving up.
+          PACKAGES="package-clice.x86_64-unknown-linux-gnu.tar.gz
+                    package-clice.aarch64-unknown-linux-gnu.tar.gz
+                    package-clice.aarch64-apple-darwin.tar.gz
+                    package-clice.x86_64-apple-darwin.tar.gz
+                    package-clice.x86_64-pc-windows-msvc.zip
+                    package-clice.aarch64-pc-windows-msvc.zip"
+          COUNT=$(wc -w <<< "$PACKAGES")
           COMMIT=""
           for ATTEMPT in 1 2 3; do
             if [ "$ATTEMPT" -gt 1 ]; then sleep 30; fi
             RUNS=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow main \
               --branch main --event push --status success --limit 100 \
               --json databaseId -q '.[].databaseId') || RUNS=""
-            LIVE=$(gh api --paginate \
-              "repos/$GITHUB_REPOSITORY/actions/artifacts?name=$PACKAGE&per_page=100" \
-              --jq '.artifacts[] | select(.expired | not)
-                    | "\(.workflow_run.id) \(.workflow_run.head_sha)"') || LIVE=""
+            LIVE=""
+            for PACKAGE in $PACKAGES; do
+              ONE=$(gh api --paginate \
+                "repos/$GITHUB_REPOSITORY/actions/artifacts?name=$PACKAGE&per_page=100" \
+                --jq '.artifacts[] | select(.expired | not)
+                      | "\(.workflow_run.id) \(.workflow_run.head_sha)"') || ONE=""
+              LIVE="$LIVE$(sort -u <<< "$ONE")"$'\n'
+            done
+            # A run qualifies only when every package is live for it.
+            LIVE=$(grep . <<< "$LIVE" | sort | uniq -c \
+              | awk -v n="$COUNT" '$1 == n { print $2, $3 }')
             echo "attempt $ATTEMPT: $(grep -c . <<< "$RUNS") green main runs," \
-              "$(grep -c . <<< "$LIVE") live packages"
+              "$(grep -c . <<< "$LIVE") fully packaged runs"
             for RUN in $RUNS; do
               COMMIT=$(awk -v run="$RUN" '$1 == run { print $2; exit }' <<< "$LIVE")
               if [ -n "$COMMIT" ]; then break; fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,18 +41,26 @@ jobs:
           # were built from, so pick the newest main commit whose green run
           # still has live package artifacts: path-filtered runs (e.g.
           # docs-only commits) build nothing, and packages expire after
-          # 30 days.
+          # 30 days. The artifacts API occasionally answers with an empty
+          # list for a while, so an empty result is retried before giving up.
+          PACKAGE=package-clice.x86_64-unknown-linux-gnu.tar.gz
           COMMIT=""
-          for RUN in $(gh run list --repo "$GITHUB_REPOSITORY" --workflow main \
+          for ATTEMPT in 1 2 3; do
+            RUNS=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow main \
               --branch main --event push --status success --limit 100 \
-              --json databaseId -q '.[].databaseId'); do
-            LIVE=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN/artifacts?name=package-clice.x86_64-unknown-linux-gnu.tar.gz" \
-              --jq '[.artifacts[] | select(.expired | not)] | length')
-            if [ "$LIVE" -gt 0 ]; then
-              COMMIT=$(gh run view "$RUN" --repo "$GITHUB_REPOSITORY" \
-                --json headSha -q .headSha)
-              break
-            fi
+              --json databaseId -q '.[].databaseId')
+            LIVE=$(gh api --paginate \
+              "repos/$GITHUB_REPOSITORY/actions/artifacts?name=$PACKAGE&per_page=100" \
+              --jq '.artifacts[] | select(.expired | not)
+                    | "\(.workflow_run.id) \(.workflow_run.head_sha)"')
+            echo "attempt $ATTEMPT: $(grep -c . <<< "$RUNS") green main runs," \
+              "$(grep -c . <<< "$LIVE") live packages"
+            for RUN in $RUNS; do
+              COMMIT=$(awk -v run="$RUN" '$1 == run { print $2; exit }' <<< "$LIVE")
+              if [ -n "$COMMIT" ]; then break; fi
+            done
+            if [ -n "$COMMIT" ]; then break; fi
+            sleep 30
           done
           if [ -z "$COMMIT" ]; then
             echo "::error::no recent green main run has live package artifacts"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,17 +42,19 @@ jobs:
           # still has live package artifacts: path-filtered runs (e.g.
           # docs-only commits) build nothing, and packages expire after
           # 30 days. The artifacts API occasionally answers with an empty
-          # list for a while, so an empty result is retried before giving up.
+          # list for a while, so an empty or failed query is retried before
+          # giving up.
           PACKAGE=package-clice.x86_64-unknown-linux-gnu.tar.gz
           COMMIT=""
           for ATTEMPT in 1 2 3; do
+            if [ "$ATTEMPT" -gt 1 ]; then sleep 30; fi
             RUNS=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow main \
               --branch main --event push --status success --limit 100 \
-              --json databaseId -q '.[].databaseId')
+              --json databaseId -q '.[].databaseId') || RUNS=""
             LIVE=$(gh api --paginate \
               "repos/$GITHUB_REPOSITORY/actions/artifacts?name=$PACKAGE&per_page=100" \
               --jq '.artifacts[] | select(.expired | not)
-                    | "\(.workflow_run.id) \(.workflow_run.head_sha)"')
+                    | "\(.workflow_run.id) \(.workflow_run.head_sha)"') || LIVE=""
             echo "attempt $ATTEMPT: $(grep -c . <<< "$RUNS") green main runs," \
               "$(grep -c . <<< "$LIVE") live packages"
             for RUN in $RUNS; do
@@ -60,7 +62,6 @@ jobs:
               if [ -n "$COMMIT" ]; then break; fi
             done
             if [ -n "$COMMIT" ]; then break; fi
-            sleep 30
           done
           if [ -z "$COMMIT" ]; then
             echo "::error::no recent green main run has live package artifacts"


### PR DESCRIPTION
## What changed

The scheduled nightly on 2026-09-03 failed in `prepare` with "no recent green main run has live package artifacts", although every recent green `main` run still had all six packages. The step queried the artifacts endpoint once per run (up to 100 calls), and the GitHub artifacts API transiently returned empty lists for the whole loop, so no candidate was found. A rerun of the same workflow passed and published v0.1.2026090310.

This rewrites the pick step:

- Query the repo-wide artifacts listing (`/actions/artifacts?name=...`) once and intersect it with the green `main` runs, instead of one artifacts call per run. Two or three API calls instead of ~100, and the head SHA comes from the same listing, so the extra `gh run view` is gone.
- Retry the whole lookup up to three times when the answer is empty or a `gh` call fails. Previously a failing `gh run list` inside the `for` header was silently swallowed by `set -e` and produced the same misleading error.
- Print how many green runs and live packages each attempt saw, so the next failure is diagnosable from the log.

## Tests

Ran the step's script locally against the real repository with `bash -e`: it picks `6accf1fc` in about 7 seconds (the same commit the passing 09-02 nightly logic would choose). Negative controls: a nonexistent package name runs three attempts and exits 1 with the error annotation; a nonexistent repository surfaces the `gh` 404 on every attempt and exits 1 instead of failing silently. `pixi run format` clean.
