### PR TITLE
ci(nightly): guard stale picks, back off marketplace retries

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,8 +43,11 @@ jobs:
           # set publish-clice.yml refuses to promote without): path-filtered
           # runs (e.g. docs-only commits) build nothing, and packages expire
           # after 30 days. The artifacts API occasionally answers with an
-          # empty list for a while, so an empty or failed query is retried
-          # before giving up.
+          # empty or stale list for a while — either no pick at all, or a
+          # pick older than an already-tagged release because the newest
+          # runs are missing from the listing. Both mean the listing is
+          # wrong, never that main went backwards, so both are retried and
+          # then fail the run rather than promote a downgrade.
           PACKAGES="package-clice.x86_64-unknown-linux-gnu.tar.gz
                     package-clice.aarch64-unknown-linux-gnu.tar.gz
                     package-clice.aarch64-apple-darwin.tar.gz
@@ -52,6 +55,7 @@ jobs:
                     package-clice.x86_64-pc-windows-msvc.zip
                     package-clice.aarch64-pc-windows-msvc.zip"
           COUNT=$(wc -w <<< "$PACKAGES")
+          TAGS=$(git tag -l 'v*.*.*')
           COMMIT=""
           for ATTEMPT in 1 2 3; do
             if [ "$ATTEMPT" -gt 1 ]; then sleep 30; fi
@@ -75,10 +79,26 @@ jobs:
               COMMIT=$(awk -v run="$RUN" '$1 == run { print $2; exit }' <<< "$LIVE")
               if [ -n "$COMMIT" ]; then break; fi
             done
+            if [ -n "$COMMIT" ]; then
+              git rev-parse -q --verify "$COMMIT^{commit}" > /dev/null \
+                || git fetch origin "$COMMIT"
+              # Strictly older than any release ever tagged — nightly or
+              # stable — means the listing missed the newer runs, since a
+              # release is only tagged on a commit that was packaged.
+              for TAG in $TAGS; do
+                TAGGED=$(git rev-parse "$TAG^{commit}")
+                if [ "$COMMIT" != "$TAGGED" ] \
+                  && git merge-base --is-ancestor "$COMMIT" "$TAGGED"; then
+                  echo "pick $COMMIT predates $TAG ($TAGGED); stale listing"
+                  COMMIT=""
+                  break
+                fi
+              done
+            fi
             if [ -n "$COMMIT" ]; then break; fi
           done
           if [ -z "$COMMIT" ]; then
-            echo "::error::no recent green main run has live package artifacts"
+            echo "::error::no green main run at or past the newest release has live package artifacts"
             exit 1
           fi
           echo "Promoting $COMMIT"

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -205,7 +205,10 @@ jobs:
           FAILED=""
           for f in vsix/*.vsix; do
             OK=""
-            for ATTEMPT in 1 2 3; do
+            DELAY=30
+            # Marketplace timeouts can persist for minutes, not seconds:
+            # back off up to ~8 minutes per vsix before giving up.
+            for ATTEMPT in 1 2 3 4 5; do
               # --skip-duplicate: a rerun meets versions an earlier attempt
               # already published; that is success, not an error.
               if pixi run publish-vscode -p "$VSCE_PAT" $FLAG --skip-duplicate \
@@ -213,9 +216,10 @@ jobs:
                 OK=1
                 break
               fi
-              if [ "$ATTEMPT" -lt 3 ]; then
-                echo "publish failed for $f (attempt $ATTEMPT); retrying in 30s"
-                sleep 30
+              if [ "$ATTEMPT" -lt 5 ]; then
+                echo "publish failed for $f (attempt $ATTEMPT); retrying in ${DELAY}s"
+                sleep "$DELAY"
+                DELAY=$((DELAY * 2))
               fi
             done
             if [ -z "$OK" ]; then


### PR DESCRIPTION
## Related issue

Fixes #676.

## What changed

The 2026-09-11 nightly (`v0.1.2026091107`) was tagged on a commit 17 commits **older** than the previous nightly and silently downgraded Marketplace pre-release users; configurations written against the current option set (e.g. `default_configuration`, introduced by #664) stopped parsing for them. The pick step trusts the artifacts listing API, which that morning answered with a stale list missing every run newer than 2026-09-02 — the pick loop happily settled on the first (old) fully-packaged run, and nothing downstream noticed the promotion was going backwards.

Two workflow fixes:

- **`nightly.yml` — monotonic pick guard.** A picked commit that is a strict ancestor of any existing release tag's commit is treated as a stale listing: retried like the existing empty-listing case, and failing the run after the retries instead of promoting a downgrade. Checking against every tag rather than the version-sort-newest one also covers the future stable case (a `v0.2.0` cut from an older RC would otherwise become the guard's reference and let the same downgrade through on the first `v0.3.*` nightly). Replayed against the incident's data: the 2026-09-11 pick (`ebc13d2c`) is rejected, the correct 2026-09-12 pick (`0423e49e`) and the no-new-commits case (pick == newest tag commit) pass.
- **`publish-vscode.yml` — Marketplace retry backoff.** `vsce publish` has been failing with `Request timeout: /_apis/gallery` for minutes at a stretch (darwin-arm64 failed all attempts on both 2026-09-11 and 2026-09-12), which three fixed 30 s retries never outlive. Now 5 attempts with exponential backoff (30/60/120/240 s, ~8 min per vsix worst case). The loop semantics are unchanged: per-file `FAILED` accumulation, `--skip-duplicate` keeping reruns idempotent.

## Tests

Workflow-only change, no sources touched. Verified locally: YAML parses; both embedded scripts pass `bash -n`; the guard logic replayed against the real incident commits (`ebc13d2c` rejected as stale, `0423e49e` accepted, last-tag commit accepted for the skip path downstream). `pixi run format` clean.
