### PR TITLE
ci: cap ccache at 1 GB per leg, save the VS Code cache from main only

### DIFF
--- a/.github/workflows/cross-pair.yml
+++ b/.github/workflows/cross-pair.yml
@@ -29,7 +29,9 @@ env:
   CCACHE_DIR: ${{ github.workspace }}/.cache/ccache
   CCACHE_BASEDIR: ${{ github.workspace }}
   CCACHE_COMPILERCHECK: content
-  CCACHE_MAXSIZE: 2G
+  # One full build per leg is 130–560 MB; eight legs must share the
+  # repository's 10 GB cache pool with everything else.
+  CCACHE_MAXSIZE: 1G
 
 jobs:
   build:

--- a/.github/workflows/editor-test.yml
+++ b/.github/workflows/editor-test.yml
@@ -42,7 +42,8 @@ jobs:
           echo "/opt/nvim-linux-x86_64/bin" >> "$GITHUB_PATH"
 
       - name: Restore VSCode download cache
-        uses: actions/cache@v6
+        id: vscode-cache
+        uses: actions/cache/restore@v6
         with:
           path: editors/vscode/.vscode-test
           key: vscode-test-${{ runner.os }}-${{ hashFiles('editors/vscode/package.json') }}
@@ -64,3 +65,10 @@ jobs:
         if: runner.os == 'macOS'
         timeout-minutes: 20
         run: pixi run -e editor vscode-e2e RelWithDebInfo
+
+      - name: Save VSCode download cache
+        if: github.ref == 'refs/heads/main' && steps.vscode-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: editors/vscode/.vscode-test
+          key: vscode-test-${{ runner.os }}-${{ hashFiles('editors/vscode/package.json') }}

--- a/.github/workflows/native-test.yml
+++ b/.github/workflows/native-test.yml
@@ -7,7 +7,9 @@ env:
   CCACHE_DIR: ${{ github.workspace }}/.cache/ccache
   CCACHE_BASEDIR: ${{ github.workspace }}
   CCACHE_COMPILERCHECK: content
-  CCACHE_MAXSIZE: 2G
+  # One full build per leg is 130–560 MB; eight legs must share the
+  # repository's 10 GB cache pool with everything else.
+  CCACHE_MAXSIZE: 1G
 
 jobs:
   build-and-test:


### PR DESCRIPTION
## What changed

Two leftovers from #667, both about keeping the repository's 10 GB Actions cache pool from evicting the compiler caches again.

- `CCACHE_MAXSIZE` drops from 2 GB to 1 GB. A full build leaves 130–560 MB per leg, but a restored directory keeps growing across main runs until it hits the cap, so eight legs at 2 GB would eventually claim 16 GB by themselves. At 1 GB a leg still holds a full build plus history, and the eight together fit alongside the other entries.
- The editor-test VS Code download cache follows the compiler caches: restored on every run, saved only from `main`. Each pull request used to add its own 0.6 GB pair of copies.

## Tests

Workflow files parse and pass the formatter; the change is exercised by this PR's own editor-test run (restore) and the first main run after the merge (save).
