### PR TITLE
test(cdb): standardize compilation database fixtures and helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ benchmarks/workloads/
 .llvm*/
 .clice/
 compile_commands.json
+!tests/data/**/compile_commands.json
 perf.data
 flamegraph.svg
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,9 @@ if(CLICE_ENABLE_TEST)
         "${PROJECT_SOURCE_DIR}/tests/unit"
     )
     target_link_libraries(unit_tests PRIVATE clice::server kota::zest kota::deco)
+    target_compile_definitions(unit_tests PRIVATE
+        CLICE_TESTS_DATA_DIR="${PROJECT_SOURCE_DIR}/tests/data"
+    )
     # The generated/ include dir propagates through clice::core, but the
     # generation order does not — depend explicitly so a test including
     # version.h cannot race the generator on a clean parallel build.

--- a/pixi.toml
+++ b/pixi.toml
@@ -219,7 +219,7 @@ depends-on = ["install-tests"]
 
 [feature.test.tasks.unit-test]
 args = [{ arg = "type", default = "RelWithDebInfo" }]
-cmd = './build/{{ type }}/bin/unit_tests --verbose'
+cmd = 'CLICE_TEST_DATA_DIR=$PIXI_PROJECT_ROOT/tests/data ./build/{{ type }}/bin/unit_tests --verbose'
 depends-on = [{ task = "check-feature-docs" }]
 
 # npm workspaces: install runs at the repo root and covers tools/, tests/

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -279,7 +279,9 @@ std::optional<CompilationDatabase::NormalizeResult>
     }
 
     CompileConfig config;
-    config.directory = directory.empty() ? "" : strings.save(directory).data();
+    llvm::SmallString<256> canonical_dir;
+    config.directory =
+        directory.empty() ? "" : strings.save(path::canonical(directory, canonical_dir)).data();
     config.driver = strings.save(arguments[0]).data();
     arguments = arguments.drop_front();
 

--- a/src/server/protocol/extension.h
+++ b/src/server/protocol/extension.h
@@ -81,6 +81,12 @@ struct SwitchContextResult {
 struct PollParams {
     /// Which loop to tick: "cdb" or "workspace".
     std::string loop;
+
+    /// CDB loop only; defaults to true. A forced tick reloads unconditionally
+    /// — no stamp gate, no settling debounce — so one request applies a
+    /// change deterministically. `false` runs the production tick, for
+    /// tests that pin the stamp gate itself.
+    std::optional<bool> force;
 };
 
 struct PollResult {

--- a/src/server/transport/lsp_client.cpp
+++ b/src/server/transport/lsp_client.cpp
@@ -644,8 +644,7 @@ void LSPClient::register_extensions() {
     // ── Test hook ───────────────────────────────────────────────────
 
     // Runs one file-tracker tick synchronously (see ext::PollParams).
-    // Test-only and not a stable API; the CDB tick runs with force=true,
-    // so the polling loop's two-tick settling debounce does not apply here.
+    // Test-only and not a stable API.
     peer.on_request(
         "clice/internal/poll",
         [this](RequestContext& ctx, const ext::PollParams& params) -> RawResult {
@@ -657,7 +656,7 @@ void LSPClient::register_extensions() {
 
             llvm::SmallVector<FileEvent> events;
             if(params.loop == "cdb") {
-                events = srv.tracker->tick_cdb(/*force=*/true);
+                events = srv.tracker->tick_cdb(params.force.value_or(true));
             } else if(params.loop == "workspace") {
                 events = co_await srv.tracker->tick_workspace();
             } else {

--- a/tests/data/cdb/command_string/compile_commands.json
+++ b/tests/data/cdb/command_string/compile_commands.json
@@ -1,0 +1,7 @@
+[
+  {
+    "directory": ".",
+    "file": "main.cpp",
+    "command": "clang++ -std=c++20 -DCMD -c main.cpp -o main.o"
+  }
+]

--- a/tests/data/cdb/command_string/main.cpp
+++ b/tests/data/cdb/command_string/main.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}

--- a/tests/data/cdb/launcher_prefix/compile_commands.json
+++ b/tests/data/cdb/launcher_prefix/compile_commands.json
@@ -1,0 +1,7 @@
+[
+  {
+    "directory": ".",
+    "file": "main.cpp",
+    "arguments": ["ccache", "clang++", "-std=c++20", "-DWRAPPED", "main.cpp"]
+  }
+]

--- a/tests/data/cdb/launcher_prefix/main.cpp
+++ b/tests/data/cdb/launcher_prefix/main.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}

--- a/tests/data/cdb/multi_entry/compile_commands.json
+++ b/tests/data/cdb/multi_entry/compile_commands.json
@@ -1,0 +1,22 @@
+[
+  {
+    "directory": ".",
+    "file": "main.cpp",
+    "output": "out/Debug/main.o",
+    "arguments": ["clang++", "-std=c++20", "-DCONFIG_A", "-c", "main.cpp", "-o", "out/Debug/main.o"]
+  },
+  {
+    "directory": ".",
+    "file": "main.cpp",
+    "output": "out/Release/main.o",
+    "arguments": [
+      "clang++",
+      "-std=c++20",
+      "-DCONFIG_B",
+      "-c",
+      "main.cpp",
+      "-o",
+      "out/Release/main.o"
+    ]
+  }
+]

--- a/tests/data/cdb/multi_entry/main.cpp
+++ b/tests/data/cdb/multi_entry/main.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}

--- a/tests/data/cdb/relative_directory/compile_commands.json
+++ b/tests/data/cdb/relative_directory/compile_commands.json
@@ -1,0 +1,7 @@
+[
+  {
+    "directory": "src",
+    "file": "main.cpp",
+    "arguments": ["clang++", "-std=c++20", "-DRELATIVE", "main.cpp"]
+  }
+]

--- a/tests/data/cdb/relative_directory/src/main.cpp
+++ b/tests/data/cdb/relative_directory/src/main.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}

--- a/tests/data/cdb/response_file/compile_commands.json
+++ b/tests/data/cdb/response_file/compile_commands.json
@@ -1,0 +1,7 @@
+[
+  {
+    "directory": ".",
+    "file": "main.cpp",
+    "arguments": ["clang++", "@flags.rsp", "main.cpp"]
+  }
+]

--- a/tests/data/cdb/response_file/flags.rsp
+++ b/tests/data/cdb/response_file/flags.rsp
@@ -1,0 +1,2 @@
+-std=c++20
+-DFROM_RSP

--- a/tests/data/cdb/response_file/main.cpp
+++ b/tests/data/cdb/response_file/main.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}

--- a/tests/data/cdb/single_root/compile_commands.json
+++ b/tests/data/cdb/single_root/compile_commands.json
@@ -1,0 +1,7 @@
+[
+  {
+    "directory": ".",
+    "file": "main.cpp",
+    "arguments": ["clang++", "-std=c++20", "-DSINGLE", "main.cpp"]
+  }
+]

--- a/tests/data/cdb/single_root/main.cpp
+++ b/tests/data/cdb/single_root/main.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}

--- a/tests/data/cdb/subdir_cdb/cmake/compile_commands.json
+++ b/tests/data/cdb/subdir_cdb/cmake/compile_commands.json
@@ -1,0 +1,7 @@
+[
+  {
+    "directory": ".",
+    "file": "../main.cpp",
+    "arguments": ["clang++", "-std=c++20", "-DOUT", "../main.cpp"]
+  }
+]

--- a/tests/data/cdb/subdir_cdb/main.cpp
+++ b/tests/data/cdb/subdir_cdb/main.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}

--- a/tests/data/config_rules_no_config/compile_commands.json
+++ b/tests/data/config_rules_no_config/compile_commands.json
@@ -1,0 +1,7 @@
+[
+  {
+    "directory": ".",
+    "file": "main.cpp",
+    "arguments": ["clang++", "-std=c++17", "-fsyntax-only", "main.cpp"]
+  }
+]

--- a/tests/data/config_rules_toml/compile_commands.json
+++ b/tests/data/config_rules_toml/compile_commands.json
@@ -1,0 +1,7 @@
+[
+  {
+    "directory": ".",
+    "file": "main.cpp",
+    "arguments": ["clang++", "-std=c++17", "-fsyntax-only", "main.cpp"]
+  }
+]

--- a/tests/data/formatting/compile_commands.json
+++ b/tests/data/formatting/compile_commands.json
@@ -1,0 +1,7 @@
+[
+  {
+    "directory": ".",
+    "file": "main.cpp",
+    "arguments": ["clang++", "-std=c++17", "-fsyntax-only", "main.cpp"]
+  }
+]

--- a/tests/data/header_context/compile_commands.json
+++ b/tests/data/header_context/compile_commands.json
@@ -1,0 +1,7 @@
+[
+  {
+    "directory": ".",
+    "file": "main.cpp",
+    "arguments": ["clang++", "-std=c++17", "-fsyntax-only", "-I.", "main.cpp"]
+  }
+]

--- a/tests/data/hello_world/compile_commands.json
+++ b/tests/data/hello_world/compile_commands.json
@@ -1,0 +1,7 @@
+[
+  {
+    "directory": ".",
+    "file": "main.cpp",
+    "arguments": ["clang++", "-std=c++17", "-fsyntax-only", "main.cpp"]
+  }
+]

--- a/tests/data/include_completion/compile_commands.json
+++ b/tests/data/include_completion/compile_commands.json
@@ -1,0 +1,7 @@
+[
+  {
+    "directory": ".",
+    "file": "main.cpp",
+    "arguments": ["clang++", "-std=c++17", "-fsyntax-only", "-I.", "main.cpp"]
+  }
+]

--- a/tests/data/multi_context/compile_commands.json
+++ b/tests/data/multi_context/compile_commands.json
@@ -1,0 +1,12 @@
+[
+  {
+    "directory": ".",
+    "file": "main.cpp",
+    "arguments": ["clang++", "-std=c++17", "-fsyntax-only", "-DCONFIG_A", "main.cpp"]
+  },
+  {
+    "directory": ".",
+    "file": "main.cpp",
+    "arguments": ["clang++", "-std=c++17", "-fsyntax-only", "-DCONFIG_B", "main.cpp"]
+  }
+]

--- a/tests/data/pch_test/compile_commands.json
+++ b/tests/data/pch_test/compile_commands.json
@@ -1,0 +1,12 @@
+[
+  {
+    "directory": ".",
+    "file": "main.cpp",
+    "arguments": ["clang++", "-std=c++17", "-fsyntax-only", "main.cpp"]
+  },
+  {
+    "directory": ".",
+    "file": "no_includes.cpp",
+    "arguments": ["clang++", "-std=c++17", "-fsyntax-only", "no_includes.cpp"]
+  }
+]

--- a/tests/integration/agentic/agentic.test.ts
+++ b/tests/integration/agentic/agentic.test.ts
@@ -1,7 +1,8 @@
 /// Tests for the agentic protocol handlers.
 
 import { findFreePort, SETTLE_TIME, sleep, waitUntil, type CliceClient } from "@clice/tools/client";
-import type { Workspace } from "@clice/tools/workspace";
+import { canonicalUri, type Workspace } from "@clice/tools/workspace";
+import { URI } from "vscode-uri";
 import { cliceExecutable, expect, test, type SessionFactory } from "../fixtures.ts";
 import { AgenticRpcClient, jsonSafe, posix, runAgentic } from "./rpc.ts";
 
@@ -79,7 +80,7 @@ test("compile command", async ({ session }) => {
         arguments: string[];
     };
     expect(data.file).toBe(mainCpp);
-    expect(data.directory).toBe(posix(workspace.root));
+    expect(canonicalUri(URI.file(data.directory).toString())).toBe(workspace.uri());
     expect(data.arguments.length).toBeGreaterThan(0);
 });
 

--- a/tests/integration/features/file_tracker.test.ts
+++ b/tests/integration/features/file_tracker.test.ts
@@ -30,8 +30,12 @@ int feature_off() { return 0; }
 #endif
 `;
 
-async function eventsOf(client: CliceClient, loop: "cdb" | "workspace"): Promise<number> {
-    return (await client.poll(loop)).events;
+async function eventsOf(
+    client: CliceClient,
+    loop: "cdb" | "workspace",
+    options: { force?: boolean } = {},
+): Promise<number> {
+    return (await client.poll(loop, options)).events;
 }
 
 test("cdb flag change recompiles", async ({ session }) => {
@@ -49,6 +53,23 @@ test("cdb flag change recompiles", async ({ session }) => {
 
     await client.waitForRecompile(mainUri);
     client.assertNoErrors(mainUri, "open file must pick up the new flags");
+});
+
+test("cdb stamped tick settles", async ({ session }) => {
+    const { client, workspace } = session.tmp();
+    workspace.write("main.cpp", GATED_MAIN);
+    workspace.writeCDB(["main.cpp"]);
+    await client.initialize(workspace);
+
+    const stamped = { force: false };
+    expect(await eventsOf(client, "cdb", stamped), "unchanged stamp must be quiet").toBe(0);
+
+    workspace.writeCDB(["main.cpp"], { extraArgs: ["-DFEATURE"] });
+    expect(
+        await eventsOf(client, "cdb", stamped),
+        "a fresh stamp only arms the settling debounce",
+    ).toBe(0);
+    expect(await eventsOf(client, "cdb", stamped), "the settled stamp reloads").toBe(1);
 });
 
 test("cdb new entry indexed", async ({ session }) => {

--- a/tests/integration/global_setup.ts
+++ b/tests/integration/global_setup.ts
@@ -1,9 +1,0 @@
-/// vitest globalSetup: runs once in the runner process before any worker,
-/// like pytest_configure on the xdist controller — workers would race
-/// writing the same compile_commands.json files.
-
-import { generateTestDataCDBs } from "@clice/tools/compile-commands";
-
-export default function setup(): void {
-    generateTestDataCDBs();
-}

--- a/tests/integration/vitest.config.ts
+++ b/tests/integration/vitest.config.ts
@@ -24,6 +24,5 @@ export default defineConfig({
         // per-test (crash recovery under ASan, stderr backpressure).
         testTimeout: 120_000,
         hookTimeout: 60_000,
-        globalSetup: ["./integration/global_setup.ts"],
     },
 });

--- a/tests/unit/command/command_tests.cpp
+++ b/tests/unit/command/command_tests.cpp
@@ -1,4 +1,5 @@
 #include "test/cdb_helper.h"
+#include "test/platform.h"
 #include "test/temp_dir.h"
 #include "test/test.h"
 #include "command/argument_parser.h"
@@ -852,6 +853,102 @@ TEST_CASE(ResourceDir) {
         }
     }
     EXPECT_EQ(count, 1);
+};
+
+TEST_CASE(FixtureLayouts) {
+    /// The checked-in layouts under tests/data/cdb go through load() like a
+    /// real project's database; each pins the one property it exists for.
+    /// Macros are asserted by name: the driver render spells -D with a
+    /// separate value.
+    auto layouts = path::join(data_dir(), "cdb");
+    auto load_layout = [&](CompilationDatabase& database,
+                           llvm::StringRef layout,
+                           llvm::StringRef cdb = "compile_commands.json") {
+        return database.load(path::join(layouts, layout, cdb)).value_or(0);
+    };
+    auto source = [&](llvm::StringRef layout, llvm::StringRef file = "main.cpp") {
+        return path::join(layouts, layout, file);
+    };
+
+    {
+        FileTable files;
+        CompilationDatabase database{files};
+        ASSERT_EQ(load_layout(database, "single_root"), 1U);
+        EXPECT_CONTAINS(print_argv(render_entry(database, source("single_root"))), "SINGLE");
+    }
+
+    {
+        /// A database inside a build directory: `directory` anchors to that
+        /// directory and the entry's relative file climbs out of it.
+        FileTable files;
+        CompilationDatabase database{files};
+        ASSERT_EQ(load_layout(database, "subdir_cdb", "cmake/compile_commands.json"), 1U);
+        auto candidates = database.candidate_entries(source("subdir_cdb"));
+        ASSERT_EQ(candidates.size(), 1U);
+        EXPECT_EQ(llvm::StringRef(database.config(candidates.front().config).directory),
+                  path::join(layouts, "subdir_cdb", "cmake"));
+        EXPECT_CONTAINS(print_argv(render_entry(database, source("subdir_cdb"))), "OUT");
+    }
+
+    {
+        /// One file, two configurations, the Ninja Multi-Config shape.
+        FileTable files;
+        CompilationDatabase database{files};
+        ASSERT_EQ(load_layout(database, "multi_entry"), 2U);
+        auto candidates = database.candidate_entries(source("multi_entry"));
+        ASSERT_EQ(candidates.size(), 2U);
+        std::string joined;
+        for(auto& entry: candidates) {
+            joined += print_argv(database.render_full(entry.config));
+            joined += ' ';
+        }
+        EXPECT_CONTAINS(joined, "CONFIG_A");
+        EXPECT_CONTAINS(joined, "CONFIG_B");
+    }
+
+    {
+        FileTable files;
+        CompilationDatabase database{files};
+        ASSERT_EQ(load_layout(database, "command_string"), 1U);
+        auto argv = print_argv(render_entry(database, source("command_string")));
+        EXPECT_CONTAINS(argv, "CMD");
+        EXPECT_NOT_CONTAINS(argv, " -c ");
+        EXPECT_NOT_CONTAINS(argv, " -o ");
+    }
+
+    {
+        FileTable files;
+        CompilationDatabase database{files};
+        ASSERT_EQ(load_layout(database, "relative_directory"), 1U);
+        auto file = source("relative_directory", "src/main.cpp");
+        auto candidates = database.candidate_entries(file);
+        ASSERT_EQ(candidates.size(), 1U);
+        EXPECT_EQ(llvm::StringRef(database.config(candidates.front().config).directory),
+                  path::join(layouts, "relative_directory", "src"));
+        EXPECT_CONTAINS(print_argv(render_entry(database, file)), "RELATIVE");
+    }
+
+    {
+        FileTable files;
+        CompilationDatabase database{files};
+        ASSERT_EQ(load_layout(database, "launcher_prefix"), 1U);
+        auto candidates = database.candidate_entries(source("launcher_prefix"));
+        ASSERT_EQ(candidates.size(), 1U);
+        EXPECT_EQ(candidates.front().wrapper.size(), 1U);
+        auto argv = render_entry(database, source("launcher_prefix"));
+        ASSERT_FALSE(argv.empty());
+        EXPECT_EQ(argv.front(), "clang++"sv);
+        EXPECT_CONTAINS(print_argv(argv), "WRAPPED");
+    }
+
+    {
+        FileTable files;
+        CompilationDatabase database{files};
+        ASSERT_EQ(load_layout(database, "response_file"), 1U);
+        auto argv = print_argv(render_entry(database, source("response_file")));
+        EXPECT_CONTAINS(argv, "FROM_RSP");
+        EXPECT_NOT_CONTAINS(argv, "@flags.rsp");
+    }
 };
 
 };  // TEST_SUITE(Command)

--- a/tests/unit/command/command_tests.cpp
+++ b/tests/unit/command/command_tests.cpp
@@ -19,6 +19,13 @@ using namespace std::literals;
 #define EXPECT_NOT_CONTAINS(haystack, needle)                                                      \
     EXPECT_FALSE(llvm::StringRef(haystack).contains(needle))
 
+/// `config.directory` is stored in canonical spelling; expectations built
+/// from native paths must be too.
+std::string canonical_dir(std::string path) {
+    path::canonicalize(path);
+    return path;
+}
+
 TEST_SUITE(Command) {
 
 /// The synthesized fallback render for a file without an entry, resource
@@ -647,7 +654,7 @@ TEST_CASE(RelativeDirectoryAnchored) {
     auto candidates = database.candidate_entries(file);
     ASSERT_EQ(candidates.size(), 1U);
     EXPECT_EQ(llvm::StringRef(database.config(candidates.front().config).directory),
-              path::join(tmp.root, "build"));
+              canonical_dir(path::join(tmp.root, "build")));
 };
 
 TEST_CASE(RelativeLoadPathAnchored) {
@@ -671,7 +678,7 @@ TEST_CASE(RelativeLoadPathAnchored) {
     auto candidates = database.candidate_entries(path::join(tmp.root, "build", "main.cpp"));
     ASSERT_EQ(candidates.size(), 1U);
     EXPECT_EQ(llvm::StringRef(database.config(candidates.front().config).directory),
-              path::join(tmp.root, "build"));
+              canonical_dir(path::join(tmp.root, "build")));
 };
 
 TEST_CASE(LoadErrorRecovery) {
@@ -886,7 +893,7 @@ TEST_CASE(FixtureLayouts) {
         auto candidates = database.candidate_entries(source("subdir_cdb"));
         ASSERT_EQ(candidates.size(), 1U);
         EXPECT_EQ(llvm::StringRef(database.config(candidates.front().config).directory),
-                  path::join(layouts, "subdir_cdb", "cmake"));
+                  canonical_dir(path::join(layouts, "subdir_cdb", "cmake")));
         EXPECT_CONTAINS(print_argv(render_entry(database, source("subdir_cdb"))), "OUT");
     }
 
@@ -924,7 +931,7 @@ TEST_CASE(FixtureLayouts) {
         auto candidates = database.candidate_entries(file);
         ASSERT_EQ(candidates.size(), 1U);
         EXPECT_EQ(llvm::StringRef(database.config(candidates.front().config).directory),
-                  path::join(layouts, "relative_directory", "src"));
+                  canonical_dir(path::join(layouts, "relative_directory", "src")));
         EXPECT_CONTAINS(print_argv(render_entry(database, file)), "RELATIVE");
     }
 

--- a/tests/unit/test/platform.h
+++ b/tests/unit/test/platform.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "llvm/ADT/SmallString.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/VirtualFileSystem.h"
@@ -30,12 +31,19 @@ constexpr inline bool CIEnvironment = false;
 
 /// The checked-in fixture tree, tests/data of the checkout that built this
 /// binary. CLICE_TEST_DATA_DIR in the environment overrides it, the way
-/// CLICE_EXECUTABLE points the TypeScript suites at another build.
+/// CLICE_EXECUTABLE points the TypeScript suites at another build. Absolute
+/// and dot-free with native separators, the spelling the database loader
+/// produces for paths anchored under it.
 inline std::string data_dir() {
+    llvm::SmallString<256> dir;
     if(const char* env = std::getenv("CLICE_TEST_DATA_DIR")) {
-        return env;
+        dir = env;
+    } else {
+        dir = CLICE_TESTS_DATA_DIR;
     }
-    return CLICE_TESTS_DATA_DIR;
+    llvm::sys::fs::make_absolute(dir);
+    llvm::sys::path::remove_dots(dir, /*remove_dot_dot=*/true);
+    return std::string(dir);
 }
 
 class TestVFS : public llvm::vfs::InMemoryFileSystem {

--- a/tests/unit/test/platform.h
+++ b/tests/unit/test/platform.h
@@ -1,3 +1,6 @@
+#pragma once
+
+#include <cstdlib>
 #include <string>
 
 #include "llvm/ADT/SmallString.h"
@@ -24,6 +27,16 @@ constexpr inline bool CIEnvironment = true;
 #else
 constexpr inline bool CIEnvironment = false;
 #endif
+
+/// The checked-in fixture tree, tests/data of the checkout that built this
+/// binary. CLICE_TEST_DATA_DIR in the environment overrides it, the way
+/// CLICE_EXECUTABLE points the TypeScript suites at another build.
+inline std::string data_dir() {
+    if(const char* env = std::getenv("CLICE_TEST_DATA_DIR")) {
+        return env;
+    }
+    return CLICE_TESTS_DATA_DIR;
+}
 
 class TestVFS : public llvm::vfs::InMemoryFileSystem {
 public:

--- a/tools/bench/bench.ts
+++ b/tools/bench/bench.ts
@@ -263,9 +263,10 @@ function firstCDBEntry(cdbPath: string): string {
     if (first === undefined) {
         fail(`empty compile_commands.json at ${cdbPath}`);
     }
-    return path.isAbsolute(first.file)
-        ? first.file
-        : path.join(first.directory ?? path.dirname(cdbPath), first.file);
+    // A relative `directory` anchors at the database's own location, the
+    // way the server resolves it.
+    const directory = path.resolve(path.dirname(cdbPath), first.directory ?? ".");
+    return path.isAbsolute(first.file) ? first.file : path.join(directory, first.file);
 }
 
 function nowMs(): number {

--- a/tools/bench/bench.ts
+++ b/tools/bench/bench.ts
@@ -368,7 +368,13 @@ function initializationOptions(opts: Options): Record<string, unknown> {
 }
 
 async function startServer(opts: Options): Promise<CliceClient> {
-    const client = CliceClient.start(opts.binary, { args: serverArgs(opts) });
+    const client = CliceClient.start(opts.binary, {
+        args: serverArgs(opts),
+        // A relative CDB `directory` anchors at the database for clice but
+        // at the process cwd for clangd; running clangd from the CDB
+        // directory makes both servers compile under the same command.
+        cwd: opts.server === "clangd" ? opts.cdbDir : undefined,
+    });
     await client.initialize(new Workspace(opts.workspace), {
         initializationOptions: initializationOptions(opts),
         testDefaults: false,

--- a/tools/bench/bench.ts
+++ b/tools/bench/bench.ts
@@ -152,7 +152,9 @@ function parseOptions(): Options {
 
     return {
         server,
-        binary,
+        // A bare name stays a PATH lookup; a path is anchored here, before
+        // the clangd process is started from the CDB directory instead.
+        binary: path.basename(binary) === binary ? binary : path.resolve(binary),
         workspace: path.resolve(values.workspace),
         cdbDir: "",
         file: values.file ?? null,

--- a/tools/client/client.ts
+++ b/tools/client/client.ts
@@ -1026,9 +1026,13 @@ export class CliceClient {
     }
 
     /// clice/internal/poll (test hook): run one tracker tick and apply its
-    /// effects synchronously.
-    poll(loop: "cdb" | "workspace"): Promise<PollResult> {
-        return this.sendRequest(PollRequest, { loop });
+    /// effects synchronously. `force: false` takes the CDB loop through its
+    /// real stamp gate and settling debounce (see PollParams).
+    poll(loop: "cdb" | "workspace", options: { force?: boolean } = {}): Promise<PollResult> {
+        return this.sendRequest(PollRequest, {
+            loop,
+            ...(options.force === undefined ? {} : { force: options.force }),
+        });
     }
 
     /// clice/internal/stats (test hook): ownership gauges for

--- a/tools/client/client.ts
+++ b/tools/client/client.ts
@@ -156,6 +156,8 @@ export interface StartOptions {
     /// to play the hostile client.
     drainStderr?: boolean | undefined;
     args?: string[] | undefined;
+    /// Working directory of the server process; the caller's by default.
+    cwd?: string | undefined;
 }
 
 export interface InitializeOptions {
@@ -316,6 +318,7 @@ export class CliceClient {
     static start(executable: string, options: StartOptions = {}): CliceClient {
         const child = spawn(executable, options.args ?? ["serve"], {
             stdio: ["pipe", "pipe", "pipe"],
+            cwd: options.cwd,
         });
         const client = new CliceClient(child, { reader: child.stdout, writer: child.stdin });
         client.stderrDrainedFromStart = options.drainStderr !== false;

--- a/tools/compile_commands.ts
+++ b/tools/compile_commands.ts
@@ -1,7 +1,9 @@
-/// Compilation database generation for test fixtures.
+/// Compilation database helpers for test fixtures: entry construction for
+/// harness-generated workspaces, and CMake generation for fixtures that
+/// carry a CMakeLists.txt. Plain fixtures under tests/data ship their
+/// compile_commands.json with relative paths, so nothing regenerates them.
 
 import { execFileSync } from "node:child_process";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -61,63 +63,4 @@ export function generateCDB(workspace: string): void {
         ],
         { timeout: 120_000, stdio: "pipe" },
     );
-}
-
-/// Generate compile_commands.json for all static test data directories.
-export function generateTestDataCDBs(dataDir: string = DATA_DIR): void {
-    const write = (directory: string, entries: CDBEntry[]) => {
-        // Atomic write: concurrent vitest invocations (one per porting agent)
-        // regenerate the same CDBs; a rename never exposes a truncated file
-        // to a server reading it.
-        const target = path.join(directory, "compile_commands.json");
-        const tmp = `${target}.tmp-${process.pid}`;
-        fs.writeFileSync(tmp, JSON.stringify(entries, null, 2));
-        fs.renameSync(tmp, target);
-    };
-
-    const single = (name: string, extraArgs: string[] = []) => {
-        const dir = path.join(dataDir, name);
-        const main = path.join(dir, "main.cpp");
-        if (fs.existsSync(main)) {
-            write(dir, [buildCDBEntry(dir, main, { extraArgs })]);
-        }
-    };
-
-    single("hello_world");
-
-    // header_context (always regenerate — absolute paths)
-    const hcDir = path.join(dataDir, "header_context");
-    single("header_context", [`-I${posix(hcDir)}`]);
-
-    // multi_context (same file, two configs)
-    const mcDir = path.join(dataDir, "multi_context");
-    const mcMain = path.join(mcDir, "main.cpp");
-    if (fs.existsSync(mcMain)) {
-        write(mcDir, [
-            buildCDBEntry(mcDir, mcMain, { extraArgs: ["-DCONFIG_A"] }),
-            buildCDBEntry(mcDir, mcMain, { extraArgs: ["-DCONFIG_B"] }),
-        ]);
-    }
-
-    single("include_completion", ["-I."]);
-
-    // config_rules_toml / config_rules_no_config — rules tests must start
-    // from a CDB that does NOT include the flag the rule will append, so the
-    // rule's effect is observable through diagnostics.
-    single("config_rules_toml");
-    single("config_rules_no_config");
-
-    single("formatting");
-
-    // pch_test
-    const ptDir = path.join(dataDir, "pch_test");
-    if (fs.existsSync(ptDir)) {
-        const entries = ["main.cpp", "no_includes.cpp"]
-            .map((name) => path.join(ptDir, name))
-            .filter((src) => fs.existsSync(src))
-            .map((src) => buildCDBEntry(ptDir, src));
-        if (entries.length > 0) {
-            write(ptDir, entries);
-        }
-    }
 }

--- a/tools/prepare.ts
+++ b/tools/prepare.ts
@@ -4,12 +4,12 @@
 ///
 /// Each fixture is a subdirectory of tests/data. Fixtures with a
 /// CMakeLists.txt get compile_commands.json generated via CMake; plain
-/// fixtures (e.g. hello_world) are covered by generateTestDataCDBs.
-/// Stale .clice caches are removed so every run starts fresh.
+/// fixtures (e.g. hello_world) ship theirs in the repository. Stale .clice
+/// caches are removed so every run starts fresh.
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { DATA_DIR, generateCDB, generateTestDataCDBs } from "./compile_commands.ts";
+import { DATA_DIR, generateCDB } from "./compile_commands.ts";
 
 const USAGE = "Usage: node tools/prepare.ts <fixture> [<fixture> ...]";
 
@@ -23,8 +23,6 @@ function main(fixtures: string[]): number {
         console.error(USAGE);
         return 64;
     }
-
-    generateTestDataCDBs(DATA_DIR);
 
     for (const fixture of fixtures) {
         const workspace = path.join(DATA_DIR, fixture);

--- a/tools/protocol/protocol.ts
+++ b/tools/protocol/protocol.ts
@@ -91,6 +91,12 @@ export const SwitchContextRequest = new RequestType<SwitchContextParams, SwitchC
 export interface PollParams {
     /// Which loop to tick: "cdb" or "workspace".
     loop: "cdb" | "workspace";
+    /// CDB loop only; defaults to true. A forced tick reloads unconditionally,
+    /// skipping the (size, mtime) stamp gate and the two-tick settling
+    /// debounce, so one request applies a change deterministically. `false`
+    /// runs the production tick: a rewrite is noticed only through its stamp,
+    /// and a changed stamp must hold for two consecutive ticks to reload.
+    force?: boolean;
 }
 
 export interface PollResult {


### PR DESCRIPTION
## Related issue

Refs #218.

## What changed

Compilation-database fixtures become checked-in files instead of generated ones, and the test helpers around them get one shape.

- The plain fixtures under `tests/data` (`hello_world`, `header_context`, `multi_context`, `include_completion`, `config_rules_*`, `formatting`, `pch_test`) now ship their `compile_commands.json` with a relative `directory` and relative paths, which the loader anchors at the database's own location. The per-fixture generator (`generateTestDataCDBs`) and the vitest `globalSetup` that ran it are gone; `tools/prepare.ts` only runs CMake for fixtures that carry a `CMakeLists.txt`. The smoke suite no longer depends on the integration suite having generated `hello_world` first.
- `.gitignore` re-includes `tests/data/**/compile_commands.json`; CMake-generated databases inside `build/` directories stay ignored.
- New layout fixtures under `tests/data/cdb/`, one property each: database at the root, database in a subdirectory with entries climbing out of it, one file with two entries (the Ninja Multi-Config shape), a `command`-string entry, a relative `directory`, a compiler-launcher prefix, and a response file. `Command.FixtureLayouts` loads each one through `CompilationDatabase::load` and pins that property.
- `testing::data_dir()` locates the fixture tree for unit tests: `CLICE_TEST_DATA_DIR` from the environment, else the build-time default the unit test target now carries.
- The `clice/internal/poll` test hook takes an optional `force` (default `true`, unchanged behaviour). `force: false` runs the CDB tick through its real stamp gate and two-tick settling debounce; a new file-tracker test pins that debounce, which the forced tick could never observe.
- `tests/unit/test/platform.h` gained the missing `#pragma once`.
- `config.directory` is stored in canonical spelling at its single write point (forward slashes and a lowercase drive letter on Windows), so a relative `directory` anchored at the database and an absolute one spelled by a generator render the same way in every consumer, including the agentic reply, which the test now compares at the URI level.
- The pixi `unit-test` task points `CLICE_TEST_DATA_DIR` at the checkout it runs in, so a cross-pair job that tests binaries built on another machine still finds the fixtures.
- The benchmark runs clangd from the compilation database's directory (clangd resolves a relative `directory` against its own cwd) and anchors a relative `--binary` before doing so.

## Tests

Debug build: unit, integration, smoke and snap suites; `npm run check`.

