### PR TITLE
build(release): keep llvm-gsymutil diagnostics out of the build log

### DIFF
--- a/cmake/gsym.cmake
+++ b/cmake/gsym.cmake
@@ -10,14 +10,18 @@ execute_process(
     RESULT_VARIABLE result
 )
 
-file(SIZE "${LOG}" log_size)
 if(NOT result EQUAL 0)
-    math(EXPR offset "${log_size} - 4000")
-    if(offset LESS 0)
-        set(offset 0)
+    set(tail "")
+    if(EXISTS "${LOG}")
+        file(SIZE "${LOG}" log_size)
+        math(EXPR offset "${log_size} - 4000")
+        if(offset LESS 0)
+            set(offset 0)
+        endif()
+        file(READ "${LOG}" tail OFFSET ${offset})
     endif()
-    file(READ "${LOG}" tail OFFSET ${offset})
     message(FATAL_ERROR "llvm-gsymutil failed (${result}); end of ${LOG}:\n${tail}")
 endif()
 
+file(SIZE "${LOG}" log_size)
 message(STATUS "Created: ${OUTPUT} (${log_size} bytes of diagnostics in ${LOG})")

--- a/cmake/gsym.cmake
+++ b/cmake/gsym.cmake
@@ -1,0 +1,23 @@
+# In LLVM 22 `--quiet` does not cover llvm-gsymutil's per-DIE warnings
+# ("duplicate line table detected", one DIE dump each); on the macOS dSYM
+# they add up to gigabytes, and streaming them through the CI runner's log
+# is what made the packaging step take 25 minutes instead of seconds.
+
+execute_process(
+    COMMAND "${GSYMUTIL}" --convert "${INPUT}" --merged-functions --quiet --out-file "${OUTPUT}"
+    OUTPUT_FILE "${LOG}"
+    ERROR_FILE "${LOG}"
+    RESULT_VARIABLE result
+)
+
+file(SIZE "${LOG}" log_size)
+if(NOT result EQUAL 0)
+    math(EXPR offset "${log_size} - 4000")
+    if(offset LESS 0)
+        set(offset 0)
+    endif()
+    file(READ "${LOG}" tail OFFSET ${offset})
+    message(FATAL_ERROR "llvm-gsymutil failed (${result}); end of ${LOG}:\n${tail}")
+endif()
+
+message(STATUS "Created: ${OUTPUT} (${log_size} bytes of diagnostics in ${LOG})")

--- a/cmake/release.cmake
+++ b/cmake/release.cmake
@@ -38,6 +38,7 @@ if(WIN32)
         COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:clice>" "${CLICE_STRIPPED}"
         DEPENDS clice
         COMMENT "Collecting PDB for clice"
+        VERBATIM
     )
 elseif(APPLE)
     add_custom_target(clice-strip
@@ -47,6 +48,7 @@ elseif(APPLE)
         COMMAND strip -x "${CLICE_STRIPPED}"
         DEPENDS clice
         COMMENT "Extracting dSYM and stripping clice"
+        VERBATIM
     )
 else()
     add_custom_target(clice-strip
@@ -54,9 +56,10 @@ else()
         COMMAND ${CMAKE_OBJCOPY} --only-keep-debug "$<TARGET_FILE:clice>" "${CLICE_SYMBOL_DIR}/${CLICE_SYMBOL_NAME}"
         COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:clice>" "${CLICE_STRIPPED}"
         COMMAND ${CMAKE_STRIP} --strip-debug --strip-unneeded "${CLICE_STRIPPED}"
-        COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink="${CLICE_SYMBOL_DIR}/${CLICE_SYMBOL_NAME}" "${CLICE_STRIPPED}"
+        COMMAND ${CMAKE_OBJCOPY} "--add-gnu-debuglink=${CLICE_SYMBOL_DIR}/${CLICE_SYMBOL_NAME}" "${CLICE_STRIPPED}"
         DEPENDS clice
         COMMENT "Extracting debug symbols and stripping clice"
+        VERBATIM
     )
 endif()
 
@@ -69,10 +72,11 @@ add_custom_target(clice-pack
     COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_SOURCE_DIR}/docs/clice.toml"
         "${PROJECT_SOURCE_DIR}/LICENSE" "${CLICE_PACK_DIR}/clice/"
     COMMAND ${CMAKE_COMMAND}
-        -DOUTPUT="${PROJECT_BINARY_DIR}/clice${CLICE_ARCHIVE_EXT}"
-        -DWORK_DIR="${CLICE_PACK_DIR}"
+        "-DOUTPUT=${PROJECT_BINARY_DIR}/clice${CLICE_ARCHIVE_EXT}"
+        "-DWORK_DIR=${CLICE_PACK_DIR}"
         -P "${PROJECT_SOURCE_DIR}/cmake/archive.cmake"
     COMMENT "Packaging clice distribution"
+    VERBATIM
 )
 
 # The released symbol package carries GSYM, not DWARF: it keeps everything
@@ -96,10 +100,14 @@ else()
     endif()
     # --merged-functions: ICF folds identical functions onto one address
     # range; without it only one of the folded names survives conversion.
-    # --quiet: the same folding trips thousands of benign line-table
-    # diagnostics that would otherwise drown the CI log.
-    set(CLICE_PACK_SYMBOL_CMD ${CLICE_GSYMUTIL} --convert "${CLICE_GSYM_INPUT}"
-        --merged-functions --quiet --out-file "${CLICE_SYMBOL_DIR}/pack/clice.gsym")
+    # The same folding trips one line-table warning per folded DIE, which
+    # gsym.cmake keeps out of the build log.
+    set(CLICE_PACK_SYMBOL_CMD ${CMAKE_COMMAND}
+        "-DGSYMUTIL=${CLICE_GSYMUTIL}"
+        "-DINPUT=${CLICE_GSYM_INPUT}"
+        "-DOUTPUT=${CLICE_SYMBOL_DIR}/pack/clice.gsym"
+        "-DLOG=${CLICE_SYMBOL_DIR}/gsymutil.log"
+        -P "${PROJECT_SOURCE_DIR}/cmake/gsym.cmake")
 endif()
 
 add_custom_target(clice-pack-symbol
@@ -108,8 +116,9 @@ add_custom_target(clice-pack-symbol
     COMMAND ${CMAKE_COMMAND} -E make_directory "${CLICE_SYMBOL_DIR}/pack"
     COMMAND ${CLICE_PACK_SYMBOL_CMD}
     COMMAND ${CMAKE_COMMAND}
-        -DOUTPUT="${PROJECT_BINARY_DIR}/clice-symbol${CLICE_SYMBOL_ARCHIVE_EXT}"
-        -DWORK_DIR="${CLICE_SYMBOL_DIR}/pack"
+        "-DOUTPUT=${PROJECT_BINARY_DIR}/clice-symbol${CLICE_SYMBOL_ARCHIVE_EXT}"
+        "-DWORK_DIR=${CLICE_SYMBOL_DIR}/pack"
         -P "${PROJECT_SOURCE_DIR}/cmake/archive.cmake"
     COMMENT "Packaging clice debug symbols"
+    VERBATIM
 )


### PR DESCRIPTION
## What changed

`clice-pack-symbol` runs `llvm-gsymutil` through `cmake/gsym.cmake`, which captures the tool's stdout and stderr in `pack-symbol/gsymutil.log` and prints one summary line; a failed conversion still fails the target and the error carries the tail of the log.

In LLVM 22 `--quiet` reaches only `GsymCreator`: the DWARF transformer still reports "duplicate line table detected" for every ICF-folded DIE, each with a full DIE dump, because `llvm-gsymutil.cpp` constructs its `OutputAggregator` with the output stream unconditionally. On the macOS dSYM that produced a 4.2 GB job log in the last main run, and streaming it through the runner is what stretched "Package release artifacts" to 25–29 minutes on both macOS RelWithDebInfo legs — dsymutil and strip account for about 3 minutes, the conversion itself for the rest. Linux emits the same warnings (44 MB) and finishes the step in 30 seconds.

## Tests

- Linux, on the `.debug` file split from the RelWithDebInfo binary: 8.4 s, a 112 MB GSYM, 30 MB of diagnostics (1616 warnings) in the log, one line on the console.
- Failure path: a missing input exits non-zero with the log tail in the CMake error.
- First run of this PR: "Package release artifacts" on macOS RelWithDebInfo 29.3 → 3.5 min, on the macos-x64 cross build 27 → 2.5 min; the macOS RelWithDebInfo job log shrank from 4.3 GB to 0.9 MB while llvm-gsymutil wrote 3.2 GB of diagnostics into the file.
