### PR TITLE
docs(home): illustrated home page with the shared mascot art

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: clice
   text: Next Generation C++ Language Server
-  tagline: Development is actively in progress
+  tagline: Fast, crash-proof and project-aware. Pre-release builds ship nightly for VS Code, Neovim and Zed.
   actions:
     - theme: brand
       text: What is clice?
@@ -16,20 +16,24 @@ hero:
       text: Contribution
       link: ./dev/contribution
   image:
-    src: /image.png
+    src: /mascot/hero-working.webp
     alt: clice
 
 features:
-  - icon: 📝
+  - icon:
+      src: /icons/clice-context.webp
     title: Compilation Context
     details: The first language server to introduce compilation context as a formal concept. Users can query and switch compilation contexts, with support for non-self-contained headers and multi-configuration projects
-  - icon: 📦
+  - icon:
+      src: /icons/clice-modules.webp
     title: C++20 Modules
     details: Reference-counted real-time module compilation DAG with cancellation and dependency cascading. Code completion, semantic highlighting, and go-to-definition fully adapted for module syntax
-  - icon: 🔍
+  - icon:
+      src: /icons/clice-templates.webp
     title: Template Resolution
     details: Resolves dependent names through pseudo-instantiation, providing accurate code completion and navigation even inside template definitions
-  - icon: ⚡
+  - icon:
+      src: /icons/clice-processes.webp
     title: Multi-Process Architecture
     details: Master + Worker process model isolating Clang crashes and memory leaks. Supports priority scheduling, real-time memory monitoring, and automatic process recovery
 ---

--- a/docs/meta/translations/index.json
+++ b/docs/meta/translations/index.json
@@ -1,4 +1,4 @@
 {
   "version": 1,
-  "pairs": [{ "kind": "yaml", "en": "13076719d51b2762", "zh": "a708cd4c829eec1d" }]
+  "pairs": [{ "kind": "yaml", "en": "2ecb764cbfb732be", "zh": "bf5e195687e6c4d7" }]
 }

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: clice
   text: 下一代 C++ 语言服务器
-  tagline: 正在积极开发中
+  tagline: 快、不崩、懂项目。预发布版本每日构建，支持 VS Code、Neovim 和 Zed。
   actions:
     - theme: brand
       text: 什么是 clice？
@@ -16,20 +16,24 @@ hero:
       text: 参与贡献
       link: ./dev/contribution
   image:
-    src: /image.png
+    src: /mascot/hero-working.webp
     alt: clice
 
 features:
-  - icon: 📝
+  - icon:
+      src: /icons/clice-context.webp
     title: 编译上下文
     details: 首个将编译上下文作为正式概念引入的语言服务器。用户可以查询和切换编译上下文，并支持非自包含头文件和多配置项目
-  - icon: 📦
+  - icon:
+      src: /icons/clice-modules.webp
     title: C++20 模块
     details: 基于引用计数的实时模块编译 DAG，支持取消操作和依赖级联。代码补全、语义高亮和跳转到定义均已全面适配模块语法
-  - icon: 🔍
+  - icon:
+      src: /icons/clice-templates.webp
     title: 模板解析
     details: 通过伪实例化解析依赖名，即使在模板定义内部也能提供准确的代码补全和代码导航
-  - icon: ⚡
+  - icon:
+      src: /icons/clice-processes.webp
     title: 多进程架构
     details: Master + Worker 进程模型可隔离 clang 崩溃和内存泄漏。支持优先级调度、实时内存监控和进程自动恢复
 ---


### PR DESCRIPTION
## Summary

The clice docs home page now uses the illustration pack hosted on docs.clice.io: the "at work" hero on the right, drawn icons for the four feature cards instead of emoji, and a tagline that says what the project is instead of "development is actively in progress".

Depends on the docs.clice.io theme PR (clice-io/docs#81) being deployed first, otherwise the image paths resolve to nothing.

## Test plan

- `pixi run check-doc-translations`, `check-feature-docs`, `check-config-docs` green.
- Previewed in the docs site checkout, light and dark.